### PR TITLE
fix: unwanted percent-encoded keys with mundi S2_MSI_L2A

### DIFF
--- a/eodag/plugins/download/s3rest.py
+++ b/eodag/plugins/download/s3rest.py
@@ -29,7 +29,7 @@ from requests import HTTPError
 from eodag.api.product.metadata_mapping import OFFLINE_STATUS
 from eodag.plugins.download.aws import AwsDownload
 from eodag.plugins.download.http import HTTPDownload
-from eodag.utils import ProgressCallback, path_to_uri, urljoin
+from eodag.utils import ProgressCallback, path_to_uri, unquote, urljoin
 from eodag.utils.exceptions import (
     AuthenticationError,
     DownloadError,
@@ -185,7 +185,9 @@ class S3RestDownload(AwsDownload):
 
         # download each node key
         for node_xml in nodes_xml_list:
-            node_key = node_xml.getElementsByTagName("Key")[0].firstChild.nodeValue
+            node_key = unquote(
+                node_xml.getElementsByTagName("Key")[0].firstChild.nodeValue
+            )
             # As "Key", "Size" and "ETag" (md5 hash) can also be retrieved from node_xml
             node_url = urljoin(bucket_url.strip("/") + "/", node_key.strip("/"))
             # output file location

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from urllib.parse import (  # noqa; noqa
     parse_qs,
     quote,
+    unquote,
     urlencode,
     urljoin,
     urlparse,


### PR DESCRIPTION
fixes #349 

When trying to download `S2_MSI_L2A` products, `mundi` returned unwanted percent-encoded keys, making its parsing fail