### PR TITLE
feat: new notebook extra dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,9 @@ setup(
             "flake8",
             "pre-commit",
         ],
+        "notebook": [
+            "tqdm[notebook]",
+        ],
         "tutorials": [
             "eodag-cube",
             "jupyter",


### PR DESCRIPTION
Adds new `notebook` extra dependency which will install  `ipywidgets` through `tqdm[notebook]`:
```sh
pip install eodag[notebook]
```

Please note that `pip >= 20.2` will be needed to install this extra as `tqdm` is already in `install_requires`, see https://github.com/pypa/pip/issues/988
