### PR TITLE
[Bugfix #234]: Error loading user config files with settings of providers loaded via plugins

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -84,6 +84,10 @@ class EODataAccessGateway(object):
         self.conf_dir = os.path.join(os.path.expanduser("~"), ".config", "eodag")
         makedirs(self.conf_dir)
 
+        self._plugins_manager = PluginManager(self.providers_config)
+        # use updated providers_config
+        self.providers_config = self._plugins_manager.providers_config
+
         # First level override: From a user configuration file
         if user_conf_file_path is None:
             env_var_name = "EODAG_CFG_FILE"
@@ -103,9 +107,8 @@ class EODataAccessGateway(object):
         # Second level override: From environment variables
         override_config_from_env(self.providers_config)
 
-        self._plugins_manager = PluginManager(self.providers_config)
-        # use updated providers_config
-        self.providers_config = self._plugins_manager.providers_config
+        # Sort providers taking into account of possible new priority orders
+        self._plugins_manager.sort_providers()
 
         # Build a search index for product types
         self._product_types_index = None

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -242,6 +242,11 @@ class PluginManager(object):
         Klass = Crunch.get_plugin_by_class_name(name)
         return Klass(options)
 
+    def sort_providers(self):
+        """Sort providers taking into account current priority order"""
+        for provider_configs in self.product_type_to_provider_config_map.values():
+            provider_configs.sort(key=attrgetter("priority"), reverse=True)
+
     def set_priority(self, provider, priority):
         """Set the priority of the given provider
 


### PR DESCRIPTION
This PR is a proposal to fix the issue https://github.com/CS-SI/eodag/issues/234.

It would nice we can add to user configuration files our own settings of providers loaded via plugins. 

This minor change allows we configure all providers in the same way, not taking care if they are implemented in the code base or via plugins.

