### PR TITLE
fix: do not use ipywidgets for the Notebookwidgets representation

### DIFF
--- a/eodag/utils/notebook.py
+++ b/eodag/utils/notebook.py
@@ -38,11 +38,10 @@ class NotebookWidgets(object):
         self.ipython = check_ipython()
 
         if self.ipython:
-            from IPython.display import display
-            from ipywidgets import HTML
+            from IPython.display import HTML, display, update_display
 
             self.display = display
-
+            self._update_display = update_display
             self.html_box = HTML()
         else:
             pass
@@ -51,14 +50,19 @@ class NotebookWidgets(object):
         """Display HTML message"""
 
         if self.ipython:
-            self.html_box.value = html_value
+            self.html_box.data = html_value
 
             if not self.html_box_shown:
-                self.display(self.html_box)
+                self._html_handle = self.display(self.html_box, display_id=True)
                 self.html_box_shown = True
+            else:
+                self._update_display(
+                    self.html_box, display_id=self._html_handle.display_id
+                )
 
     def clear_html(self):
         """Clear HTML message"""
 
         if self.ipython:
-            self.html_box.value = ""
+            self.html_box.data = ""
+            self._update_display(self.html_box, display_id=self._html_handle.display_id)


### PR DESCRIPTION
Fixes #222 

I quickly tried to add a small test for this but it would really need to be run in an ipython shell, since `IPython.display.display` always returns None if executed outside such a context, while in an ipython shell it would return the handle (asked for with `display_id=True`).

Instead I've tested it manually and it worked fine.