### PR TITLE
fix: CI failure following deps upgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
             "sphinx==3.5.3",
             "sphinx-book-theme==0.0.42",
             "sphinx-copybutton==0.3.1",
-            "nbsphinx==0.8.3",
+            "nbsphinx==0.8.5",
         ],
     },
     entry_points={

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -321,13 +321,13 @@ class TestEodagCli(unittest.TestCase):
                     "--cruncher-args",
                     cruncher,
                     "minimum_overlap",
-                    10,
+                    "10",
                 ],
             )
             api_obj.crunch.assert_called_with(
                 search_results,
                 search_criteria=criteria,
-                **{cruncher: {"minimum_overlap": 10}}
+                **{cruncher: {"minimum_overlap": "10"}}
             )
 
     @mock.patch("eodag.cli.EODataAccessGateway", autospec=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,7 +140,8 @@ class TestEodagCli(unittest.TestCase):
             result = self.runner.invoke(
                 eodag, ["search", "--conf", conf_file, "-p", "whatever", "-b", 1, 2]
             )
-            self.assertIn("Error: -b option requires 4 arguments", result.output)
+            self.assertIn("-b", result.output)
+            self.assertIn("requires 4 arguments", result.output)
             self.assertNotEqual(result.exit_code, 0)
 
     @mock.patch("eodag.cli.EODataAccessGateway", autospec=True)


### PR DESCRIPTION
- Fixes 2 tests failing when using click v8.0.0 https://github.com/CS-SI/eodag/runs/2598488725: 
  - One due to options error message reformatting, see https://github.com/pallets/click/commit/8d49e146ab8c2312e7917bb7c3f8abf01b8b55bf#diff-948f9e0cc733616a6b18aa152ac6703e819fec61dd752d1efa40e5736c3bdce7R423
  - Another one caused by wrong type args (`int` instead of `str`) passed to CLI cruncher in tests. This was ignored with `click<8.0`

- Updates `nbsphinx` following `Jinja2` update that broke the pinned version, see https://github.com/spatialaudio/nbsphinx/issues/563