### PR TITLE
feat: prune providers without credentials needing auth for search

### DIFF
--- a/docs/_static/params_mapping_extra.csv
+++ b/docs/_static/params_mapping_extra.csv
@@ -1,30 +1,30 @@
-parameter,astraea_eod,aws_eos,creodias,earth_search,earth_search_cog,mundi,onda,peps,sobloo,theia,usgs,usgs_satapi_aws
-assets,metadata only,,,metadata only,metadata only,,,,,,,metadata only
-awsProductId,,,,,,,,,,,,metadata only
-cultivatedCover,,,:green:`queryable metadata`,,,,,,,,,
-desertCover,,,:green:`queryable metadata`,,,,,,,,,
-downloadLink,metadata only,,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,,metadata only
-floodedCover,,,:green:`queryable metadata`,,,,,,,,,
-forestCover,,,:green:`queryable metadata`,,,,,,,,,
-geometry,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,,:green:`queryable metadata`
-herbaceousCover,,,:green:`queryable metadata`,,,,,,,,,
-iceCover,,,:green:`queryable metadata`,,,,,,,,,
-id,:green:`queryable metadata`,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,:green:`queryable metadata`
-orderLink,,,,,,,metadata only,,,,,
-polarizationChannels,metadata only,,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,metadata only,,metadata only,metadata only,,:green:`queryable metadata`
-polarizationMode,,,,,metadata only,metadata only,,:green:`queryable metadata`,,metadata only,,
-processingBaseline,,,:green:`queryable metadata`,,,,,,,,,
-publishedAfter,,,:green:`queryable metadata`,,,,,,,,,
-publishedBefore,,,:green:`queryable metadata`,,,,,,,,,
-quicklook,metadata only,,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,,metadata only
-relativeOrbitNumber,,,:green:`queryable metadata`,,,,,,,,,
-sortOrder,,,:green:`queryable metadata`,,,,,,,,,
-sortParam,,,:green:`queryable metadata`,,,,,,,,,
-specification,,,,,,metadata only,,,,,,
-status,,,:green:`queryable metadata`,,,,,,,,,
-storageStatus,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,,metadata only
-thumbnail,metadata only,,metadata only,metadata only,metadata only,metadata only,,metadata only,,metadata only,,metadata only
-timeliness,,,:green:`queryable metadata`,,,,,,,,,
-uid,,,metadata only,,,metadata only,metadata only,metadata only,metadata only,metadata only,,
-urbanCover,,,:green:`queryable metadata`,,,,,,,,,
-waterCover,,,:green:`queryable metadata`,,,,,,,,,
+parameter,astraea_eod,creodias,earth_search,earth_search_cog,mundi,onda,peps,sobloo,theia,usgs_satapi_aws
+assets,metadata only,,metadata only,metadata only,,,,,,metadata only
+awsProductId,,,,,,,,,,metadata only
+cultivatedCover,,:green:`queryable metadata`,,,,,,,,
+desertCover,,:green:`queryable metadata`,,,,,,,,
+downloadLink,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only
+floodedCover,,:green:`queryable metadata`,,,,,,,,
+forestCover,,:green:`queryable metadata`,,,,,,,,
+geometry,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`
+herbaceousCover,,:green:`queryable metadata`,,,,,,,,
+iceCover,,:green:`queryable metadata`,,,,,,,,
+id,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,:green:`queryable metadata`
+orderLink,,,,,,metadata only,,,,
+polarizationChannels,metadata only,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,metadata only,,metadata only,metadata only,:green:`queryable metadata`
+polarizationMode,,,,metadata only,metadata only,,:green:`queryable metadata`,,metadata only,
+processingBaseline,,:green:`queryable metadata`,,,,,,,,
+publishedAfter,,:green:`queryable metadata`,,,,,,,,
+publishedBefore,,:green:`queryable metadata`,,,,,,,,
+quicklook,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only
+relativeOrbitNumber,,:green:`queryable metadata`,,,,,,,,
+sortOrder,,:green:`queryable metadata`,,,,,,,,
+sortParam,,:green:`queryable metadata`,,,,,,,,
+specification,,,,,metadata only,,,,,
+status,,:green:`queryable metadata`,,,,,,,,
+storageStatus,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only
+thumbnail,metadata only,metadata only,metadata only,metadata only,metadata only,,metadata only,,metadata only,metadata only
+timeliness,,:green:`queryable metadata`,,,,,,,,
+uid,,metadata only,,,metadata only,metadata only,metadata only,metadata only,metadata only,
+urbanCover,,:green:`queryable metadata`,,,,,,,,
+waterCover,,:green:`queryable metadata`,,,,,,,,

--- a/docs/_static/params_mapping_opensearch.csv
+++ b/docs/_static/params_mapping_opensearch.csv
@@ -1,63 +1,63 @@
-parameter,astraea_eod,aws_eos,creodias,earth_search,earth_search_cog,mundi,onda,peps,sobloo,theia,usgs,usgs_satapi_aws
-:abbr:`abstract ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] Abstract. (String))`,metadata only,,metadata only,metadata only,metadata only,metadata only,,metadata only,,,,metadata only
-":abbr:`accessConstraint ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] Applied to assure the protection of privacy or intellectual property, and any special restrictions or limitations on obtaining the resource (String ))`",,,metadata only,,,metadata only,,metadata only,,metadata only,,
-acquisitionStation,metadata only,,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,,,metadata only,,:green:`queryable metadata`
-acquisitionSubType,metadata only,,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,,,metadata only,,:green:`queryable metadata`
-acquisitionType,,,,,,metadata only,,metadata only,,,,
-antennaLookDirection,,,,,,metadata only,,,,metadata only,,
-archivingCenter,,,,,,metadata only,,,,metadata only,,
-availabilityTime,metadata only,,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,,metadata only,metadata only,,:green:`queryable metadata`
-:abbr:`classification ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] Name of the handling restrictions on the resource or metadata (String ))`,,,,,,metadata only,,,,,,
-cloudCover,metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,,:green:`queryable metadata`
-completionTimeFromAscendingNode,:green:`queryable metadata`,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,,:green:`queryable metadata`
-:abbr:`compositeType ([OpenSearch Parameters for Collection Search] Type of composite product expressed as time period that the composite product covers (e.g. P10D for a 10 day composite) (String))`,,,,,,metadata only,,,,,,
-creationDate,metadata only,,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,metadata only,metadata only,metadata only,metadata only,,:green:`queryable metadata`
-":abbr:`dissemination ([OpenSearch Parameters for Collection Search] A string identifying the dissemination method (e.g. EUMETCast, EUMETCast-Europe, DataCentre) (String))`",,,,,,metadata only,,,,,,
-:abbr:`doi ([OpenSearch Parameters for Collection Search] Digital Object Identifier identifying the product (see http://www.doi.org) (String))`,metadata only,,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,,,,,:green:`queryable metadata`
-dopplerFrequency,metadata only,,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,,,metadata only,,:green:`queryable metadata`
-frame,,,,,,metadata only,,,,,,
-":abbr:`hasSecurityConstraints ([OpenSearch Parameters for Collection Search] A string informing if the resource has any security constraints. Possible values: TRUE, FALSE (String))`",,,,,,metadata only,,,,,,
-highestLocation,,,,,,metadata only,,,,,,
-illuminationAzimuthAngle,metadata only,,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,,,metadata only,,:green:`queryable metadata`
-illuminationElevationAngle,metadata only,,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,,,metadata only,,:green:`queryable metadata`
-illuminationZenithAngle,,,,,,metadata only,,,,metadata only,,
-incidenceAngleVariation,,,,,,metadata only,,,,metadata only,,
-":abbr:`instrument ([OpenSearch Parameters for Collection Search] A string identifying the instrument (e.g. MERIS, AATSR, ASAR, HRVIR. SAR). (String))`",metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,,:green:`queryable metadata`
-:abbr:`keyword ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] Commonly used word(s) or formalised word(s) or phrase(s) used to describe the subject. (String))`,,,metadata only,,,metadata only,,metadata only,,metadata only,,
-:abbr:`language ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] Language of the intellectual content of the metadata record (String ))`,,,,,,metadata only,,,,,,
-:abbr:`lineage ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] General explanation of the data producer’s knowledge about the lineage of a dataset. (String))`,,,,,,metadata only,,,,,,
-lowestLocation,,,,,,metadata only,,,,,,
-maximumIncidenceAngle,,,,,,metadata only,,,,metadata only,,
-minimumIncidenceAngle,,,,,,metadata only,,,,metadata only,,
-modificationDate,metadata only,,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,metadata only,,metadata only,,:green:`queryable metadata`
-orbitDirection,metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,metadata only,:green:`queryable metadata`,metadata only,,,:green:`queryable metadata`
-orbitNumber,metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,metadata only,:green:`queryable metadata`,metadata only,metadata only,,:green:`queryable metadata`
-":abbr:`orbitType ([OpenSearch Parameters for Collection Search] A string identifying the platform orbit type (e.g. LEO, GEO) (String))`",,,,,,metadata only,,,,,,
-:abbr:`organisationName ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] A string identifying the name of the organization responsible for the resource (String))`,,,:green:`queryable metadata`,,,metadata only,,:green:`queryable metadata`,,metadata only,,
-:abbr:`organisationRole ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] The function performed by the responsible party (String ))`,,,,,,metadata only,,,,,,
-:abbr:`otherConstraint ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] Other restrictions and legal prerequisites for accessing and using the resource or metadata. (String))`,,,,,,metadata only,,,,,,
-parentIdentifier,,,:green:`queryable metadata`,,,metadata only,,:green:`queryable metadata`,,metadata only,,
-:abbr:`platform ([OpenSearch Parameters for Collection Search] A string with the platform short name (e.g. Sentinel-1) (String))`,metadata only,,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,metadata only,metadata only,:green:`queryable metadata`,,:green:`queryable metadata`
-:abbr:`platformSerialIdentifier ([OpenSearch Parameters for Collection Search] A string with the Platform serial identifier (String))`,metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,metadata only,metadata only,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,,:green:`queryable metadata`
-processingCenter,,,,,,metadata only,,metadata only,,,,
-processingDate,,,,,,metadata only,metadata only,,,metadata only,,
-:abbr:`processingLevel ([OpenSearch Parameters for Collection Search] A string identifying the processing level applied to the entry (String))`,metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,,:green:`queryable metadata`
-processingMode,,,,,,metadata only,,,,metadata only,,
-processorName,,,,,,metadata only,,metadata only,,,,
-productQualityDegradationTag,,,,,,metadata only,,,,,,
-productQualityStatus,,,,,,metadata only,metadata only,metadata only,,,,
-":abbr:`productType ([OpenSearch Parameters for Collection Search] A string identifying the entry type (e.g. ER02_SAR_IM__0P, MER_RR__1P, SM_SLC__1S, GES_DISC_AIRH3STD_V005) (String ))`",:green:`queryable metadata`,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,,:green:`queryable metadata`
-productVersion,metadata only,,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,metadata only,metadata only,,metadata only,,:green:`queryable metadata`
-:abbr:`publicationDate ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] The date when the resource was issued (Date time))`,metadata only,,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,metadata only,metadata only,metadata only,,:green:`queryable metadata`
-resolution,metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,:green:`queryable metadata`,,metadata only,,:green:`queryable metadata`
-sensorMode,metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,metadata only,:green:`queryable metadata`,metadata only,metadata only,,:green:`queryable metadata`
-":abbr:`sensorType ([OpenSearch Parameters for Collection Search] A string identifying the sensor type. Suggested values are: OPTICAL, RADAR, ALTIMETRIC, ATMOSPHERIC, LIMB (String))`",,,,,,metadata only,,,,,,
-snowCover,,,:green:`queryable metadata`,,,metadata only,,:green:`queryable metadata`,,metadata only,,
-":abbr:`spectralRange ([OpenSearch Parameters for Collection Search] A string identifying the sensor spectral range (e.g. INFRARED, NEAR-INFRARED, UV, VISIBLE) (String))`",,,,,,metadata only,,,,,,
-startTimeFromAscendingNode,metadata only,,:green:`queryable metadata`,metadata only,metadata only,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,,metadata only
-swathIdentifier,,,,,,metadata only,,:green:`queryable metadata`,,,,
-:abbr:`title ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] A name given to the resource (String ))`,metadata only,,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,,metadata only
-:abbr:`topicCategory ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] Main theme(s) of the dataset (String ))`,,,,,,metadata only,,metadata only,,,,
-track,,,,,,metadata only,,,,,,
-:abbr:`useLimitation ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] A string identifying informing if the resource has usage limitations (String))`,,,,,,metadata only,,,,,,
-wavelengths,,,,,,metadata only,,,,,,
+parameter,astraea_eod,creodias,earth_search,earth_search_cog,mundi,onda,peps,sobloo,theia,usgs_satapi_aws
+:abbr:`abstract ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] Abstract. (String))`,metadata only,metadata only,metadata only,metadata only,metadata only,,metadata only,,,metadata only
+":abbr:`accessConstraint ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] Applied to assure the protection of privacy or intellectual property, and any special restrictions or limitations on obtaining the resource (String ))`",,metadata only,,,metadata only,,metadata only,,metadata only,
+acquisitionStation,metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,,,metadata only,:green:`queryable metadata`
+acquisitionSubType,metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,,,metadata only,:green:`queryable metadata`
+acquisitionType,,,,,metadata only,,metadata only,,,
+antennaLookDirection,,,,,metadata only,,,,metadata only,
+archivingCenter,,,,,metadata only,,,,metadata only,
+availabilityTime,metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,,metadata only,metadata only,:green:`queryable metadata`
+:abbr:`classification ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] Name of the handling restrictions on the resource or metadata (String ))`,,,,,metadata only,,,,,
+cloudCover,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`
+completionTimeFromAscendingNode,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`
+:abbr:`compositeType ([OpenSearch Parameters for Collection Search] Type of composite product expressed as time period that the composite product covers (e.g. P10D for a 10 day composite) (String))`,,,,,metadata only,,,,,
+creationDate,metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,metadata only,metadata only,metadata only,metadata only,:green:`queryable metadata`
+":abbr:`dissemination ([OpenSearch Parameters for Collection Search] A string identifying the dissemination method (e.g. EUMETCast, EUMETCast-Europe, DataCentre) (String))`",,,,,metadata only,,,,,
+:abbr:`doi ([OpenSearch Parameters for Collection Search] Digital Object Identifier identifying the product (see http://www.doi.org) (String))`,metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,,,,:green:`queryable metadata`
+dopplerFrequency,metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,,,metadata only,:green:`queryable metadata`
+frame,,,,,metadata only,,,,,
+":abbr:`hasSecurityConstraints ([OpenSearch Parameters for Collection Search] A string informing if the resource has any security constraints. Possible values: TRUE, FALSE (String))`",,,,,metadata only,,,,,
+highestLocation,,,,,metadata only,,,,,
+illuminationAzimuthAngle,metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,,,metadata only,:green:`queryable metadata`
+illuminationElevationAngle,metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,,,metadata only,:green:`queryable metadata`
+illuminationZenithAngle,,,,,metadata only,,,,metadata only,
+incidenceAngleVariation,,,,,metadata only,,,,metadata only,
+":abbr:`instrument ([OpenSearch Parameters for Collection Search] A string identifying the instrument (e.g. MERIS, AATSR, ASAR, HRVIR. SAR). (String))`",metadata only,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,:green:`queryable metadata`
+:abbr:`keyword ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] Commonly used word(s) or formalised word(s) or phrase(s) used to describe the subject. (String))`,,metadata only,,,metadata only,,metadata only,,metadata only,
+:abbr:`language ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] Language of the intellectual content of the metadata record (String ))`,,,,,metadata only,,,,,
+:abbr:`lineage ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] General explanation of the data producer’s knowledge about the lineage of a dataset. (String))`,,,,,metadata only,,,,,
+lowestLocation,,,,,metadata only,,,,,
+maximumIncidenceAngle,,,,,metadata only,,,,metadata only,
+minimumIncidenceAngle,,,,,metadata only,,,,metadata only,
+modificationDate,metadata only,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,metadata only,,metadata only,:green:`queryable metadata`
+orbitDirection,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,metadata only,:green:`queryable metadata`,metadata only,,:green:`queryable metadata`
+orbitNumber,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,metadata only,:green:`queryable metadata`,metadata only,metadata only,:green:`queryable metadata`
+":abbr:`orbitType ([OpenSearch Parameters for Collection Search] A string identifying the platform orbit type (e.g. LEO, GEO) (String))`",,,,,metadata only,,,,,
+:abbr:`organisationName ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] A string identifying the name of the organization responsible for the resource (String))`,,:green:`queryable metadata`,,,metadata only,,:green:`queryable metadata`,,metadata only,
+:abbr:`organisationRole ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] The function performed by the responsible party (String ))`,,,,,metadata only,,,,,
+:abbr:`otherConstraint ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] Other restrictions and legal prerequisites for accessing and using the resource or metadata. (String))`,,,,,metadata only,,,,,
+parentIdentifier,,:green:`queryable metadata`,,,metadata only,,:green:`queryable metadata`,,metadata only,
+:abbr:`platform ([OpenSearch Parameters for Collection Search] A string with the platform short name (e.g. Sentinel-1) (String))`,metadata only,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,metadata only,metadata only,:green:`queryable metadata`,:green:`queryable metadata`
+:abbr:`platformSerialIdentifier ([OpenSearch Parameters for Collection Search] A string with the Platform serial identifier (String))`,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,metadata only,metadata only,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,:green:`queryable metadata`
+processingCenter,,,,,metadata only,,metadata only,,,
+processingDate,,,,,metadata only,metadata only,,,metadata only,
+:abbr:`processingLevel ([OpenSearch Parameters for Collection Search] A string identifying the processing level applied to the entry (String))`,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,:green:`queryable metadata`
+processingMode,,,,,metadata only,,,,metadata only,
+processorName,,,,,metadata only,,metadata only,,,
+productQualityDegradationTag,,,,,metadata only,,,,,
+productQualityStatus,,,,,metadata only,metadata only,metadata only,,,
+":abbr:`productType ([OpenSearch Parameters for Collection Search] A string identifying the entry type (e.g. ER02_SAR_IM__0P, MER_RR__1P, SM_SLC__1S, GES_DISC_AIRH3STD_V005) (String ))`",:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`
+productVersion,metadata only,,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,metadata only,metadata only,,metadata only,:green:`queryable metadata`
+:abbr:`publicationDate ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] The date when the resource was issued (Date time))`,metadata only,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,metadata only,metadata only,metadata only,:green:`queryable metadata`
+resolution,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,,:green:`queryable metadata`,,metadata only,:green:`queryable metadata`
+sensorMode,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,metadata only,:green:`queryable metadata`,metadata only,metadata only,:green:`queryable metadata`
+":abbr:`sensorType ([OpenSearch Parameters for Collection Search] A string identifying the sensor type. Suggested values are: OPTICAL, RADAR, ALTIMETRIC, ATMOSPHERIC, LIMB (String))`",,,,,metadata only,,,,,
+snowCover,,:green:`queryable metadata`,,,metadata only,,:green:`queryable metadata`,,metadata only,
+":abbr:`spectralRange ([OpenSearch Parameters for Collection Search] A string identifying the sensor spectral range (e.g. INFRARED, NEAR-INFRARED, UV, VISIBLE) (String))`",,,,,metadata only,,,,,
+startTimeFromAscendingNode,metadata only,:green:`queryable metadata`,metadata only,metadata only,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,metadata only
+swathIdentifier,,,,,metadata only,,:green:`queryable metadata`,,,
+:abbr:`title ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] A name given to the resource (String ))`,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only
+:abbr:`topicCategory ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] Main theme(s) of the dataset (String ))`,,,,,metadata only,,metadata only,,,
+track,,,,,metadata only,,,,,
+:abbr:`useLimitation ([Additional INSPIRE obligated OpenSearch Parameters for Collection Search] A string identifying informing if the resource has usage limitations (String))`,,,,,metadata only,,,,,
+wavelengths,,,,,metadata only,,,,,

--- a/docs/add_provider.rst
+++ b/docs/add_provider.rst
@@ -23,6 +23,7 @@ the `STAC client page <notebooks/tutos/tuto_stac_client.ipynb#stac-api>`_, shows
       search:
          type: StacSearch
          api_endpoint: https://tamn.snapplanet.io/search
