### PR TITLE
fix: continue if error on gh actions tests publish

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,7 @@ jobs:
 
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1
+      continue-on-error: true
       with:
         files: artifacts/**/*junit-report.xml
     - name: Publish Coverage Report


### PR DESCRIPTION
Use `continue-on-error: true` option to skip error when running `Publish Unit Test Results` GH actions step:
```
Pull down action image 'ghcr.io/enricomi/publish-unit-test-result-action:v1.40'
  /usr/bin/docker pull ghcr.io/enricomi/publish-unit-test-result-action:v1.40
  Error response from daemon: received unexpected HTTP status: 503 Service Unavailable
  Warning: Docker pull failed with exit code 1, back off 8.516 seconds before retry.
  /usr/bin/docker pull ghcr.io/enricomi/publish-unit-test-result-action:v1.40
  Error response from daemon: received unexpected HTTP status: 503 Service Unavailable
  Warning: Docker pull failed with exit code 1, back off 9.323 seconds before retry.
  /usr/bin/docker pull ghcr.io/enricomi/publish-unit-test-result-action:v1.40
  Error response from daemon: received unexpected HTTP status: 503 Service Unavailable
Error: Docker pull failed with exit code 1
```
See https://github.com/EnricoMi/publish-unit-test-result-action/issues/379