### PR TITLE
CI with GitHub actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,10 @@
-name: Publish to PyPI / GitHub
+name: Publish to PyPI
 
 on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 jobs:
   build-n-publish:
@@ -20,7 +21,7 @@ jobs:
           python-version: "3.7"
 
       - name: Check that the current version isn't already on PyPi
-        run |
+        run: |
           if [ "$(./get_pypi_latest_version.sh)" != "$(python setup.py --version)" ]
           then
             echo "Current version is not on PyPI, proceed with bulding"
@@ -31,13 +32,13 @@ jobs:
 
       - name: Check long description is OK for PyPI with tox
         run: |
+          python -m pip install --upgrade pip
           python -m pip install tox
           tox -e pypi
 
       - name: Build a binary wheel and a source tarball
         run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
+          python -m pip install setuptools wheel
           python setup.py sdist bdist_wheel
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: Publish to PyPI / GitHub
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-n-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+
+      - name: Check that the current version isn't already on PyPi
+        run |
+          if [ "$(./get_pypi_latest_version.sh)" != "$(python setup.py --version)" ]
+          then
+            echo "Current version is not on PyPI, proceed with bulding"
+          else
+            echo "Current version is the latest version uploaded to PyPI"
+            exit 1
+          fi
+
+      - name: Check long description is OK for PyPI with tox
+        run: |
+          python -m pip install tox
+          tox -e pypi
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+          python setup.py sdist bdist_wheel
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,6 @@ jobs:
 
   tests:
     name: Test it!
-    needs: lint
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -48,7 +47,6 @@ jobs:
   build-docs:
     name: Build the docs
     runs-on: ubuntu-latest
-    needs: lint
     steps:
     - name: Checkout the repo
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,10 +37,23 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install tox and tox-gh-actions
+    - name: Update pip
+      run: python -m pip install --upgrade pip
+    - name: Get pip cache dir
+      id: pip-cache
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox tox-gh-actions
+        echo "::set-output name=dir::$(pip cache dir)"
+    - name: Get current week number
+      id: get-week
+      shell: bash
+      run: echo "::set-output name=week::$(date +'%V')"
+    - name: Pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ steps.get-week.outputs.week }}-${{ hashFiles('setup.py') }}
+    - name: Install tox and tox-gh-actions
+      run: python -m pip install tox tox-gh-actions
     - name: Test with tox
       run: tox
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,69 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master, develop]
+
+jobs:
+  lint:
+    name: Linting with flake8
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the repo
+      uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.7"
+    - name: Install tox
+      run: |
+        pip install --upgrade pip
+        pip install tox
+    - name: Linting with tox
+      run: tox -e flake8
+
+  tests:
+    name: Test it!
+    needs: lint
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.6]
+        os: [ubuntu-latest]
+    steps:
+    - name: Checkout the repo
+      uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install tox and tox-gh-actions
+      run: |
+        pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Testing with tox
+      run: tox
+
+  build-doc:
+    name: Build the docs
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+    - name: Checkout the repo
+      uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.7"
+    - name: Install pandoc
+      run: |
+        sudo apt update
+        sudo apt install -y make pandoc
+    - name: Install tox
+      run: |
+        pip install --upgrade pip
+        pip install tox
+    - name: Testing with tox
+      run: tox -e docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,12 +37,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install tox
+    - name: Install tox and tox-gh-actions
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tox
-    - name: Testing with tox
-      run: python -m tox -e py
+        python -m pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox
 
   build-docs:
     name: Build the docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,15 +2,16 @@ name: Run Tests
 
 on:
   push:
-    branches: [master]
+    branches: [master, develop]
   pull_request:
     branches: [master, develop]
   schedule:
     - cron: "0 7 * * 1"
+  workflow_dispatch:
 
 jobs:
   lint:
-    name: Linting with flake8
+    name: Linting (pre-commit)
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the repo
@@ -19,12 +20,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.7"
-    - name: Install tox
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox
-    - name: Linting with tox
-      run: tox -e flake8
+    - name: Run pre-commit action
+      uses: pre-commit/action@v2.0.0
 
   tests:
     name: Test it!
@@ -32,8 +29,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6]
-        os: [ubuntu-latest]
+        python-version: [3.6, 3.9]
+        os: [ubuntu-latest, windows-latest]
     steps:
     - name: Checkout the repo
       uses: actions/checkout@v2
@@ -41,14 +38,14 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install tox and tox-gh-actions
+    - name: Install tox
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tox tox-gh-actions
+        python -m pip install tox
     - name: Testing with tox
-      run: tox
+      run: python -m tox -e py
 
-  build-doc:
+  build-docs:
     name: Build the docs
     runs-on: ubuntu-latest
     needs: lint
