### PR TITLE
Fix type hint of kwargs

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -525,7 +525,7 @@ class EODataAccessGateway(object):
         :type locations: dict
         :param kwargs: Some other criteria that will be used to do the search,
                        using paramaters compatibles with the provider
-        :type kwargs: dict
+        :type kwargs: Union[int, str, bool, dict]
         :returns: A collection of EO products matching the criteria and the total
                   number of results found
         :rtype: tuple(:class:`~eodag.api.search_result.SearchResult`, int)
@@ -590,7 +590,7 @@ class EODataAccessGateway(object):
         :type locations: dict
         :param kwargs: Some other criteria that will be used to do the search,
                        using paramaters compatibles with the provider
-        :type kwargs: dict
+        :type kwargs: Union[int, str, bool, dict]
         :returns: An iterator that yields page per page a collection of EO products
                   matching the criteria
         :rtype: Iterator[:class:`~eodag.api.search_result.SearchResult`]
@@ -740,7 +740,7 @@ class EODataAccessGateway(object):
         :type locations: dict
         :param kwargs: Some other criteria that will be used to do the search,
                        using paramaters compatibles with the provider
-        :type kwargs: dict
+        :type kwargs: Union[int, str, bool, dict]
         :returns: An iterator that yields page per page a collection of EO products
                   matching the criteria
         :rtype: Iterator[:class:`~eodag.api.search_result.SearchResult`]
@@ -803,7 +803,7 @@ class EODataAccessGateway(object):
                          knows this product is available on the given provider
         :type provider: str
         :param kwargs: Search criteria to help finding the right product
-        :type kwargs: dict
+        :type kwargs: Any
         :returns: A search result with one EO product or None at all, and the number
                   of EO products retrieved (0 or 1)
         :rtype: tuple(:class:`~eodag.api.search_result.SearchResult`, int)
@@ -864,7 +864,7 @@ class EODataAccessGateway(object):
                        * id and/or a provider for a search by
                        * search criteria to guess the product type
                        * other criteria compatible with the provider
-        :type kwargs: dict
+        :type kwargs: Any
         :returns: The prepared kwargs to make a query.
         :rtype: dict
         """
@@ -978,7 +978,7 @@ class EODataAccessGateway(object):
                              True, the error is raised
         :type raise_errors: bool
         :param kwargs: Some other criteria that will be used to do the search
-        :type kwargs: dict
+        :type kwargs: Any
         :returns: A collection of EO products matching the criteria and the total
                   number of results found if count is True else None
         :rtype: tuple(:class:`~eodag.api.search_result.SearchResult`, int or None)
@@ -1201,11 +1201,11 @@ class EODataAccessGateway(object):
         :param timeout: (optional) If download fails, maximum time in minutes
                         before stop retrying to download
         :type timeout: int
-        :param kwargs: `outputs_prefix` (str), `extract` (bool) and
-                        `dl_url_params` (dict) can be provided here and will
-                        override any other values defined in a configuration file
-                        or with environment variables.
-        :type kwargs: dict
+        :param kwargs: `outputs_prefix` (str), `extract` (bool), `delete_archive` (bool)
+                        and `dl_url_params` (dict) can be provided as additional kwargs
+                        and will override any other values defined in a configuration
+                        file or with environment variables.
+        :type kwargs: Union[str, bool, dict]
         :returns: A collection of the absolute paths to the downloaded products
         :rtype: list
         """
@@ -1308,7 +1308,7 @@ class EODataAccessGateway(object):
         :type timeout: float
         :param kwargs: Parameters that will be stored in the result as
                        search criteria
-        :type kwargs: dict
+        :type kwargs: Any
         :returns: The search results encoded in `filename`
         :rtype: :class:`~eodag.api.search_result.SearchResult`
 
@@ -1400,7 +1400,7 @@ class EODataAccessGateway(object):
                         and `dl_url_params` (dict) can be provided as additional kwargs
                         and will override any other values defined in a configuration
                         file or with environment variables.
-        :type kwargs: dict
+        :type kwargs: Union[str, bool, dict]
         :returns: The absolute path to the downloaded product in the local filesystem
         :rtype: str
         :raises: :class:`~eodag.utils.exceptions.PluginImplementationError`

