### PR TITLE
fix: ignore and log misconfigured provider from user conf

### DIFF
--- a/eodag/config.py
+++ b/eodag/config.py
@@ -331,8 +331,14 @@ def override_config_from_mapping(config, mapping):
             try:
                 new_conf["name"] = new_conf.get("name", provider)
                 config[provider] = ProviderConfig.from_mapping(new_conf)
-            except (AttributeError, ValidationError) as e:
-                logger.warning("%s skipped: %s", provider, e)
+            except Exception:
+                logger.warning(
+                    "%s skipped: could not be loaded from user configuration", provider
+                )
+
+                import traceback as tb
+
+                logger.debug(tb.format_exc())
 
 
 def merge_configs(config, other_config):


### PR DESCRIPTION
Trying to load misconfigured provider from user configuration might result in the following error:
```py
from eodag import EODataAccessGateway
dag = EODataAccessGateway()

2021-06-08 16:48:18,555-15s eodag.config                     [INFO    ] wekeo: unknown provider found in user conf, trying to use provided configuration
Traceback (most recent call last):
    dag = EODataAccessGateway()
  File "/home/sylvain/workspace/eodag/eodag/api/core.py", line 107, in __init__
    override_config_from_file(self.providers_config, user_conf_file_path)
  File "/home/sylvain/workspace/eodag/eodag/config.py", line 268, in override_config_from_file
    override_config_from_mapping(config, config_in_file)
  File "/home/sylvain/workspace/eodag/eodag/config.py", line 333, in override_config_from_mapping
    config[provider] = ProviderConfig.from_mapping(new_conf)
  File "/home/sylvain/workspace/eodag/eodag/config.py", line 114, in from_mapping
    mapping[key] = PluginConfig.from_mapping(mapping[key])
  File "/home/sylvain/workspace/eodag/eodag/config.py", line 180, in from_mapping
    c.__dict__.update(mapping)
TypeError: 'NoneType' object is not iterable
```
In this case the error occurred when having some partial settings (only credentials and priority) for a non-existing provider