### PR TITLE
Add Windows support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        os: [windows-latest]
+        python-version: [3.6, 3.9]
+        os: [ubuntu-latest, windows-latest]
     steps:
     - name: Checkout the repo
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.9]
-        os: [ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [windows-latest]
     steps:
     - name: Checkout the repo
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.9]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
     steps:
     - name: Checkout the repo
       uses: actions/checkout@v2

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -119,9 +119,13 @@ class EODataAccessGateway(object):
                     with open(locations_conf_template) as infile, open(
                         locations_conf_path, "w"
                     ) as outfile:
+                        # The template contains paths in the form of:
+                        # /path/to/locations/file.shp
+                        path_template = "/path/to/locations/"
                         for line in infile:
                             line = line.replace(
-                                "/path/to/locations", os.path.join(self.conf_dir, "shp")
+                                path_template,
+                                os.path.join(self.conf_dir, "shp") + os.path.sep,
                             )
                             outfile.write(line)
                     # copy sample shapefile dir

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -205,7 +205,7 @@ class EODataAccessGateway(object):
         """Set max priority for the given provider.
 
         >>> import tempfile, os
-        >>> config = tempfile.NamedTemporaryFile(delete=True)
+        >>> config = tempfile.NamedTemporaryFile(delete=False)
         >>> dag = EODataAccessGateway(user_conf_file_path=os.path.join(
         ...     tempfile.gettempdir(), config.name))
         >>> # This also tests get_preferred_provider method by the way
@@ -230,6 +230,7 @@ class EODataAccessGateway(object):
         >>> dag.get_preferred_provider()
         ('usgs', 4)
         >>> config.close()
+        >>> os.unlink(config.name)
 
         :param provider: The name of the provider that should be considered as the
                          preferred provider to be used for this instance

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -314,7 +314,7 @@ class TestConfigFunctions(unittest.TestCase):
         self.assertEqual(peps_conf.download.outputs_prefix, "/data")
 
         theia_conf = default_config["theia"]
-        self.assertEqual(theia_conf.download.outputs_prefix[-4:], "/tmp")
+        self.assertEqual(theia_conf.download.outputs_prefix, tempfile.gettempdir())
 
         my_new_provider_conf = default_config["my_new_provider"]
         self.assertEqual(my_new_provider_conf.priority, 4)

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,9 @@ commands =
         --with-doctest\
         --cover-erase\
         --cover-inclusive \
+        # To fix an issue on Windows from Python 3.8 that would break
+        # tests discovery.
+        --traverse-namespace \
         {posargs:--ignore-files=test_end_to_end.py {toxinidir}/eodag {toxinidir}/tests}
 deps =
     -r{toxinidir}/requirements-dev.txt


### PR DESCRIPTION
Fixes #162 

Small updates required to add Windows support:
* `tempfile.NamedTemporaryFile` doesn't work exactly the same on Windows: https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile
* One test expected a Unix "/tmp" directory
* The template path for the locations shapefile expected a `/` path separator

The tests now also run on Windows.