--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -62,7 +62,7 @@ class EOProduct(object):
     :ivar remote_location: The remote path to the product
     :vartype remote_location: str
     :ivar search_kwargs: The search kwargs used by eodag to search for the product
-    :vartype search_kwargs: dict
+    :vartype search_kwargs: Any
     :ivar geometry: The geometry of the product
     :vartype geometry: :class:`shapely.geometry.base.BaseGeometry`
     :ivar search_intersection: The intersection between the product's geometry
@@ -247,11 +247,11 @@ class EOProduct(object):
         :param timeout: (optional) If download fails, maximum time in minutes
                         before stop retrying to download
         :type timeout: int
-        :param kwargs: `outputs_prefix` (str), `extract` (bool) and
-                        `dl_url_params` (dict) can be provided as additional kwargs
+        :param kwargs: `outputs_prefix` (str), `extract` (bool), `delete_archive` (bool)
+                        and `dl_url_params` (dict) can be provided as additional kwargs
                         and will override any other values defined in a configuration
                         file or with environment variables.
-        :type kwargs: dict
+        :type kwargs: Union[str, bool, dict]
         :returns: The absolute path to the downloaded product on the local filesystem
         :rtype: str
         :raises: :class:`~eodag.utils.exceptions.PluginImplementationError`

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -145,7 +145,7 @@ def format_metadata(search_param, *args, **kwargs):
     :param args: (optional) Additional arguments to use in the formatting process
     :type args: tuple
     :param kwargs: (optional) Additional named-arguments to use when formatting
-    :type kwargs: dict
+    :type kwargs: Any
     :returns: The formatted string
     :rtype: str
     """

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -90,7 +90,7 @@ class ProviderConfig(yaml.YAMLObject):
     :param auth: (optional) The configuration of a plugin of type Authentication
     :type auth: :class:`~eodag.config.PluginConfig`
     :param kwargs: Additional configuration variables for this provider
-    :type kwargs: dict
+    :type kwargs: Any
     """
 
     yaml_loader = yaml.Loader

--- a/eodag/plugins/apis/base.py
+++ b/eodag/plugins/apis/base.py
@@ -87,11 +87,11 @@ class Api(PluginTopic):
         :param timeout: (optional) If download fails, maximum time in minutes before stop retrying
                         to download
         :type timeout: int
-        :param kwargs: ``outputs_prefix` (``str``), `extract` (``bool``) and
-                       ``dl_url_params`` (``dict``) can be provided as additional kwargs and will
-                       override any other values defined in a configuration file or with
-                       environment variables.
-        :type kwargs: dict
+        :param kwargs: `outputs_prefix` (str), `extract` (bool), `delete_archive` (bool)
+                        and `dl_url_params` (dict) can be provided as additional kwargs
+                        and will override any other values defined in a configuration
+                        file or with environment variables.
+        :type kwargs: Union[str, bool, dict]
         :returns: The absolute path to the downloaded product in the local filesystem
             (e.g. '/tmp/product.zip' on Linux or
             'C:\\Users\\username\\AppData\\Local\\Temp\\product.zip' on Windows)
@@ -132,11 +132,11 @@ class Api(PluginTopic):
         :param timeout: (optional) If download fails, maximum time in minutes before stop retrying
                         to download
         :type timeout: int
-        :param kwargs: ``outputs_prefix` (``str``), `extract` (``bool``) and
-                       ``dl_url_params`` (``dict``) can be provided as additional kwargs and will
-                       override any other values defined in a configuration file or with
-                       environment variables.
-        :type kwargs: dict
+        :param kwargs: `outputs_prefix` (str), `extract` (bool), `delete_archive` (bool)
+                        and `dl_url_params` (dict) can be provided as additional kwargs
+                        and will override any other values defined in a configuration
+                        file or with environment variables.
+        :type kwargs: Union[str, bool, dict]
         :returns: List of absolute paths to the downloaded products in the local
             filesystem (e.g. ``['/tmp/product.zip']`` on Linux or
             ``['C:\\Users\\username\\AppData\\Local\\Temp\\product.zip']`` on Windows)

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -183,6 +183,11 @@ class AwsDownload(Download):
                                   creation and update to give the user a
                                   feedback on the download progress
         :type progress_callback: :class:`~eodag.utils.ProgressCallback` or None
