### PR TITLE
feat: allow empty geometry for stac providers

### DIFF
--- a/eodag/resources/stac_provider.yml
+++ b/eodag/resources/stac_provider.yml
@@ -134,7 +134,7 @@ search:
       - '$.id'
     geometry:
       - '{{"intersects":{geometry#to_geo_interface}}}'
-      - '$.geometry'
+      - '($.geometry.`str()`.`sub(/^None$/, POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90)))`)|($.geometry[*])'
     downloadLink: '$.links[?(@.rel="self")].href'
     quicklook: '$.assets.quicklook.href'
     thumbnail: '$.assets.thumbnail.href'


### PR DESCRIPTION
Allows STAC providers to return `None` as item geometry, and use `[-180, -90, 180, 90]` as default value