### PR TITLE
fix: simplify S2_MSI_L1C internal usage with peps

### DIFF
--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -781,37 +781,15 @@ class QueryStringSearch(Search):
             else:
                 collections.add(collection)
             return tuple(collections)
-        if self.provider == "peps":
-            if product_type == "S2_MSI_L1C":
-                date = kwargs.get("startTimeFromAscendingNode")
-                # If there is no criteria on date, we want to query all the collections
-                # known for providing L1C products
-                if date is None:
-                    collections = ("S2", "S2ST")
-                else:
-                    match = re.match(
-                        r"(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})", date
-                    ).groupdict()
-                    year, month, day = (
-                        int(match["year"]),
-                        int(match["month"]),
-                        int(match["day"]),
-                    )
-                    if year > 2016 or (year == 2016 and month == 12 and day > 5):
-                        collections = ("S2ST",)
-                    else:
-                        collections = ("S2", "S2ST")
-            else:
-                collections = (self.product_type_def_params.get("collection", ""),)
-        else:
-            collection = getattr(self.config, "collection", None)
-            if collection is None:
-                collection = (
-                    self.product_type_def_params.get("collection", None) or product_type
-                )
-            collections = (
-                (collection,) if not isinstance(collection, list) else tuple(collection)
+
+        collection = getattr(self.config, "collection", None)
+        if collection is None:
+            collection = (
+                self.product_type_def_params.get("collection", None) or product_type
             )
+        collections = (
+            (collection,) if not isinstance(collection, list) else tuple(collection)
+        )
         return collections
 
     def map_product_type(self, product_type):

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -44,15 +44,7 @@ THEIA_SEARCH_ARGS = [
     "2019-03-15",
     [0.2563590566012408, 43.19555008715042, 2.379835675499976, 43.907759172380565],
 ]
-PEPS_BEFORE_20161205_SEARCH_ARGS = [
-    "peps",
-    "S2_MSI_L1C",
-    "2016-06-05",
-    "2016-06-16",
-    [137.772897, -37.134202, 153.749135, 73.885986],
-    True,
-]
-PEPS_AFTER_20161205_SEARCH_ARGS = [
+PEPS_SEARCH_ARGS = [
     "peps",
     "S2_MSI_L1C",
     "2020-08-08",
@@ -391,16 +383,9 @@ class TestEODagEndToEnd(EndToEndBase):
         expected_filename = "{}.tar.gz".format(product.properties["title"])
         self.execute_download(product, expected_filename)
 
-    # may take up to 10 minutes
-    @unittest.skip("Long test skipped")
-    def test_end_to_end_search_download_peps_before_20161205(self):
-        product = self.execute_search(*PEPS_BEFORE_20161205_SEARCH_ARGS)
-        expected_filename = "{}.zip".format(product.properties["title"])
-        self.execute_download(product, expected_filename, wait_sec=30, timeout_sec=600)
-
     # @unittest.skip("service unavailable for the moment")
-    def test_end_to_end_search_download_peps_after_20161205(self):
-        product = self.execute_search(*PEPS_AFTER_20161205_SEARCH_ARGS)
+    def test_end_to_end_search_download_peps(self):
+        product = self.execute_search(*PEPS_SEARCH_ARGS)
         expected_filename = "{}.zip".format(product.properties["title"])
         self.execute_download(product, expected_filename)
 
@@ -923,7 +908,7 @@ class TestEODagEndToEndWrongCredentials(EndToEndBase):
             self.eodag.download(product)
 
     def test_end_to_end_wrong_credentials_peps(self):
-        product = self.execute_search(*PEPS_AFTER_20161205_SEARCH_ARGS)
+        product = self.execute_search(*PEPS_SEARCH_ARGS)
         with self.assertRaises(AuthenticationError):
             self.eodag.download(product)
 


### PR DESCRIPTION
Remove `peps` specific code from `QueryStringSearch` for `S2_MSI_L1C` usage, that handled 2 collections `S2` and `S2ST`.

Related to https://peps-mission.cnes.fr/fr/peps-info-suppression-des-donnees-sentinel-2-datatake