+        :param kwargs: `outputs_prefix` (str), `extract` (bool), `delete_archive` (bool)
+                        and `dl_url_params` (dict) can be provided as additional kwargs
+                        and will override any other values defined in a configuration
+                        file or with environment variables.
+        :type kwargs: Union[str, bool, dict]
         :returns: The absolute path to the downloaded product in the local filesystem
         :rtype: str
         """

--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -106,11 +106,11 @@ class Download(PluginTopic):
         :param timeout: (optional) If download fails, maximum time in minutes before stop retrying
                         to download
         :type timeout: int
-        :param kwargs: ``outputs_prefix` (``str``), `extract` (``bool``) and
-                       ``dl_url_params`` (``dict``) can be provided as additional kwargs and will
-                       override any other values defined in a configuration file or with
-                       environment variables.
-        :type kwargs: dict
+        :param kwargs: `outputs_prefix` (str), `extract` (bool), `delete_archive` (bool)
+                        and `dl_url_params` (dict) can be provided as additional kwargs
+                        and will override any other values defined in a configuration
+                        file or with environment variables.
+        :type kwargs: Union[str, bool, dict]
         :returns: The absolute path to the downloaded product in the local filesystem
             (e.g. '/tmp/product.zip' on Linux or
             'C:\\Users\\username\\AppData\\Local\\Temp\\product.zip' on Windows)
@@ -401,11 +401,11 @@ class Download(PluginTopic):
         :param timeout: (optional) If download fails, maximum time in minutes before stop retrying
                         to download
         :type timeout: int
-        :param kwargs: ``outputs_prefix` (``str``), `extract` (``bool``) and
-                       ``dl_url_params`` (``dict``) can be provided as additional kwargs and will
-                       override any other values defined in a configuration file or with
-                       environment variables.
-        :type kwargs: dict
+        :param kwargs: `outputs_prefix` (str), `extract` (bool), `delete_archive` (bool)
+                        and `dl_url_params` (dict) can be provided as additional kwargs
+                        and will override any other values defined in a configuration
+                        file or with environment variables.
+        :type kwargs: Union[str, bool, dict]
         :returns: List of absolute paths to the downloaded products in the local
             filesystem (e.g. ``['/tmp/product.zip']`` on Linux or
             ``['C:\\Users\\username\\AppData\\Local\\Temp\\product.zip']`` on Windows)

--- a/eodag/plugins/download/s3rest.py
+++ b/eodag/plugins/download/s3rest.py
@@ -62,6 +62,11 @@ class S3RestDownload(AwsDownload):
                                   creation and update to give the user a
                                   feedback on the download progress
         :type progress_callback: :class:`~eodag.utils.ProgressCallback` or None
+        :param kwargs: `outputs_prefix` (str), `extract` (bool), `delete_archive` (bool)
+                        and `dl_url_params` (dict) can be provided as additional kwargs
+                        and will override any other values defined in a configuration
+                        file or with environment variables.
+        :type kwargs: Union[str, bool, dict]
         :returns: The absolute path to the downloaded product in the local filesystem
         :rtype: str
         """

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -132,7 +132,7 @@ class StacCommon(object):
         :param extension: Extension name
         :type extension: str
         :param kwargs: Additional variables needed for parsing extension
-        :type kwargs: dict
+        :type kwargs: Any
         :returns: STAC extension as dictionnary
         :rtype: dict
         """


### PR DESCRIPTION
Close #385 

The type hints used for `**kwargs` arguments were not following [PEP 484](https://peps.python.org/pep-0484/#arbitrary-argument-lists-and-default-argument-values)
The type hint for `**kwargs` must document the type of the values, so if `kwargs` is of type `dict[str, int]` its type hint must be just `int`. Because **kwargs** will always be `dict[str, X]`, only X, the values types, must be given. This is why default value is `Any`, meaning `dict[str, Any]`