### PR TITLE
docs: fixed rtype for guess_product_type

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -764,7 +764,7 @@ class EODataAccessGateway(object):
 
         :param kwargs: A set of search parameters as keywords arguments
         :returns: The best match for the given parameters
-        :rtype: str
+        :rtype: list[str]
         :raises: :class:`~eodag.utils.exceptions.NoMatchingProductType`
         """
         supported_params = {


### PR DESCRIPTION
fixes rtype for [guess_product_type()](https://eodag.readthedocs.io/en/latest/api_reference/core.html#eodag.api.core.EODataAccessGateway.guess_product_type)