### PR TITLE
ci: pre-commit repos update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ fail_fast: false
 repos:
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v3.4.0
+    rev: v4.3.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -17,13 +17,13 @@ repos:
     -   id: debug-statements
     -   id: check-merge-conflict
 
--   repo: 'https://gitlab.com/pycqa/flake8'
-    rev: 3.9.0
+-   repo: 'https://gitlab.com/PyCQA/flake8'
+    rev: 5.0.4
     hooks:
     -   id: flake8
 
 -   repo: 'https://github.com/ambv/black'
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
     -   id: black
         args: ['--safe']
@@ -34,6 +34,6 @@ repos:
     -   id: pydocstyle
 
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.7.0
+    rev: v5.10.1
     hooks:
     -   id: isort


### PR DESCRIPTION
Updates versions of pre-commit repos versions.

Fixes issue with `flake8` on `python3.7` raising:
```
 flake8...................................................................Failed
- hook id: flake8
- exit code: 1

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repo2rulx4j3/py_env-python3.7/bin/flake8", line 8, in <module>
    sys.exit(main())
  File "/home/runner/.cache/pre-commit/repo2rulx4j3/py_env-python3.7/lib/python3.7/site-packages/flake8/main/cli.py", line 22, in main
    app.run(argv)
  File "/home/runner/.cache/pre-commit/repo2rulx4j3/py_env-python3.7/lib/python3.7/site-packages/flake8/main/application.py", line 363, in run
    self._run(argv)
  File "/home/runner/.cache/pre-commit/repo2rulx4j3/py_env-python3.7/lib/python3.7/site-packages/flake8/main/application.py", line 350, in _run
    self.initialize(argv)
  File "/home/runner/.cache/pre-commit/repo2rulx4j3/py_env-python3.7/lib/python3.7/site-packages/flake8/main/application.py", line 330, in initialize
    self.find_plugins(config_finder)
  File "/home/runner/.cache/pre-commit/repo2rulx4j3/py_env-python3.7/lib/python3.7/site-packages/flake8/main/application.py", line 153, in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
  File "/home/runner/.cache/pre-commit/repo2rulx4j3/py_env-python3.7/lib/python3.7/site-packages/flake8/plugins/manager.py", line 357, in __init__
    self.namespace, local_plugins=local_plugins
  File "/home/runner/.cache/pre-commit/repo2rulx4j3/py_env-python3.7/lib/python3.7/site-packages/flake8/plugins/manager.py", line 238, in __init__
    self._load_entrypoint_plugins()
  File "/home/runner/.cache/pre-commit/repo2rulx4j3/py_env-python3.7/lib/python3.7/site-packages/flake8/plugins/manager.py", line 254, in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
AttributeError: 'EntryPoints' object has no attribute 'get'
```