### PR TITLE
fix: use PR in github action to update external product types reference

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         export JSON_OUTPUT_FILE="eodag/resources/ext_product_types.json"
         export JSON_REF_FILE=$(python -c "import eodag; print(eodag.config.EXT_PRODUCT_TYPES_CONF_URI)")
-        eodag discover --storage ${JSON_OUTPUT_FILE}
+        eodag -vvv discover --storage ${JSON_OUTPUT_FILE}
         git config user.name "github-actions[bot]"
         git config user.email "'github-actions[bot]@users.noreply.github.com"
         git add "${JSON_OUTPUT_FILE}"
@@ -57,5 +57,18 @@ jobs:
         git show --name-only --format=tformat: >> $GITHUB_STEP_SUMMARY
         (diff <(curl ${JSON_REF_FILE} | jq ) <(cat ${JSON_OUTPUT_FILE} | jq) || true) >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
-        git pull --rebase
-        git push
+        echo 'UPDATE_SUMMARY<<EOF' >> $GITHUB_ENV
+        cat $GITHUB_STEP_SUMMARY >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        branch: external-product-types-ref-update
+        delete-branch: true
+        title: 'fix: update external product types reference'
+        body: |
+          Update external product types reference from daily fetch. See
+          [Python API User Guide / Product types discovery](https://eodag.readthedocs.io/en/latest/notebooks/api_user_guide/2_providers_products_available.html#Product-types-discovery)
+          ${{ env.UPDATE_SUMMARY }}
+        labels: |
+          automated pr


### PR DESCRIPTION
Create a Pull Request instead of a new commit with newly discovered external product types configuration