### PR TITLE
fix: update black and adapts json data handling to flask 2.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     -   id: flake8
 
 -   repo: 'https://github.com/ambv/black'
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     -   id: black
         args: ['--safe']

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -353,13 +353,16 @@ def format_metadata(search_param, *args, **kwargs):
             id_match = id_regex.match(string)
             if id_match:
                 id_dict = id_match.groupdict()
-                return "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/%s/%s/%s/%s/%s/%s/0/{collection}.json" % (
-                    id_dict["tile1"],
-                    id_dict["tile2"],
-                    id_dict["tile3"],
-                    id_dict["year"],
-                    int(id_dict["month"]),
-                    int(id_dict["day"]),
+                return (
+                    "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/%s/%s/%s/%s/%s/%s/0/{collection}.json"
+                    % (
+                        id_dict["tile1"],
+                        id_dict["tile2"],
+                        id_dict["tile3"],
+                        id_dict["year"],
+                        int(id_dict["month"]),
+                        int(id_dict["day"]),
+                    )
                 )
             else:
                 logger.error("Could not extract title infos from %s" % string)

--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -393,8 +393,8 @@ def stac_collections_items(collection_id):
 def stac_search():
     """STAC collections items"""
 
-    if request.get_json():
-        arguments = dict(request.args.to_dict(), **request.get_json())
+    if request.get_json(silent=True, force=True):
+        arguments = dict(request.args.to_dict(), **request.get_json(force=True))
     else:
         arguments = request.args.to_dict()
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -317,7 +317,7 @@ class TestEODagEndToEnd(EndToEndBase):
         else:
             downloaded_size = os.stat(self.downloaded_file_path).st_size
         # The partially downloaded file should be greater or equal to 5 KB
-        self.assertGreaterEqual(downloaded_size, 5 * 2 ** 10)
+        self.assertGreaterEqual(downloaded_size, 5 * 2**10)
 
     def test_end_to_end_search_download_usgs(self):
         product = self.execute_search(*USGS_SEARCH_ARGS)
@@ -413,7 +413,7 @@ class TestEODagEndToEnd(EndToEndBase):
             os.path.dirname(quicklook_file_path),
             os.path.join(product.downloader.config.outputs_prefix, "quicklooks"),
         )
-        self.assertGreaterEqual(os.stat(quicklook_file_path).st_size, 2 ** 5)
+        self.assertGreaterEqual(os.stat(quicklook_file_path).st_size, 2**5)
 
     def test__search_by_id_sobloo(self):
         # A single test with sobloo to check that _search_by_id returns
@@ -535,7 +535,7 @@ class TestEODagEndToEndComplete(unittest.TestCase):
         )
         # Its size should be >= 5 KB
         archive_size = os.stat(archive_file_path).st_size
-        self.assertGreaterEqual(archive_size, 5 * 2 ** 10)
+        self.assertGreaterEqual(archive_size, 5 * 2**10)
         # The product remote_location should be the same
         self.assertEqual(prev_remote_location, product.remote_location)
         # However its location should have been update
@@ -597,7 +597,7 @@ class TestEODagEndToEndComplete(unittest.TestCase):
         downloaded_size = sum(
             f.stat().st_size for f in Path(product_dir_path).glob("**/*") if f.is_file()
         )
-        self.assertGreaterEqual(downloaded_size, 5 * 2 ** 10)
+        self.assertGreaterEqual(downloaded_size, 5 * 2**10)
         # The product remote_location should be the same
         self.assertEqual(prev_remote_location, product.remote_location)
         # However its location should have been update

--- a/tests/units/test_eoproduct.py
+++ b/tests/units/test_eoproduct.py
@@ -234,7 +234,7 @@ class TestEOProduct(EODagTestCase):
             """Emulation of a response to requests.get method for a quicklook"""
 
             def __init__(response):
-                response.headers = {"content-length": 2 ** 5}
+                response.headers = {"content-length": 2**5}
 
             def __enter__(response):
                 return response
@@ -244,7 +244,7 @@ class TestEOProduct(EODagTestCase):
 
             @staticmethod
             def iter_content(**kwargs):
-                with io.BytesIO(b"a" * 2 ** 5) as fh:
+                with io.BytesIO(b"a" * 2**5) as fh:
                     while True:
                         chunk = fh.read(kwargs["chunk_size"])
                         if not chunk:


### PR DESCRIPTION
- Updates pinned black version in pre-commit, fixes conflict with click v8.1.0:
```
ImportError: cannot import name '_unicodefun' from 'click'
```
See https://github.com/psf/black/issues/2964
- [`get_json()`](https://flask.palletsprojects.com/en/2.1.x/api/#flask.Request.get_json) method usage before content type is defined. Fixes error introduced with Flask v2.1.0:
```
werkzeug.exceptions.BadRequest: 400 Bad Request: Did not attempt to load JSON data because the request Content-Type was not 'application/json'.
```