### PR TITLE
fix: aws bucket extraction

### DIFF
--- a/eodag/plugins/download/s3rest.py
+++ b/eodag/plugins/download/s3rest.py
@@ -27,10 +27,15 @@ import requests
 from requests import RequestException
 
 from eodag.api.product.metadata_mapping import OFFLINE_STATUS
-from eodag.plugins.download.aws import AwsDownload
-from eodag.plugins.download.base import DEFAULT_STREAM_REQUESTS_TIMEOUT
+from eodag.plugins.download.base import DEFAULT_STREAM_REQUESTS_TIMEOUT, Download
 from eodag.plugins.download.http import HTTPDownload
-from eodag.utils import ProgressCallback, path_to_uri, unquote, urljoin
+from eodag.utils import (
+    ProgressCallback,
+    get_bucket_name_and_prefix,
+    path_to_uri,
+    unquote,
+    urljoin,
+)
 from eodag.utils.exceptions import (
     AuthenticationError,
     DownloadError,
@@ -42,7 +47,7 @@ from eodag.utils.stac_reader import HTTP_REQ_TIMEOUT
 logger = logging.getLogger("eodag.plugins.download.s3rest")
 
 
-class S3RestDownload(AwsDownload):
+class S3RestDownload(Download):
     """Http download on S3-like object storage location
     for example using Mundi REST API (free account)
     https://mundiwebservices.com/keystoneapi/uploads/documents/CWS-DATA-MUT-087-EN-Mundi_Download_v1.1.pdf#page=13
@@ -78,7 +83,9 @@ class S3RestDownload(AwsDownload):
             progress_callback = ProgressCallback(disable=True)
 
         # get bucket urls
-        bucket_name, prefix = self.get_bucket_name_and_prefix(product)
+        bucket_name, prefix = get_bucket_name_and_prefix(
+            url=product.location, bucket_path_level=self.config.bucket_path_level
+        )
 
         if (
             bucket_name is None

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1261,7 +1261,7 @@
   url: https://mundiwebservices.com/
   search: !plugin
     type: QueryStringSearch
-    api_endpoint: 'https://mundiwebservices.com/acdc/catalog/proxy/search/{collection}/opensearch'
+    api_endpoint: 'https://{collection}.browse.catalog.mundiwebservices.com/opensearch'
     need_auth: false
     result_type: 'xml'
     results_entry: '//ns:entry'
@@ -1390,6 +1390,7 @@
     base_uri: 'https://mundiwebservices.com/dp'
     extract: true
     auth_error_code: 401
+    bucket_path_level: 0
   auth: !plugin
     type: HTTPHeaderAuth
     headers:

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -1028,3 +1028,33 @@ def cached_parse(str_to_parse):
     :rtype: :class:`jsonpath_ng.JSONPath`
     """
     return parse(str_to_parse)
+
+
+def get_bucket_name_and_prefix(url=None, bucket_path_level=None):
+    """Extract bucket name and prefix from URL
+
+    :param url: (optional) URL to use as product.location
+    :type url: str
+    :param bucket_path_level: (optional) bucket location index in path.split('/')
+    :type bucket_path_level: int
+    :returns: bucket_name and prefix as str
+    :rtype: tuple
+    """
+    bucket, prefix = None, None
+
+    scheme, netloc, path, params, query, fragment = urlparse(url)
+    subdomain = netloc.split(".")[0]
+    path = path.strip("/")
+
+    if scheme and bucket_path_level is None:
+        bucket = subdomain
+        prefix = path
+    elif not scheme and bucket_path_level is None:
+        prefix = path
+    elif bucket_path_level is not None:
+        parts = path.split("/")
+        bucket, prefix = parts[bucket_path_level], "/".join(
+            parts[(bucket_path_level + 1) :]
+        )
+
+    return bucket, prefix

--- a/tests/context.py
+++ b/tests/context.py
@@ -61,6 +61,7 @@ from eodag.plugins.download.http import HTTPDownload
 from eodag.plugins.manager import PluginManager
 from eodag.plugins.search.base import Search
 from eodag.utils import (
+    get_bucket_name_and_prefix,
     get_geometry_from_various,
     get_timestamp,
     makedirs,

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -314,3 +314,40 @@ class TestDownloadPluginHttpRetry(BaseDownloadPluginTest):
             self.assertEqual(len(responses.calls), 1)
 
         run()
+
+
+class TestDownloadPluginAws(BaseDownloadPluginTest):
+    def setUp(self):
+        super(TestDownloadPluginAws, self).setUp()
+        self.product = EOProduct(
+            "astraea_eod",
+            dict(
+                geometry="POINT (0 0)",
+                title="dummy_product",
+                id="dummy",
+            ),
+            productType="S2_MSI_L2A",
+        )
+
+    def test_plugins_download_aws_get_bucket_prefix(self):
+        """AwsDownload.get_bucket_name_and_prefix() must extract bucket & prefix from location"""
+
+        plugin = self.get_download_plugin(self.product)
+        plugin.config.products["S2_MSI_L2A"]["default_bucket"] = "default_bucket"
+        self.product.properties["id"] = "someproduct"
+
+        self.product.location = (
+            self.product.remote_location
+        ) = "http://somebucket.somehost.com/path/to/some/product"
+        bucket, prefix = plugin.get_bucket_name_and_prefix(self.product)
+        self.assertEqual((bucket, prefix), ("somebucket", "path/to/some/product"))
+
+        plugin.config.bucket_path_level = 1
+        bucket, prefix = plugin.get_bucket_name_and_prefix(self.product)
+        self.assertEqual((bucket, prefix), ("to", "some/product"))
+        del plugin.config.bucket_path_level
+
+        bucket, prefix = plugin.get_bucket_name_and_prefix(
+            self.product, url="/somewhere/else"
+        )
+        self.assertEqual((bucket, prefix), ("default_bucket", "somewhere/else"))

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -25,6 +25,7 @@ from io import StringIO
 from tests.context import (
     DownloadedCallback,
     ProgressCallback,
+    get_bucket_name_and_prefix,
     get_timestamp,
     merge_mappings,
     path_to_uri,
@@ -162,3 +163,51 @@ class TestUtils(unittest.TestCase):
         mapping = {"keyA": True}
         merge_mappings(mapping, {"keya": "bar"})
         self.assertEqual(mapping, {"keyA": True})
+
+    def test_get_bucket_name_and_prefix(self):
+        """get_bucket_name_and_prefix must extract bucket and prefix from url"""
+        self.assertEqual(
+            get_bucket_name_and_prefix(
+                "s3://sentinel-s2-l1c/tiles/50/R/LR/2021/6/8/0/B02.jp2"
+            ),
+            ("sentinel-s2-l1c", "tiles/50/R/LR/2021/6/8/0/B02.jp2"),
+        )
+        self.assertEqual(
+            get_bucket_name_and_prefix(
+                "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/44/2022/10/S2B_20221011/B01.tif"
+            ),
+            (
+                "sentinel-cogs",
+                "sentinel-s2-l2a-cogs/44/2022/10/S2B_20221011/B01.tif",
+            ),
+        )
+        self.assertEqual(
+            get_bucket_name_and_prefix(
+                "https://obs.eu-de.otc.t-systems.com/s2-l1c-2021-q4/30/T/2021/11/14/S2A_MSIL1C_20211114T110321_N0301",
+                0,
+            ),
+            ("s2-l1c-2021-q4", "30/T/2021/11/14/S2A_MSIL1C_20211114T110321_N0301"),
+        )
+        self.assertEqual(
+            get_bucket_name_and_prefix(
+                "products/2021/1/5/S2A_MSIL1C_20210105T105441_N0209_R051_T30TYN_20210105T130129",
+            ),
+            (
+                None,
+                "products/2021/1/5/S2A_MSIL1C_20210105T105441_N0209_R051_T30TYN_20210105T130129",
+            ),
+        )
+        self.assertEqual(
+            get_bucket_name_and_prefix(
+                "bucket/path/to/product",
+                0,
+            ),
+            ("bucket", "path/to/product"),
+        )
+        self.assertEqual(
+            get_bucket_name_and_prefix(
+                "http://foo/bar/bucket/path/to/product",
+                1,
+            ),
+            ("bucket", "path/to/product"),
+        )


### PR DESCRIPTION
- Refactors and updates `get_bucket_name_and_prefix()`
- updates `mundi` configuration with `bucket_path_level = 0` and up-to-date search endpoint

fixes #519 