### PR TITLE
Fix download stall when connection is lost

### DIFF
--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -35,6 +35,7 @@ from eodag.plugins.apis.base import Api
 from eodag.plugins.download.base import (
     DEFAULT_DOWNLOAD_TIMEOUT,
     DEFAULT_DOWNLOAD_WAIT,
+    DEFAULT_STREAM_REQUESTS_TIMEOUT,
     Download,
 )
 from eodag.utils import (
@@ -240,6 +241,7 @@ class UsgsApi(Download, Api):
         with requests.get(
             req_url,
             stream=True,
+            timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
         ) as stream:
             try:
                 stream.raise_for_status()

--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -38,8 +38,9 @@ from eodag.utils.notebook import NotebookWidgets
 logger = logging.getLogger("eodag.plugins.download.base")
 
 # default wait times in minutes
-DEFAULT_DOWNLOAD_WAIT = 2
-DEFAULT_DOWNLOAD_TIMEOUT = 20
+DEFAULT_DOWNLOAD_WAIT = 2  # in minutes
+DEFAULT_DOWNLOAD_TIMEOUT = 20  # in minutes
+DEFAULT_STREAM_REQUESTS_TIMEOUT = 60  # in seconds
 
 
 class Download(PluginTopic):

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -31,6 +31,7 @@ from eodag.api.product.metadata_mapping import OFFLINE_STATUS, ONLINE_STATUS
 from eodag.plugins.download.base import (
     DEFAULT_DOWNLOAD_TIMEOUT,
     DEFAULT_DOWNLOAD_WAIT,
+    DEFAULT_STREAM_REQUESTS_TIMEOUT,
     Download,
 )
 from eodag.utils import ProgressCallback, path_to_uri
@@ -147,6 +148,7 @@ class HTTPDownload(Download):
                         stream=True,
                         auth=auth,
                         params=params,
+                        timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
                     ) as stream:
                         try:
                             stream.raise_for_status()
@@ -349,6 +351,7 @@ class HTTPDownload(Download):
                 stream=True,
                 auth=auth,
                 params=params,
+                timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
             ) as stream:
                 try:
                     stream.raise_for_status()

--- a/eodag/plugins/download/s3rest.py
+++ b/eodag/plugins/download/s3rest.py
@@ -28,6 +28,7 @@ from requests import HTTPError
 
 from eodag.api.product.metadata_mapping import OFFLINE_STATUS
 from eodag.plugins.download.aws import AwsDownload
+from eodag.plugins.download.base import DEFAULT_STREAM_REQUESTS_TIMEOUT
 from eodag.plugins.download.http import HTTPDownload
 from eodag.utils import ProgressCallback, path_to_uri, unquote, urljoin
 from eodag.utils.exceptions import (
@@ -198,7 +199,12 @@ class S3RestDownload(AwsDownload):
             if not os.path.isdir(local_filename_dir):
                 os.makedirs(local_filename_dir)
 
-            with requests.get(node_url, stream=True, auth=auth) as stream:
+            with requests.get(
+                node_url,
+                stream=True,
+                auth=auth,
+                timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
+            ) as stream:
                 try:
                     stream.raise_for_status()
                 except HTTPError:


### PR DESCRIPTION
Closes #375.

It appears that if there is any interruption to the network during the download, the stream hangs up, and the connection goes dead. However, the code seems to wait for more packets to arrive over the dead connection.

I've added a timeout to streamed requests, and once the timeout is reached after the last received package, the code raises an exception `requests.exceptions.ConnectionError`.

The issue [requests#1803](https://github.com/psf/requests/issues/1803) of the `requests` module confirms this.