### PR TITLE
test: less restrictive comparison in download retry tests

### DIFF
--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -194,7 +194,7 @@ class TestDownloadPluginHttpRetry(BaseDownloadPluginTest):
                 self.plugin.download(
                     self.product,
                     outputs_prefix=self.output_dir,
-                    wait=0.01 / 60,
+                    wait=0.1 / 60,
                     timeout=0.2 / 60,
                 )
 


### PR DESCRIPTION
The margin was too thin when comparing *download retry* counts in `test_plugins_download_http_retry_error_timeout()`.

Changes this margin to be sure that we cannot have a false test failure.