### PR TITLE
fix: discover_product_types auth

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -55,6 +55,7 @@ from eodag.utils import (
     uri_to_path,
 )
 from eodag.utils.exceptions import (
+    AuthenticationError,
     NoMatchingProductType,
     PluginImplementationError,
     UnsupportedProvider,
@@ -640,6 +641,10 @@ class EODataAccessGateway(object):
                     )
                     if callable(getattr(auth_plugin, "authenticate", None)):
                         search_plugin.auth = auth_plugin.authenticate()
+                    else:
+                        raise AuthenticationError(
+                            f"Could not authenticate using {auth_plugin} plugin"
+                        )
 
                 ext_product_types_conf[
                     provider

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -858,7 +858,7 @@ class QueryStringSearch(Search):
             else:
                 if info_message:
                     logger.info(info_message)
-                response = requests.get(url)
+                response = requests.get(url, **kwargs)
                 response.raise_for_status()
         except (requests.RequestException, urllib_HTTPError) as err:
             err_msg = err.readlines() if hasattr(err, "readlines") else ""

--- a/tests/context.py
+++ b/tests/context.py
@@ -42,6 +42,7 @@ from eodag.config import (
 )
 from eodag.plugins.apis.ecmwf import EcmwfApi
 from eodag.plugins.authentication.base import Authentication
+from eodag.plugins.authentication.header import HeaderAuth
 from eodag.plugins.crunch.filter_date import FilterDate
 from eodag.plugins.crunch.filter_latest_tpl_name import FilterLatestByName
 from eodag.plugins.crunch.filter_property import FilterProperty


### PR DESCRIPTION
Fixes issue with `discover_product_types()` that did not use configured auth plugin to query on provider's endpoint