### PR TITLE
fix: make map_product_type accept kwargs

### DIFF
--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -814,7 +814,7 @@ class QueryStringSearch(Search):
             )
         return collections
 
-    def map_product_type(self, product_type):
+    def map_product_type(self, product_type, **kwargs):
         """Map the eodag product type to the provider product type"""
         if product_type is None:
             return


### PR DESCRIPTION
Fixes https://github.com/CS-SI/eodag-sentinelsat/issues/37

Makes `QueryStringSearch.map_product_type()` accept extra keyword-arguments