### PR TITLE
Update tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,9 @@ commands = make html
 passenv = HOME
 
 [testenv:pypi]
+skip_install = true
+# To prevent from installing eodag and the dev deps set in testenv
+deps =
 allowlist_externals = /bin/bash
 commands =
     # Check that the long description is ready to be published on PyPI without errors

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 [tox]
-envlist = py36, py37, py38, py39, docs, pypi, flake8
+envlist = py36, py37, py38, py39, docs, pypi, linters
 skipdist = true
 
 # Mapping required by tox-gh-actions, only used in CI


### PR DESCRIPTION
* Small changes to the *pypi* tox job so that it runs faster (skips eodag and deps install)
* Add the linters env to the default envlist (a bare `tox` command will run it)