### PR TITLE
ISO 8601 format accepted everywhere

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -487,9 +487,11 @@ class EODataAccessGateway(object):
         :param raise_errors:  When an error occurs when searching, if this is set to
                               True, the error is raised (default: False)
         :type raise_errors: bool
-        :param start: Start sensing UTC time in iso format
+        :param start: Start sensing UTC time in ISO 8601 format (e.g. "1990-11-26",
+                      "1990-11-26T14:30:10.153Z", etc.)
         :type start: str
-        :param end: End sensing UTC time in iso format
+        :param end: End sensing UTC time in ISO 8601 format (e.g. "1990-11-26",
+                    "1990-11-26T14:30:10.153Z", etc.)
         :type end: str
         :param geom: Search area that can be defined in different ways:
 
@@ -600,9 +602,11 @@ class EODataAccessGateway(object):
 
         :param items_per_page: The number of results requested per page (default: 20)
         :type items_per_page: int
-        :param start: Start sensing UTC time in iso format
+        :param start: Start sensing UTC time in ISO 8601 format (e.g. "1990-11-26",
+                      "1990-11-26T14:30:10.153Z", etc.)
         :type start: str
-        :param end: End sensing UTC time in iso format
+        :param end: End sensing UTC time in ISO 8601 format (e.g. "1990-11-26",
+                    "1990-11-26T14:30:10.153Z", etc.)
         :type end: str
         :param geom: Search area that can be defined in different ways:
 
@@ -728,9 +732,11 @@ class EODataAccessGateway(object):
                                available, a default value of 50 is used instead.
                                items_per_page can also be set to any arbitrary value.
         :type items_per_page: int
-        :param start: Start sensing UTC time in iso format
+        :param start: Start sensing UTC time in ISO 8601 format (e.g. "1990-11-26",
+                      "1990-11-26T14:30:10.153Z", etc.)
         :type start: str
-        :param end: End sensing UTC time in iso format
+        :param end: End sensing UTC time in ISO 8601 format (e.g. "1990-11-26",
+                    "1990-11-26T14:30:10.153Z", etc.)
         :type end: str
         :param geom: Search area that can be defined in different ways:
 

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -487,11 +487,13 @@ class EODataAccessGateway(object):
         :param raise_errors:  When an error occurs when searching, if this is set to
                               True, the error is raised (default: False)
         :type raise_errors: bool
-        :param start: Start sensing UTC time in ISO 8601 format (e.g. "1990-11-26",
-                      "1990-11-26T14:30:10.153Z", etc.)
+        :param start: Start sensing time in ISO 8601 format (e.g. "1990-11-26",
+                      "1990-11-26T14:30:10.153Z", "1990-11-26T14:30:10+02:00", ...).
+                      If no time offset is given, the time is assumed to be given in UTC.
         :type start: str
-        :param end: End sensing UTC time in ISO 8601 format (e.g. "1990-11-26",
-                    "1990-11-26T14:30:10.153Z", etc.)
+        :param end: End sensing time in ISO 8601 format (e.g. "1990-11-26",
+                    "1990-11-26T14:30:10.153Z", "1990-11-26T14:30:10+02:00", ...).
+                    If no time offset is given, the time is assumed to be given in UTC.
         :type end: str
         :param geom: Search area that can be defined in different ways:
 
@@ -602,11 +604,13 @@ class EODataAccessGateway(object):
 
         :param items_per_page: The number of results requested per page (default: 20)
         :type items_per_page: int
-        :param start: Start sensing UTC time in ISO 8601 format (e.g. "1990-11-26",
-                      "1990-11-26T14:30:10.153Z", etc.)
+        :param start: Start sensing time in ISO 8601 format (e.g. "1990-11-26",
+                      "1990-11-26T14:30:10.153Z", "1990-11-26T14:30:10+02:00", ...).
+                      If no time offset is given, the time is assumed to be given in UTC.
         :type start: str
-        :param end: End sensing UTC time in ISO 8601 format (e.g. "1990-11-26",
-                    "1990-11-26T14:30:10.153Z", etc.)
+        :param end: End sensing time in ISO 8601 format (e.g. "1990-11-26",
+                    "1990-11-26T14:30:10.153Z", "1990-11-26T14:30:10+02:00", ...).
+                    If no time offset is given, the time is assumed to be given in UTC.
         :type end: str
         :param geom: Search area that can be defined in different ways:
 
