### PR TITLE
Fixed url and search API endpoint for earth_search_cog

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1690,10 +1690,10 @@
   roles:
     - host
   description: Earth Search
-  url: https://www.element84.com/earth-search/
+  url: https://sentinel-cogs.s3.us-west-2.amazonaws.com
   search: !plugin
     type: StacSearch
-    api_endpoint: https://earth-search.aws.element84.com/v0/search
+    api_endpoint: https://sentinel-cogs.s3.us-west-2.amazonaws.com
     pagination:
       # Override the default next page url key path of StacSearch because the next link returned
       # by Earth Search is invalid (as of 2021/04/29). Entry set to null (None) to avoid using the


### PR DESCRIPTION
The previous url and search API for the `earth_search_cog` provider were the same as the `earth_search` provider. This produced a bug where the product are searched on the `earth_search` API, getting the wrong download urls as the `earth_search_cog` provider uses another API for downloading