### PR TITLE
fix: pin flask version to prevent doctest error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     flasgger
     jsonpath-ng
     lxml
-    flask >= 1.0.2
+    flask >= 1.0.2, < 2.2.0
     markdown >= 3.0.1
     whoosh
     pystac >= 1.0.0b1


### PR DESCRIPTION
Use temporarily `flask < 2.2.0` to prevent doctest error, see https://github.com/pallets/werkzeug/issues/2485