### PR TITLE
feat: add two new methods to search for products, search_iter_page and search_all

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -550,7 +550,7 @@ class EODataAccessGateway(object):
         search_kwargs = self._prepare_search(
             start=start, end=end, geom=geom, locations=locations, **kwargs
         )
-        if "id" in search_kwargs:
+        if search_kwargs.get("id"):
             provider = search_kwargs.get("provider")
             return self._search_by_id(search_kwargs["id"], provider)
         search_plugin = search_kwargs.pop("search_plugin")

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -391,22 +391,6 @@ class EODataAccessGateway(object):
     def guess_product_type(self, **kwargs):
         """Find the eodag product type code that best matches a set of search params
 
-        >>> from eodag import EODataAccessGateway
-        >>> dag = EODataAccessGateway()
-        >>> dag.guess_product_type(
-        ...     instrument="MSI",
-        ...     platform="SENTINEL2",
-        ...     platformSerialIdentifier="S2A",
-        ... ) # doctest: +NORMALIZE_WHITESPACE
-        ['S2_MSI_L1C', 'S2_MSI_L2A', 'S2_MSI_L2A_MAJA', 'S2_MSI_L2B_MAJA_SNOW',
-            'S2_MSI_L2B_MAJA_WATER', 'S2_MSI_L3A_WASP']
-        >>> import eodag.utils.exceptions
-        >>> try:
-        ...     dag.guess_product_type()
-        ...     raise AssertionError(u"NoMatchingProductType exception not raised")
-        ... except eodag.utils.exceptions.NoMatchingProductType:
-        ...     pass
-
         :param kwargs: A set of search parameters as keywords arguments
         :return: The best match for the given parameters
         :rtype: str

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -551,9 +551,10 @@ class EODataAccessGateway(object):
         search_kwargs.update(
             page=page,
             items_per_page=items_per_page,
-            raise_errors=raise_errors,
         )
-        return self._do_search(search_plugin, count=True, **search_kwargs)
+        return self._do_search(
+            search_plugin, count=True, raise_errors=raise_errors, **search_kwargs
+        )
 
     def _search_by_id(self, uid, provider=None):
         """Internal method that enables searching a product by its id.
@@ -620,6 +621,8 @@ class EODataAccessGateway(object):
                             * id and/or a provider for a search by
                             * search criteria to guess the product type
                             * other criteria compatible with the provider
+        :returns: The prepared kwargs to make a query.
+        :rtype: dict
 
         .. versionadded:: 2.2
         """
@@ -702,8 +705,20 @@ class EODataAccessGateway(object):
 
         return dict(search_plugin=search_plugin, auth=auth_plugin, **kwargs)
 
-    def _do_search(self, search_plugin, count=True, **kwargs):
+    def _do_search(self, search_plugin, count=True, raise_errors=False, **kwargs):
         """Internal method that performs a search on a given provider.
+
+        :param search_plugin: A search plugin
+        :type search_plugin: eodag.plugins.base.Search
+        :param count: Whether to run a query with a count request or not (default: True)
+        :type count: bool
+        :param raise_errors:  When an error occurs when searching, if this is set to
+                              True, the error is raised (default: False)
+        :type raise_errors: bool
+        :param dict kwargs: some other criteria that will be used to do the search
+        :returns: A collection of EO products matching the criteria and the total
+                  number of results found if count is True else None
+        :rtype: tuple(:class:`~eodag.api.search_result.SearchResult`, int or None)
 
         .. versionadded:: 1.0
         """
@@ -802,7 +817,7 @@ class EODataAccessGateway(object):
                 "verbosity of log messages for details",
                 search_plugin.provider,
             )
-            if kwargs.get("raise_errors"):
+            if raise_errors:
                 # Raise the error, letting the application wrapping eodag know that
                 # something went bad. This way it will be able to decide what to do next
                 raise

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -643,6 +643,11 @@ class EODataAccessGateway(object):
             kwargs["startTimeFromAscendingNode"] = start
         if end is not None:
             kwargs["completionTimeFromAscendingNode"] = end
+        if "box" in kwargs or "bbox" in kwargs:
+            logger.warning(
+                "'box' or 'bbox' parameters are only supported for backwards "
+                " compatibility reasons. Usage of 'geom' is recommended."
+            )
         if geom is not None:
             kwargs["geometry"] = geom
         box = kwargs.pop("box", None)

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -247,7 +247,9 @@ class EODataAccessGateway(object):
         :type provider: str
         """
         if provider not in self.available_providers():
