### PR TITLE
fix: temporarily add py dep for pytest-html

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,9 @@ install_requires =
 dev =
     pytest
     pytest-cov
-    # max version set until https://github.com/pytest-dev/pytest-html/issues/559 is fixed
+    # pytest-html max version set and py requirement added
+    # until https://github.com/pytest-dev/pytest-html/issues/559 is fixed
+    py >= 1.8.2
     pytest-html < 3.2.0
     tox
     faker


### PR DESCRIPTION
fixes https://github.com/CS-SI/eodag/pull/540#issuecomment-1300259732

See
> `py` is still required by `tox`, which prevents our tests to fail.
But as `pytest 7.2.0` removed `py` from its dependencies and  `pytest-html` still needs it, I should also include it temporarily in our deps, in case `tox` also removes it from its dependencies (won't be needed with `pytest-html >= 3.2.0`).