+         need_auth: false
       products:
          S2_MSI_L1C:
                productType: S2

--- a/docs/notebooks/api_user_guide/2_providers_products_available.ipynb
+++ b/docs/notebooks/api_user_guide/2_providers_products_available.ipynb
@@ -1,64 +1,35 @@
 {
- "metadata": {
-  "nbsphinx": {
-   "execute": "always"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.6"
-  },
-  "orig_nbformat": 2,
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.8.6 64-bit",
-   "metadata": {
-    "interpreter": {
-     "hash": "0cf725079c7d16f2cba0a185a776402bb287255802a557bed9d05e4eed5bfa43"
-    }
-   }
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2,
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Providers and products"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from eodag import EODataAccessGateway\n",
     "dag = EODataAccessGateway()"
-   ],
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": 44,
-   "outputs": []
+   ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Providers available"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "The method [available_providers()](../../api_reference/core.rst#eodag.api.core.EODataAccessGateway.available_providers) returns a list of the pre-configured providers."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -66,7 +37,6 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "['astraea_eod',\n",
@@ -82,8 +52,9 @@
        " 'usgs_satapi_aws']"
       ]
      },
+     "execution_count": 45,
      "metadata": {},
-     "execution_count": 45
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -97,8 +68,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "eodag has 12 providers already configured.\n"
      ]
