### PR TITLE
fix: drop support for python3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, "3.10"]
+        python-version: [3.7, "3.10"]
         os: [ubuntu-latest, windows-latest]
     steps:
     - name: Checkout the repo

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -75,7 +75,7 @@ To run the entire tests (units, integraton and end-to-end):
       you, please `install <https://pandoc.org/installing.html>`_ pandoc and try
       again.
 
-    * eodag is tested against python versions 3.6, 3.7, 3.8, 3.9 and 3.10. Ensure you have
+    * eodag is tested against python versions 3.7, 3.8, 3.9 and 3.10. Ensure you have
       these versions installed before you run tox. You can use
       `pyenv <https://github.com/pyenv/pyenv>`_ to manage many different versions
       of python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2,<7"]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ classifiers =
     Operating System :: POSIX :: Linux
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,5 @@ def _get_fallback_version():
 if __name__ == "__main__":
     setuptools.setup(
         use_scm_version={"fallback_version": _get_fallback_version()},
-        setup_requires=["setuptools_scm<7"],
+        setup_requires=["setuptools_scm"],
     )

--- a/tox.ini
+++ b/tox.ini
@@ -16,13 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 [tox]
-envlist = py36, py37, py38, py39, py310, docs, pypi, linters
+envlist = py37, py38, py39, py310, docs, pypi, linters
 skipdist = true
 
 # Mapping required by tox-gh-actions, only used in CI
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
fixes #476 

Drop support for `python3.6`, update setup and test files (reverts #477)