### PR TITLE
fix: pin markupsafe for doc build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,9 @@ setup(
             "sphinx-book-theme >= 0.1.0",
             "sphinx-copybutton",
             "nbsphinx == 0.8.5",
+            # pined markup safe until fixed in sphinx or jinja
+            # see https://github.com/pallets/jinja/issues/1585
+            "markupsafe < 2.1.0",
         ],
     },
     entry_points={


### PR DESCRIPTION
Fixes issue when running `tox -e docs`:
```
ImportError: cannot import name 'soft_unicode' from 'markupsafe' 
```
eodag documentation build depends on `sphinx` which depends on `jinja2` using `markupsafe`.

Temporary fix is to pin `markupsafe < 2.1.0`, see https://github.com/pallets/jinja/issues/1585 , https://github.com/pallets/jinja/issues/1587