### PR TITLE
Display star number instead of watch number in the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,6 +115,7 @@ html_theme_options = {
     "show_powered_by": False,
     "github_user": "CS-SI",
     "github_repo": "eodag",
+    "github_type": "star",
     "github_banner": True,
     "page_width": "1140px",
     "pre_bg": "#eeffcc",


### PR DESCRIPTION
It looks like this:

![image](https://user-images.githubusercontent.com/35924738/111484279-e8949480-8735-11eb-8555-d941ebdcec25.png)