-            raise UnsupportedProvider("This provider is not recognised by eodag")
+            raise UnsupportedProvider(
+                f"This provider is not recognised by eodag: {provider}"
+            )
         preferred_provider, max_priority = self.get_preferred_provider()
         if preferred_provider != provider:
             new_priority = max_priority + 1
@@ -443,7 +445,7 @@ class EODataAccessGateway(object):
         end=None,
         geom=None,
         locations=None,
-        **kwargs
+        **kwargs,
     ):
         """Look for products matching criteria on known providers.
 
@@ -567,7 +569,7 @@ class EODataAccessGateway(object):
         end=None,
         geom=None,
         locations=None,
-        **kwargs
+        **kwargs,
     ):
         """Iterate over the pages of a products search.
 
@@ -657,7 +659,7 @@ class EODataAccessGateway(object):
         end=None,
         geom=None,
         locations=None,
-        **kwargs
+        **kwargs,
     ):
         """Search and return all the products matching the search criteria.
 
@@ -728,7 +730,7 @@ class EODataAccessGateway(object):
             end=end,
             geom=geom,
             locations=locations,
-            **kwargs
+            **kwargs,
         ):
             all_results.data.extend(page_results.data)
         logger.info(
@@ -865,7 +867,7 @@ class EODataAccessGateway(object):
                     for p in self.list_product_types(search_plugin.provider)
                     if p["ID"] == product_type
                 ][0],
-                **{"productType": product_type}
+                **{"productType": product_type},
             )
         # If the product isn't in the catalog, it's a generic product type.
         except IndexError:
@@ -875,7 +877,7 @@ class EODataAccessGateway(object):
                     for p in self.list_product_types(search_plugin.provider)
                     if p["ID"] == GENERIC_PRODUCT_TYPE
                 ][0],
-                **{"productType": product_type}
+                **{"productType": product_type},
             )
         # Remove the ID since this is equal to productType.
         search_plugin.config.product_type_config.pop("ID", None)
@@ -1063,7 +1065,7 @@ class EODataAccessGateway(object):
         progress_callback=None,
         wait=DEFAULT_DOWNLOAD_WAIT,
         timeout=DEFAULT_DOWNLOAD_TIMEOUT,
-        **kwargs
+        **kwargs,
     ):
         """Download all products resulting from a search.
 
@@ -1101,7 +1103,7 @@ class EODataAccessGateway(object):
                 progress_callback=progress_callback,
                 wait=wait,
                 timeout=timeout,
-                **kwargs
+                **kwargs,
             )
             # close progress_bar when finished
             if hasattr(progress_callback, "pb") and hasattr(
@@ -1167,7 +1169,7 @@ class EODataAccessGateway(object):
         provider=None,
         productType=None,
         timeout=HTTP_REQ_TIMEOUT,
-        **kwargs
+        **kwargs,
     ):
         """Loads STAC items from a geojson file / STAC catalog or collection, and convert to SearchResult.
 
@@ -1236,7 +1238,7 @@ class EODataAccessGateway(object):
         progress_callback=None,
         wait=DEFAULT_DOWNLOAD_WAIT,
         timeout=DEFAULT_DOWNLOAD_TIMEOUT,
-        **kwargs
+        **kwargs,
     ):
         """Download a single product.
 

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -154,8 +154,31 @@ class QueryStringSearch(Search):
         self.query_params = dict()
         self.query_string = ""
 
