### PR TITLE
fix: missing space needed in pytest cli call

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
     mkdir -p test-reports
     pytest -v --show-capture=no --cov --cov-report term-missing \
         --cov-report term-missing \
-		--cov-report=html:test-reports/coverage\
+		--cov-report=html:test-reports/coverage \
 		--cov-report=xml:test-reports/coverage.xml \
 		--junitxml=test-reports/junit-report.xml \
 		--html=test-reports/tests/report.html \


### PR DESCRIPTION
Fixes issue in windows tests / github actions:
```
INTERNALERROR> NotADirectoryError: [WinError 267] The directory name is invalid: 'test-reports/coverage--cov-report=xml:test-reports'
```