### PR TITLE
fix: reload plugins after providers settings update from user conf

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -109,6 +109,11 @@ class EODataAccessGateway(object):
         # Second level override: From environment variables
         override_config_from_env(self.providers_config)
 
+        # re-create _plugins_manager using up-to-date providers_config
+        self._plugins_manager = PluginManager(self.providers_config)
+        # use updated and checked providers_config
+        self.providers_config = self._plugins_manager.providers_config
+
         # Sort providers taking into account of possible new priority orders
         self._plugins_manager.sort_providers()
 


### PR DESCRIPTION
fixes #305 

Reload plugins (and check configuration) after providers settings update from user configuration file