-    def query(self, items_per_page=None, page=None, count=True, **kwargs):
-        """Perform a search on an OpenSearch-like interface"""
+    def query(
+        self,
+        items_per_page=None,
+        page=None,
+        count=True,
+        set_next_page_url=False,
+        **kwargs
+    ):
+        """Perform a search on an OpenSearch-like interface
+
+        :param page: The page number to retur (default: 1)
+        :type page: int
+        :param items_per_page: The number of results that must appear in one single
+                               page
+        :type items_per_page: int
+        :param count:  To trigger a count request (default: True)
+        :type count: bool
+        :param set_next_page_url: If True, the config key 'next_page_url_tpl' is
+                                  replaced after a response has been obtained by the
+                                  next page URL, which is fetched by using the key
+                                  'total_items_nb_key_path'. This allows to implement
+                                  pagination for interfaces that support 'next' but
+                                  not 'page'.
+        :type set_next_page_url: bool
+        """
         product_type = kwargs.get("productType", None)
         if product_type == GENERIC_PRODUCT_TYPE:
             logger.warning(
@@ -193,7 +216,9 @@ class QueryStringSearch(Search):
         self.search_urls, total_items = self.collect_search_urls(
             page=page, items_per_page=items_per_page, count=count, **kwargs
         )
-        provider_results = self.do_search(items_per_page=items_per_page, **kwargs)
+        provider_results = self.do_search(
+            items_per_page=items_per_page, set_next_page_url=set_next_page_url, **kwargs
+        )
         eo_products = self.normalize_results(provider_results, **kwargs)
         total_items = len(eo_products) if total_items == 0 else total_items
         return eo_products, total_items
@@ -397,13 +422,16 @@ class QueryStringSearch(Search):
             urls.append(next_url)
         return urls, total_results
 
-    def do_search(self, items_per_page=None, **kwargs):
+    def do_search(self, items_per_page=None, set_next_page_url=False, **kwargs):
         """Perform the actual search request.
 
         If there is a specified number of items per page, return the results as soon
         as this number is reached
 
         :param int items_per_page: (Optional) The number of items to return for one page
+        :param bool set_next_page_url: (Optional) Trigger the next page mechanism that
+                                       updates a search plugin with the next url found
+                                       in the current search.
         """
         results = []
         for search_url in self.search_urls:
@@ -426,8 +454,23 @@ class QueryStringSearch(Search):
                             self.config.results_entry, namespaces=namespaces
                         )
                     ]
+                    if set_next_page_url:
+                        raise NotImplementedError(
+                            "Setting the next page url from an XML response has not "
+                            "been implemented yet"
+                        )
                 else:
