### PR TITLE
Recreate whoosh index when unsupported pickle protocol

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -167,16 +167,9 @@ class EODataAccessGateway(object):
                 if self._product_types_index is None:
                     logger.debug("Opening product types index in %s", index_dir)
                     self._product_types_index = open_dir(index_dir)
-                try:
-                    self.guess_product_type(eodagVersion=eodag_version)
-                except NoMatchingProductType:
-                    create_index = True
-                finally:
-                    if create_index:
-                        shutil.rmtree(index_dir)
-                        logger.debug(
-                            "Out-of-date product types index removed from %s", index_dir
-                        )
+                self.guess_product_type(eodagVersion=eodag_version)
+        except NoMatchingProductType:
+            create_index = True
         except ValueError as ve:
             # Whoosh uses pickle internally. New versions of Python sometimes introduce
             # a new pickle protocol (e.g. 3.4 -> 4, 3.8 -> 5), the new version not
@@ -192,6 +185,12 @@ class EODataAccessGateway(object):
                     index_dir,
                 )
                 raise
+        finally:
+            if create_index:
+                shutil.rmtree(index_dir)
+                logger.debug(
+                    "Out-of-date product types index removed from %s", index_dir
+                )
 
         if create_index:
             logger.debug("Creating product types index in %s", index_dir)

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -162,35 +162,38 @@ class EODataAccessGateway(object):
 
         try:
             create_index = not exists_in(index_dir)
-            # check index version
-            if not create_index:
-                if self._product_types_index is None:
-                    logger.debug("Opening product types index in %s", index_dir)
-                    self._product_types_index = open_dir(index_dir)
-                self.guess_product_type(eodagVersion=eodag_version)
-        except NoMatchingProductType:
-            create_index = True
         except ValueError as ve:
             # Whoosh uses pickle internally. New versions of Python sometimes introduce
             # a new pickle protocol (e.g. 3.4 -> 4, 3.8 -> 5), the new version not
             # being supported by previous versions of Python (e.g. Python 3.7 doesn't
             # support Protocol 5). In that case, we need to recreate the .index.
             if "unsupported pickle protocol" in str(ve):
+                logger.debug("Need to recreate whoosh .index: '%s'", ve)
                 create_index = True
+                shutil.rmtree(index_dir)
             # Unexpected error
             else:
                 logger.error(
-                    "Error while building .index using whoosh, "
-                    "please report this issue and try to delete %s manually",
+                    "Error while opening .index using whoosh, "
+                    "please report this issue and try to delete '%s' manually",
                     index_dir,
                 )
                 raise
-        finally:
-            if create_index:
-                shutil.rmtree(index_dir)
-                logger.debug(
-                    "Out-of-date product types index removed from %s", index_dir
-                )
+        # check index version
+        if not create_index:
+            if self._product_types_index is None:
+                logger.debug("Opening product types index in %s", index_dir)
+                self._product_types_index = open_dir(index_dir)
+            try:
+                self.guess_product_type(eodagVersion=eodag_version)
+            except NoMatchingProductType:
+                create_index = True
+            finally:
+                if create_index:
+                    shutil.rmtree(index_dir)
+                    logger.debug(
+                        "Out-of-date product types index removed from %s", index_dir
+                    )
 
         if create_index:
             logger.debug("Creating product types index in %s", index_dir)


### PR DESCRIPTION
Fixes #240 

Thanks @sbrunato for the snippet!

I could test this by running eodag with python 3.8 first (which introduced a new pickle protocol) and then python 3.7, the error was properly caught and the index recreated.