### PR TITLE
fix: rest search without stac formatting

### DIFF
--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -381,13 +381,15 @@ def get_criterias_from_metadata_mapping(metadata_mapping, arguments):
     return criterias
 
 
-def search_products(product_type, arguments):
+def search_products(product_type, arguments, stac_formatted=True):
     """Returns product search results
 
     :param product_type: The product type criteria
     :type product_type: str
     :param arguments: Request args
     :type arguments: dict
+    :param stac_formatted: Whether input is STAC-formatted or not
+    :type stac_formatted: bool
     :returns: A search result
     :rtype serialized GeoJSON response"""
 
@@ -409,13 +411,16 @@ def search_products(product_type, arguments):
             "geom": geom,
         }
 
-        stac_provider_metadata_mapping = stac_provider_config.get("search", {}).get(
-            "metadata_mapping", {}
-        )
-        extra_criterias = get_criterias_from_metadata_mapping(
-            stac_provider_metadata_mapping, arguments
-        )
-        criterias.update(extra_criterias)
+        if stac_formatted:
+            stac_provider_metadata_mapping = stac_provider_config.get("search", {}).get(
+                "metadata_mapping", {}
+            )
+            extra_criterias = get_criterias_from_metadata_mapping(
+                stac_provider_metadata_mapping, arguments
+            )
+            criterias.update(extra_criterias)
+        else:
+            criterias.update(arguments)
 
         # We remove potential None values to use the default values of the search method
         criterias = dict((k, v) for k, v in criterias.items() if v is not None)

--- a/tests/units/test_stac_utils.py
+++ b/tests/units/test_stac_utils.py
@@ -342,5 +342,76 @@ class TestStacUtils(unittest.TestCase):
         self.rest_utils.search_products("S2_MSI_L1C", {})
         self.rest_utils.search_products("S2_MSI_L1C", {"unserialized": "true"})
 
+        # STAC formatted
+        self.rest_utils.search_products(
+            "S2_MSI_L1C",
+            {
+                "intersects": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [0.25, 43.2],
+                            [0.25, 43.9],
+                            [2.8, 43.9],
+                            [2.8, 43.2],
+                            [0.25, 43.2],
+                        ]
+                    ],
+                },
+                "query": {"eo:cloud_cover": {"lte": 50}},
+                "dtstart": "2020-02-01T00:00:00.000Z",
+                "dtend": "2021-02-20T00:00:00.000Z",
+                "product_type": "S2_MSI_L1C",
+                "unserialized": "true",
+            },
+        )
+        call_args, call_kwargs = mock_do_search.call_args
+        self.assertDictContainsSubset(
+            {
+                "productType": "S2_MSI_L1C",
+                "cloudCover": 50,
+                "startTimeFromAscendingNode": "2020-02-01T00:00:00",
+                "completionTimeFromAscendingNode": "2021-02-20T00:00:00",
+            },
+            call_kwargs,
+        )
+        self.assertEqual(call_kwargs["geometry"].bounds, (0.25, 43.2, 2.8, 43.9))
+
+        # Not STAC formatted
+        self.rest_utils.search_products(
+            "S2_MSI_L1C",
+            {
+                "geom": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [0.25, 43.2],
+                            [0.25, 43.9],
+                            [2.8, 43.9],
+                            [2.8, 43.2],
+                            [0.25, 43.2],
+                        ]
+                    ],
+                },
+                "cloudCover": 50,
+                "dtstart": "2020-02-01T00:00:00.000Z",
+                "dtend": "2021-02-20T00:00:00.000Z",
+                "product_type": "S2_MSI_L1C",
+                "unserialized": "true",
+            },
+            stac_formatted=False,
+        )
+        call_args, call_kwargs = mock_do_search.call_args
+        self.assertDictContainsSubset(
+            {
+                "productType": "S2_MSI_L1C",
+                "cloudCover": 50,
+                "startTimeFromAscendingNode": "2020-02-01T00:00:00",
+                "completionTimeFromAscendingNode": "2021-02-20T00:00:00",
+            },
+            call_kwargs,
+        )
+        self.assertEqual(call_kwargs["geometry"].bounds, (0.25, 43.2, 2.8, 43.9))
+
     def test_search_stac_items(self):
         pass  # TODO


### PR DESCRIPTION
Adds a `stac_formatted` parameter to `eodag.rest.utils.search_products()` to accept parameters that are not STAC formatted.

Needed by https://github.com/CS-SI/eodag-labextension/issues/71