@@ -732,11 +736,13 @@ class EODataAccessGateway(object):
                                available, a default value of 50 is used instead.
                                items_per_page can also be set to any arbitrary value.
         :type items_per_page: int
-        :param start: Start sensing UTC time in ISO 8601 format (e.g. "1990-11-26",
-                      "1990-11-26T14:30:10.153Z", etc.)
+        :param start: Start sensing time in ISO 8601 format (e.g. "1990-11-26",
+                      "1990-11-26T14:30:10.153Z", "1990-11-26T14:30:10+02:00", ...).
+                      If no time offset is given, the time is assumed to be given in UTC.
         :type start: str
-        :param end: End sensing UTC time in ISO 8601 format (e.g. "1990-11-26",
-                    "1990-11-26T14:30:10.153Z", etc.)
+        :param end: End sensing time in ISO 8601 format (e.g. "1990-11-26",
+                    "1990-11-26T14:30:10.153Z", "1990-11-26T14:30:10+02:00", ...).
+                    If no time offset is given, the time is assumed to be given in UTC.
         :type end: str
         :param geom: Search area that can be defined in different ways:
 
@@ -850,9 +856,13 @@ class EODataAccessGateway(object):
             * TODO: better expose cloudCover
             * other search params are passed to Searchplugin.query()
 
-        :param start: Start sensing UTC time in iso format
+        :param start: Start sensing time in ISO 8601 format (e.g. "1990-11-26",
+                      "1990-11-26T14:30:10.153Z", "1990-11-26T14:30:10+02:00", ...).
+                      If no time offset is given, the time is assumed to be given in UTC.
         :type start: str
-        :param end: End sensing UTC time in iso format
+        :param end: End sensing time in ISO 8601 format (e.g. "1990-11-26",
+                    "1990-11-26T14:30:10.153Z", "1990-11-26T14:30:10+02:00", ...).
+                    If no time offset is given, the time is assumed to be given in UTC.
         :type end: str
         :param geom: Search area that can be defined in different ways (see search)
         :type geom: Union[str, dict, shapely.geometry.base.BaseGeometry]

--- a/eodag/cli.py
+++ b/eodag/cli.py
@@ -156,13 +156,15 @@ def version():
     "-s",
     "--start",
     type=click.DateTime(),
