### PR TITLE
fix: AwsDownload SAFE build fix and more tests

### DIFF
--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -274,18 +274,20 @@ class AwsDownload(Download):
             bucket_names_and_prefixes = []
             for complementary_url in getattr(product, "assets", {}).values():
                 bucket_names_and_prefixes.append(
-                    self.get_bucket_name_and_prefix(
+                    self.get_product_bucket_name_and_prefix(
                         product, complementary_url.get("href", "")
                     )
                 )
         else:
-            bucket_names_and_prefixes = [self.get_bucket_name_and_prefix(product)]
+            bucket_names_and_prefixes = [
+                self.get_product_bucket_name_and_prefix(product)
+            ]
 
         # add complementary urls
         try:
             for complementary_url_key in product_conf.get("complementary_url_key", []):
                 bucket_names_and_prefixes.append(
-                    self.get_bucket_name_and_prefix(
+                    self.get_product_bucket_name_and_prefix(
                         product, product.properties[complementary_url_key]
                     )
                 )
@@ -588,7 +590,7 @@ class AwsDownload(Download):
         self.s3_session = s3_session
         return objects
 
-    def get_bucket_name_and_prefix(self, product, url=None):
+    def get_product_bucket_name_and_prefix(self, product, url=None):
         """Extract bucket name and prefix from product URL
 
         :param product: The EO product to download

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -912,10 +912,14 @@ class AwsDownload(Download):
                     product.properties["title"],
                     found_dict["file"],
                 )
+            # out of SAFE format
+            else:
+                logger.debug(f"{chunk.key} out of SAFE matching pattern")
+                product_path = chunk.key.split(dir_prefix.strip("/") + "/")[-1]
         # no SAFE format
         else:
             product_path = chunk.key.split(dir_prefix.strip("/") + "/")[-1]
-        logger.debug("Downloading %s to %s" % (chunk.key, product_path))
+        logger.debug(f"Downloading {chunk.key} to {product_path}")
         return product_path
 
     def download_all(

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -589,26 +589,25 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
             ),
             productType="S2_MSI_L2A",
         )
-
-    def test_plugins_download_aws_get_bucket_prefix(self):
-        """AwsDownload.get_bucket_name_and_prefix() must extract bucket & prefix from location"""
-
-        plugin = self.get_download_plugin(self.product)
-        plugin.config.products["S2_MSI_L2A"]["default_bucket"] = "default_bucket"
-        self.product.properties["id"] = "someproduct"
-
         self.product.location = (
             self.product.remote_location
         ) = "http://somebucket.somehost.com/path/to/some/product"
-        bucket, prefix = plugin.get_bucket_name_and_prefix(self.product)
+
+    def test_plugins_download_aws_get_bucket_prefix(self):
+        """AwsDownload.get_product_bucket_name_and_prefix() must extract bucket & prefix from location"""
+
+        plugin = self.get_download_plugin(self.product)
+        plugin.config.products["S2_MSI_L2A"]["default_bucket"] = "default_bucket"
+
+        bucket, prefix = plugin.get_product_bucket_name_and_prefix(self.product)
         self.assertEqual((bucket, prefix), ("somebucket", "path/to/some/product"))
 
         plugin.config.bucket_path_level = 1
-        bucket, prefix = plugin.get_bucket_name_and_prefix(self.product)
+        bucket, prefix = plugin.get_product_bucket_name_and_prefix(self.product)
         self.assertEqual((bucket, prefix), ("to", "some/product"))
         del plugin.config.bucket_path_level
 
-        bucket, prefix = plugin.get_bucket_name_and_prefix(
+        bucket, prefix = plugin.get_product_bucket_name_and_prefix(
             self.product, url="/somewhere/else"
         )
         self.assertEqual((bucket, prefix), ("default_bucket", "somewhere/else"))


### PR DESCRIPTION
- renamed `AwsDownload.get_bucket_name_and_prefix()` to `AwsDownload.get_product_bucket_name_and_prefix()`
- asset out of SAFE pattern won't break `AwsDownload.download()`
- more `AwsDownload` tests