-                    result = response.json().get(self.config.results_entry, [])
+                    resp_as_json = response.json()
+                    if set_next_page_url:
+                        path_parsed = parse(
+                            self.config.pagination["next_page_url_key_path"]
+                        )
+                        next_page_url = path_parsed.find(resp_as_json)[0].value
+                        logger.debug(
+                            "Next page url collected and set for the next search",
+                        )
+                        self.config.pagination["next_page_url_tpl"] = next_page_url
+                    result = resp_as_json.get(self.config.results_entry, [])
                 if getattr(self.config, "merge_responses", False):
                     results = (
                         [dict(r, **result[i]) for i, r in enumerate(results)]

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -504,6 +504,8 @@
     pagination:
       next_page_url_tpl: '{url}?{search}&maxRecords={items_per_page}&page={page}'
       total_items_nb_key_path: '$.properties.totalResults'
+      # 2019/03/19: Returns a 400 error code if greater than 500.
+      max_items_per_page: 500
     discover_metadata:
       auto_discovery: true
       metadata_pattern: '^(?!collection)[a-zA-Z0-9_]+$'
@@ -676,6 +678,8 @@
     pagination:
       next_page_url_tpl: '{url}?{search}&maxRecords={items_per_page}&page={page}'
       total_items_nb_key_path: '$.properties.totalResults'
+      # 2019/03/19: 500 is the max, no error if greater
+      max_items_per_page: 500
     discover_metadata:
       auto_discovery: true
       metadata_pattern: '^(?!collection)[a-zA-Z0-9_]+$'
@@ -866,6 +870,9 @@
     pagination:
       next_page_url_tpl: '{url}?{search}&size={items_per_page}&from={skip}'
       total_items_nb_key_path: '$.totalnb'
+      # 2019/03/19: It's not possible to get more than 10_000 products
+      # Returns a 400 Bad Request if more products are requested.
+      max_items_per_page: 10_000
     results_entry: 'hits'
     discover_metadata:
       auto_discovery: true
@@ -953,6 +960,8 @@
     pagination:
       next_page_url_tpl: '{url}?{search}&maxRecords={items_per_page}&page={page}'
       total_items_nb_key_path: '$.properties.totalResults'
+      # 2019/03/19: 2000 is the max, 400 error if greater
+      max_items_per_page: 2_000
     discover_metadata:
       auto_discovery: true
       metadata_pattern: '^(?!collection)[a-zA-Z0-9]+$'
@@ -1106,6 +1115,8 @@
     pagination:
       next_page_url_tpl: '{url}?{search}&maxRecords={items_per_page}&startIndex={skip_base_1}'
       total_items_nb_key_path: '//os:totalResults/text()'
+      # 2019/03/19: 50 is the max, no error if greater
+      max_items_per_page: 50
     discover_metadata:
       auto_discovery: true
       metadata_pattern: '^(?!collection)[a-zA-Z0-9]+$'
@@ -1328,6 +1339,8 @@
     pagination:
       count_endpoint: 'https://catalogue.onda-dias.eu/dias-catalogue/Products/$count'
       next_page_url_tpl: '{url}?{search}&$top={items_per_page}&$skip={skip}'
+      # 2019/03/19: 2000 is the max, if greater 200 response but contains an error message
+      max_items_per_page: 2_000
     results_entry: 'value'
     literal_search_params:
       $format: json
@@ -1463,6 +1476,13 @@
   search: !plugin
     type: StacSearch
     api_endpoint: https://eod-catalog-svc-prod.astraea.earth/search
+    pagination:
+      # 2019/03/19: The docs (https://eod-catalog-svc-prod.astraea.earth/api.html#operation/getSearchSTAC)
+      # say the max is 10_000. In practice 1_000 products are returned if more are asked (even greater
+      # than 10_000), without any error.
+      # This provider doesn't implement any pagination, let's just try to get the maximum number of
+      # products available at once then, so we stick to 10_000.
+      max_items_per_page: 10_000
   products:
     S2_MSI_L1C:
       productType: sentinel2_l1c
@@ -1496,6 +1516,10 @@
     api_endpoint: https://landsatlook.usgs.gov/sat-api/collections/{collection}/items
     pagination:
       total_items_nb_key_path: '$.meta.found'
+      # 2019/03/19: no more than 10_000 (if greater, returns a 500 error code)
+      # but in practive if an Internal Server Error is returned for more than
+      # about 500 products.
+      max_items_per_page: 500
     metadata_mapping:
       productType: '$.collection'
       completionTimeFromAscendingNode:

--- a/eodag/resources/stac_provider.yml
+++ b/eodag/resources/stac_provider.yml
@@ -20,8 +20,7 @@ search:
   pagination:
     next_page_url_tpl: '{url}?{search}&limit={items_per_page}&page={page}'
     total_items_nb_key_path: '$.context.matched'
-    pagination:
-      next_page_url_key_path: '$.links[?(@.rel="next")].href'
+    next_page_url_key_path: '$.links[?(@.rel="next")].href'
   discover_metadata:
     auto_discovery: true
     metadata_pattern: '^[a-zA-Z0-9_:-]+$'

--- a/tests/context.py
+++ b/tests/context.py
@@ -50,6 +50,7 @@ from eodag.utils.exceptions import (
     DownloadError,
     MisconfiguredError,
     NoMatchingProductType,
+    PluginImplementationError,
     UnsupportedDatasetAddressScheme,
     UnsupportedProvider,
     ValidationError,

--- a/tests/context.py
+++ b/tests/context.py
@@ -25,7 +25,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from eodag import EODataAccessGateway, api, config
-from eodag.api.core import DEFAULT_ITEMS_PER_PAGE
+from eodag.api.core import DEFAULT_ITEMS_PER_PAGE, DEFAULT_MAX_ITEMS_PER_PAGE
 from eodag.api.product import EOProduct
 from eodag.api.product.drivers import DRIVERS
 from eodag.api.product.drivers.base import NoDriver

--- a/tests/context.py
+++ b/tests/context.py
@@ -49,6 +49,7 @@ from eodag.utils.exceptions import (
     AuthenticationError,
     DownloadError,
     MisconfiguredError,
+    NoMatchingProductType,
     UnsupportedDatasetAddressScheme,
     UnsupportedProvider,
     ValidationError,

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -357,6 +357,17 @@ class TestEODagEndToEnd(EndToEndBase):
         )
         self.assertGreaterEqual(os.stat(quicklook_file_path).st_size, 2 ** 5)
 
+    def test__search_by_id_sobloo(self):
+        # A single test with sobloo to check that _search_by_id returns
+        # correctly the exact product looked for.
+        uid = "S2A_MSIL1C_20200810T030551_N0209_R075_T53WPU_20200810T050611"
+        provider = "sobloo"
+
+        products, _ = self.eodag._search_by_id(uid=uid, provider=provider)
+        product = products[0]
+
+        self.assertEqual(product.properties["id"], uid)
+
 
 class TestEODagEndToEndWrongCredentials(EndToEndBase):
     """Make real case tests with wrong credentials. This assumes the existence of a

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -140,17 +140,17 @@ class EndToEndBase(unittest.TestCase):
         - Return one product to be downloaded
         """
         search_criteria = {
+            "productType": product_type,
             "startTimeFromAscendingNode": start,
             "completionTimeFromAscendingNode": end,
             "geom": geom,
         }
+        if items_per_page:
+            search_criteria["items_per_page"] = items_per_page
+        if page:
+            search_criteria["page"] = page
         self.eodag.set_preferred_provider(provider)
-        results, nb_results = self.eodag.search(
-            productType=product_type,
-            page=page,
-            items_per_page=items_per_page,
-            **search_criteria
-        )
+        results, nb_results = self.eodag.search(**search_criteria)
         if offline:
             results = [
                 prod

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -524,10 +524,11 @@ class TestCoreSearch(unittest.TestCase):
         prepared_search = self.dag._prepare_search()
         expected = {
             "geometry": None,
-            "locations": None,
             "productType": None,
         }
         self.assertDictContainsSubset(expected, prepared_search)
+        expected = set(["geometry", "productType", "auth", "search_plugin"])
+        self.assertSetEqual(expected, set(prepared_search))
 
     def test__prepare_search_dates(self):
         """_prepare_search must handle start & end dates"""

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -28,6 +28,7 @@ from eodag.utils import GENERIC_PRODUCT_TYPE
 from tests import TEST_RESOURCES_PATH
 from tests.context import (
     EODataAccessGateway,
+    NoMatchingProductType,
     UnsupportedProvider,
     get_geometry_from_various,
     makedirs,
@@ -471,3 +472,31 @@ class TestCoreGeometry(unittest.TestCase):
         self.assertEquals(
             len(geom_combined), 3
         )  # The bounding box overlaps with France inland
+
+
+class TestCoreSearch(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.dag = EODataAccessGateway()
+
+    def test_guess_product_type_with_kwargs(self):
+        kwargs = dict(
+            instrument="MSI",
+            platform="SENTINEL2",
+            platformSerialIdentifier="S2A",
+        )
+        actual = self.dag.guess_product_type(**kwargs)
+        expected = [
+            "S2_MSI_L1C",
+            "S2_MSI_L2A",
+            "S2_MSI_L2A_MAJA",
+            "S2_MSI_L2B_MAJA_SNOW",
+            "S2_MSI_L2B_MAJA_WATER",
+            "S2_MSI_L3A_WASP",
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_guess_product_type_without_kwargs(self):
+        """guess_product_type must raise an exception when no kwargs are provided"""
+        with self.assertRaises(NoMatchingProductType):
+            self.dag.guess_product_type()


### PR DESCRIPTION
Fixes #191 

Two new methods for `EODataAccessGateWay`:
* `search_iter_page`: to iterate over the pages of a products search
* `search_all`: to get all the products matching some search criteria -> it uses `seach_iter_page` internally to iterate over all the pages that return products

`search_all` tries to be a little smarter than `search_iter_page` or  `search`, in the sense that it tries to minimize the number of requests made. It makes use of an internal parameter `max_items_per_page` configured per provider (see `providers.yml`). 8 providers have such a parameter configured, I have found these values either in their documentation (and checked it) or by trial and error. If this internal parameter isn't set, a default value of 50 is used. I chose it because it's the lowest one between all the providers (mundi) but it's still higher than the default items_per_page of 20 used by `search` originally. The user can also defined the value she wants to use dynamically (`search_all(items_per_page=...)`), which could come in handy if the value we have set doesn't work properly.

Note also that `search_iter_page` stops yielding products if the number of products found is less than the number of items requested. This spares one last request.

Next to that:
* The logic that prepared the search kwargs passed to `search_plugin.query` was extracted from `search` and put into a new private method `_prepare_search`. It's used in the three search methods.
* `test_core.py` was refactored to make it easier to add tests
* Lots of unit tests were added to `test_core.py`, for: `guess_by_product`, `_prepare_search`, `_do_search`, `search_iter_page` and `search_all`
* An end-to-end test was added for searching a product by ID (just a provider tested, sobloo)
* There is no a log warning emitted when `box` or `bbox` are used in any of the search methods. It recommends using `geom` instead

As discussed privately, there appears to be some search plugins or providers that do not support pagination. This is a problem for `search_iter_page` - and `search_all` as a consequence - since it means it would just iterate indefinitely. A solution to this problem was implemented, by comparing the first product of the next page with the first product of the previous one (their `properties["id"]` and `provider` values). The iteration stops if they are equal. There is a test for this approach, which I have also tested manually with `astraea_eod` whose API only implements a *limit* and not a *page*.

I plan to add a proper documentation to these two new methods in a following PR, since the tutorials need to be refactored a little.