### PR TITLE
fix: usgs plugin

### DIFF
--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -16,16 +16,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
-import hashlib
 import logging
-import os
-import re
-import zipfile
+import shutil
+import tarfile
 
 import requests
+from jsonpath_ng.ext import parse
 from requests import HTTPError
-from shapely import geometry
-from tqdm import tqdm
 from usgs import USGSError, api
 
 from eodag.api.product import EOProduct
@@ -35,16 +32,30 @@ from eodag.api.product.metadata_mapping import (
     properties_from_json,
 )
 from eodag.plugins.apis.base import Api
+from eodag.plugins.download.base import (
+    DEFAULT_DOWNLOAD_TIMEOUT,
+    DEFAULT_DOWNLOAD_WAIT,
+    Download,
+)
+from eodag.utils import GENERIC_PRODUCT_TYPE, format_dict_items, get_progress_callback
 from eodag.utils.exceptions import AuthenticationError, NotAvailableError
 
 logger = logging.getLogger("eodag.plugins.apis.usgs")
 
 
-class UsgsApi(Api):
+class UsgsApi(Api, Download):
     """A plugin that enables to query and download data on the USGS catalogues"""
 
-    def query(self, product_type=None, count=True, **kwargs):
+    def query(
+        self, product_type=None, items_per_page=None, page=None, count=True, **kwargs
+    ):
         """Search for data on USGS catalogues
+
+        .. versionchanged::
+           2.2.0
+
+                * Based on usgs library v0.3.0 which now uses M2M API. The library
+                  is used for both search & download
 
         .. versionchanged::
             1.0
@@ -62,8 +73,11 @@ class UsgsApi(Api):
             )
         except USGSError:
             raise AuthenticationError("Please check your USGS credentials.") from None
-        usgs_dataset = self.config.products[product_type]["dataset"]
-        usgs_catalog_node = self.config.products[product_type]["catalog_node"]
+
+        product_type_def_params = self.config.products.get(
+            product_type, self.config.products[GENERIC_PRODUCT_TYPE]
+        )
+        usgs_dataset = format_dict_items(product_type_def_params, **kwargs)["dataset"]
         start_date = kwargs.pop("startTimeFromAscendingNode", None)
         end_date = kwargs.pop("completionTimeFromAscendingNode", None)
         geom = kwargs.pop("geometry", None)
@@ -78,16 +92,6 @@ class UsgsApi(Api):
         else:
             footprint = geom
 
-        # Configuration to generate the download url of search results
-        result_summary_pattern = re.compile(
-            r"^ID: .+, Acquisition Date: .+, Path: (?P<path>\d+), Row: (?P<row>\d+)$"  # noqa
-        )
-        # See https://pyformat.info/, on section "Padding and aligning strings" to
-        # understand {path:0>3} and {row:0>3}.
-        # It roughly means: 'if the string that will be passed as "path" has length < 3,
-        # prepend as much "0"s as needed to reach length 3' and same for "row"
-        dl_url_pattern = "{base_url}/L8/{path:0>3}/{row:0>3}/{entity}.tar.bz"
-
         final = []
         if footprint and len(footprint.keys()) == 4:  # a rectangle (or bbox)
             lower_left = {
@@ -101,50 +105,32 @@ class UsgsApi(Api):
         else:
             lower_left, upper_right = None, None
         try:
-            results = api.search(
+            results = api.scene_search(
                 usgs_dataset,
-                usgs_catalog_node,
                 start_date=start_date,
                 end_date=end_date,
                 ll=lower_left,
                 ur=upper_right,
+                max_results=items_per_page,
+                starting_number=(1 + (page - 1) * items_per_page),
             )
 
-            for result in results["data"]["results"]:
-                r_lower_left = result["spatialFootprint"]["coordinates"][0][0]
-                r_upper_right = result["spatialFootprint"]["coordinates"][0][2]
-                summary_match = result_summary_pattern.match(
-                    result["summary"]
-                ).groupdict()
-                result["geometry"] = geometry.box(
-                    r_lower_left[0], r_lower_left[1], r_upper_right[0], r_upper_right[1]
-                )
+            # Same method as in base.py, Search.__init__()
+            # Prepare the metadata mapping
+            # Do a shallow copy, the structure is flat enough for this to be sufficient
+            metas = DEFAULT_METADATA_MAPPING.copy()
+            # Update the defaults with the mapping value. This will add any new key
+            # added by the provider mapping that is not in the default metadata.
+            # A deepcopy is done to prevent self.config.metadata_mapping from being modified when metas[metadata]
+            # is a list and is modified
+            metas.update(copy.deepcopy(self.config.metadata_mapping))
+            metas = mtd_cfg_as_jsonpath(metas)
 
-                # Same method as in base.py, Search.__init__()
-                # Prepare the metadata mapping
-                # Do a shallow copy, the structure is flat enough for this to be sufficient
-                metas = DEFAULT_METADATA_MAPPING.copy()
-                # Update the defaults with the mapping value. This will add any new key
-                # added by the provider mapping that is not in the default metadata.
-                # A deepcopy is done to prevent self.config.metadata_mapping from being modified when metas[metadata]
-                # is a list and is modified
-                metas.update(copy.deepcopy(self.config.metadata_mapping))
-                metas = mtd_cfg_as_jsonpath(metas)
+            for result in results["data"]["results"]:
 
                 result["productType"] = usgs_dataset
 
                 product_properties = properties_from_json(result, metas)
-
-                if getattr(self.config, "product_location_scheme", "https") == "file":
-                    product_properties["downloadLink"] = dl_url_pattern.format(
-                        base_url="file://"
-                    )
-                else:
-                    product_properties["downloadLink"] = dl_url_pattern.format(
-                        base_url=self.config.google_base_url.rstrip("/"),
-                        entity=result["entityId"],
-                        **summary_match
-                    )
 
                 final.append(
                     EOProduct(
@@ -155,97 +141,149 @@ class UsgsApi(Api):
                     )
                 )
         except USGSError as e:
-            logger.debug(
-                "Product type %s does not exist on catalogue %s",
+            logger.warning(
+                "Product type %s does not exist on USGS EE catalog",
                 usgs_dataset,
-                usgs_catalog_node,
             )
-            logger.debug("Skipping error: %s", e)
+            logger.warning("Skipping error: %s", e)
         api.logout()
-        total_results = len(final) if count else None
+
+        if final:
+            # parse total_results
+            path_parsed = parse(self.config.pagination["total_items_nb_key_path"])
+            total_results = path_parsed.find(results["data"])[0].value
+        else:
+            total_results = 0
+
         return final, total_results
 
     def download(self, product, auth=None, progress_callback=None, **kwargs):
         """Download data from USGS catalogues"""
-        url = product.remote_location
-        if not url:
-            logger.debug(
-                "Unable to get download url for %s, skipping download", product
-            )
-            return
-        logger.info("Download url: %s", url)
 
-        filename = product.properties["title"] + ".tar.bz"
-        outputs_prefix = (
-            kwargs.pop("outputs_prefix", None) or self.config.outputs_prefix
+        fs_path, record_filename = self._prepare_download(
+            product, outputs_extension=".tar.gz", **kwargs
         )
-        local_file_path = os.path.join(outputs_prefix, filename)
-        download_records = os.path.join(outputs_prefix, ".downloaded")
-        if not os.path.exists(download_records):
-            os.makedirs(download_records)
-        url_hash = hashlib.md5(url.encode("utf-8")).hexdigest()
-        record_filename = os.path.join(download_records, url_hash)
-        if os.path.isfile(record_filename) and os.path.isfile(local_file_path):
-            logger.info(
-                "Product already downloaded. Retrieve it at %s", local_file_path
+        if not fs_path or not record_filename:
+            return fs_path
+
+        # progress bar init
+        if progress_callback is None:
+            progress_callback = get_progress_callback()
+        progress_callback.desc = product.properties.get("id", "")
+        progress_callback.position = 1
+
+        try:
+            api.login(
+                self.config.credentials["username"],
+                self.config.credentials["password"],
+                save=True,
             )
-            return local_file_path
-        # Remove the record file if local_file_path is absent (e.g. it was deleted
-        # while record wasn't)
-        elif os.path.isfile(record_filename):
-            logger.debug(
-                "Record file found (%s) but not the actual file", record_filename
-            )
-            logger.debug("Removing record file : %s", record_filename)
-            os.remove(record_filename)
-        params = kwargs.pop("dl_url_params", None) or getattr(
-            self.config, "dl_url_params", {}
+        except USGSError:
+            raise AuthenticationError("Please check your USGS credentials.") from None
+
+        download_options = api.download_options(
+            product.properties["productType"], product.properties["id"]
         )
+
+        try:
+            product_ids = [
+                p["id"]
+                for p in download_options["data"]
+                if p["downloadSystem"] == "dds"
+            ]
+        except KeyError as e:
+            raise NotAvailableError(
+                "%s not found in %s's products" % (e, product.properties["id"])
+            )
+
+        if not product_ids:
+            raise NotAvailableError(
+                "No USGS products found for %s" % product.properties["id"]
+            )
+
+        req_urls = []
+        for product_id in product_ids:
+            download_request = api.download_request(
+                product.properties["productType"], product.properties["id"], product_id
+            )
+            try:
+                req_urls.extend(
+                    [x["url"] for x in download_request["data"]["preparingDownloads"]]
+                )
+            except KeyError as e:
+                raise NotAvailableError(
+                    "%s not found in %s download_request"
+                    % (e, product.properties["id"])
+                )
+
+        if len(req_urls) > 1:
+            logger.warning(
+                "%s usgs products found for %s. Only first will be downloaded"
+                % (len(req_urls), product.properties["id"])
+            )
+        elif not req_urls:
+            raise NotAvailableError(
+                "No usgs request url was found for %s" % product.properties["id"]
+            )
+
+        req_url = req_urls[0]
+        progress_callback.reset()
         with requests.get(
-            url,
+            req_url,
             stream=True,
-            auth=auth,
-            params=params,
-            verify=False,
-            hooks={"response": lambda r, *args, **kwargs: print("\n", r.url)},
         ) as stream:
-            stream_size = int(stream.headers.get("content-length", 0))
-            with open(local_file_path, "wb") as fhandle:
-                for chunk in stream.iter_content(chunk_size=64 * 1024):
-                    if chunk:
-                        fhandle.write(chunk)
-                        progress_callback(len(chunk), stream_size)
             try:
                 stream.raise_for_status()
-            except HTTPError as e:
-                if e.response.status_code == 404:
-                    raise NotAvailableError(
-                        "%s not available, request returned: %s"
-                        % (product.properties["title"], e)
-                    )
-                else:
-                    import traceback
+            except HTTPError:
+                import traceback as tb
 
-                    logger.error(
-                        "Error while getting resource : %s", traceback.format_exc()
-                    )
+                logger.error(
+                    "Error while getting resource :\n%s",
+                    tb.format_exc(),
+                )
             else:
-                with open(record_filename, "w") as fh:
-                    fh.write(url)
-                logger.debug("Download recorded in %s", record_filename)
-                extract = kwargs.pop("extract", None)
-                extract = extract if extract is not None else self.config.extract
-                if extract and zipfile.is_zipfile(local_file_path):
-                    logger.info("Extraction activated")
-                    with zipfile.ZipFile(local_file_path, "r") as zfile:
-                        fileinfos = zfile.infolist()
-                        with tqdm(
-                            fileinfos,
-                            unit="file",
-                            desc="Extracting files from {}".format(local_file_path),
-                        ) as progressbar:
-                            for fileinfo in progressbar:
-                                zfile.extract(fileinfo, path=outputs_prefix)
-                    return local_file_path[: local_file_path.index(".tar.bz")]
-                else:
-                    return local_file_path
+                stream_size = int(stream.headers.get("content-length", 0))
+                progress_callback.max_size = stream_size
+                progress_callback.reset()
+                with open(fs_path, "wb") as fhandle:
+                    for chunk in stream.iter_content(chunk_size=64 * 1024):
+                        if chunk:
+                            fhandle.write(chunk)
+                            progress_callback(len(chunk), stream_size)
+
+        with open(record_filename, "w") as fh:
+            fh.write(product.properties["downloadLink"])
+        logger.debug("Download recorded in %s", record_filename)
+
+        api.logout()
+
+        # Check that the downloaded file is really a tar file
+        if not tarfile.is_tarfile(fs_path):
+            logger.warning(
+                "Downloaded product is not a tar File. Please check its file type before using it"
+            )
+            new_fs_path = fs_path[: fs_path.index(".tar.gz")]
+            shutil.move(fs_path, new_fs_path)
+            return new_fs_path
+        return self._finalize(fs_path, outputs_extension=".tar.gz", **kwargs)
+
+    def download_all(
+        self,
+        products,
+        auth=None,
+        progress_callback=None,
+        wait=DEFAULT_DOWNLOAD_WAIT,
+        timeout=DEFAULT_DOWNLOAD_TIMEOUT,
+        **kwargs
+    ):
+        """
+        download_all using parent (base plugin) method
+        """
+        return super(UsgsApi, self).download_all(
+            products,
+            auth=auth,
+            progress_callback=progress_callback,
+            wait=wait,
+            timeout=timeout,
+            **kwargs
+        )

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -96,7 +96,16 @@ class PluginManager(object):
                         self.providers_config = plugin_providers_config
 
         self.product_type_to_provider_config_map = {}
-        for provider_config in self.providers_config.values():
+        for provider in list(self.providers_config):
+            provider_config = self.providers_config[provider]
+            if not hasattr(provider_config, "products"):
+                logger.info(
+                    "%s: provider has no product configured and will be skipped"
+                    % provider
+                )
+                providers_config.pop(provider)
+                continue
+
             for product_type in provider_config.products:
                 product_type_providers = (
                     self.product_type_to_provider_config_map.setdefault(  # noqa

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -26,23 +26,29 @@
   api: !plugin
     type: UsgsApi
     google_base_url: 'http://storage.googleapis.com/earthengine-public/landsat/'
+    pagination:
+      max_items_per_page: 5000
+      total_items_nb_key_path: '$.totalHits'
     metadata_mapping:
       id: '$.entityId'
-      geometry: '$.geometry'
+      geometry: '$.spatialBounds'
       productType: '$.productType'
       title: '$.displayId'
       abstract: '$.summary'
-      startTimeFromAscendingNode: '$.startTime'
-      completionTimeFromAscendingNode: '$.endTime'
-      quicklook: '$.browseUrl'
+      cloudCover: '$.cloudCover'
+      startTimeFromAscendingNode: '$.temporalCoverage.startDate'
+      completionTimeFromAscendingNode: '$.temporalCoverage.endDate'
+      quicklook: '$.browse[0].thumbnailPath'
       # storageStatus set to ONLINE for consistency between providers
       storageStatus: '{$.null#replace_str("Not Available","ONLINE")}'
+      downloadLink: 'https://dds.cr.usgs.gov/{id}'
     extract: True
   products:
     # datasets list http://kapadia.github.io/usgs/_sources/reference/catalog/ee.txt
     L8_OLI_TIRS_C1L1:
       dataset: LANDSAT_8_C1
-      catalog_node: EE  # Possible values: CWIC, EE, HDDS, LPCS
+    GENERIC_PRODUCT_TYPE:
+      dataset: '{productType}'
 
 ---
 !provider

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "owslib",
         "geojson",
         "pyproj",
-        "usgs",
+        "usgs >= 0.3.0",
         "boto3",
         "flasgger",
         "jsonpath-ng",

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -301,7 +301,7 @@ class TestEODagEndToEnd(EndToEndBase):
 
     def test_end_to_end_search_download_usgs(self):
         product = self.execute_search(*USGS_SEARCH_ARGS)
-        expected_filename = "{}.tar.bz".format(product.properties["title"])
+        expected_filename = "{}.tar.gz".format(product.properties["title"])
         self.execute_download(product, expected_filename)
 
     def test_end_to_end_search_download_sobloo(self):
@@ -416,6 +416,7 @@ class TestEODagEndToEnd(EndToEndBase):
         self.assertGreater(len(results), 10)
 
 
+# @unittest.skip("skip auto run")
 class TestEODagEndToEndWrongCredentials(EndToEndBase):
     """Make real case tests with wrong credentials. This assumes the existence of a
     wrong_credentials_cong.yml file in resources folder named user_conf.yml"""

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -129,6 +129,7 @@ class TestCore(unittest.TestCase):
             "sobloo",
             "onda",
             "mundi",
+            "usgs",
             "creodias",
             "astraea_eod",
             "usgs_satapi_aws",


### PR DESCRIPTION
fixes #147 

`UsgsApi` uses latest [usgs v0.3.0](https://github.com/kapadia/usgs/) for both search and download. Previously it was just used to perform search. Download was done on [Google Cloud](https://cloud.google.com/storage/docs/public-datasets/landsat).

Previous [usgs](https://github.com/kapadia/usgs/) versions used a deprecated API. It now uses [Machine-to-Machine API](https://m2m.cr.usgs.gov/).