### PR TITLE
New optional "quicklooks" flag in "download" command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -206,6 +206,10 @@ Start playing with the CLI:
 
      eodag download --search-results search_results.geojson
 
+- To download only the result quicklooks of the previous call to search::
+
+     eodag download --quicklooks --search-results search_results.geojson
+
 - To list all available product types and supported providers::
 
      eodag list

--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -337,7 +337,7 @@ class EOProduct(object):
         if progress_callback is None:
             progress_callback = ProgressCallback()
 
-        if self.properties["quicklook"] is None:
+        if self.properties.get("quicklook", None) is None:
             logger.warning(
                 "Missing information to retrieve quicklook for EO product: %s",
                 self.properties["id"],


### PR DESCRIPTION
This PR is a proposal of implementation for https://github.com/CS-SI/eodag/issues/264.

It works here for me, I hope it can be useful in some manner for your future implementation.
Thanks for developing this amazing software.

NOTE:
I have not implemented this code defining a `get_quicklook` command because of parser internally changes the parameter name to `get-quicklook`. I was not able to define the necessary extra setting.

