### PR TITLE
fix: ordered keywords in discovered product types

### DIFF
--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -279,14 +279,19 @@ class QueryStringSearch(Search):
                                 != NOT_AVAILABLE
                             ]
                         )
-                        keywords_values_str = keywords_values_str.replace(
-                            ", ", ","
-                        ).replace(" ", "-")
+                        # cleanup str list from unwanted characters
+                        keywords_values_str = (
+                            keywords_values_str.replace(", ", ",")
+                            .replace(" ", "-")
+                            .replace("_", "-")
+                            .lower()
+                        )
                         keywords_values_str = re.sub(
                             r"[\[\]'\"]", "", keywords_values_str
                         )
+                        # sorted list of unique lowercase keywords
                         keywords_values_str = ",".join(
-                            set(keywords_values_str.split(","))
+                            sorted(set(keywords_values_str.split(",")))
                         )
                         conf_update_dict["product_types_config"][
                             generic_product_type_id

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -205,10 +205,10 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
                     "id": "foo_collection",
                     "keywords": ["foo", "bar"],
                     "summaries": {
-                        "instruments": ["baz"],
+                        "instruments": ["baZ"],
                         "constellation": "qux,foo",
                         "platform": ["quux", "corge", "bar"],
-                        "processing:level": "grault",
+                        "processing:level": "GRAULT",
                     },
                 },
             ]
@@ -218,18 +218,19 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
             "keywords"
         ].split(",")
 
-        self.assertEqual(len(keywords_list), 8)
-        for k in [
-            "foo_collection",
-            "foo",
-            "bar",
-            "baz",
-            "qux",
-            "quux",
-            "corge",
-            "grault",
-        ]:
-            self.assertIn(k, keywords_list)
+        self.assertEqual(
+            [
+                "bar",
+                "baz",
+                "corge",
+                "foo",
+                "foo-collection",
+                "grault",
+                "quux",
+                "qux",
+            ],
+            keywords_list,
+        )
 
 
 class TestSearchPluginPostJsonSearch(BaseSearchPluginTest):


### PR DESCRIPTION
following #592, sort keywords for discovered product types to prevent unneeded PRs from github-actions bot