### PR TITLE
fix: update flask version limit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     flasgger
     jsonpath-ng
     lxml
-    flask >= 1.0.2, < 2.2.0
+    flask >= 1.0.2, != 2.2.0, != 2.2.1
     markdown >= 3.0.1
     whoosh
     pystac >= 1.0.0b1


### PR DESCRIPTION
Updates update flask version limit after `flask v2.2.2` release, which fixes issue with doctest. 
See https://github.com/pallets/werkzeug/pull/2497.
Related to https://github.com/CS-SI/eodag/pull/492.