### PR TITLE
fix: landsat c1 no more available on usgs

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -52,9 +52,6 @@
   products:
     # datasets list http://kapadia.github.io/usgs/_sources/reference/catalog/ee.txt may be outdated
     # see also https://dds.cr.usgs.gov/ee-data/coveragemaps/shp/ee/
-    L8_OLI_TIRS_C1L1:
-      dataset: LANDSAT_8_C1
-      outputs_extension: .tar.gz
     LANDSAT_C2L1:
       dataset: landsat_ot_c2_l1
       outputs_extension: .tar.gz

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -135,9 +135,9 @@ ONDA_SEARCH_ARGS = [
 ]
 USGS_SEARCH_ARGS = [
     "usgs",
-    "L8_OLI_TIRS_C1L1",
-    "2017-03-01",
-    "2017-03-15",
+    "LANDSAT_C2L1",
+    (today - 6 * week_span).isoformat(),
+    (today - 5 * week_span).isoformat(),
     [50, 50, 50.3, 50.3],
 ]
 ECMWF_SEARCH_ARGS = [

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -448,7 +448,7 @@ class TestApisPluginUsgsApi(BaseApisPluginTest):
         """UsgsApi.query must search using usgs api"""
 
         search_kwargs = {
-            "productType": "L8_OLI_TIRS_C1L1",
+            "productType": "LANDSAT_C2L1",
             "startTimeFromAscendingNode": "2020-02-01",
             "completionTimeFromAscendingNode": "2020-02-10",
             "geometry": get_geometry_from_various(geometry=[10, 20, 30, 40]),
@@ -457,7 +457,7 @@ class TestApisPluginUsgsApi(BaseApisPluginTest):
         }
         search_results, total_count = self.api_plugin.query(**search_kwargs)
         mock_api_scene_search.assert_called_once_with(
-            "LANDSAT_8_C1",
+            "landsat_ot_c2_l1",
             start_date="2020-02-01",
             end_date="2020-02-10",
             ll={"longitude": 10.0, "latitude": 20.0},
@@ -466,7 +466,7 @@ class TestApisPluginUsgsApi(BaseApisPluginTest):
             starting_number=6,
         )
         self.assertEqual(search_results[0].provider, "usgs")
-        self.assertEqual(search_results[0].product_type, "L8_OLI_TIRS_C1L1")
+        self.assertEqual(search_results[0].product_type, "LANDSAT_C2L1")
         self.assertEqual(
             search_results[0].geometry,
             shape(

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -84,7 +84,6 @@ class TestCore(TestCoreBase):
         "L57_REFLECTANCE": ["theia"],
         "L8_OLI_TIRS_C1L1": [
             "onda",
-            "usgs",
             "aws_eos",
             "earth_search",
             "earth_search_gcs",


### PR DESCRIPTION
`L8_OLI_TIRS_C1L1` removed from `usgs` available product types, following https://www.usgs.gov/landsat-missions/news/landsat-collection-1-datasets-be-removed-december-30-2022:
> All Landsat Collection 1 data and science products in the USGS archives will become unavailable on December 30, 2022. Additionally, the ability to submit orders through the ESPA On-Demand Interface for Landsat Collection 1-based science products will end on Friday, December 16, 2022.