@@ -109,11 +80,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "It can take a product type as an argument and will return the providers known to `eodag` that offer this product."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -121,7 +92,6 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "['astraea_eod',\n",
@@ -134,8 +104,9 @@
        " 'sobloo']"
       ]
      },
+     "execution_count": 47,
      "metadata": {},
-     "execution_count": 47
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -143,18 +114,31 @@
    ]
   },
   {
-   "source": [
-    "## Product types available"
-   ],
    "cell_type": "markdown",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "Note\n",
+    "\n",
+    "If a provider is configured to need authentication for search, and has no crendentials set, it will be pruned on EODAG initialization, and will not appear in available providers list.\n",
+    "\n",
+    "</div>"
+   ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Product types available"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "The method [list_product_types()](../../api_reference/core.rst#eodag.api.core.EODataAccessGateway.list_product_types) returns a dictionary that represents `eodag`'s internal product type catalog."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -171,7 +155,6 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "{'ID': 'CBERS4_AWFI_L2',\n",
@@ -186,8 +169,9 @@
        " 'title': 'CBERS-4 AWFI Level-2'}"
       ]
      },
+     "execution_count": 52,
      "metadata": {},
-     "execution_count": 52
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -200,7 +184,6 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "['CBERS4_AWFI_L2',\n",
@@ -257,8 +240,9 @@
        " 'VENUS_L3A_MAJA']"
       ]
      },
