### PR TITLE
feat: configurable eodag logging in docker stac-server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,7 +175,8 @@ Simply run:
     git clone https://github.com/CS-SI/eodag.git
     cd eodag
     docker-compose up
-
+    # or for a more verbose logging:
+    EODAG_LOGGING=3 docker-compose up
 
 And browse http://127.0.0.1:5001:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     build:
       context: .
       dockerfile: docker/stac-server.dockerfile
+    environment:
+      - "EODAG_LOGGING=${EODAG_LOGGING}"
     container_name: stac_server
     restart: unless-stopped
     networks:

--- a/docker/run-stac-server.sh
+++ b/docker/run-stac-server.sh
@@ -2,5 +2,13 @@
 
 # some pre-start operation
 
+LOGGING_OPTIONS=""
+re='^[0-9]+$'
+if [[ ${EODAG_LOGGING} =~ $re ]] && [ "${EODAG_LOGGING} " -gt "0" ]; then
+   LOGGING_OPTIONS="-"$(printf '%0.sv' $(seq 1 ${EODAG_LOGGING}))
+else
+    echo "Logging level can be changed using EODAG_LOGGING environment variable [1-3]"
+fi
+
 # start
-eodag serve-rest -w
+eodag $LOGGING_OPTIONS serve-rest -w

--- a/docs/stac_rest.rst
+++ b/docs/stac_rest.rst
@@ -98,7 +98,11 @@ Browsing over catalogs can be experienced connecting EODAG STAC API to
     git clone https://github.com/CS-SI/eodag.git
     cd eodag
     docker-compose up
+    # or for a more verbose logging:
+    EODAG_LOGGING=3 docker-compose up
 
+(``EODAG_LOGGING`` environment variable definition will increase ``eodag``
+logging level, and accepts values: 1, 2, or 3 for maximum level)
 
 And browse http://127.0.0.1:5001:
 


### PR DESCRIPTION
`EODAG_LOGGING` environment variable can be used with `docker-compose up` to increase `eodag` logging level in `stac-server`.
It accepts values: 1, 2, or 3 for maximum level.

Example:
```sh
EODAG_LOGGING=3 docker-compose up
```