### PR TITLE
Make setup_logging easier to import

### DIFF
--- a/eodag/__init__.py
+++ b/eodag/__init__.py
@@ -26,6 +26,7 @@ import warnings
 
 from .__meta__ import __version__  # noqa
 from .api.core import EODataAccessGateway  # noqa
+from .utils.logging import setup_logging  # noqa
 
 warnings.filterwarnings("ignore", message="numpy.dtype size changed")
 warnings.filterwarnings("ignore", message="numpy.ufunc size changed")


### PR DESCRIPTION
with `from eodag import setup_logging` since we use it in most tutorials.