### PR TITLE
fix: fixed flatten top dirs mechanism

### DIFF
--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -19,7 +19,6 @@
 import logging
 import os
 import re
-import shutil
 from pathlib import Path
 
 import boto3
@@ -36,6 +35,7 @@ from eodag.api.product.metadata_mapping import (
 from eodag.plugins.download.base import Download
 from eodag.utils import (
     ProgressCallback,
+    flatten_top_directories,
     get_bucket_name_and_prefix,
     path_to_uri,
     rename_subfolder,
@@ -421,13 +421,7 @@ class AwsDownload(Download):
             self.finalize_s2_safe_product(product_local_path)
         # flatten directory structure
         elif flatten_top_dirs:
-            tmp_product_local_path = "%s-tmp" % product_local_path
-            for d, dirs, files in os.walk(product_local_path):
-                if len(files) != 0:
-                    shutil.copytree(d, tmp_product_local_path)
-                    shutil.rmtree(product_local_path)
-                    os.rename(tmp_product_local_path, product_local_path)
-                    break
+            flatten_top_directories(product_local_path, common_prefix)
 
         if build_safe:
             self.check_manifest_file_list(product_local_path)

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -33,7 +33,12 @@ from eodag.plugins.download.base import (
     DEFAULT_STREAM_REQUESTS_TIMEOUT,
     Download,
 )
-from eodag.utils import ProgressCallback, path_to_uri, uri_to_path
+from eodag.utils import (
+    ProgressCallback,
+    flatten_top_directories,
+    path_to_uri,
+    uri_to_path,
+)
 from eodag.utils.exceptions import (
     AuthenticationError,
     MisconfiguredError,
@@ -421,13 +426,7 @@ class HTTPDownload(Download):
 
         # flatten directory structure
         if flatten_top_dirs:
-            tmp_product_local_path = "%s-tmp" % fs_dir_path
-            for d, dirs, files in os.walk(fs_dir_path):
-                if len(files) != 0:
-                    shutil.copytree(d, tmp_product_local_path)
-                    shutil.rmtree(fs_dir_path)
-                    os.rename(tmp_product_local_path, fs_dir_path)
-                    break
+            flatten_top_directories(fs_dir_path)
 
         # save hash/record file
         with open(record_filename, "w") as fh:

--- a/tests/context.py
+++ b/tests/context.py
@@ -73,6 +73,7 @@ from eodag.utils import (
     parse_qsl,
     urlsplit,
     GENERIC_PRODUCT_TYPE,
+    flatten_top_directories,
 )
 from eodag.utils.exceptions import (
     AddressNotFound,


### PR DESCRIPTION
fixes #573 

Before this fix, some files could be deleted after download, during the product directory structure modification