### PR TITLE
fix: unwanted string in logging time

### DIFF
--- a/eodag/utils/logging.py
+++ b/eodag/utils/logging.py
@@ -60,7 +60,7 @@ def setup_logging(verbose, no_progress_bar=False):
                 "disable_existing_loggers": False,
                 "formatters": {
                     "standard": {
-                        "format": "%(asctime)s-15s %(name)-32s [%(levelname)-8s] %(message)s"
+                        "format": "%(asctime)-15s %(name)-32s [%(levelname)-8s] %(message)s"
                     }
                 },
                 "handlers": {
@@ -91,7 +91,7 @@ def setup_logging(verbose, no_progress_bar=False):
                 "disable_existing_loggers": False,
                 "formatters": {
                     "verbose": {
-                        "format": "%(asctime)s-15s %(name)-32s [%(levelname)-8s] (%(module)-17s) %(message)s"
+                        "format": "%(asctime)-15s %(name)-32s [%(levelname)-8s] (%(module)-17s) %(message)s"
                     }
                 },
                 "handlers": {


### PR DESCRIPTION
Removes unwanted `-15s` string in logging time.
Before:
`2022-04-22 16:07:26,508-15s eodag.core                       [DEBUG   ] (core             ) Using plugin class for search: QueryStringSearch`
After:
`2022-04-22 16:07:26,508 eodag.core                       [DEBUG   ] (core             ) Using plugin class for search: QueryStringSearch`