### PR TITLE
fix: optimized jsonpath.parse using common_metadata_mapping_path

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -19,6 +19,7 @@ import logging
 import os
 import re
 import shutil
+from copy import deepcopy
 from operator import itemgetter
 
 import geojson
@@ -379,7 +380,9 @@ class EODataAccessGateway(object):
             ):
                 # also build as jsonpath the incoming conf
                 mtd_cfg_as_jsonpath(
-                    conf_update[provider][search_plugin_key]["metadata_mapping"],
+                    deepcopy(
+                        conf_update[provider][search_plugin_key]["metadata_mapping"]
+                    ),
                     conf_update[provider][search_plugin_key]["metadata_mapping"],
                 )
 

--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -167,7 +167,13 @@ class UsgsApi(Download, Api):
             # A deepcopy is done to prevent self.config.metadata_mapping from being modified when metas[metadata]
             # is a list and is modified
             metas.update(copy.deepcopy(self.config.metadata_mapping))
-            metas = mtd_cfg_as_jsonpath(metas)
+            # common_jsonpath usage to optimize jsonpath build process
+            mtd_cfg_as_jsonpath_options = {}
+            if hasattr(self.config, "common_metadata_mapping_path"):
+                mtd_cfg_as_jsonpath_options[
+                    "common_jsonpath"
+                ] = self.config.common_metadata_mapping_path
+            metas = mtd_cfg_as_jsonpath(metas, **mtd_cfg_as_jsonpath_options)
 
             for result in results["data"]["results"]:
 

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -40,8 +40,14 @@ class Search(PluginTopic):
         # Update the defaults with the mapping value. This will add any new key
         # added by the provider mapping that is not in the default metadata
         metas.update(self.config.metadata_mapping)
+        # common_jsonpath usage to optimize jsonpath build process
+        mtd_cfg_as_jsonpath_options = {}
+        if hasattr(self.config, "common_metadata_mapping_path"):
+            mtd_cfg_as_jsonpath_options[
+                "common_jsonpath"
+            ] = self.config.common_metadata_mapping_path
         self.config.metadata_mapping = mtd_cfg_as_jsonpath(
-            metas, self.config.metadata_mapping
+            metas, self.config.metadata_mapping, **mtd_cfg_as_jsonpath_options
         )
 
     def clear(self):

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -30,6 +30,7 @@
     pagination:
       max_items_per_page: 5000
       total_items_nb_key_path: '$.totalHits'
+    common_metadata_mapping_path: '$'
     metadata_mapping:
       id: '$.displayId'
       geometry: '$.spatialBounds'
@@ -109,6 +110,7 @@
       metadata_pattern: '^[a-zA-Z0-9_]+$'
       search_param: '{{{{"search":{{{{"{metadata}":"{{{metadata}}}" }}}} }}}}'
       metadata_path: '$.*'
+    common_metadata_mapping_path: '$'
     metadata_mapping:
       # landsat8_downloadLink : 's3://landsat-pds/c{storedInCollection}/L8/{path}/{row}/{productID}'
       geometry:
@@ -558,6 +560,7 @@
       metadata_pattern: '^(?!collection)[a-zA-Z0-9_]+$'
       search_param: '{metadata}={{{metadata}}}'
       metadata_path: '$.properties.*'
+    common_metadata_mapping_path: '$'
     metadata_mapping:
       # Opensearch resource identifier within the search engine context (in our case
       # within the context of the data provider)
@@ -733,6 +736,7 @@
       metadata_pattern: '^(?!collection)[a-zA-Z0-9_]+$'
       search_param: '{metadata}={{{metadata}}}'
       metadata_path: '$.properties.*'
+    common_metadata_mapping_path: '$'
     metadata_mapping:
       # Opensearch resource identifier within the search engine context (in our case
       # within the context of the data provider)
@@ -903,6 +907,7 @@
         sensorType: '$.null'
         license: '$.null'
         missionStartDate: '$.null'
+    common_metadata_mapping_path: '$'
     metadata_mapping:
       # Opensearch resource identifier within the search engine context (in our case
       # within the context of the data provider)
@@ -1360,7 +1365,7 @@
       metadata_path: '$.Metadata'
       metadata_path_id: 'id'
       metadata_path_value: 'value'
-
+    common_metadata_mapping_path: '$'
     metadata_mapping:
       # Opensearch resource identifier within the search engine context (in our case
       # within the context of the data provider)
@@ -1835,6 +1840,7 @@
     type: EcmwfApi
     api_endpoint: https://api.ecmwf.int/v1
     extract: false
+    common_metadata_mapping_path: '$'
     metadata_mapping:
       productType: '$.productType'
       title: '$.id'
@@ -2057,6 +2063,7 @@
     type: CdsApi
     api_endpoint: https://ads.atmosphere.copernicus.eu/api/v2
     extract: false
+    common_metadata_mapping_path: '$'
     metadata_mapping:
       productType: '$.productType'
       title: '$.id'
@@ -2374,6 +2381,7 @@
     type: CdsApi
     api_endpoint: https://cds.climate.copernicus.eu/api/v2
     extract: false
+    common_metadata_mapping_path: '$'
     metadata_mapping:
       productType: '$.productType'
       title: '$.id'
@@ -2625,6 +2633,7 @@
       metadata_pattern: '^(?!collection)[a-zA-Z0-9_]+$'
       search_param: '{metadata}={{{metadata}}}'
       metadata_path: '$.properties.*'
+    common_metadata_mapping_path: '$'
     metadata_mapping:
       # Opensearch resource identifier within the search engine context (in our case
       # within the context of the data provider)
@@ -2888,6 +2897,7 @@
       metadata_pattern: '^[a-zA-Z0-9_]+$'
       search_param: '{{{{"{metadata}":{{{metadata}#to_geojson}} }}}}'
       metadata_path: '$.*'
+    common_metadata_mapping_path: '$'
     metadata_mapping:
       startTimeFromAscendingNode: '{$.startTimeFromAscendingNode#to_iso_utc_datetime}'
       completionTimeFromAscendingNode:

--- a/eodag/resources/stac_provider.yml
+++ b/eodag/resources/stac_provider.yml
@@ -46,6 +46,7 @@ search:
         license: '$.license'
         title: '$.title'
         missionStartDate: '$.extent.temporal.interval[0][0]'
+  common_metadata_mapping_path: '$'
   metadata_mapping:
     # OpenSearch Parameters for Collection Search (Table 3)
     productType:


### PR DESCRIPTION
Fixes #520 , optimizes `jsonpath.parse()` using new `common_metadata_mapping_path` entry in providers configuration.

The time saving is noticeable, see the following chart comparing search times for a random search with and without optimization:
![image](https://user-images.githubusercontent.com/61419125/216066678-c84f2ab0-c309-4fda-97e2-dc1fa3d83480.png)

