### PR TITLE
fix: update provider with new plugin entry

### DIFF
--- a/eodag/config.py
+++ b/eodag/config.py
@@ -163,8 +163,11 @@ class ProviderConfig(yaml.YAMLObject):
         )
         for key in ("api", "search", "download", "auth"):
             current_value = getattr(self, key, None)
+            mapping_value = mapping.get(key, {})
             if current_value is not None:
-                current_value.update(mapping.get(key, {}))
+                current_value.update(mapping_value)
+            elif mapping_value:
+                setattr(self, key, PluginConfig.from_mapping(mapping_value))
 
 
 class PluginConfig(yaml.YAMLObject):

--- a/tests/context.py
+++ b/tests/context.py
@@ -38,6 +38,7 @@ from eodag.config import (
     load_stac_provider_config,
     get_ext_product_types_conf,
     EXT_PRODUCT_TYPES_CONF_URI,
+    PluginConfig,
 )
 from eodag.plugins.apis.ecmwf import EcmwfApi
 from eodag.plugins.authentication.base import Authentication

--- a/tests/integration/test_core_config.py
+++ b/tests/integration/test_core_config.py
@@ -19,7 +19,7 @@
 import tempfile
 from unittest import TestCase, mock
 
-from tests.context import EODataAccessGateway
+from tests.context import EODataAccessGateway, PluginConfig
 
 
 class TestCoreProvidersConfig(TestCase):
@@ -93,3 +93,18 @@ class TestCoreProvidersConfig(TestCase):
         mock__request.return_value.json.side_effect = mock__request_side_effect
         prods, _ = self.dag.search(raise_errors=True)
         self.assertEqual(prods[0].properties["title"], "baz")
+
+        # update provider with new plugin entry
+        self.dag.update_providers_config(
+            """
+            foo_provider:
+                auth:
+                    type: GenericAuth
+            """
+        )
+        self.assertIsInstance(
+            self.dag.providers_config["foo_provider"].auth, PluginConfig
+        )
+        self.assertEqual(
+            self.dag.providers_config["foo_provider"].auth.type, "GenericAuth"
+        )


### PR DESCRIPTION
Fixes missing plugin when added through a provider's config update, that did not have a plugin entry of this type configured yet

See test as example (`foo_provider` had no `auth` plugin configured before):
https://github.com/CS-SI/eodag/blob/a973a8d340710bfda2f67194a135ae8dcfe7ac81/tests/integration/test_core_config.py#L97-L110