### PR TITLE
feat: do not run flasgger automatically

### DIFF
--- a/eodag/cli.py
+++ b/eodag/cli.py
@@ -679,7 +679,10 @@ def serve_rest(ctx, daemon, world, port, config, locs, debug):
     if locs:
         os.environ["EODAG_LOCS_CFG_FILE"] = locs
 
-    from eodag.rest.server import app
+    from eodag.rest.server import app, run_swagger, stac_api_config
+
+    # run swagger / service-doc
+    run_swagger(app=app, config=stac_api_config)
 
     bind_host = "127.0.0.1"
     if world:

--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -30,7 +30,7 @@ from flasgger import Swagger
 from flask import abort, jsonify, make_response, request, send_file
 
 from eodag.config import load_stac_api_config
-from eodag.rest.utils import (  # get_stac_landing_page,; get_stac_product_types_catalog,; search_products,
+from eodag.rest.utils import (
     download_stac_item_by_id,
     get_detailled_collections_list,
     get_stac_catalogs,
@@ -39,7 +39,6 @@ from eodag.rest.utils import (  # get_stac_landing_page,; get_stac_product_types
     get_stac_conformance,
     get_stac_extension_oseo,
     get_stac_item_by_id,
-    load_stac_config,
     search_stac_items,
 )
 from eodag.utils.exceptions import (
@@ -61,10 +60,7 @@ metadata_str = distribution.get_metadata(distribution.PKG_INFO)
 metadata_obj = dist.DistributionMetadata()
 metadata_obj.read_pkg_file(io.StringIO(metadata_str))
 
-# confs from resources yaml files
-stac_config = load_stac_config()
-
-stac_api_config = {"info": {}}
+# conf from resources/stac_api.yml
 stac_api_config = load_stac_api_config()
 root_catalog = get_stac_catalogs(url="", fetch_providers=False)
 stac_api_version = stac_api_config["info"]["version"]
@@ -98,7 +94,24 @@ stac_api_config["specs"] = [
 stac_api_config["static_url_path"] = "/service-static"
 stac_api_config["specs_route"] = "/service-doc/"
 stac_api_config.pop("servers", None)
-swagger = Swagger(app, config=stac_api_config, merge=True)
+
+
+def run_swagger(app=None, config=None, merge=True, **kwargs):
+    """Run `flasgger.Swagger`.
+    Needs to be run once after `eodag.rest.server` module import.
+
+    :param app: flask application that will run flasgger
+    :type app: :class:`~flask.Flask`
+    :param config: flasgger configuration
+    :type config: dict
+    :param merge: merge config with flasgger defaults
+    :type merge: bool
+    :param kwargs: keyword arguments passed to `flasgger.Swagger` constructor
+    :type kwargs: Any
+    :returns: running Swagger object
+    :rtype: :class:`~flasgger.Swagger`
+    """
+    return Swagger(app=app, config=config, merge=True, **kwargs)
 
 
 def cross_origin(request_handler):

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -9,7 +9,6 @@ import re
 from collections import namedtuple
 
 import dateutil.parser
-import markdown
 from dateutil import tz
 from shapely.geometry import Polygon, shape
 
@@ -22,7 +21,7 @@ from eodag.plugins.crunch.filter_latest_intersect import FilterLatestIntersect
 from eodag.plugins.crunch.filter_latest_tpl_name import FilterLatestByName
 from eodag.plugins.crunch.filter_overlap import FilterOverlap
 from eodag.rest.stac import StacCatalog, StacCollection, StacCommon, StacItem
-from eodag.utils import cached_parse, dict_items_recursive_apply
+from eodag.utils import _deprecated, cached_parse, dict_items_recursive_apply
 from eodag.utils.exceptions import (
     MisconfiguredError,
     NoMatchingProductType,
@@ -43,6 +42,10 @@ stac_provider_config = load_stac_provider_config()
 STAC_QUERY_PATTERN = "query.*.*"
 
 
+@_deprecated(
+    reason="Function internally used by get_home_page_content, also deprecated",
+    version="2.6.1",
+)
 def format_product_types(product_types):
     """Format product_types
 
@@ -71,6 +74,7 @@ def get_detailled_collections_list(provider=None, fetch_providers=True):
     )
 
 
+@_deprecated(reason="No more needed with STAC API + Swagger", version="2.6.1")
 def get_home_page_content(base_url, ipp=None):
     """Compute eodag service home page content
 
@@ -79,18 +83,18 @@ def get_home_page_content(base_url, ipp=None):
     :param ipp: (optional) Items per page number
     :type ipp: int
     """
-
-    with open(os.path.join(os.path.dirname(__file__), "description.md"), "rt") as fp:
-        content = fp.read()
-    content = content.format(
-        base_url=base_url,
-        product_types=format_product_types(eodag_api.list_product_types()),
-        ipp=ipp or DEFAULT_ITEMS_PER_PAGE,
-    )
-    content = markdown.markdown(content)
+    base_url = base_url.rstrip("/") + "/"
+    content = f"""<h1>EODAG Server</h1><br />
+    <a href='{base_url}'>root</a><br />
+    <a href='{base_url}service-doc'>service-doc</a><br />
+    """
     return content
 
 
+@_deprecated(
+    reason="Used to format output from deprecated function get_home_page_content",
+    version="2.6.1",
+)
 def get_templates_path():
     """Returns Jinja templates path"""
     return os.path.join(os.path.dirname(__file__), "templates")

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,6 @@ install_requires =
     jsonpath-ng
     lxml
     flask >= 1.0.2, != 2.2.0, != 2.2.1
-    markdown >= 3.0.1
     whoosh
     pystac >= 1.0.0b1
     ecmwf-api-client

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -47,6 +47,13 @@ class RequestTestCase(unittest.TestCase):
 
         cls.eodag_http_server = eodag_http_server
 
+        # run swagger / service-doc
+        eodag_http_server.run_swagger(
+            app=eodag_http_server.app,
+            config=eodag_http_server.stac_api_config,
+            merge=True,
+        )
+
         # backup os.environ as it will be modified by tests
         cls.eodag_env_pattern = re.compile(r"EODAG_\w+")
         cls.eodag_env_backup = {


### PR DESCRIPTION
Do not run [flasgger](https://github.com/flasgger/flasgger) automatically, in order to be able to edit its configuration, which needs to be done before it is linked to the `Flask` app.

Needed by https://github.com/CS-SI/eodag-labextension/issues/81

Deprecated no more used functions: `rest.utils.format_product_types()`, `rest.utils.get_home_page_content()`, `rest.utils.get_templates_path()`.

Removed dependency to no more used `markdown`.