### PR TITLE
Automatic archive deletion

### DIFF
--- a/docs/getting_started_guide/configure.rst
+++ b/docs/getting_started_guide/configure.rst
@@ -39,6 +39,7 @@ one (e.g. credentials). *PEPS*'s configuration template is shown below:
            extract:  # whether to extract the downloaded products (true or false).
            outputs_prefix: # where to store downloaded products.
            dl_url_params:  # additional parameters to pass over to the download url as an url parameter
+           delete_archive: # whether to delete the downloaded archives (true or false, Default: true).
        auth:
            credentials:
                username:
@@ -99,6 +100,7 @@ See for instance the following configuration extracted from YAML file:
        download:
            extract: True
            outputs_prefix: /absolute/path/to/a/folder/
+           delete_archive: False
 
 
 The same configuration could be achieved by setting environment variables:
@@ -107,6 +109,7 @@ The same configuration could be achieved by setting environment variables:
 
    export EODAG__SOBLOO__DOWNLOAD__EXTRACT=True
    export EODAG__SOBLOO__DOWNLOAD__OUTPUTS_PREFIX=/absolute/path/to/a/folder/
+   export EODAG__SOBLOO__DOWNLOAD__DELETE_ARCHIVE=False
 
 
 Each configuration parameter can be set with an environment variable.
@@ -159,6 +162,9 @@ Two useful download parameters can be set by a user:
 
 *  ``outputs_prefix`` indicates the absolute file path to `eodag`'s download folder.
    It is the temporary folder by default (e.g. ``/tmp`` on Linux).
+
+* ``delete_archive`` indicates whether the downloaded product archive should be automatically
+  deleted after extraction or not. ``True`` by default.
 
 Credentials settings
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/notebooks/api_user_guide/1_overview.ipynb
+++ b/docs/notebooks/api_user_guide/1_overview.ipynb
@@ -64,6 +64,7 @@
     "        extract:  # whether to extract the downloaded products (true or false).\n",
     "        outputs_prefix: # where to store downloaded products.\n",
     "        dl_url_params:  # additional parameters to pass over to the download url as an url parameter\n",
+    "        delete_archive: # whether to delete the downloaded archives (true or false, Default: true).\n",
     "    auth:\n",
     "        credentials:\n",
     "            username: PLEASE_CHANGE_ME\n",

--- a/docs/notebooks/api_user_guide/7_download.ipynb
+++ b/docs/notebooks/api_user_guide/7_download.ipynb
@@ -623,7 +623,8 @@
     "\n",
     "* `outputs_prefix` (`str`): absolute path to a folder where the products should be saved\n",
     "* `extract` (`bool`): whether to automatically extract or not the downloaded product archive\n",
