### PR TITLE
fix: odata free text search operands filter

### DIFF
--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -506,7 +506,8 @@ class QueryStringSearch(Search):
                     format_metadata(operand, **kwargs)
                     for operand in operands
                     if any(
-                        kw in operand and val is not None for kw, val in kwargs.items()
+                        re.search(rf"{{{kw}[}}#]", operand) and val is not None
+                        for kw, val in kwargs.items()
                     )
                 )
                 # Finally wrap the operation string as specified by the wrapper and add


### PR DESCRIPTION
Fixes free text search operands filtering in `format_free_text_search()` usage from `ODataV4Search` plugin. 