### PR TITLE
fix: eodag-cube 0.2.0 required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
             "tqdm[notebook]",
         ],
         "tutorials": [
-            "eodag-cube",
+            "eodag-cube >= 0.2.0",
             "jupyter",
             "ipyleaflet >= 0.10.0",
             "ipywidgets",


### PR DESCRIPTION
Minimal [eodag-cube](https://github.com/CS-SI/eodag-cube) version set to [0.2.0](https://github.com/CS-SI/eodag-cube/releases/tag/v0.2.0)