### PR TITLE
fix: adapt to shapely v2.0

### DIFF
--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -35,9 +35,10 @@ from eodag.utils import ProgressCallback, get_geometry_from_various
 from eodag.utils.exceptions import DownloadError, MisconfiguredError
 
 try:
-    from shapely.errors import TopologicalError
+    from shapely.errors import GEOSException
 except ImportError:
-    from shapely.geos import TopologicalError
+    # shapely < 2.0 compatibility
+    from shapely.errors import TopologicalError as GEOSException
 
 
 logger = logging.getLogger("eodag.api.product")
@@ -129,7 +130,7 @@ class EOProduct(object):
             )
             try:
                 self.search_intersection = self.geometry.intersection(searched_geom)
-            except TopologicalError:
+            except GEOSException:
                 logger.warning(
                     "Unable to intersect the requested extent: %s with the product "
                     "geometry: %s",

--- a/eodag/plugins/crunch/filter_overlap.py
+++ b/eodag/plugins/crunch/filter_overlap.py
@@ -22,9 +22,10 @@ from eodag.plugins.crunch.base import Crunch
 from eodag.utils import get_geometry_from_various
 
 try:
-    from shapely.errors import TopologicalError
+    from shapely.errors import GEOSException
 except ImportError:
-    from shapely.geos import TopologicalError
+    # shapely < 2.0 compatibility
+    from shapely.errors import TopologicalError as GEOSException
 
 
 logger = logging.getLogger("eodag.plugins.crunch.filter_overlap")
@@ -107,7 +108,7 @@ class FilterOverlap(Crunch):
                         product_geometry = product.geometry.buffer(0)
                         try:
                             intersection = search_geom.intersection(product_geometry)
-                        except TopologicalError:
+                        except GEOSException:
                             logger.debug(
                                 "Product geometry still invalid. Overlap test restricted to containment"
                             )

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     python-dateutil
     PyYAML
     tqdm
-    shapely < 2.0 # TODO: update code for 2.0 compatibility
+    shapely
     pyshp
     owslib < 0.26;python_version>='3.10'
     owslib;python_version<'3.10'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -215,7 +215,8 @@ class TestEodagCli(unittest.TestCase):
                 eodag,
                 ["search", "--conf", conf_file, "-p", "whatever", "-g", "not a wkt"],
             )
-            self.assertIn("WKTReadingError", str(result))
+            # GEOSException for shapely >= 2.0
+            assert "WKTReadingError" in str(result) or "GEOSException" in str(result)
             self.assertNotEqual(result.exit_code, 0)
 
     @mock.patch("eodag.cli.EODataAccessGateway", autospec=True)

--- a/tests/units/test_eoproduct.py
+++ b/tests/units/test_eoproduct.py
@@ -58,7 +58,7 @@ class TestEOProduct(EODagTestCase):
         self.assertEqual(product.geometry, product.search_intersection)
 
     def test_eoproduct_search_intersection_none(self):
-        """EOProduct search_intersection attr must be None if shapely.errors.TopologicalError when intersecting"""  # noqa
+        """EOProduct search_intersection attr must be None if shapely.errors.GEOSException when intersecting"""  # noqa
         # Invalid geometry
         self.eoproduct_props["geometry"] = {
             "type": "Polygon",


### PR DESCRIPTION
update related to `shapely v2.0` release. See [Breaking API changes](https://shapely.readthedocs.io/en/latest/release/2.x.html#breaking-api-changes)