### PR TITLE
docs: fixed and scrollable sidebar

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,4 @@
+div.sphinxsidebar {
+    max-height: 100%;
+    overflow-y: auto;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,7 +111,7 @@ html_theme_options = {
     "logo": "eodag_logo.png",
     "logo_name": False,
     "show_related": True,
-    "fixed_sidebar": False,
+    "fixed_sidebar": True,
     "show_powered_by": False,
     "github_user": "CS-SI",
     "github_repo": "eodag",


### PR DESCRIPTION
Fixes #193 

Making the sidebar always visible had the side effect of hiding the bottom of it since it is not scrollable by default.

This workaround from a SO answer([here](https://stackoverflow.com/questions/57031848/sphinx-alabaster-theme-scroll-inside-of-fixed-sidebar/57040610)) solved the problem by making the sidebar scrollable.

Now the sidebar is always visible and a scroll bar appears when it becomes too big to fit into a single page.

![image](https://user-images.githubusercontent.com/35924738/111947799-67931f80-8ade-11eb-8890-fabb9cca5044.png)
