### PR TITLE
fix: discover product types for new default providers

### DIFF
--- a/docs/notebooks/api_user_guide/2_providers_products_available.ipynb
+++ b/docs/notebooks/api_user_guide/2_providers_products_available.ipynb
@@ -433,7 +433,7 @@
     "In EODAG, the discovered *EODAG external product types configuration file* can be set to:\n",
     "\n",
     "* a file automatically built from github actions and stored in [eodag/resources/ext_product_types.json](https://raw.githubusercontent.com/CS-SI/eodag/develop/eodag/resources/ext_product_types.json) (default settings)\n",
-    "* a custom remote or local file by setting its path in `EODAG_EXT_PRODUCT_TYPES_CFG_FILE` environment variable.\n",
+    "* a custom remote or local file by setting its path in `EODAG_EXT_PRODUCT_TYPES_CFG_FILE` environment variable (if the file is not readable, only user-modified providers will be fetched).\n",
     "\n",
     "Then, when listing product types using [list_product_types(fetch_providers=True)](../../api_reference/core.rst#eodag.api.core.EODataAccessGateway.list_product_types), EODAG will first read the content of the *EODAG external product types configuration file* using [fetch_product_types_list()](../../api_reference/core.rst#eodag.api.core.EODataAccessGateway.fetch_product_types_list) \n",
     "then update [EODataAccessGateway](../../api_reference/core.rst#eodag.api.core.EODataAccessGateway) instance product types configuration, if needed.\n",

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -594,14 +594,26 @@ class EODataAccessGateway(object):
                     default_provider_search_config, "discover_product_types", {}
                 )
                 # compare confs
-                if default_discovery_conf == user_discovery_conf:
+                if default_discovery_conf == user_discovery_conf and (
+                    not default_discovery_conf.get("fetch_url", None)
+                    or "ext_product_types_conf" not in locals()
+                    or "ext_product_types_conf" in locals()
+                    and (
+                        provider in ext_product_types_conf
+                        or len(ext_product_types_conf.keys()) == 0
+                    )
+                ):
                     continue
+                # providers not skipped here should be user-modified
+                # or not in ext_product_types_conf (if eodag system conf != eodag conf used for ext_product_types_conf)
 
             # discover product types for user configured provider
-            ext_product_types_conf = self.discover_product_types(provider=provider)
+            provider_ext_product_types_conf = self.discover_product_types(
+                provider=provider
+            )
 
             # update eodag product types list with new conf
-            self.update_product_types_list(ext_product_types_conf)
+            self.update_product_types_list(provider_ext_product_types_conf)
 
     def discover_product_types(self, provider=None):
         """Fetch providers for product types


### PR DESCRIPTION
For new system-wide providers (updated system `providers.yml`), launch product types discovery after having fetched external products types configuration:

If a new provider `foo`, is added by user in `{eodag_install_dir}/resources/providers.yml`, it will not be listed in the remote [`ext_product_types.json`](https://cs-si.github.io/eodag/eodag/resources/ext_product_types.json) which will trigger its product types discovery.

This behavior will also be the same when the providers configuration from eodag github `develop` branch differs from the user one.

See [product types discovery documentation](https://eodag.readthedocs.io/en/latest/notebooks/api_user_guide/2_providers_products_available.html#Product-types-discovery) for more information