### PR TITLE
fix: pin ipython version in docs for nbsphinx

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,9 +85,13 @@ tutorials =
     imageio
     rasterio
     netcdf4
-docs = sphinx; sphinx-book-theme >= 0.1.0; sphinx-copybutton; nbsphinx == 0.8.5; markupsafe < 2.1.0
-# pined markup safe until fixed in sphinx or jinja
-# see https://github.com/pallets/jinja/issues/1585
+docs =
+    sphinx
+    sphinx-book-theme >= 0.1.0
+    sphinx-copybutton
+    nbsphinx
+    ipython!=8.7.0
+    # pined ipython until https://github.com/spatialaudio/nbsphinx/issues/687 is fixed
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
fixes issue when building docs:
```
WARNING: Pygments lexer name 'ipython3' is not known
```
The warnings where raised by `nbsphinx`.

Temporarily pin `ipython` until https://github.com/spatialaudio/nbsphinx/issues/687 is fixed 
