### PR TITLE
test: cli verbose level fix in tests 

### DIFF
--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -266,7 +266,7 @@ def format_metadata(search_param, *args, **kwargs):
         @staticmethod
         def convert_to_bounds_lists(input_geom):
             if isinstance(input_geom, MultiPolygon):
-                geoms = [geom for geom in input_geom]
+                geoms = [geom for geom in input_geom.geoms]
                 # sort with larger one at first (stac-browser only plots first one)
                 geoms.sort(key=lambda x: x.area, reverse=True)
                 return [list(x.bounds[0:4]) for x in geoms]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,7 @@ from tests.context import (
     download,
     eodag,
     search_crunch,
+    setup_logging,
 )
 from tests.units.test_core import TestCore
 from tests.utils import mock, no_blanks
@@ -52,8 +53,14 @@ class TestEodagCli(unittest.TestCase):
             yield conf_file
 
     def setUp(self):
+        super(TestEodagCli, self).setUp()
         self.runner = CliRunner()
         self.faker = Faker()
+
+    def tearDown(self):
+        super(TestEodagCli, self).tearDown()
+        # Default logging: no logging but still displays progress bars
+        setup_logging(1)
 
     def test_eodag_without_args(self):
         """Calling eodag without arguments should print help message"""

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -402,7 +402,7 @@ class TestCoreGeometry(unittest.TestCase):
             locations_config, locations=dict(country="FRA")
         )
         self.assertIsInstance(geom_france, MultiPolygon)
-        self.assertEqual(len(geom_france), 3)  # France + Guyana + Corsica
+        self.assertEqual(len(geom_france.geoms), 3)  # France + Guyana + Corsica
 
     def test_get_geometry_from_various_locations_with_wrong_location_name_in_kwargs(
         self,
@@ -437,7 +437,7 @@ class TestCoreGeometry(unittest.TestCase):
             locations_config, locations=dict(country="PA[A-Z]")
         )
         self.assertIsInstance(geom_regex_pa, MultiPolygon)
-        self.assertEqual(len(geom_regex_pa), 2)
+        self.assertEqual(len(geom_regex_pa.geoms), 2)
 
     def test_get_geometry_from_various_locations_no_match_raises_error(self):
         """If the location search doesn't match any of the feature attribute a ValueError must be raised"""
@@ -461,7 +461,7 @@ class TestCoreGeometry(unittest.TestCase):
         )
         self.assertIsInstance(geom_combined, MultiPolygon)
         # France + Guyana + Corsica + somewhere over Poland
-        self.assertEqual(len(geom_combined), 4)
+        self.assertEqual(len(geom_combined.geoms), 4)
         geometry = {
             "lonmin": 0,
             "latmin": 50,
@@ -473,7 +473,7 @@ class TestCoreGeometry(unittest.TestCase):
         )
         self.assertIsInstance(geom_combined, MultiPolygon)
         # The bounding box overlaps with France inland
-        self.assertEqual(len(geom_combined), 3)
+        self.assertEqual(len(geom_combined.geoms), 3)
 
 
 class TestCoreSearch(unittest.TestCase):

--- a/tests/units/test_safe_build.py
+++ b/tests/units/test_safe_build.py
@@ -84,7 +84,7 @@ class TestSafeBuild(unittest.TestCase):
 
         with self.assertLogs(self.logger, logging.WARN) as cm:
             # assertLogs fails if no warning is raised
-            self.logger.warn("Dummy warning")
+            self.logger.warning("Dummy warning")
             self.awsd.check_manifest_file_list(product_path)
 
         self.assertEqual(len(cm.output), 1)
@@ -128,7 +128,7 @@ class TestSafeBuild(unittest.TestCase):
 
         with self.assertLogs(self.logger, logging.WARN) as cm:
             # assertLogs fails if no warning is raised
-            self.logger.warn("Dummy warning")
+            self.logger.warning("Dummy warning")
             self.awsd.check_manifest_file_list(product_path)
 
         self.assertEqual(len(cm.output), 1)
@@ -172,7 +172,7 @@ class TestSafeBuild(unittest.TestCase):
 
         with self.assertLogs(self.logger, logging.WARN) as cm:
             # assertLogs fails if no warning is raised
-            self.logger.warn("Dummy warning")
+            self.logger.warning("Dummy warning")
             self.awsd.check_manifest_file_list(product_path)
 
         self.assertEqual(len(cm.output), 2)


### PR DESCRIPTION
Fixes cli verbose level in tests which kept progress bars disabled in further tests. 
These errors occurred when runing `pytest`:
```
========================================================= short test summary info ======================================================================
FAILED tests/units/test_utils.py::TestUtils::test_progresscallback_copy - AttributeError: 'ProgressCallback' object has no attribute 'unit'
FAILED tests/units/test_utils.py::TestUtils::test_progresscallback_disable - AssertionError: '50%' not found in ''
FAILED tests/units/test_utils.py::TestUtils::test_progresscallback_init - AttributeError: 'ProgressCallback' object has no attribute 'unit'
FAILED tests/units/test_utils.py::TestUtils::test_progresscallback_init_customize - AttributeError: 'ProgressCallback' object has no attribute 'unit'
```
And also fixes some deprecation warnings.