### PR TITLE
fix: need_auth and api plugin search

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -1027,7 +1027,9 @@ class EODataAccessGateway(object):
         auth_plugin = self._plugins_manager.get_auth_plugin(search_plugin.provider)
 
         # append auth to search plugin if needed
-        if getattr(search_plugin.config, "need_auth", False):
+        if getattr(search_plugin.config, "need_auth", False) and callable(
+            getattr(auth_plugin, "authenticate", None)
+        ):
             search_plugin.auth = auth_plugin.authenticate()
 
         return dict(search_plugin=search_plugin, auth=auth_plugin, **kwargs)


### PR DESCRIPTION
Fixes issue related to new `need_auth` settting with api plugins search (like usgs), leading to this error when performing search:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/sylvain/workspace/eodag/eodag/api/core.py", line 599, in search
    search_kwargs = self._prepare_search(
  File "/home/sylvain/workspace/eodag/eodag/api/core.py", line 1031, in _prepare_search
    search_plugin.auth = auth_plugin.authenticate()
AttributeError: 'NoneType' object has no attribute 'authenticate'
```