### PR TITLE
build: setuptools_scm max version for py36

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2,<7"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,5 @@ def _get_fallback_version():
 if __name__ == "__main__":
     setuptools.setup(
         use_scm_version={"fallback_version": _get_fallback_version()},
-        setup_requires=["setuptools_scm"],
+        setup_requires=["setuptools_scm<7"],
     )


### PR DESCRIPTION
Set `setuptools_scm` maximum version until #476 is fixed