### PR TITLE
chore: tox fix for pypi

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Check long description is OK for PyPI with tox
         run: |
           python -m pip install --upgrade pip
-          python -m pip install tox
+          python -m pip install tox sphinx
           tox -e pypi
 
       - name: Build a binary wheel and a source tarball

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,3 +91,34 @@ jobs:
         python -m pip install tox
     - name: Testing with tox
       run: python -m tox -e docs
+
+  check-pypi:
+    name: Long description check for PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the repo
+      uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.7"
+    - name: Update pip
+      run: python -m pip install --upgrade pip
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+    - name: Get current week number
+      id: get-week
+      shell: bash
+      run: echo "::set-output name=week::$(date +'%V')"
+    - name: Pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ steps.get-week.outputs.week }}-${{ hashFiles('setup.py') }}
+    - name: Install tox and sphinx (to have rst2html.py utility available)
+      run: |
+        python -m pip install tox sphinx
+    - name: Testing with tox
+      run: python -m tox -e pypi

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ passenv = HOME
 skip_install = true
 # To prevent from installing eodag and the dev deps set in testenv
 deps =
-allowlist_externals = /bin/bash
+allowlist_externals = bash
 commands =
     # Check that the long description is ready to be published on PyPI without errors
     bash -c 'ERROR=$(\{ python setup.py --long-description | rst2html.py >/dev/null;\} 2>&1) && if [[ ! -z $ERROR ]];'\


### PR DESCRIPTION
`allowlist_externals = /bin/bash` in `tox.ini` was too restrictive and raised a warning (`/bin/bash` is used in local tests, but `/usr/bin/bash` in github actions).
See https://tox.readthedocs.io/en/latest/config.html#conf-allowlist_externals

Also added `pip install sphinx` to have rst2html.py utility available)