### PR TITLE
fix: creodias archive_depth and e2e complete test

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -1396,8 +1396,8 @@ class EODataAccessGateway(object):
         :param timeout: (optional) If download fails, maximum time in minutes
                         before stop retrying to download
         :type timeout: int
-        :param kwargs: `outputs_prefix` (str), `extract` (bool) and
-                        `dl_url_params` (dict) can be provided as additional kwargs
+        :param kwargs: `outputs_prefix` (str), `extract` (bool), `delete_archive` (bool)
+                        and `dl_url_params` (dict) can be provided as additional kwargs
                         and will override any other values defined in a configuration
                         file or with environment variables.
         :type kwargs: dict

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1107,6 +1107,7 @@
     base_uri: 'https://zipper.creodias.eu/download/'
     extract: true
     order_enabled: false
+    archive_depth: 2
   auth: !plugin
     type: KeycloakOIDCPasswordAuth
     auth_base_uri: 'https://auth.creodias.eu/auth'
@@ -1657,12 +1658,6 @@
       # about 500 products.
       max_items_per_page: 500
     metadata_mapping:
-      cloudCover:
-        - '{{"query":{{"eo:cloud_cover":{{"lte":{cloudCover}}}}}}}'
-        - '$.properties."eo:cloud_cover"'
-      platformSerialIdentifier:
-        - '{{"query":{{"platform":{{"eq":"{platformSerialIdentifier}"}}}}}}'
-        - '$.properties.platform'
       assets: '{$.assets#recursive_sub_str(r"https?(.*)landsatlook.usgs.gov/data/",r"s3\1usgs-landsat/")}'
       awsProductId: '{$.assets.thumbnail.href#replace_str(r".+/([A-Z0-9_]+)/[\w.]+$",r"\1")}'
   products:

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -372,6 +372,7 @@ class TestEODagEndToEnd(EndToEndBase):
         expected_filename = "{}.zip".format(product.properties["title"])
         self.execute_download(product, expected_filename)
 
+    # @unittest.skip("expired aws_eos api key")
     def test_end_to_end_search_download_aws_eos(self):
         product = self.execute_search(*AWSEOS_SEARCH_ARGS)
         expected_filename = "{}".format(product.properties["title"])
@@ -442,6 +443,7 @@ class TestEODagEndToEnd(EndToEndBase):
         self.assertGreater(len(results), 10)
 
 
+# @unittest.skip("skip auto run")
 class TestEODagEndToEndComplete(unittest.TestCase):
     """Make real and complete test cases that search for products, download them and
     extract them. There should be just a tiny number of these tests which can be quite
@@ -587,7 +589,9 @@ class TestEODagEndToEndComplete(unittest.TestCase):
         # download it, if its location points to the remote location.
         # The product should be automatically extracted.
         product.location = product.remote_location
-        product_dir_path = self.eodag.download(product, extract=True)
+        product_dir_path = self.eodag.download(
+            product, extract=True, delete_archive=False
+        )
 
         # Its size should be >= 5 KB
         downloaded_size = sum(
@@ -679,6 +683,7 @@ class TestEODagEndToEndWrongCredentials(EndToEndBase):
                 ),
             )
 
+    # @unittest.skip("expired aws_eos api key")
     def test_end_to_end_good_apikey_wrong_credentials_aws_eos(self):
         # Setup
         # We retrieve correct credentials from the user_conf.yml file


### PR DESCRIPTION
- fixes `archive_depth` setting for `creodias`
- fixes `delete_archive` setting in `test_end_to_end_complete_peps()`