+     "execution_count": 62,
      "metadata": {},
-     "execution_count": 62
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -272,8 +256,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "EODAG has 52 product types stored in its internal catalog.\n"
      ]
@@ -284,11 +268,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "The method can take a provider name as an argument and will return the product types known to `eodag` that are offered by this provider."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -296,7 +280,6 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "['S1_SAR_GRD',\n",
@@ -313,8 +296,9 @@
        " 'S3_SLSTR_L2LST']"
       ]
      },
+     "execution_count": 64,
      "metadata": {},
-     "execution_count": 64
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -323,18 +307,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Combine these two methods"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "These two methods can be combined to find which product type is the most common in `eodag`'s catalog among all the providers."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -342,14 +326,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "('S2_MSI_L1C', 9)"
       ]
      },
+     "execution_count": 65,
      "metadata": {},
-     "execution_count": 65
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -363,11 +347,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "These can be also used to find out which provider (as configured by `eodag`) offers the hights number of different product types."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -375,8 +359,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "The provider with the largest number of product types is 'onda' with 18.\n"
      ]
@@ -397,5 +381,34 @@
     "print(f\"The provider with the largest number of product types is '{provider}' with {nb_p_types}.\")"
    ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.8.6 64-bit",
+   "metadata": {
+    "interpreter": {
+     "hash": "0cf725079c7d16f2cba0a185a776402bb287255802a557bed9d05e4eed5bfa43"
+    }
+   },
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  },
+  "nbsphinx": {
+   "execute": "always"
+  },
+  "orig_nbformat": 2
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -269,15 +269,15 @@ class EODataAccessGateway(object):
         ...                           'as expected')
         ... except eodag.utils.exceptions.UnsupportedProvider:
         ...     pass
