### PR TITLE
feat: external product types conf on gh pages

### DIFF
--- a/eodag/config.py
+++ b/eodag/config.py
@@ -39,7 +39,9 @@ from eodag.utils.exceptions import ValidationError
 
 logger = logging.getLogger("eodag.config")
 
-EXT_PRODUCT_TYPES_CONF_URI = "https://raw.githubusercontent.com/CS-SI/eodag/develop/eodag/resources/ext_product_types.json"  # noqa
+EXT_PRODUCT_TYPES_CONF_URI = (
+    "https://cs-si.github.io/eodag/eodag/resources/ext_product_types.json"
+)
 
 
 class SimpleYamlProxyConfig(object):


### PR DESCRIPTION
Github pages usage to serve static [*external product types configuration* file](https://cs-si.github.io/eodag/eodag/resources/ext_product_types.json) (see [Product types discovery documentation](https://eodag.readthedocs.io/en/latest/notebooks/api_user_guide/2_providers_products_available.html#Product-types-discovery))