### PR TITLE
fix: jsonpath issue causing missing productPath property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Release history
 ---------------
 
+2.5.2 (2022-07-05)
+++++++++++++++++++
+
+* Fixes missing ``productPath`` property for some ``earth_search`` products (:pull:`480`)
+
 2.5.1 (2022-06-27)
 ++++++++++++++++++
 

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1725,7 +1725,7 @@
         platformSerialIdentifier: '$.id.`split(_, 0, -1)`'
         polarizationMode: '$.id.`sub(/.{14}([A-Z]{2}).*/, \\1)`'
         productPath: |
-          $.properties."sentinel:product_id".`sub(/([S2AB]{3})_MSIL1C_([0-9]{4})([0-9]{2})([0-9]{2})(T.*)/, products/\\2/\\3/\\4/\\1_MSIL1C_\\2\\3\\4\\5)`.`sub(/\/0+/, \/)`
+          $.properties."sentinel:product_id".`sub(/([S2AB]{3})_MSIL1C_([0-9]{4})([0-9]{2})([0-9]{2})(T.*)/, products!\\2!\\3!\\4!\\1_MSIL1C_\\2\\3\\4\\5)`.`sub(/!0*/, /)`
         tilePath: |
           $.assets.info.href.`sub(/.*/sentinel-s2-l1c\/(tiles\/.*)\/tileInfo\.json/, \\1)`
     S2_MSI_L2A:
@@ -1735,7 +1735,7 @@
         platformSerialIdentifier: '$.id.`split(_, 0, -1)`'
         polarizationMode: '$.id.`sub(/.{14}([A-Z]{2}).*/, \\1)`'
         productPath: |
-          $.properties."sentinel:product_id".`sub(/([S2AB]{3})_MSIL2A_([0-9]{4})([0-9]{2})([0-9]{2})(T.*)/, products/\\2/\\3/\\4/\\1_MSIL2A_\\2\\3\\4\\5)`.`sub(/\/0+/, \/)`
+          $.properties."sentinel:product_id".`sub(/([S2AB]{3})_MSIL2A_([0-9]{4})([0-9]{2})([0-9]{2})(T.*)/, products!\\2!\\3!\\4!\\1_MSIL2A_\\2\\3\\4\\5)`.`sub(/!0*/, /)`
         tilePath: |
           $.assets.info.href.`sub(/.*/sentinel-s2-l2a\/(tiles\/.*)\/tileInfo\.json/, \\1)`
     L8_OLI_TIRS_C1L1:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,4 @@ requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2,<7"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-fallback_version = "2.5.2.dev0"
+fallback_version = "2.5.3.dev0"

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -327,6 +327,13 @@ class TestSearchPluginStacSearch(BaseSearchPluginTest):
                             "sentinel:product_id": "S2B_MSIL1C_20200910T012345_N0209_R008_T31TCJ_20200910T123456",
                         },
                     },
+                    {
+                        "id": "bar",
+                        "geometry": geojson_geometry,
+                        "properties": {
+                            "sentinel:product_id": "S2B_MSIL1C_20201010T012345_N0209_R008_T31TCJ_20201010T123456",
+                        },
+                    },
                 ]
             },
         ]
@@ -343,4 +350,8 @@ class TestSearchPluginStacSearch(BaseSearchPluginTest):
         self.assertEqual(
             products[1].properties["productPath"],
             "products/2020/9/10/S2B_MSIL1C_20200910T012345_N0209_R008_T31TCJ_20200910T123456",
+        )
+        self.assertEqual(
+            products[2].properties["productPath"],
+            "products/2020/10/10/S2B_MSIL1C_20201010T012345_N0209_R008_T31TCJ_20201010T123456",
         )


### PR DESCRIPTION
fixes #479 

Issue caused by `jsonpath-ng.ext` `sub()` method returning no result if nothing is found to substitute. A PR is already opened to fix this behavior https://github.com/h2non/jsonpath-ng/pull/83