### PR TITLE
fix: conf updatable from non-queryable params to queryable

### DIFF
--- a/tests/context.py
+++ b/tests/context.py
@@ -49,6 +49,7 @@ from eodag.utils import (
     get_geometry_from_various,
     get_timestamp,
     makedirs,
+    merge_mappings,
     path_to_uri,
     ProgressCallback,
     uri_to_path,


### PR DESCRIPTION
Fixes GH-278

`provider.search` configuration can now be dynamically updated from queryable parameters (`list`) to non-queryable (`str`) and vice-versa