### PR TITLE
Update read_local_json to catch OSErrors (#519)

### DIFF
--- a/eodag/utils/stac_reader.py
+++ b/eodag/utils/stac_reader.py
@@ -50,7 +50,7 @@ class _TextOpener:
                     return json.load(f)
                 else:
                     return f.read()
-        except (FileNotFoundError, OSError):
+        except OSError:
             logger.debug("read_local_json is not the right STAC opener")
             raise STACOpenerError
 

--- a/eodag/utils/stac_reader.py
+++ b/eodag/utils/stac_reader.py
@@ -50,7 +50,7 @@ class _TextOpener:
                     return json.load(f)
                 else:
                     return f.read()
-        except FileNotFoundError:
+        except (FileNotFoundError, OSError):
             logger.debug("read_local_json is not the right STAC opener")
             raise STACOpenerError
 


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description
Resolves #519 failure:

```
with open(url) as f:
OSError: [Errno 22] Invalid argument: 'https://capella-open-data.s3.us-west-2.amazonaws.com/stac/capella-open-data-by-datetime/capella-open-data-2021/capella-open-data-2021-4/capella-open-data-2021-4-10/CAPELLA_C03_SP_SLC_HH_20210410140302_20210410140304/CAPELLA_C03_SP_SLC_HH_20210410140302_20210410140304.json'
```

It was trying to read a remote json with the `read_local_json` (in `stac_reader`). As expected it failed, but (I think) with an unhandled exeception: an `OSError`, instead of a `FileNotFoundError`.

This behavior breaks the function, which is supposed to work or return a STACOpenerError.