-    help="Start sensing UTC time of the product (in ISO8601 format: yyyy-MM-ddThh:mm:ss.SSSZ)",
+    help="Start sensing UTC time of the product in ISO 8601 format (e.g. '1990-11-26', "
+    "'1990-11-26T14:30:10.153Z', etc.)",
 )
 @click.option(
     "-e",
     "--end",
     type=click.DateTime(),
-    help="End sensing UTC time of the product (in ISO8601 format: yyyy-MM-ddThh:mm:ss.SSSZ)",
+    help="End sensing UTC time of the product in ISO 8601 format (e.g. '1990-11-26', "
+    "'1990-11-26T14:30:10.153Z', etc.)",
 )
 @click.option(
     "-c",

--- a/eodag/cli.py
+++ b/eodag/cli.py
@@ -156,15 +156,13 @@ def version():
     "-s",
     "--start",
     type=click.DateTime(),
-    help="Start sensing UTC time of the product in ISO 8601 format (e.g. '1990-11-26', "
-    "'1990-11-26T14:30:10.153Z', etc.)",
+    help="Start sensing time in ISO8601 format (e.g. '1990-11-26', '1990-11-26T14:30:10'). UTC is assumed",
 )
 @click.option(
     "-e",
     "--end",
     type=click.DateTime(),
-    help="End sensing UTC time of the product in ISO 8601 format (e.g. '1990-11-26', "
-    "'1990-11-26T14:30:10.153Z', etc.)",
+    help="End sensing time in ISO8601 format (e.g. '1990-11-26', '1990-11-26T14:30:10'). UTC is assumed",
 )
 @click.option(
     "-c",

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -913,10 +913,10 @@
       # OpenSearch Parameters for Acquistion Parameters Search (Table 6)
       availabilityTime: '$.data.availabilityTime'
       startTimeFromAscendingNode:
-        - 'f=acquisition.beginViewingDate:gte:{startTimeFromAscendingNode#utc_to_timestamp_milliseconds}'
+        - 'f=acquisition.beginViewingDate:gte:{startTimeFromAscendingNode#datetime_to_timestamp_milliseconds}'
         - '{$.data.acquisition.beginViewingDate#to_iso_utc_datetime_from_milliseconds}'
       completionTimeFromAscendingNode:
-        - 'f=acquisition.endViewingDate:lte:{completionTimeFromAscendingNode#utc_to_timestamp_milliseconds}'
+        - 'f=acquisition.endViewingDate:lte:{completionTimeFromAscendingNode#datetime_to_timestamp_milliseconds}'
         - '{$.data.acquisition.endViewingDate#to_iso_utc_datetime_from_milliseconds}'
       polarizationChannels: '$.data.acquisition.polarization'
       sensorMode: '$.data.acquisition.sensorMode'

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -333,8 +333,9 @@ def maybe_generator(obj):
 
 
 def get_timestamp(date_time):
-    """Return the Unix timestamp of a UTC (or considered as if) date/datetime
-    in seconds.
+    """Return the Unix timestamp of an ISO8601 date/datetime in seconds.
+
+    If the datetime has no offset, it is assumed to be an UTC datetime.
 
     :param date_time: the datetime string to return as timestamp
     :type date_time: str
@@ -342,8 +343,6 @@ def get_timestamp(date_time):
     :rtype: float
     """
     dt = isoparse(date_time)
-    if dt.tzinfo and dt.tzinfo is not UTC:
-        raise ValueError("date_time must be a UTC time or have no timezone info")
     if not dt.tzinfo:
         dt = dt.replace(tzinfo=UTC)
     return dt.timestamp()

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -33,7 +33,6 @@ import types
 import unicodedata
 import warnings
 from collections import defaultdict
-from datetime import datetime, timezone
 from itertools import repeat, starmap
 from pathlib import Path
 
@@ -52,6 +51,8 @@ from urllib.request import url2pathname
 import click
 import shapefile
 import shapely.wkt
+from dateutil.parser import isoparse
+from dateutil.tz import UTC
 from jsonpath_ng import jsonpath
 from jsonpath_ng.ext import parse
 from requests.auth import AuthBase
@@ -331,28 +332,20 @@ def maybe_generator(obj):
         yield obj
 
 
-def get_timestamp(date_time, date_format="%Y-%m-%dT%H:%M:%S", as_utc=False):
-    """Returns the given UTC date_time string formatted with date_format as timestamp
+def get_timestamp(date_time):
+    """Return the Unix timestamp of a UTC (or considered as if) date/datetime
+    in seconds.
 
     :param date_time: the datetime string to return as timestamp
     :type date_time: str
-    :param date_format: (optional) the date format in which date_time is given,
-                        defaults to '%Y-%m-%dT%H:%M:%S'
-    :type date_format: str
-    :param as_utc: (optional) if ``True``, consider the input ``date_time`` as UTC,
-                        defaults to ``False``
-    :type date_format: bool
     :returns: the timestamp corresponding to the date_time string in seconds
     :rtype: float
-
-    .. versionchanged::
-        2.1.0
-
-            * The optional parameter ``as_utc`` to consider the input date as UTC.
     """
-    dt = datetime.strptime(date_time, date_format)
-    if as_utc:
-        dt = dt.replace(tzinfo=timezone.utc)
+    dt = isoparse(date_time)
+    if dt.tzinfo and dt.tzinfo is not UTC:
+        raise ValueError("date_time must be a UTC time or have no timezone info")
+    if not dt.tzinfo:
+        dt = dt.replace(tzinfo=UTC)
     return dt.timestamp()
 
 

--- a/tests/context.py
+++ b/tests/context.py
@@ -29,6 +29,7 @@ from eodag.api.core import DEFAULT_ITEMS_PER_PAGE, DEFAULT_MAX_ITEMS_PER_PAGE
 from eodag.api.product import EOProduct
 from eodag.api.product.drivers import DRIVERS
 from eodag.api.product.drivers.base import NoDriver
+from eodag.api.product.metadata_mapping import format_metadata
 from eodag.api.search_result import SearchResult
 from eodag.cli import download, eodag, list_pt, search_crunch
 from eodag.config import load_default_config, merge_configs

--- a/tests/units/test_metadata_mapping.py
+++ b/tests/units/test_metadata_mapping.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021, CS GROUP - France, http://www.c-s.fr
+#
+# This file is part of EODAG project
+#     https://www.github.com/CS-SI/EODAG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from tests.context import format_metadata
+
+
+class TestMetadataFormatter(unittest.TestCase):
+    def test_convert_utc_to_timestamp_milliseconds(self):
+        to_format = "{fieldname#utc_to_timestamp_milliseconds}"
+        self.assertEqual(
+            format_metadata(to_format, fieldname="2021-04-21T18:27:19.123Z"),
+            "1619029639123",
+        )
+        self.assertEqual(
+            format_metadata(to_format, fieldname="2021-04-21T18:27:19.123"),
+            "1619029639123",
+        )
+        self.assertEqual(
+            format_metadata(to_format, fieldname="2021-04-21"), "1618963200000"
+        )
+
+    def test_convert_to_iso_utc_datetime(self):
+        to_format = "{fieldname#to_iso_utc_datetime}"
+        self.assertEqual(
+            format_metadata(to_format, fieldname="2021-04-21T18:27:19.123Z"),
+            "2021-04-21T18:27:19.123Z",
+        )
+        self.assertEqual(
+            format_metadata(to_format, fieldname="2021-04-21T18:27:19.123"),
+            "2021-04-21T18:27:19.123Z",
+        )
+        self.assertEqual(
+            format_metadata(to_format, fieldname="2021-04-21"),
+            "2021-04-21T00:00:00.000Z",
+        )
+
+    def test_convert_to_iso_date(self):
+        to_format = "{fieldname#to_iso_date}"
+        self.assertEqual(
+            format_metadata(to_format, fieldname="2021-04-21T18:27:19.123Z"),
+            "2021-04-21",
+        )
+        self.assertEqual(
+            format_metadata(to_format, fieldname="2021-04-21T18:27:19.123"),
+            "2021-04-21",
+        )
+        self.assertEqual(
+            format_metadata(to_format, fieldname="2021-04-21"), "2021-04-21"
+        )
+
+    def test_convert_to_iso_utc_datetime_from_milliseconds(self):
+        to_format = "{fieldname#to_iso_utc_datetime_from_milliseconds}"
+        self.assertEqual(
+            format_metadata(to_format, fieldname=1619029639123),
+            "2021-04-21T18:27:19.123Z",
+        )
+        self.assertEqual(
+            format_metadata(to_format, fieldname=1618963200000),
+            "2021-04-21T00:00:00.000Z",
+        )

--- a/tests/units/test_metadata_mapping.py
+++ b/tests/units/test_metadata_mapping.py
@@ -21,8 +21,8 @@ from tests.context import format_metadata
 
 
 class TestMetadataFormatter(unittest.TestCase):
-    def test_convert_utc_to_timestamp_milliseconds(self):
-        to_format = "{fieldname#utc_to_timestamp_milliseconds}"
+    def test_convert_datetime_to_timestamp_milliseconds(self):
+        to_format = "{fieldname#datetime_to_timestamp_milliseconds}"
         self.assertEqual(
             format_metadata(to_format, fieldname="2021-04-21T18:27:19.123Z"),
             "1619029639123",
@@ -33,6 +33,10 @@ class TestMetadataFormatter(unittest.TestCase):
         )
         self.assertEqual(
             format_metadata(to_format, fieldname="2021-04-21"), "1618963200000"
+        )
+        self.assertEqual(
+            format_metadata(to_format, fieldname="2021-04-21T00:00:00+02:00"),
+            "1618956000000",
         )
 
     def test_convert_to_iso_utc_datetime(self):
@@ -49,6 +53,10 @@ class TestMetadataFormatter(unittest.TestCase):
             format_metadata(to_format, fieldname="2021-04-21"),
             "2021-04-21T00:00:00.000Z",
         )