-        >>> dag.set_preferred_provider(u'usgs')
+        >>> dag.set_preferred_provider(u'creodias')
         >>> dag.get_preferred_provider()
-        ('usgs', 2)
+        ('creodias', 2)
         >>> dag.set_preferred_provider(u'theia')
         >>> dag.get_preferred_provider()
         ('theia', 3)
-        >>> dag.set_preferred_provider(u'usgs')
+        >>> dag.set_preferred_provider(u'creodias')
         >>> dag.get_preferred_provider()
-        ('usgs', 4)
+        ('creodias', 4)
         >>> config.close()
         >>> os.unlink(config.name)
 

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -118,6 +118,9 @@ class EODataAccessGateway(object):
         # use updated and checked providers_config
         self.providers_config = self._plugins_manager.providers_config
 
+        # filter out providers needing auth that have no credentials set
+        self._prune_providers_list()
+
         # Sort providers taking into account of possible new priority orders
         self._plugins_manager.sort_providers()
 
@@ -338,6 +341,39 @@ class EODataAccessGateway(object):
         for provider in conf_update.keys():
             provider_config_init(self.providers_config[provider])
         self._plugins_manager = PluginManager(self.providers_config)
+
+    def _prune_providers_list(self):
+        """Removes from config providers needing auth that have no credentials set."""
+        for provider in list(self.providers_config.keys()):
+            conf = self.providers_config[provider]
+
+            if hasattr(conf, "api") and getattr(conf.api, "need_auth", False):
+                credentials_exist = any(
+                    [
+                        cred is not None
+                        for cred in getattr(conf.api, "credentials", {}).values()
+                    ]
+                )
+                if not credentials_exist:
+                    # credentials needed but not found
+                    del self.providers_config[provider]
+            elif hasattr(conf, "search") and getattr(conf.search, "need_auth", False):
+                if not hasattr(conf, "auth"):
+                    # credentials needed but no auth plugin was found
+                    del self.providers_config[provider]
+                    continue
+                credentials_exist = any(
+                    [
+                        cred is not None
+                        for cred in getattr(conf.auth, "credentials", {}).values()
+                    ]
+                )
+                if not credentials_exist:
+                    # credentials needed but not found
+                    del self.providers_config[provider]
+            elif not hasattr(conf, "api") and not hasattr(conf, "search"):
+                # provider should have at least an api or search plugin
+                del self.providers_config[provider]
 
     def set_locations_conf(self, locations_conf_path):
         """Set locations configuration.

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -106,6 +106,10 @@ class PluginManager(object):
                 providers_config.pop(provider)
                 continue
 
+            # provider priority set to lowest if not set
+            if getattr(provider_config, "priority", None) is None:
+                provider_config.priority = 0
+
             for product_type in provider_config.products:
                 product_type_providers = (
                     self.product_type_to_provider_config_map.setdefault(  # noqa

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -25,6 +25,7 @@
   url: https://earthexplorer.usgs.gov/
   api: !plugin
     type: UsgsApi
+    need_auth: true
     google_base_url: 'http://storage.googleapis.com/earthengine-public/landsat/'
     pagination:
       max_items_per_page: 5000
@@ -61,6 +62,7 @@
   search: !plugin
     type: PostJsonSearch
     api_endpoint: 'https://gate.eos.com/api/lms/search/v2/{collection}?api_key={apikey}'
+    need_auth: true
     auth_error_code: 403
     pagination:
       next_page_query_obj: '{{"limit":{items_per_page},"page":{page}}}'
@@ -512,6 +514,7 @@
   search: !plugin
     type: QueryStringSearch
     api_endpoint: 'https://theia.cnes.fr/atdistrib/resto2/api/collections/{collection}/search.json'
+    need_auth: false
     pagination:
       next_page_url_tpl: '{url}?{search}&maxRecords={items_per_page}&page={page}'
       total_items_nb_key_path: '$.properties.totalResults'
@@ -686,6 +689,7 @@
   search: !plugin
     type: QueryStringSearch
     api_endpoint: 'https://peps.cnes.fr/resto/api/collections/{collection}/search.json'
+    need_auth: false
     pagination:
       next_page_url_tpl: '{url}?{search}&maxRecords={items_per_page}&page={page}'
       total_items_nb_key_path: '$.properties.totalResults'
@@ -869,6 +873,7 @@
   search: !plugin
     type: QueryStringSearch
     api_endpoint: 'https://sobloo.eu/api/v1/services/search'
+    need_auth: false
     collection: catalog
     result_type: 'json'
     pagination:
@@ -961,6 +966,7 @@
   search: !plugin
     type: QueryStringSearch
     api_endpoint: 'https://finder.creodias.eu/resto/api/collections/{collection}/search.json'
+    need_auth: false
     pagination:
       next_page_url_tpl: '{url}?{search}&maxRecords={items_per_page}&page={page}'
       total_items_nb_key_path: '$.properties.totalResults'
@@ -1199,6 +1205,7 @@
   search: !plugin
     type: QueryStringSearch
     api_endpoint: 'https://mundiwebservices.com/acdc/catalog/proxy/search/{collection}/opensearch'
+    need_auth: false
     result_type: 'xml'
     results_entry: '//ns:entry'
     literal_search_params:
@@ -1371,6 +1378,7 @@
   search: !plugin
     type: ODataV4Search
     api_endpoint: 'https://catalogue.onda-dias.eu/dias-catalogue/Products'
+    need_auth: false
     dont_quote:
       - '['
       - ']'
@@ -1536,6 +1544,7 @@
   search: !plugin
     type: StacSearch
     api_endpoint: https://eod-catalog-svc-prod.astraea.earth/search
+    need_auth: false
     pagination:
       # 2021/03/19: The docs (https://eod-catalog-svc-prod.astraea.earth/api.html#operation/getSearchSTAC)
       # say the max is 10_000. In practice 1_000 products are returned if more are asked (even greater
@@ -1652,6 +1661,7 @@
   search: !plugin
     type: StacSearch
     api_endpoint: https://landsatlook.usgs.gov/stac-server/search
+    need_auth: false
     pagination:
       # 2021/03/19: no more than 10_000 (if greater, returns a 500 error code)
       # but in practive if an Internal Server Error is returned for more than
@@ -1695,6 +1705,7 @@
   search: !plugin
     type: StacSearch
     api_endpoint: https://earth-search.aws.element84.com/v0/search
+    need_auth: false
     pagination:
       # Override the default next page url key path of StacSearch because the next link returned
       # by Earth Search is invalid (as of 2021/04/29). Entry set to null (None) to avoid using the
@@ -1761,6 +1772,7 @@
   search: !plugin
     type: StacSearch
     api_endpoint: https://earth-search.aws.element84.com/v0/search
+    need_auth: false
     pagination:
       # Override the default next page url key path of StacSearch because the next link returned
       # by Earth Search is invalid (as of 2021/04/29). Entry set to null (None) to avoid using the

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -551,6 +551,10 @@ class StacCollection(StacCommon):
                     )
                 ).provider
             )
+            #
+            # if provider not in self.eodag_api.available_providers():
+            #     for p in self.eodag_api._plugins_manager.get_search_plugins(product_type=product_type["ID"]):
+            #         print(p.provider)
 
             # parse jsonpath
             product_type_collection = jsonpath_parse_dict_items(

--- a/tests/integration/test_config_ext_plugin.py
+++ b/tests/integration/test_config_ext_plugin.py
@@ -16,8 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import tempfile
 import unittest
+from tempfile import TemporaryDirectory
 
 import pkg_resources
 
@@ -30,7 +30,7 @@ class TestExternalPluginConfig(unittest.TestCase):
     def setUp(self):
         super(TestExternalPluginConfig, self).setUp()
         # Mock home and eodag conf directory to tmp dir
-        self.tmp_home_dir = tempfile.TemporaryDirectory()
+        self.tmp_home_dir = TemporaryDirectory()
         self.expanduser_mock = mock.patch(
             "os.path.expanduser", autospec=True, return_value=self.tmp_home_dir.name
         )

--- a/tests/integration/test_config_ext_plugin.py
+++ b/tests/integration/test_config_ext_plugin.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import shutil
 import tempfile
 import unittest
 
@@ -31,9 +30,9 @@ class TestExternalPluginConfig(unittest.TestCase):
     def setUp(self):
         super(TestExternalPluginConfig, self).setUp()
         # Mock home and eodag conf directory to tmp dir
-        self.tmp_home_dir = tempfile.mkdtemp()
+        self.tmp_home_dir = tempfile.TemporaryDirectory()
         self.expanduser_mock = mock.patch(
-            "os.path.expanduser", autospec=True, return_value=self.tmp_home_dir
+            "os.path.expanduser", autospec=True, return_value=self.tmp_home_dir.name
         )
         self.expanduser_mock.start()
 
@@ -51,10 +50,7 @@ class TestExternalPluginConfig(unittest.TestCase):
 
         # stop Mock and remove tmp config dir
         self.expanduser_mock.stop()
-        try:
-            shutil.rmtree(self.tmp_home_dir)
-        except OSError:
-            pass
+        self.tmp_home_dir.cleanup()
 
     def test_update_providers_from_ext_plugin(self):
         """Load fake external plugin and check if it updates providers config"""

--- a/tests/integration/test_core_search_results.py
+++ b/tests/integration/test_core_search_results.py
@@ -32,9 +32,9 @@ class TestCoreSearchResults(EODagTestCase):
     def setUp(self):
         super(TestCoreSearchResults, self).setUp()
         # Mock home and eodag conf directory to tmp dir
-        self.tmp_home_dir = tempfile.mkdtemp()
+        self.tmp_home_dir = tempfile.TemporaryDirectory()
         self.expanduser_mock = mock.patch(
-            "os.path.expanduser", autospec=True, return_value=self.tmp_home_dir
+            "os.path.expanduser", autospec=True, return_value=self.tmp_home_dir.name
         )
         self.expanduser_mock.start()
         self.dag = EODataAccessGateway()
@@ -113,10 +113,7 @@ class TestCoreSearchResults(EODagTestCase):
         super(TestCoreSearchResults, self).tearDown()
         # stop Mock and remove tmp config dir
         self.expanduser_mock.stop()
-        try:
-            shutil.rmtree(self.tmp_home_dir)
-        except OSError:
-            pass
+        self.tmp_home_dir.cleanup()
 
     def test_core_serialize_search_results(self):
         """The core api must serialize a search results to geojson"""

--- a/tests/integration/test_search_stac_static.py
+++ b/tests/integration/test_search_stac_static.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import shutil
 import tempfile
 import unittest
 
@@ -37,9 +36,9 @@ class TestSearchStacStatic(unittest.TestCase):
         super(TestSearchStacStatic, self).setUp()
 
         # Mock home and eodag conf directory to tmp dir
-        self.tmp_home_dir = tempfile.mkdtemp()
+        self.tmp_home_dir = tempfile.TemporaryDirectory()
         self.expanduser_mock = mock.patch(
-            "os.path.expanduser", autospec=True, return_value=self.tmp_home_dir
+            "os.path.expanduser", autospec=True, return_value=self.tmp_home_dir.name
         )
         self.expanduser_mock.start()
 
@@ -89,10 +88,7 @@ class TestSearchStacStatic(unittest.TestCase):
         super(TestSearchStacStatic, self).tearDown()
         # stop Mock and remove tmp config dir
         self.expanduser_mock.stop()
-        try:
-            shutil.rmtree(self.tmp_home_dir)
-        except OSError:
-            pass
+        self.tmp_home_dir.cleanup()
 
     def test_search_stac_static_load_child(self):
         """load_stac_items from child catalog must provide items"""

--- a/tests/integration/test_search_stac_static.py
+++ b/tests/integration/test_search_stac_static.py
@@ -16,8 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import tempfile
 import unittest
+from tempfile import TemporaryDirectory
 
 from tests import TEST_RESOURCES_PATH
 from tests.context import (
@@ -36,7 +36,7 @@ class TestSearchStacStatic(unittest.TestCase):
         super(TestSearchStacStatic, self).setUp()
 
         # Mock home and eodag conf directory to tmp dir
-        self.tmp_home_dir = tempfile.TemporaryDirectory()
+        self.tmp_home_dir = TemporaryDirectory()
         self.expanduser_mock = mock.patch(
             "os.path.expanduser", autospec=True, return_value=self.tmp_home_dir.name
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,7 @@ import os
 import random
 import unittest
 from contextlib import contextmanager
+from tempfile import TemporaryDirectory
 
 import click
 from click.testing import CliRunner
@@ -38,7 +39,7 @@ from tests.context import (
     setup_logging,
 )
 from tests.units import test_core
-from tests.utils import mock, no_blanks
+from tests.utils import mock, no_blanks, write_eodag_conf_with_fake_credentials
 
 
 class TestEodagCli(unittest.TestCase):
@@ -57,10 +58,29 @@ class TestEodagCli(unittest.TestCase):
         self.runner = CliRunner()
         self.faker = Faker()
 
+        # Mock home and eodag conf directory to tmp dir
+        self.tmp_home_dir = TemporaryDirectory()
+        self.expanduser_mock = mock.patch(
+            "os.path.expanduser", autospec=True, return_value=self.tmp_home_dir.name
+        )
+        self.expanduser_mock.start()
+
+        # create eodag conf dir in tmp home dir
+        eodag_conf_dir = os.path.join(self.tmp_home_dir.name, ".config", "eodag")
+        os.makedirs(eodag_conf_dir, exist_ok=False)
+        # use empty config file with fake credentials in order to have full
+        # list for tests and prevent providers to be pruned
+        write_eodag_conf_with_fake_credentials(
+            os.path.join(eodag_conf_dir, "eodag.yml")
+        )
+
     def tearDown(self):
         super(TestEodagCli, self).tearDown()
         # Default logging: no logging but still displays progress bars
         setup_logging(1)
+        # stop Mock and remove tmp config dir
+        self.expanduser_mock.stop()
+        self.tmp_home_dir.cleanup()
 
     def test_eodag_without_args(self):
         """Calling eodag without arguments should print help message"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 import os
