### PR TITLE
fix: better download wait time precision

### DIFF
--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -592,7 +592,9 @@ class Download(PluginTopic):
                         nb_info.display_html(retry_info)
                         product.next_try = datetime_now
                     elif datetime_now < product.next_try and datetime_now < stop_time:
-                        wait_seconds = (product.next_try - datetime_now).seconds
+                        wait_seconds = (product.next_try - datetime_now).seconds + (
+                            product.next_try - datetime_now
+                        ).microseconds / 1e6
                         retry_count += 1
                         retry_info = (
                             f"[Retry #{retry_count}] Waiting {wait_seconds}s until next download try"

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -529,7 +529,7 @@ class TestDownloadPluginHttpRetry(BaseDownloadPluginTest):
                     self.product,
                     outputs_prefix=self.output_dir,
                     wait=0.1 / 60,
-                    timeout=0.001 / 60,
+                    timeout=1e-9 / 60,
                 )
 
             # there must have been only one try


### PR DESCRIPTION
Improve [download() wait time](https://eodag.readthedocs.io/en/stable/notebooks/api_user_guide/7_download.html#Order-OFFLINE-products) precision to microsecond