+        self.assertEqual(
+            format_metadata(to_format, fieldname="2021-04-21T00:00:00.000+02:00"),
+            "2021-04-20T22:00:00.000Z",
+        )
 
     def test_convert_to_iso_date(self):
         to_format = "{fieldname#to_iso_date}"
@@ -62,6 +70,10 @@ class TestMetadataFormatter(unittest.TestCase):
         )
         self.assertEqual(
             format_metadata(to_format, fieldname="2021-04-21"), "2021-04-21"
+        )
+        self.assertEqual(
+            format_metadata(to_format, fieldname="2021-04-21T00:00:00+06:00"),
+            "2021-04-20",
         )
 
     def test_convert_to_iso_utc_datetime_from_milliseconds(self):

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -25,15 +25,22 @@ from tests.context import get_timestamp, path_to_uri, uri_to_path
 
 class TestUtils(unittest.TestCase):
     def test_utils_get_timestamp(self):
-        """get_timestamp must handle UTC dates"""
+        """get_timestamp must handle different date formats and assume they're in UTC"""
+        # Date to timestamp to date
         requested_date = "2020-08-08"
-        date_format = "%Y-%m-%d"
-        # If as_utc is False, get_timestamp takes into account the
-        # local timezone (because of datetime.timestamp)
-        ts_in_secs = get_timestamp(requested_date, date_format=date_format, as_utc=True)
-        expected_dt = datetime.strptime(requested_date, date_format)
+        ts_in_secs = get_timestamp(requested_date)
+        expected_dt = datetime.strptime(requested_date, "%Y-%m-%d")
         actual_utc_dt = datetime.utcfromtimestamp(ts_in_secs)
         self.assertEqual(actual_utc_dt, expected_dt)
