### PR TITLE
fix: prevent eol auto changes on windows causing docker crashes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# for all paths end-of-line normalization should not be attempted
+* -text

--- a/docker/run-stac-server.sh
+++ b/docker/run-stac-server.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-
 # some pre-start operation
-
 LOGGING_OPTIONS=""
 re='^[0-9]+$'
 if [[ ${EODAG_LOGGING} =~ $re ]] && [ "${EODAG_LOGGING} " -gt "0" ]; then
@@ -9,6 +7,5 @@ if [[ ${EODAG_LOGGING} =~ $re ]] && [ "${EODAG_LOGGING} " -gt "0" ]; then
 else
     echo "Logging level can be changed using EODAG_LOGGING environment variable [1-3]"
 fi
-
 # start
 eodag $LOGGING_OPTIONS serve-rest -w

--- a/docker/run-stac-server.sh
+++ b/docker/run-stac-server.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 # some pre-start operation
 

--- a/docker/stac-server.dockerfile
+++ b/docker/stac-server.dockerfile
@@ -71,4 +71,4 @@ RUN addgroup --system user \
 USER user
 
 # and then start STAC
-CMD ["/eodag/run-stac-server.sh"]
+CMD ["/bin/bash", "/eodag/run-stac-server.sh"]


### PR DESCRIPTION
fixes #322 

Adds a `.gitattributes` file containing `* -text` to prevent `git` from normalizing EOL when running on windows.
Also some minor reformatting.