+import re
 import tempfile
 import unittest
 from io import StringIO
@@ -231,12 +232,19 @@ class TestConfigFunctions(unittest.TestCase):
     def setUpClass(cls):
         super(TestConfigFunctions, cls).setUpClass()
         # backup os.environ as it will be modified by tests
-        cls.os_environ_backup = os.environ
+        cls.eodag_env_pattern = re.compile(r"EODAG_\w+")
+        cls.eodag_env_backup = {
+            k: v for k, v in os.environ.items() if cls.eodag_env_pattern.match(k)
+        }
 
     @classmethod
     def tearDownClass(cls):
         super(TestConfigFunctions, cls).tearDownClass()
-        os.environ = cls.os_environ_backup
+        # restore os.environ
+        for k, v in os.environ.items():
+            if cls.eodag_env_pattern.match(k):
+                os.environ.pop(k)
+        os.environ.update(cls.eodag_env_backup)
 
     def test_load_default_config(self):
         """Default config must be successfully loaded"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -227,6 +227,17 @@ class TestPluginConfig(unittest.TestCase):
 
 
 class TestConfigFunctions(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestConfigFunctions, cls).setUpClass()
+        # backup os.environ as it will be modified by tests
+        cls.os_environ_backup = os.environ
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestConfigFunctions, cls).tearDownClass()
+        os.environ = cls.os_environ_backup
+
     def test_load_default_config(self):
         """Default config must be successfully loaded"""
         conf = config.load_default_config()

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -657,6 +657,13 @@ class TestEODagEndToEndWrongCredentials(EndToEndBase):
             TEST_RESOURCES_PATH, "wrong_credentials_conf.yml"
         )
         cls.eodag = EODataAccessGateway(user_conf_file_path=tests_wrong_conf)
+        # backup os.environ as it will be modified by tests
+        cls.os_environ_backup = os.environ
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestEODagEndToEndWrongCredentials, cls).tearDownClass()
+        os.environ = cls.os_environ_backup
 
     def test_end_to_end_wrong_credentials_theia(self):
         product = self.execute_search(*THEIA_SEARCH_ARGS)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -21,6 +21,7 @@ import glob
 import hashlib
 import multiprocessing
 import os
+import re
 import shutil
 import time
 import unittest
@@ -658,12 +659,19 @@ class TestEODagEndToEndWrongCredentials(EndToEndBase):
         )
         cls.eodag = EODataAccessGateway(user_conf_file_path=tests_wrong_conf)
         # backup os.environ as it will be modified by tests
-        cls.os_environ_backup = os.environ
+        cls.eodag_env_pattern = re.compile(r"EODAG_\w+")
+        cls.eodag_env_backup = {
+            k: v for k, v in os.environ.items() if cls.eodag_env_pattern.match(k)
+        }
 
     @classmethod
     def tearDownClass(cls):
         super(TestEODagEndToEndWrongCredentials, cls).tearDownClass()
-        os.environ = cls.os_environ_backup
+        # restore os.environ
+        for k, v in os.environ.items():
+            if cls.eodag_env_pattern.match(k):
+                os.environ.pop(k)
+        os.environ.update(cls.eodag_env_backup)
 
     def test_end_to_end_wrong_credentials_theia(self):
         product = self.execute_search(*THEIA_SEARCH_ARGS)

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -316,14 +316,13 @@ class TestCoreConfWithEnvVar(TestCoreBase):
     def setUpClass(cls):
         super(TestCoreConfWithEnvVar, cls).setUpClass()
         cls.dag = EODataAccessGateway()
+        # backup os.environ as it will be modified by tests
+        cls.os_environ_backup = os.environ
 
     @classmethod
     def tearDownClass(cls):
         super(TestCoreConfWithEnvVar, cls).tearDownClass()
-        if os.getenv("EODAG_CFG_FILE") is not None:
-            os.environ.pop("EODAG_CFG_FILE")
-        if os.getenv("EODAG_LOCS_CFG_FILE") is not None:
-            os.environ.pop("EODAG_LOCS_CFG_FILE")
+        os.environ = cls.os_environ_backup
 
     def test_core_object_prioritize_locations_file_in_envvar(self):
         """The core object must use the locations file pointed to by the EODAG_LOCS_CFG_FILE env var"""  # noqa

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -326,25 +326,33 @@ class TestCoreConfWithEnvVar(TestCoreBase):
 
     def test_core_object_prioritize_locations_file_in_envvar(self):
         """The core object must use the locations file pointed to by the EODAG_LOCS_CFG_FILE env var"""  # noqa
-        os.environ["EODAG_LOCS_CFG_FILE"] = os.path.join(
-            TEST_RESOURCES_PATH, "file_locations_override.yml"
-        )
-        dag = EODataAccessGateway()
-        self.assertEqual(
-            dag.locations_config,
-            [dict(attr="dummyattr", name="dummyname", path="dummypath.shp")],
-        )
+        try:
+            os.environ["EODAG_LOCS_CFG_FILE"] = os.path.join(
+                TEST_RESOURCES_PATH, "file_locations_override.yml"
+            )
+            dag = EODataAccessGateway()
+            self.assertEqual(
+                dag.locations_config,
+                [dict(attr="dummyattr", name="dummyname", path="dummypath.shp")],
+            )
+        finally:
+            os.environ("EODAG_CFG_FILE", None)
 
     def test_core_object_prioritize_config_file_in_envvar(self):
         """The core object must use the config file pointed to by the EODAG_CFG_FILE env var"""  # noqa
-        os.environ["EODAG_CFG_FILE"] = os.path.join(
-            TEST_RESOURCES_PATH, "file_config_override.yml"
-        )
-        dag = EODataAccessGateway()
-        # usgs priority is set to 5 in the test config overrides
-        self.assertEqual(dag.get_preferred_provider(), ("usgs", 5))
-        # peps outputs prefix is set to /data
-        self.assertEqual(dag.providers_config["peps"].download.outputs_prefix, "/data")
+        try:
+            os.environ["EODAG_CFG_FILE"] = os.path.join(
+                TEST_RESOURCES_PATH, "file_config_override.yml"
+            )
+            dag = EODataAccessGateway()
+            # usgs priority is set to 5 in the test config overrides
+            self.assertEqual(dag.get_preferred_provider(), ("usgs", 5))
+            # peps outputs prefix is set to /data
+            self.assertEqual(
+                dag.providers_config["peps"].download.outputs_prefix, "/data"
+            )
+        finally:
+            os.environ("EODAG_CFG_FILE", None)
 
 
 class TestCoreInvolvingConfDir(unittest.TestCase):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,9 +15,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 
 # All tests files should import mock from this place
 from unittest import mock  # noqa
+
+import yaml
+from pkg_resources import resource_filename
 
 
 def no_blanks(string):
@@ -29,3 +33,28 @@ def no_blanks(string):
     :returns the same string with all blank characters removed
     """
     return string.replace("\n", "").replace("\t", "").replace(" ", "")