+
+        # Check different formats
+        self.assertEqual(get_timestamp("2021-04-21T18:27:19.123Z"), 1619029639.123)
+        self.assertEqual(get_timestamp("2021-04-21T18:27:19.123"), 1619029639.123)
+        self.assertEqual(get_timestamp("2021-04-21"), 1618963200)
+
+        # Non UTC dates are not allowed
+        with self.assertRaises(ValueError):
+            get_timestamp("2018-02-01T12:52:34+09:00")
 
     def test_uri_to_path(self):
         if sys.platform == "win32":

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -25,22 +25,27 @@ from tests.context import get_timestamp, path_to_uri, uri_to_path
 
 class TestUtils(unittest.TestCase):
     def test_utils_get_timestamp(self):
-        """get_timestamp must handle different date formats and assume they're in UTC"""
-        # Date to timestamp to date
-        requested_date = "2020-08-08"
+        """get_timestamp must return a UNIX timestamp"""
+        # Date to timestamp to date, this assumes the date is in UTC
+        requested_date = "2020-08-08"  # Considered as 2020-08-08T00:00:00Z
         ts_in_secs = get_timestamp(requested_date)
         expected_dt = datetime.strptime(requested_date, "%Y-%m-%d")
         actual_utc_dt = datetime.utcfromtimestamp(ts_in_secs)
         self.assertEqual(actual_utc_dt, expected_dt)
 
-        # Check different formats
+        # Handle UTC datetime
         self.assertEqual(get_timestamp("2021-04-21T18:27:19.123Z"), 1619029639.123)
-        self.assertEqual(get_timestamp("2021-04-21T18:27:19.123"), 1619029639.123)
-        self.assertEqual(get_timestamp("2021-04-21"), 1618963200)
+        # If date/datetime not in UTC, it assumes it's in UTC
+        self.assertEqual(
+            get_timestamp("2021-04-21T18:27:19.123"),
+            get_timestamp("2021-04-21T18:27:19.123Z"),
+        )
+        self.assertEqual(
+            get_timestamp("2021-04-21"), get_timestamp("2021-04-21T00:00:00.000Z")
+        )
 
-        # Non UTC dates are not allowed
-        with self.assertRaises(ValueError):
-            get_timestamp("2018-02-01T12:52:34+09:00")
+        # Non UTC datetime are also supported
+        self.assertEqual(get_timestamp("2021-04-21T00:00:00+02:00"), 1618956000)
 
     def test_uri_to_path(self):
         if sys.platform == "win32":


### PR DESCRIPTION
Fixes #227 

I used the function `datutil.parser.isoparse` to parse user input dates, which should cover most cases.