### PR TITLE
test: use tmp eodag conf dir

### DIFF
--- a/tests/integration/test_config_ext_plugin.py
+++ b/tests/integration/test_config_ext_plugin.py
@@ -16,17 +16,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import shutil
+import tempfile
 import unittest
 
 import pkg_resources
 
 from tests import TEST_RESOURCES_PATH
 from tests.context import EODataAccessGateway
+from tests.utils import mock
 
 
 class TestExternalPluginConfig(unittest.TestCase):
     def setUp(self):
         super(TestExternalPluginConfig, self).setUp()
+        # Mock home and eodag conf directory to tmp dir
+        self.tmp_home_dir = tempfile.mkdtemp()
+        self.expanduser_mock = mock.patch(
+            "os.path.expanduser", autospec=True, return_value=self.tmp_home_dir
+        )
+        self.expanduser_mock.start()
+
         self.dag = EODataAccessGateway()
 
     def tearDown(self):
@@ -38,6 +48,13 @@ class TestExternalPluginConfig(unittest.TestCase):
         distpath = pkg_resources.working_set.by_key.pop("eodag-fakeplugin").location
         pkg_resources.working_set.entry_keys.pop(distpath)
         pkg_resources.working_set.entries.remove(distpath)
+
+        # stop Mock and remove tmp config dir
+        self.expanduser_mock.stop()
+        try:
+            shutil.rmtree(self.tmp_home_dir)
+        except OSError:
+            pass
 
     def test_update_providers_from_ext_plugin(self):
         """Load fake external plugin and check if it updates providers config"""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,7 +37,7 @@ from tests.context import (
     search_crunch,
     setup_logging,
 )
-from tests.units.test_core import TestCore
+from tests.units import test_core
 from tests.utils import mock, no_blanks
 
 
@@ -376,7 +376,7 @@ class TestEodagCli(unittest.TestCase):
         """Calling eodag list without provider return all supported product types"""
         all_supported_product_types = [
             pt
-            for pt, provs in TestCore.SUPPORTED_PRODUCT_TYPES.items()
+            for pt, provs in test_core.TestCore.SUPPORTED_PRODUCT_TYPES.items()
             if len(provs) != 0 and pt != GENERIC_PRODUCT_TYPE
         ]
         result = self.runner.invoke(eodag, ["list"])
@@ -386,10 +386,10 @@ class TestEodagCli(unittest.TestCase):
 
     def test_eodag_list_product_type_with_provider_ok(self):
         """Calling eodag list with provider should return all supported product types of specified provider"""  # noqa
-        provider = random.choice(TestCore.SUPPORTED_PROVIDERS)
+        provider = random.choice(test_core.TestCore.SUPPORTED_PROVIDERS)
         provider_supported_product_types = [
             pt
-            for pt, provs in TestCore.SUPPORTED_PRODUCT_TYPES.items()
+            for pt, provs in test_core.TestCore.SUPPORTED_PRODUCT_TYPES.items()
             if provider in provs
             if pt != GENERIC_PRODUCT_TYPE
         ]
@@ -406,7 +406,7 @@ class TestEodagCli(unittest.TestCase):
         self.assertIn("Unsupported provider. You may have a typo", result.output)
         self.assertIn(
             "Available providers: {}".format(
-                ", ".join(sorted(TestCore.SUPPORTED_PROVIDERS))
+                ", ".join(sorted(test_core.TestCore.SUPPORTED_PROVIDERS))
             ),
             result.output,
         )


### PR DESCRIPTION
Use tmp dir as mocked home directory during tests. 

This will prevent conflicts with existing eodag configuration, or between tests running in parallel.