### PR TITLE
fix: use mock in stac server search tests

### DIFF
--- a/tests/units/test_stac_utils.py
+++ b/tests/units/test_stac_utils.py
@@ -71,6 +71,7 @@ class TestStacUtils(unittest.TestCase):
         cls.empty_products = SearchResult([])
         cls.empty_arguments = {}
         cls.empty_criterias = {}
+        eodag_api.set_preferred_provider("peps")
 
     def test_download_stac_item_by_id(self):
         pass  # TODO
@@ -261,11 +262,21 @@ class TestStacUtils(unittest.TestCase):
         """get_stac_extension_oseo runs without any error"""
         get_stac_extension_oseo(url="")
 
-    def test_get_stac_item_by_id(self):
+    @mock.patch(
+        "eodag.plugins.search.qssearch.QueryStringSearch.do_search", autospec=True
+    )
+    def test_get_stac_item_by_id(self, mock_do_search):
         """get_stac_item_by_id returns None if no StacItem was found"""
+        mock_do_search.return_value = [
+            {
+                "geometry": "POINT (0 0)",
+                "properties": {"productIdentifier": "foo", "title": "foo"},
+            }
+        ]
         self.assertIsNotNone(
-            get_stac_item_by_id(url="", item_id="", catalogs=["S2_MSI_L1C"])
+            get_stac_item_by_id(url="", item_id="foo", catalogs=["S2_MSI_L1C"])
         )
+        mock_do_search.return_value = []
         self.assertIsNone(
             get_stac_item_by_id(url="", item_id="", catalogs=["S3_MSI_L1C"])
         )
@@ -280,7 +291,17 @@ class TestStacUtils(unittest.TestCase):
     def test_search_product_by_id(self):
         pass  # TODO
 
-    def test_search_products(self):
+    @mock.patch(
+        "eodag.plugins.search.qssearch.QueryStringSearch.do_search",
+        autospec=True,
+        return_value=[
+            {
+                "geometry": "POINT (0 0)",
+                "properties": {"productIdentifier": "foo", "title": "foo"},
+            }
+        ],
+    )
+    def test_search_products(self, mock_do_search):
         """search_products runs without any error"""
         search_products("S2_MSI_L1C", {})
         search_products("S2_MSI_L1C", {"unserialized": "true"})


### PR DESCRIPTION
fixes [failing test](https://github.com/CS-SI/eodag/runs/6686102426) caused by some provider maintenance.

Except in end-to-end tests, mocks should be used in order to be able to run tests independently of providers statuses.