### PR TITLE
Fix progress callback

### DIFF
--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -427,18 +427,18 @@ class ProgressCallback(tqdm):
 
         super(ProgressCallback, self).__init__(*args, **kwargs)
 
-    def __call__(self, current_size, total=None):
+    def __call__(self, increment, total=None):
         """Update the progress bar.
 
-        :param current_size: amount of data already processed
-        :type current_size: int
+        :param increment: amount of data already processed
+        :type increment: int
         :param total: maximum amount of data to be processed
         :type total: int
         """
         if total is not None:
             self.reset(total=total)
 
-        self.update(current_size)
+        self.update(increment)
         self.refresh()
 
     def copy(self, *args, **kwargs):

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -435,7 +435,7 @@ class ProgressCallback(tqdm):
         :param total: maximum amount of data to be processed
         :type total: int
         """
-        if total is not None:
+        if total is not None and total != self.total:
             self.reset(total=total)
 
         self.update(increment)


### PR DESCRIPTION
Fixes #343 

In ProgressCallback:
- Rename `__call__` parameter `current_size` to `increment`.
- Inside of `__call__`, add condition to the call of the reset method in order to prevent resetting the progress bar each time.