### PR TITLE
fix: guess and set product_type when searching by id

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -840,6 +840,12 @@ class EODataAccessGateway(object):
             auth = self._plugins_manager.get_auth_plugin(plugin.provider)
             results, _ = self._do_search(plugin, auth=auth, id=uid)
             if len(results) == 1:
+                if not results[0].product_type:
+                    # guess product type from properties
+                    guesses = self.guess_product_type(**results[0].properties)
+                    results[0].product_type = guesses[0]
+                    # reset driver
+                    results[0].driver = results[0].get_driver()
                 return results, 1
         return SearchResult([]), 0
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -418,6 +418,7 @@ class TestEODagEndToEnd(EndToEndBase):
         product = products[0]
 
         self.assertEqual(product.properties["id"], uid)
+        self.assertIsNotNone(product.product_type)
 
     def test_end_to_end_search_all_mundi_default(self):
         # 23/03/2021: Got 16 products for this search


### PR DESCRIPTION
fixes #311 

Guess and set `product.product_type` when searching by id, using `guess_product_type()` with `product.properties`