### PR TITLE
test: fixes root link in stac static resources

### DIFF
--- a/tests/resources/stac/country/FRA/year/2018/items/S2A_MSIL1C_20181231T141041_N0207_R110_T21NYF_20181231T155050/S2A_MSIL1C_20181231T141041_N0207_R110_T21NYF_20181231T155050.json
+++ b/tests/resources/stac/country/FRA/year/2018/items/S2A_MSIL1C_20181231T141041_N0207_R110_T21NYF_20181231T155050/S2A_MSIL1C_20181231T141041_N0207_R110_T21NYF_20181231T155050.json
@@ -68,7 +68,7 @@
     "links": [
         {
             "rel": "root",
-            "href": "./catalog.json"
+            "href": "../../../../../../catalog.json"
         },
         {
             "rel": "parent",

--- a/tests/resources/stac/country/FRA/year/2018/items/S2A_MSIL1C_20181231T141041_N0207_R110_T22NBJ_20181231T155050/S2A_MSIL1C_20181231T141041_N0207_R110_T22NBJ_20181231T155050.json
+++ b/tests/resources/stac/country/FRA/year/2018/items/S2A_MSIL1C_20181231T141041_N0207_R110_T22NBJ_20181231T155050/S2A_MSIL1C_20181231T141041_N0207_R110_T22NBJ_20181231T155050.json
@@ -92,7 +92,7 @@
     "links": [
         {
             "rel": "root",
-            "href": "./catalog.json"
+            "href": "../../../../../../catalog.json"
         },
         {
             "rel": "parent",

--- a/tests/resources/stac/country/GBR/year/2019/items/S2A_MSIL1C_20191231T112451_N0208_R037_T30UUD_20191231T115143/S2A_MSIL1C_20191231T112451_N0208_R037_T30UUD_20191231T115143.json
+++ b/tests/resources/stac/country/GBR/year/2019/items/S2A_MSIL1C_20191231T112451_N0208_R037_T30UUD_20191231T115143/S2A_MSIL1C_20191231T112451_N0208_R037_T30UUD_20191231T115143.json
@@ -97,7 +97,7 @@
     "links": [
         {
             "rel": "root",
-            "href": "/"
+            "href": "../../../../../../catalog.json"
         },
         {
             "rel": "parent",

--- a/tests/resources/stac/country/GBR/year/2019/items/S2A_MSIL1C_20191231T112451_N0208_R037_T30VVH_20191231T115143/S2A_MSIL1C_20191231T112451_N0208_R037_T30VVH_20191231T115143.json
+++ b/tests/resources/stac/country/GBR/year/2019/items/S2A_MSIL1C_20191231T112451_N0208_R037_T30VVH_20191231T115143/S2A_MSIL1C_20191231T112451_N0208_R037_T30VVH_20191231T115143.json
@@ -97,7 +97,7 @@
     "links": [
         {
             "rel": "root",
-            "href": "/"
+            "href": "../../../../../../catalog.json"
         },
         {
             "rel": "parent",


### PR DESCRIPTION
Root link in tests stac items was not valid and made pystac raise an exception.

This link was not checked until `pystac v0.5.6` but now it is