@@ -59,13 +56,27 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.7"
+    - name: Update pip
+      run: python -m pip install --upgrade pip
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+    - name: Get current week number
+      id: get-week
+      shell: bash
+      run: echo "::set-output name=week::$(date +'%V')"
+    - name: Pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ steps.get-week.outputs.week }}-${{ hashFiles('setup.py') }}
     - name: Install pandoc
       run: |
         sudo apt update
         sudo apt install -y make pandoc
     - name: Install tox
       run: |
-        python -m pip install --upgrade pip
         python -m pip install tox
     - name: Testing with tox
-      run: tox -e docs
+      run: python -m tox -e docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master, develop]
+  schedule:
+    - cron: "0 7 * * 1"
 
 jobs:
   lint:
@@ -19,8 +21,8 @@ jobs:
         python-version: "3.7"
     - name: Install tox
       run: |
-        pip install --upgrade pip
-        pip install tox
+        python -m pip install --upgrade pip
+        python -m pip install tox
     - name: Linting with tox
       run: tox -e flake8
 
@@ -41,8 +43,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install tox and tox-gh-actions
       run: |
-        pip install --upgrade pip
-        pip install tox tox-gh-actions
+        python -m pip install --upgrade pip
+        python -m pip install tox tox-gh-actions
     - name: Testing with tox
       run: tox
 
@@ -63,7 +65,7 @@ jobs:
         sudo apt install -y make pandoc
     - name: Install tox
       run: |
-        pip install --upgrade pip
-        pip install tox
+        python -m pip install --upgrade pip
+        python -m pip install tox
     - name: Testing with tox
       run: tox -e docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.9]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     steps:
     - name: Checkout the repo
       uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -19,14 +19,6 @@
 envlist = py36, py37, py38, py39, docs, pypi, flake8
 skipdist = true
 
-# Mapping required by tox-gh-actions, only used in CI
-[gh-actions]
-python =
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39
-
 [testenv]
 commands =
     mkdir -p test-reports
@@ -40,7 +32,7 @@ commands =
 deps =
     -r{toxinidir}/requirements-dev.txt
 
-whitelist_externals = /bin/mkdir
+whitelist_externals = mkdir
 
 setenv =
     CPLUS_INCLUDE_PATH=/usr/include/gdal

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,14 @@
 envlist = py36, py37, py38, py39, docs, pypi, flake8
 skipdist = true
 
+# Mapping required by tox-gh-actions, only used in CI
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+
 [testenv]
 commands =
     mkdir -p test-reports

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ commands =
 deps =
     -r{toxinidir}/requirements-dev.txt
 
-whitelist_externals = mkdir
+allowlist_externals = mkdir
 
 setenv =
     CPLUS_INCLUDE_PATH=/usr/include/gdal
@@ -56,12 +56,12 @@ basepython = python3
 changedir = {toxinidir}/docs
 usedevelop = false
 deps = -r{toxinidir}/requirements-docs.txt
-whitelist_externals = /usr/bin/make
+allowlist_externals = /usr/bin/make
 commands = make html
 passenv = HOME
 
 [testenv:pypi]
-whitelist_externals = /bin/bash
+allowlist_externals = /bin/bash
 commands =
     # Check that the long description is ready to be published on PyPI without errors
     bash -c 'ERROR=$(\{ python setup.py --long-description | rst2html.py >/dev/null;\} 2>&1) && if [[ ! -z $ERROR ]];'\


### PR DESCRIPTION
First attempt at using GitHub actions. I've decided to run the tests (lint, test, docs) with tox in the CI. This is different from what we were doing on GitLab but this seems more natural since locally we run the tests with tox.

The biggest difference so far with our previous setting is that there doesn't seem to be an integrated way to feed the tests and coverage reports to GitHub actions. I've looked at some popular repos and couldn't find anything interesting, it seems that in most cases the reports are just not handled in a specific way (one just has to go to the workflow logs to find some more details if need be). Some alternatives though:
* This action that adds a bot which can publish junit test reports: https://github.com/marketplace/actions/publish-unit-test-results
* The github docs show how to [upload test reports as an artifact](https://docs.github.com/en/actions/guides/building-and-testing-python#packaging-workflow-data-as-artifacts). I'm not sure this is of any interest though, besides that after that the report can be downloaded.
* Code coverage seems to be a little bit easier to handle (compared to test reports), with solutions like Codecov

To be done:
* [x] Port the Deploy workflow

Some ideas:
 * Since we use pre-commit locally, shouldn't we run it also on the CI? There's actually [an action](https://github.com/pre-commit/action) to simplify running pre-commit.
 * In GitLab we run the CI on Python 3.6 on linux. By expending the matrix we could run it on multiple versions of Python (not sure if it's required) and/or multiple OS (sounds more interesting, specially for windows).