### PR TITLE
Fix get_quicklook method for onda provider

### DIFF
--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -15,6 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import base64
 import logging
 import os
 import re
@@ -391,14 +392,15 @@ class EOProduct(object):
 
         if not os.path.isfile(quicklook_file):
             # VERY SPECIAL CASE (introduced by the onda provider): first check if
-            # it is a HTTP URL. If not, we assume it is a byte string, in which case
-            # we just write the content into the quicklook_file and return it.
+            # it is a HTTP URL. If not, we assume it is a base64 string, in which case
+            # we just decode the content, write it into the quicklook_file and return it.
             if not (
                 self.properties["quicklook"].startswith("http")
                 or self.properties["quicklook"].startswith("https")
             ):
                 with open(quicklook_file, "wb") as fd:
-                    fd.write(self.properties["quicklook"])
+                    img = self.properties["quicklook"].encode("ascii")
+                    fd.write(base64.b64decode(img))
                 return quicklook_file
 
             auth = (


### PR DESCRIPTION
This PR aims to solve the issue of getting overviews for ONDA provider:
```
TypeError                                 Traceback (most recent call last)
<ipython-input-7-3c773c92be6c> in <module>
      1 workspace = "eodag_workspace_overview"
      2 quicklooks_dir = os.path.join(workspace, "quicklooks")
----> 3 product.get_quicklook(base_dir=quicklooks_dir)

~/eodag/eodag/api/product/_product.py in get_quicklook(self, filename, base_dir, progress_callback)
    399             ):
    400                 with open(quicklook_file, "wb") as fd:
--> 401                     fd.write(self.properties["quicklook"])
    402                 return quicklook_file
    403 

TypeError: a bytes-like object is required, not 'str'
```

The quicklook in this case is a [base64](https://gist.github.com/drnextgis/e494a1150fffda1189c80362312b9275) string which should be decoded.