### PR TITLE
fix: disable cloudCover for RADAR product types

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -306,6 +306,7 @@
       productType: GRD
       collection: sentinel1
       metadata_mapping:
+        cloudCover: '$.null'
         # OpenSearch Parameters for Collection Search (Table 3)
         platformSerialIdentifier:
           - '{{"search":{{"missionId":"{platformSerialIdentifier}" }} }}'
@@ -792,12 +793,18 @@
     S1_SAR_OCN:
       productType: OCN
       collection: S1
+      metadata_mapping:
+        cloudCover: '$.null'
     S1_SAR_GRD:
       productType: GRD
       collection: S1
+      metadata_mapping:
+        cloudCover: '$.null'
     S1_SAR_SLC:
       productType: SLC
       collection: S1
+      metadata_mapping:
+        cloudCover: '$.null'
     S2_MSI_L1C:
       collection: S2ST
       productType: S2MSI1C
@@ -835,12 +842,20 @@
       productType: S2MSI2A
     S1_SAR_RAW:
       productType: RAW
+      metadata_mapping:
+        cloudCover: '$.null'
     S1_SAR_GRD:
       productType: GRD
+      metadata_mapping:
+        cloudCover: '$.null'
     S1_SAR_SLC:
       productType: SLC
+      metadata_mapping:
+        cloudCover: '$.null'
     S1_SAR_OCN:
       productType: OCN
+      metadata_mapping:
+        cloudCover: '$.null'
     GENERIC_PRODUCT_TYPE:
       productType: '{productType}'
     # S3_LAN:
@@ -1111,27 +1126,43 @@
     S1_SAR_RAW:
       productType: RAW
       collection: Sentinel1
+      metadata_mapping:
+        cloudCover: '$.null'
     S1_SAR_GRD:
       productType: GRD
       collection: Sentinel1
+      metadata_mapping:
+        cloudCover: '$.null'
     S1_SAR_SLC:
       productType: SLC
       collection: Sentinel1
+      metadata_mapping:
+        cloudCover: '$.null'
     S1_SAR_OCN:
       productType: OCN
       collection: Sentinel1
+      metadata_mapping:
+        cloudCover: '$.null'
     S3_LAN:
       productType: LAN
       collection: Sentinel3
+      metadata_mapping:
+        cloudCover: '$.null'
     S3_SRA:
       productType: SRA
       collection: Sentinel3
+      metadata_mapping:
+        cloudCover: '$.null'
     S3_SRA_BS:
       productType: SRA_BS
       collection: Sentinel3
+      metadata_mapping:
+        cloudCover: '$.null'
     S3_SRA_A_BS:
       productType: SRA_A
       collection: Sentinel3
+      metadata_mapping:
+        cloudCover: '$.null'
     S3_EFR:
       productType: EFR
       collection: Sentinel3
@@ -1303,10 +1334,14 @@
       productType: GRD
       processingLevel: L1_
       collection: Sentinel1
+      metadata_mapping:
+        cloudCover: 'null/text()'
     S1_SAR_SLC:
       productType: SLC
       processingLevel: L1_
       collection: Sentinel1
+      metadata_mapping:
+        cloudCover: 'null/text()'
     S2_MSI_L1C:
       productType: IMAGE
       processingLevel: L1C
@@ -1422,12 +1457,20 @@
   products:
     S1_SAR_OCN:
       productType: '*OCN*'
+      metadata_mapping:
+        cloudCover: '$.null'
     S1_SAR_GRD:
       productType: '*GRD*'
+      metadata_mapping:
+        cloudCover: '$.null'
     S1_SAR_SLC:
       productType: '*SLC*'
+      metadata_mapping:
+        cloudCover: '$.null'
     S1_SAR_RAW:
       productType: '*RAW*'
+      metadata_mapping:
+        cloudCover: '$.null'
     S2_MSI_L1C:
       productType: S2MSI1C
     S2_MSI_L2A:
@@ -1446,14 +1489,24 @@
       productType: SL_2_LST___
     S3_LAN:
       productType: SR_2_LAN___
+      metadata_mapping:
+        cloudCover: '$.null'
     S3_SRA:
       productType: SR_1_SRA_A_
+      metadata_mapping:
+        cloudCover: '$.null'
     S3_SRA_BS:
       productType: SR_1_SRA_BS
+      metadata_mapping:
+        cloudCover: '$.null'
     S3_SRA_A_BS:
       productType: SR_1_SRA___
+      metadata_mapping:
+        cloudCover: '$.null'
     S3_WAT:
       productType: SR_2_WAT___
+      metadata_mapping:
+        cloudCover: '$.null'
     L8_OLI_TIRS_C1L1:
       platform: 'Landsat-*'
     GENERIC_PRODUCT_TYPE:
@@ -1522,6 +1575,7 @@
     S1_SAR_GRD:
       productType: sentinel1_l1c_grd
       metadata_mapping:
+        cloudCover: '$.null'
         platformSerialIdentifier: '$.id.`split(_, 0, -1)`'
         polarizationMode: '$.id.`sub(/.{14}([A-Z]{2}).*/, \\1)`'
         awsPath: '$.assets.productInfo.href.`sub(/(.*)\/productInfo\.json/, \\1)`'


### PR DESCRIPTION
fixes #369 , disable `cloudCover` for RADAR product types in providers configuration (S1 and S3 SRAL).

Even if `cloudCover` is used as query paramater for these product types, it will be ignored and not sent in the query.