### PR TITLE
Add a --all option to the search command to search for all the products

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,22 +178,23 @@ Then you can start playing with it:
         --start 2018-01-01 \
         --end 2018-01-31 \
         --cloudCover 20 \
-        --productType S2_MSI_L1C
-        --cruncher FilterLatestIntersect \
+        --productType S2_MSI_L1C \
+        --all \
         --storage my_search.geojson
 
-The request above search for product types `S2_MSI_L1C` and will crunch the result using cruncher `FilterLatestIntersect`
-and storing the overall result to `my_search.geojson`.
+The request above searches for `S2_MSI_L1C` product types in a given bounding box, in January 2018. The command fetches internally all
+the products that match these criteria. Without `--all`, it would only fetch the products found on the first result page.
+It finally saves the results in a GeoJSON file.
 
 You can pass arguments to a cruncher on the command line by doing this (example with using `FilterOverlap` cruncher
 which takes `minimum_overlap` as argument)::
 
-        eodag search -f my_conf.yml -b 1 43 2 44 -s 2018-01-01 -e 2018-01-31 -p S2_MSI_L1C \
+        eodag search -f my_conf.yml -b 1 43 2 44 -s 2018-01-01 -e 2018-01-31 -p S2_MSI_L1C --all \
                      --cruncher FilterOverlap \
                      --cruncher-args FilterOverlap minimum_overlap 10
 
 The request above means : "Give me all the products of type `S2_MSI_L1C`, use `FilterOverlap` to keep only those products
-that are contained in the bbox I gave you, or whom spatial extent overlaps at least 10% (`minimum_overlap`) of the surface
+that are contained in the bbox I gave you, or whose spatial extent overlaps at least 10% (`minimum_overlap`) of the surface
 of this bbox"
 
 * To download the result of a previous call to `search`::

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -172,23 +172,24 @@ Then you can start playing with it:
         --box 1 43 2 44 \
         --start 2018-01-01 --end 2018-01-31 \
         --productType S2_MSI_L1C \
-        --cruncher FilterLatestIntersect \
+        --all \
         --storage my_search.geojson
 
-The request above search for product types `S2_MSI_L1C` and will crunch the result using cruncher `FilterLatestIntersect`
-and storing the overall result to `my_search.geojson`.
+The request above searches for `S2_MSI_L1C` product types in a given bounding box, in January 2018. The command fetches internally all
+the products that match these criteria. Without `--all`, it would only fetch the products found on the first result page.
+It finally saves the results in a GeoJSON file.
 
 You can pass arguments to a cruncher on the command line by doing this (example with using `FilterOverlap` cruncher
 which takes `minimum_overlap` as argument):
 
 .. code-block:: console
 
-        eodag search -f my_conf.yml -b 1 43 2 44 -s 2018-01-01 -e 2018-01-31 -p S2_MSI_L1C \
+        eodag search -f my_conf.yml -b 1 43 2 44 -s 2018-01-01 -e 2018-01-31 -p S2_MSI_L1C --all \
                      --cruncher FilterOverlap \
                      --cruncher-args FilterOverlap minimum_overlap 10
 
 The request above means : "Give me all the products of type `S2_MSI_L1C`, use `FilterOverlap` to keep only those products
-that are contained in the bbox I gave you, or whom spatial extent overlaps at least 10% (`minimum_overlap`) of the surface
+that are contained in the bbox I gave you, or whose spatial extent overlaps at least 10% (`minimum_overlap`) of the surface
 of this bbox"
 
 You can use `eaodag search` with custom parameters. Custom parameters will be used as is in the query string search sent

--- a/eodag/cli.py
+++ b/eodag/cli.py
@@ -210,11 +210,12 @@ def version():
 @click.option(
     "--items",
     type=int,
-    default=DEFAULT_ITEMS_PER_PAGE,
-    show_default=True,
+    # default=DEFAULT_ITEMS_PER_PAGE,
+    show_default=False,
     help="The number of items to return. Eodag is bound to whatever limitation the "
     "providers have on the number of results they return. This option allows "
-    "to control how many items eodag should request",
+    "to control how many items eodag should request "
+    f"[default: {DEFAULT_ITEMS_PER_PAGE}]",
 )
 @click.option(
     "--page",
@@ -222,6 +223,15 @@ def version():
     default=DEFAULT_PAGE,
     show_default=True,
     help="Retrieve the given page",
+)
+@click.option(
+    "--all",
+    is_flag=True,
+    help="Retrieve ALL the products that match the search criteria. It collects "
+    "products by iterating over the results pages until no more products are available."
+    "At each iteration, the maximum number of items searched is either 'items' if set, "
+    "or a maximum value defined internally for the requested provider, or a default "
+    "maximum value equals to 50.",
 )
 @click.option(
     "--locations",
@@ -333,10 +343,21 @@ def search_crunch(ctx, **kwargs):
     )
 
     # Search
