### PR TITLE
fix: NotAvailableError using usgs api

### DIFF
--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -205,9 +205,20 @@ class UsgsApi(Download, Api):
                 product.properties["productType"], product.properties["id"], product_id
             )
             try:
-                req_urls.extend(
-                    [x["url"] for x in download_request["data"]["preparingDownloads"]]
-                )
+                if len(download_request["data"]["preparingDownloads"]) > 0:
+                    req_urls.extend(
+                        [
+                            x["url"]
+                            for x in download_request["data"]["preparingDownloads"]
+                        ]
+                    )
+                else:
+                    req_urls.extend(
+                        [
+                            x["url"]
+                            for x in download_request["data"]["availableDownloads"]
+                        ]
+                    )
             except KeyError as e:
                 raise NotAvailableError(
                     "%s not found in %s download_request"


### PR DESCRIPTION
Fixes an issue when downloading a product using usgs provider that raised:
```
eodag.utils.exceptions.NotAvailableError: No usgs request url was found for LC81680252017074LGN00
```
Solution:
In USGS API plugin, look for products in `download_request["data"]["availableDownloads"]` in addition of `download_request["data"]["preparingDownloads"]`.

