### PR TITLE
fix: temporarily set pytest-html max version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,19 @@ install_requires =
     cdsapi
 
 [options.extras_require]
-dev = pytest; pytest-cov; pytest-html; tox; faker; moto; twine; wheel; flake8; pre-commit; responses
+dev =
+    pytest
+    pytest-cov
+    # max version set until https://github.com/pytest-dev/pytest-html/issues/559 is fixed
+    pytest-html < 3.2.0
+    tox
+    faker
+    moto
+    twine
+    wheel
+    flake8
+    pre-commit
+    responses
 notebook = tqdm[notebook]
 tutorials =
     eodag-cube >= 0.2.0


### PR DESCRIPTION
Use `pytest-html < 3.2.0` until https://github.com/pytest-dev/pytest-html/issues/559 is fixed.

Fixes issue with `pytest-html 3.2.0` on windows:
```
Traceback (most recent call last):
    File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\runpy.py", line 193, in _run_module_as_main
      "__main__", mod_spec)
    File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\runpy.py", line 85, in _run_code
      exec(code, run_globals)
    File "D:\a\eodag\eodag\.tox\py37\Scripts\pytest.EXE\__main__.py", line 7, in <module>
      sys.exit(console_main())
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\_pytest\config\__init__.py", line 190, in console_main
      code = main()
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\_pytest\config\__init__.py", line 168, in main
      config=config
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\pluggy\_hooks.py", line 265, in __call__
      return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\pluggy\_manager.py", line 80, in _hookexec
      return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\pluggy\_callers.py", line 39, in _multicall
      res = hook_impl.function(*args)
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\pluggy\_result.py", line 60, in get_result
      raise ex[1].with_traceback(ex[2])
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\pluggy\_callers.py", line 39, in _multicall
      res = hook_impl.function(*args)
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\_pytest\main.py", line 317, in pytest_cmdline_main
      return wrap_session(config, _main)
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\_pytest\main.py", line 270, in wrap_session
      session.exitstatus = doit(config, session) or 0
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\pluggy\_hooks.py", line 265, in __call__
      return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\pluggy\_manager.py", line 80, in _hookexec
      return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\pluggy\_callers.py", line 55, in _multicall
      gen.send(outcome)
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\_pytest\terminal.py", line 808, in pytest_sessionfinish
      outcome.get_result()
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\pluggy\_result.py", line 60, in get_result
      raise ex[1].with_traceback(ex[2])
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\pluggy\_callers.py", line 39, in _multicall
      res = hook_impl.function(*args)
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\pytest_html\html_report.py", line 333, in pytest_sessionfinish
      self._save_report(report_content)
    File "D:\a\eodag\eodag\.tox\py37\lib\site-packages\pytest_html\html_report.py", line 259, in _save_report
      self.logfile.write_text(report_content)
    File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\pathlib.py", line 1241, in write_text
      return f.write(data)
    File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\encodings\cp1252.py", line 19, in encode
      return codecs.charmap_encode(input,self.errors,encoding_table)[0]
  UnicodeEncodeError: 'charmap' codec can't encode character '\u258e' in position 58160: character maps to <undefined>
 ```