### PR TITLE
fix: cors issue with docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 networks:
-  eodag.stac.net:
+  eodag-stac-network:
     driver: bridge
 
 services:
@@ -12,7 +12,7 @@ services:
     container_name: stac_browser
     restart: unless-stopped
     networks:
-      - eodag.stac.net
+      - eodag-stac-network
     ports:
       - "5001:80"
   stac:
@@ -22,6 +22,6 @@ services:
     container_name: stac_server
     restart: unless-stopped
     networks:
-      - eodag.stac.net
+      - eodag-stac-network
     ports:
       - "5000:5000"

--- a/docker/stac-browser.dockerfile
+++ b/docker/stac-browser.dockerfile
@@ -15,7 +15,7 @@ WORKDIR /stac-browser
 RUN npm install
 
 # start application
-RUN CATALOG_URL=http://stac:5000 npm run build
+RUN CATALOG_URL=http://localhost:5000 npm run build
 
 # production stage, self describing
 FROM nginx:stable-alpine as production-stage


### PR DESCRIPTION
I had to change `stac:5000` by `localhost:5000` for stac-browser because of an issue with CORS in my environment:

![image](https://user-images.githubusercontent.com/61419125/111815928-85913200-88dc-11eb-8ef2-f134b19df364.png)
