### PR TITLE
ci: cov reports only for PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,7 @@ jobs:
         files: artifacts/**/*junit-report.xml
     - name: Publish Coverage Report
       uses: 5monkeys/cobertura-action@master
+      if: ${{ github.event_name == 'pull_request' }}
       with:
         path: artifacts/**/*coverage.xml
         repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Triggers coverage reports publish GH action only for pull requests events (by default on opened, synchronize, or reopened, see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)