### PR TITLE
fix: dockerfile update for stac-browser v2.0

### DIFF
--- a/docker/stac-browser.dockerfile
+++ b/docker/stac-browser.dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM node:lts-jessie-slim as build-stage
+FROM node:lts-buster-slim as build-stage
 
 # install git
 RUN apt-get update \
@@ -15,7 +15,7 @@ WORKDIR /stac-browser
 RUN npm install
 
 # start application
-RUN CATALOG_URL=http://localhost:5000 npm run build
+RUN npm run build -- --CATALOG_URL=http://localhost:5000
 
 # production stage, self describing
 FROM nginx:stable-alpine as production-stage


### PR DESCRIPTION
Fixes #313 

Use `node:lts-buster-slim` instead of `node:lts-jessie-slim` to have `Node.js >= 12`.

Update `stac-browser` `npm build` command,  see [stac-browser v2.0.0-rc.3 changelog](https://github.com/radiantearth/stac-browser/releases/tag/v2.0.0-rc.3)