+
+
+def write_eodag_conf_with_fake_credentials(config_file):
+    """Writes fake EODAG config file with fake credentials.
+    Uses empty default conf with fake credentials. When loading
+    this conf, eodag will not prune any provider that may need
+    credentials for search.
+
+    :param config_file: path to the file where the conf must be written
+    :type config_file: str
+    """
+    empty_conf_file_path = resource_filename(
+        "eodag", os.path.join("resources", "user_conf_template.yml")
+    )
+    with open(os.path.abspath(os.path.realpath(empty_conf_file_path)), "r") as fh:
+        was_empty_conf = yaml.safe_load(fh)
+    for provider, conf in was_empty_conf.items():
+        if "credentials" in conf.get("auth", {}):
+            cred_key = next(iter(conf["auth"]["credentials"]))
+            conf["auth"]["credentials"][cred_key] = "foo"
+        elif "credentials" in conf.get("api", {}):
+            cred_key = next(iter(conf["api"]["credentials"]))
+            was_empty_conf[provider]["api"]["credentials"][cred_key] = "foo"
+    with open(config_file, mode="w") as fh:
+        yaml.dump(was_empty_conf, fh, default_flow_style=False)


### PR DESCRIPTION
- Adds a boolean (`need_auth`) to providers configuration to tell if it needs auth for search or not.
- During `EODataAccessGateway` init, removes from available providers list the ones without credentials needing auth for search

See #368 