-    "* `dl_url_params` (`dict`): additional parameters to pass over to the download url as an url parameter"
+    "* `dl_url_params` (`dict`): additional parameters to pass over to the download url as an url parameter\n",
+    "* `delete_archive` (`bool`): whether to delete the downloaded archives"
    ]
   },
   {

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -245,6 +245,8 @@ def provider_config_init(provider_config):
             param_value = getattr(provider_config, param_name)
             if not getattr(param_value, "outputs_prefix", None):
                 param_value.outputs_prefix = tempfile.gettempdir()
+            if not getattr(param_value, "delete_archive", None):
+                param_value.delete_archive = True
     # Set default priority to 0
     provider_config.__dict__.setdefault("priority", 0)
 

--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -251,6 +251,12 @@ class Download(PluginTopic):
         extract = (
             extract if extract is not None else getattr(self.config, "extract", True)
         )
+        delete_archive = kwargs.pop("delete_archive", None)
+        delete_archive = (
+            delete_archive
+            if delete_archive is not None
+            else getattr(self.config, "delete_archive", True)
+        )
         outputs_extension = kwargs.pop("outputs_extension", ".zip")
 
         if not extract:
@@ -329,6 +335,16 @@ class Download(PluginTopic):
                     progress_callback(1)
             else:
                 progress_callback(1, total=1)
+
+            if delete_archive:
+                logger.info("Deleting archive {}".format(os.path.basename(fs_path)))
+                os.unlink(fs_path)
+            else:
+                logger.info(
+                    "Archive deletion is deactivated, keeping {}".format(
+                        os.path.basename(fs_path)
+                    )
+                )
         else:
             progress_callback(1, total=1)
 

--- a/eodag/resources/user_conf_template.yml
+++ b/eodag/resources/user_conf_template.yml
@@ -22,6 +22,7 @@ peps:
         extract:  # whether to extract the downloaded products, only applies to archived products (true or false, Default: true).
         outputs_prefix: # where to store downloaded products, as an absolute file path (Default: local temporary directory)
         dl_url_params:  # additional parameters to pass over to the download url as an url parameter
+        delete_archive: # whether to delete the downloaded archives (true or false, Default: true).
     auth:
         credentials:
             username:

--- a/tests/units/test_eoproduct.py
+++ b/tests/units/test_eoproduct.py
@@ -278,7 +278,11 @@ class TestEOProduct(EODagTestCase):
         )
         self.requests_http_get.return_value = self._download_response_archive()
         dl_config = config.PluginConfig.from_mapping(
-            {"base_uri": "fake_base_uri", "outputs_prefix": tempfile.gettempdir()}
+            {
+                "base_uri": "fake_base_uri",
+                "outputs_prefix": tempfile.gettempdir(),
+                "delete_archive": False,
+            }
         )
         downloader = HTTPDownload(provider=self.provider, config=dl_config)
         product.register_downloader(downloader, None)
@@ -326,6 +330,7 @@ class TestEOProduct(EODagTestCase):
                 "base_uri": "fake_base_uri",
                 "outputs_prefix": tempfile.gettempdir(),
                 "extract": True,
+                "delete_archive": False,
             }
         )
         downloader = HTTPDownload(provider=self.provider, config=dl_config)

--- a/tests/units/test_eoproduct.py
+++ b/tests/units/test_eoproduct.py
@@ -318,6 +318,42 @@ class TestEOProduct(EODagTestCase):
             os.remove(str(records_file))
             os.rmdir(str(download_records_dir))
 
+    def test_eoproduct_download_http_delete_archive(self):
+        """eoproduct.download must delete the downloaded archive"""  # noqa
+        # Setup
+        product = EOProduct(
+            self.provider, self.eoproduct_props, productType=self.product_type
+        )
+        self.requests_http_get.return_value = self._download_response_archive()
+        dl_config = config.PluginConfig.from_mapping(
+            {
+                "base_uri": "fake_base_uri",
+                "outputs_prefix": tempfile.gettempdir(),
+                "delete_archive": True,
+            }
+        )
+        downloader = HTTPDownload(provider=self.provider, config=dl_config)
+        product.register_downloader(downloader, None)
+
+        try:
+            # Download
+            product_dir_path = product.download()
+            product_dir_path = pathlib.Path(product_dir_path)
+            # Check that the mocked request was properly called.
+            self.requests_http_get.assert_called_with(
+                self.download_url, stream=True, auth=None, params={}
+            )
+            download_records_dir = product_dir_path.parent / ".downloaded"
+            # Check that the product's directory exists.
+            self.assertTrue(os.path.isdir(product_dir_path))
+            # Check that the ZIP file was deleted there
+            product_zip = product_dir_path.parent / (product_dir_path.name + ".zip")
+            self.assertFalse(os.path.exists(product_zip))
+        finally:
+            # Teardown
+            shutil.rmtree(product_dir_path)
+            shutil.rmtree(download_records_dir)
+
     def test_eoproduct_download_http_extract(self):
         """eoproduct.download over must be able to extract a product"""
         # Setup


### PR DESCRIPTION
Closes #144

Adds deletion of the product's archive after download. Also, the extraction of the product's archive is done inside of a temporary folder to avoid pollution of the download directory with incomplete products if extraction was canceled.

Also, fix some tests and add a test to check this new feature.