-    results, total = gateway.search(
-        page=page, items_per_page=items_per_page, **criteria
-    )
-    click.echo("Found a total number of {} products".format(total))
+    get_all_products = kwargs.pop("all")
+    if get_all_products:
+        # search_all needs items_per_page to be None if the user lets eodag determines
+        # what value it should take.
+        items_per_page = None if items_per_page is None else items_per_page
+        results = gateway.search_all(items_per_page=items_per_page, **criteria)
+    else:
+        # search should better take a value that is not None
+        items_per_page = (
+            DEFAULT_ITEMS_PER_PAGE if items_per_page is None else items_per_page
+        )
+        results, total = gateway.search(
+            page=page, items_per_page=items_per_page, **criteria
+        )
+        click.echo("Found a total number of {} products".format(total))
     click.echo("Returned {} products".format(len(results)))
 
     # Crunch !
@@ -384,7 +405,7 @@ def list_pt(ctx, **kwargs):
             platformSerialIdentifier=kwargs.get("platformserialidentifier"),
             processingLevel=kwargs.get("processinglevel"),
             sensorType=kwargs.get("sensortype"),
-            **kwargs
+            **kwargs,
         )
     except NoMatchingProductType:
         if any(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,7 @@ from pkg_resources import resource_filename
 from eodag.utils import GENERIC_PRODUCT_TYPE
 from tests import TEST_RESOURCES_PATH
 from tests.context import (
+    DEFAULT_ITEMS_PER_PAGE,
     AuthenticationError,
     MisconfiguredError,
     download,
@@ -153,7 +154,7 @@ class TestEodagCli(unittest.TestCase):
             )
             api_obj = dag.return_value
             api_obj.search.assert_called_once_with(
-                items_per_page=20,
+                items_per_page=DEFAULT_ITEMS_PER_PAGE,
                 page=1,
                 startTimeFromAscendingNode=None,
                 completionTimeFromAscendingNode=None,
@@ -198,7 +199,7 @@ class TestEodagCli(unittest.TestCase):
             )
             api_obj = dag.return_value
             api_obj.search.assert_called_once_with(
-                items_per_page=20,
+                items_per_page=DEFAULT_ITEMS_PER_PAGE,
                 page=1,
                 startTimeFromAscendingNode=None,
                 completionTimeFromAscendingNode=None,
@@ -295,7 +296,7 @@ class TestEodagCli(unittest.TestCase):
                 user_conf_file_path=conf_file, locations_conf_path=None
             )
             api_obj.search.assert_called_once_with(
-                items_per_page=20, page=1, **criteria
+                items_per_page=DEFAULT_ITEMS_PER_PAGE, page=1, **criteria
             )
             api_obj.crunch.assert_called_once_with(
                 search_results, search_criteria=criteria, **{cruncher: {}}
@@ -326,6 +327,41 @@ class TestEodagCli(unittest.TestCase):
                 search_results,
                 search_criteria=criteria,
                 **{cruncher: {"minimum_overlap": 10}}
+            )
+
+    @mock.patch("eodag.cli.EODataAccessGateway", autospec=True)
+    def test_eodag_search_all(self, dag):
+        """Calling eodag search with --bbox argument valid"""
+        with self.user_conf() as conf_file:
+            product_type = "whatever"
+            self.runner.invoke(
+                eodag,
+                [
+                    "search",
+                    "--conf",
+                    conf_file,
+                    "-p",
+                    product_type,
+                    "-g",
+                    "POLYGON ((1 43, 1 44, 2 44, 2 43, 1 43))",
+                    "--all",
+                ],
+            )
+            api_obj = dag.return_value
+            api_obj.search_all.assert_called_once_with(
+                items_per_page=None,
+                startTimeFromAscendingNode=None,
+                completionTimeFromAscendingNode=None,
+                cloudCover=None,
+                geometry="POLYGON ((1 43, 1 44, 2 44, 2 43, 1 43))",
+                instrument=None,
+                platform=None,
+                platformSerialIdentifier=None,
+                processingLevel=None,
+                sensorType=None,
+                productType=product_type,
+                id=None,
+                locations=None,
             )
 
     def test_eodag_list_product_type_ok(self):


### PR DESCRIPTION
Fixes #202 

I had to remove the default value of `--items` at the "click" level, since it's not used in the same way by `search` and `search_all`. Instead it is set inside the CLI search function. I have adapted the "help" of `--items` so that it still displays the default value (as of now: 20).

Depends on #190 