### PR TITLE
_deprecated wasn't resetting the warning filters correctly

### DIFF
--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -853,13 +853,13 @@ def _deprecated(reason="", version=None):
 
         @functools.wraps(callable)
         def wrapper(*args, **kwargs):
-            warnings.simplefilter("always", DeprecationWarning)
-            warnings.warn(
-                f"Call to deprecated {ctype} {cname} {reason_}{version_}",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-            warnings.simplefilter("default", DeprecationWarning)
+            with warnings.catch_warnings():
+                warnings.simplefilter("always", DeprecationWarning)
+                warnings.warn(
+                    f"Call to deprecated {ctype} {cname} {reason_}{version_}",
+                    category=DeprecationWarning,
+                    stacklevel=2,
+                )
             return callable(*args, **kwargs)
 
         return wrapper


### PR DESCRIPTION
I saw a lot of warnings popping up while running tox. This was due to the _deprecated decorator not resetting properly the warning filters.