### PR TITLE
fix: pystac v1.0 update

### DIFF
--- a/eodag/utils/stac_reader.py
+++ b/eodag/utils/stac_reader.py
@@ -33,7 +33,7 @@ HTTP_REQ_TIMEOUT = 5
 
 
 class _TextOpener:
-    """Exhaust read methods for pystac.STAC_IO in the order defined
+    """Exhaust read methods for pystac.StacIO in the order defined
     in the openers list"""
 
     def __init__(self, timeout):
@@ -117,7 +117,7 @@ def fetch_stac_items(
     # URI opener used by PySTAC internally, instantiated here
     # to retrieve the timeout.
     _text_opener = _TextOpener(timeout)
-    pystac.STAC_IO.read_text_method = _text_opener
+    pystac.StacIO.read_text = _text_opener
 
     stac_obj = pystac.read_file(stac_path)
     # Single STAC item

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "flask >= 1.0.2",
         "markdown >= 3.0.1",
         "whoosh",
-        "pystac",
+        "pystac >= 1.0.0",
     ],
     python_requires=">=3.6",
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "flask >= 1.0.2",
         "markdown >= 3.0.1",
         "whoosh",
-        "pystac >= 1.0.0",
+        "pystac >= 1.0.0b1",
     ],
     python_requires=">=3.6",
     extras_require={

--- a/tests/integration/test_search_stac_static.py
+++ b/tests/integration/test_search_stac_static.py
@@ -160,6 +160,9 @@ class TestSearchStacStatic(unittest.TestCase):
         self.assertIn("foo", item[0].properties)
         self.assertEqual(item[0].properties["foo"], "descending")
 
+    @unittest.skip(
+        "skipped as single-file-stac has been removed and is being rethought"
+    )
     def test_search_stac_static_load_singlefile_catalog(self):
         """load_stac_items from child catalog must provide items"""
         items = self.dag.load_stac_items(

--- a/tests/units/test_stac_reader.py
+++ b/tests/units/test_stac_reader.py
@@ -71,6 +71,9 @@ class TestStacReader(unittest.TestCase):
         self.assertEqual(item[0]["type"], "Feature")
         self.assertEqual(item[0]["collection"], "S2_MSI_L1C")
 
+    @unittest.skip(
+        "skipped as single-file-stac has been removed and is being rethought"
+    )
     def test_stact_reader_fetch_singlefile_catalog(self):
         """fetch_stact_items must return all the items from a single file catalog"""
         items = fetch_stac_items(self.singlefile_cat)


### PR DESCRIPTION
Fixes [CI failure](https://github.com/CS-SI/eodag/runs/3101522106) after [pystac v1.0](https://github.com/stac-utils/pystac/releases) update.

Note that [single-file-stac](https://github.com/stac-extensions/single-file-stac) has been removed from `pystac` as the extension is being rethought