### PR TITLE
feat: add support for py311

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, "3.10"]
+        python-version: [3.7, "3.11"]
         os: [ubuntu-latest, windows-latest]
     steps:
     - name: Checkout the repo

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -75,7 +75,7 @@ To run the entire tests (units, integration and end-to-end):
       you, please `install <https://pandoc.org/installing.html>`_ pandoc and try
       again.
 
-    * eodag is tested against python versions 3.7, 3.8, 3.9 and 3.10. Ensure you have
+    * eodag is tested against python versions 3.7, 3.8, 3.9, 3.10 and 3.11. Ensure you have
       these versions installed before you run tox. You can use
       `pyenv <https://github.com/pyenv/pyenv>`_ to manage many different versions
       of python

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Internet :: WWW/HTTP :: Indexing/Search
     Topic :: Scientific/Engineering :: GIS

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 [tox]
-envlist = py37, py38, py39, py310, docs, pypi, linters
+envlist = py37, py38, py39, py310, py311, docs, pypi, linters
 skipdist = true
 
 # Mapping required by tox-gh-actions, only used in CI
@@ -26,6 +26,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 commands =


### PR DESCRIPTION
Adds support for `python3.11` and use it in github actions instead of `python3.10`.
Fixes #537