### PR TITLE
test: prevent failing actions for windows py3.9.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.9]
+        # skip 3.9.8 which fails on windows
+        python-version: [3.6, "3.9.9 - 3.9"]
         os: [ubuntu-latest, windows-latest]
     steps:
     - name: Checkout the repo

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -19,6 +19,7 @@
 import os
 import random
 import shutil
+import tempfile
 import unittest
 from collections import OrderedDict, namedtuple
 from io import StringIO
@@ -35,7 +36,7 @@ dirn = os.path.dirname
 
 TEST_RESOURCES_PATH = jp(dirn(__file__), "resources")
 RESOURCES_PATH = jp(dirn(__file__), "..", "eodag", "resources")
-TESTS_DOWNLOAD_PATH = "/tmp/eodag_tests"
+TESTS_DOWNLOAD_PATH = jp(tempfile.gettempdir(), "eodag_tests")
 
 
 class EODagTestCase(unittest.TestCase):


### PR DESCRIPTION
CI fails for `py3.9.8` on `windows-latest` (`pathlib` issue).

Skip this version for `py3.9.9` which is already available