### PR TITLE
build: downgrade owslib with py310

### DIFF
--- a/docs/getting_started_guide/install.rst
+++ b/docs/getting_started_guide/install.rst
@@ -11,7 +11,7 @@ EODAG is really simple to install with ``pip``:
 
 .. note::
 
-   ``pyproj`` requires Cython or pip>=10.0.1. If the install of ``eodag`` fails, check your
+   ``pyproj`` requires Cython or pip>=19.3. If the install of ``eodag`` fails, check your
    version of pip (Ubuntu 18.04 comes installed with pip 9.0.1).
 
 Or with ``conda`` from the *conda-forge* channel:

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,8 @@ install_requires =
     tqdm
     shapely
     pyshp
-    owslib
+    owslib < 0.26;python_version>='3.10'
+    owslib;python_version<'3.10'
     geojson
     pyproj
     usgs >= 0.3.1


### PR DESCRIPTION
Fixes [error](https://github.com/CS-SI/eodag/runs/6856763522?check_suite_focus=true) with `pyproj` install on `python3.10`
```
   Collecting pyproj
    Downloading pyproj-3.2.1.tar.gz (213 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 213.3/213.3 KB 55.8 MB/s eta 0:00:00
    Installing build dependencies: started
    Installing build dependencies: finished with status 'done'
    Getting requirements to build wheel: started
    Getting requirements to build wheel: finished with status 'error'
    error: subprocess-exited-with-error
  
    × Getting requirements to build wheel did not run successfully.
    │ exit code: 1
    ╰─> [1 lines of output]
        proj executable not found. Please set the PROJ_DIR variable. For more information see: https://pyproj4.github.io/pyproj/stable/installation.html
        [end of output]
```

`owslib` latest release (`0.26.0`, 2022-06-06) set `pyproj < 3.3.0` as max version (see https://github.com/geopython/OWSLib/pull/807), which is not compatible with `python3.10`.

To keep compatibility with `python3.10`, we set `owslib < 0.26.0` for this python version.