### PR TITLE
test: optimizes and fixes tests

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -260,34 +260,6 @@ class EODataAccessGateway(object):
     def set_preferred_provider(self, provider):
         """Set max priority for the given provider.
 
-        >>> import tempfile, os
-        >>> config = tempfile.NamedTemporaryFile(delete=False)
-        >>> dag = EODataAccessGateway(user_conf_file_path=os.path.join(
-        ...     tempfile.gettempdir(), config.name))
-        >>> # This also tests get_preferred_provider method by the way
-        >>> dag.get_preferred_provider()
-        ('peps', 1)
-        >>> # For the following lines, see
-        >>> # http://python3porting.com/problems.html#handling-expected-exceptions
-        >>> import eodag.utils.exceptions
-        >>> try:
-        ...     dag.set_preferred_provider(u'unknown')
-        ...     raise AssertionError(u'UnsupportedProvider exception was not raised'
-        ...                           'as expected')
-        ... except eodag.utils.exceptions.UnsupportedProvider:
-        ...     pass
-        >>> dag.set_preferred_provider(u'creodias')
-        >>> dag.get_preferred_provider()
-        ('creodias', 2)
-        >>> dag.set_preferred_provider(u'theia')
-        >>> dag.get_preferred_provider()
-        ('theia', 3)
-        >>> dag.set_preferred_provider(u'creodias')
-        >>> dag.get_preferred_provider()
-        ('creodias', 4)
-        >>> config.close()
-        >>> os.unlink(config.name)
-
         :param provider: The name of the provider that should be considered as the
                          preferred provider to be used for this instance
         :type provider: str
@@ -319,35 +291,6 @@ class EODataAccessGateway(object):
         """Update providers configuration with given input.
         Can be used to add a provider to existing configuration or update
         an existing one.
-
-        >>> from eodag import EODataAccessGateway
-        >>> dag = EODataAccessGateway()
-        >>> new_config = '''
-        ...     my_new_provider:
-        ...         search:
-        ...             type: StacSearch
-        ...             api_endpoint: https://api.my_new_provider/search
-        ...         products:
-        ...             GENERIC_PRODUCT_TYPE:
-        ...                 productType: '{productType}'
-        ... '''
-        >>> # add new provider
-        >>> dag.update_providers_config(new_config)
-        >>> type(dag.providers_config["my_new_provider"])
-        <class 'eodag.config.ProviderConfig'>
-        >>> dag.providers_config["my_new_provider"].priority
-        0
-        >>> # run 2nd time (update provider)
-        >>> update_config = '''
-        ...     my_new_provider:
-        ...         search:
-        ...             type: StacSearch
-        ...             api_endpoint: https://api.my_new_provider/search
-        ...         products:
-        ...             GENERIC_PRODUCT_TYPE:
-        ...                 productType: '{productType}'
-        ... '''
-        >>> dag.update_providers_config(new_config)
 
         :param yaml_conf: YAML formated provider configuration
         :type yaml_conf: str
@@ -519,7 +462,9 @@ class EODataAccessGateway(object):
                     if product_type_id not in product_types:
                         product_types.append(product_type)
                 return sorted(product_types, key=itemgetter("ID"))
-            raise UnsupportedProvider("The requested provider is not (yet) supported")
+            raise UnsupportedProvider(
+                f"The requested provider is not (yet) supported: {provider}"
+            )
         # Only get the product types supported by the available providers
         for provider in self.available_providers():
             current_product_type_ids = [pt["ID"] for pt in product_types]

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -299,15 +299,6 @@ def get_datetime(arguments):
 def get_metadata_query_paths(metadata_mapping):
     """Get dict of query paths and their names from metadata_mapping
 
-    >>> metadata_mapping = {
-    ...     'cloudCover': [
-    ...         '{{"query":{{"eo:cloud_cover":{{"lte":"{cloudCover}"}}}}}}',
-    ...         '$.properties."eo:cloud_cover"'
-    ...     ]
-    ... }
-    >>> get_metadata_query_paths(metadata_mapping)
-    {'query.eo:cloud_cover.lte': 'cloudCover'}
-
     :param metadata_mapping: STAC metadata mapping (see 'resources/stac_provider.yml')
     :type metadata_mapping: dict
     :returns: Mapping of query paths with their corresponding names
@@ -344,10 +335,6 @@ def get_arguments_query_paths(arguments):
     Build a mapping of the query paths present in the arguments
     with their values. All matching paths of our STAC_QUERY_PATTERN
     ('query.*.*') are used.
-
-    >>> arguments = {'another': 'example', 'query': {'eo:cloud_cover': {'lte': '10'}, 'foo': {'eq': 'bar'}}}
-    >>> get_arguments_query_paths(arguments)
-    {'query.eo:cloud_cover.lte': '10', 'query.foo.eq': 'bar'}
 
     :param arguments: Request args
     :type arguments: dict

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 testpaths =
-    eodag
+    eodag/utils
     tests
 addopts = --doctest-modules --disable-socket
 ; logging disabled to prevent conflicts with click, see https://github.com/pallets/click/issues/824

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,6 @@
 testpaths =
     eodag
     tests
-addopts = --doctest-modules
+addopts = --doctest-modules --disable-socket
 ; logging disabled to prevent conflicts with click, see https://github.com/pallets/click/issues/824
 log_cli = 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ dev =
     # until https://github.com/pytest-dev/pytest-html/issues/559 is fixed
     py >= 1.8.2
     pytest-html < 3.2.0
+    pytest-socket
     tox
     faker
     moto

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,9 @@ dev =
     # until https://github.com/pytest-dev/pytest-html/issues/559 is fixed
     py >= 1.8.2
     pytest-html < 3.2.0
+    pytest-xdist
     pytest-socket
+    pytest-instafail
     tox
     faker
     moto

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,7 +18,6 @@
 
 import io
 import os
-import pathlib
 import random
 import shutil
 import tempfile
@@ -41,7 +40,6 @@ dirn = os.path.dirname
 
 TEST_RESOURCES_PATH = jp(dirn(__file__), "resources")
 RESOURCES_PATH = jp(dirn(__file__), "..", "eodag", "resources")
-TESTS_DOWNLOAD_PATH = jp(tempfile.gettempdir(), "eodag_tests")
 
 
 class EODagTestCase(unittest.TestCase):
@@ -302,10 +300,11 @@ class EODagTestCase(unittest.TestCase):
         delete_archive=None,
     ):
         self._set_download_simulation()
+        self.tmp_download_dir = tempfile.TemporaryDirectory()
         dl_config = config.PluginConfig.from_mapping(
             {
                 "base_uri": "fake_base_uri" if base_uri is None else base_uri,
-                "outputs_prefix": tempfile.gettempdir()
+                "outputs_prefix": self.tmp_download_dir.name
                 if outputs_prefix is None
                 else outputs_prefix,
                 "extract": True if extract is None else extract,
@@ -319,13 +318,7 @@ class EODagTestCase(unittest.TestCase):
         return product
 
     def _clean_product(self, product_path):
-        product_path = pathlib.Path(product_path)
-        download_records_dir = product_path.parent / ".downloaded"
-        product_zip = product_path.parent / (product_path.name + ".zip")
-        shutil.rmtree(product_path)
-        shutil.rmtree(download_records_dir)
-        if os.path.exists(product_zip):
-            os.remove(product_zip)
+        self.tmp_download_dir.cleanup()
 
     def _set_download_simulation(self):
         self.requests_request.return_value = self._download_response_archive()

--- a/tests/context.py
+++ b/tests/context.py
@@ -92,5 +92,5 @@ from eodag.utils.exceptions import (
     STACOpenerError,
 )
 from eodag.utils.stac_reader import fetch_stac_items, HTTP_REQ_TIMEOUT, _TextOpener
-from tests import TESTS_DOWNLOAD_PATH, TEST_RESOURCES_PATH
+from tests import TEST_RESOURCES_PATH
 from usgs.api import USGSAuthExpiredError, USGSError

--- a/tests/context.py
+++ b/tests/context.py
@@ -28,7 +28,7 @@ from eodag import EODataAccessGateway, api, config, setup_logging
 from eodag.api.core import DEFAULT_ITEMS_PER_PAGE, DEFAULT_MAX_ITEMS_PER_PAGE
 from eodag.api.product import EOProduct
 from eodag.api.product.drivers import DRIVERS
-from eodag.api.product.drivers.base import NoDriver
+from eodag.api.product.drivers.base import DatasetDriver
 from eodag.api.product.metadata_mapping import (
     format_metadata,
     OFFLINE_STATUS,

--- a/tests/context.py
+++ b/tests/context.py
@@ -45,6 +45,7 @@ from eodag.config import (
     get_ext_product_types_conf,
     EXT_PRODUCT_TYPES_CONF_URI,
     PluginConfig,
+    ProviderConfig,
 )
 from eodag.plugins.apis.ecmwf import EcmwfApi
 from eodag.plugins.authentication.base import Authentication

--- a/tests/integration/test_core_config.py
+++ b/tests/integration/test_core_config.py
@@ -45,8 +45,13 @@ class TestCoreProvidersConfig(TestCase):
         self.expanduser_mock.stop()
         self.tmp_home_dir.cleanup()
 
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
     @mock.patch("eodag.plugins.search.qssearch.PostJsonSearch._request", autospec=True)
-    def test_core_providers_config_update(self, mock__request):
+    def test_core_providers_config_update(
+        self, mock__request, mock_fetch_product_types_list
+    ):
         """Providers config must be updatable"""
         mock__request.return_value = mock.Mock()
         mock__request_side_effect = [

--- a/tests/integration/test_search_stac_static.py
+++ b/tests/integration/test_search_stac_static.py
@@ -90,7 +90,10 @@ class TestSearchStacStatic(unittest.TestCase):
         self.expanduser_mock.stop()
         self.tmp_home_dir.cleanup()
 
-    def test_search_stac_static_load_child(self):
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test_search_stac_static_load_child(self, mock_fetch_product_types_list):
         """load_stac_items from child catalog must provide items"""
         items = self.dag.load_stac_items(
             self.child_cat, recursive=True, provider=self.stac_provider
@@ -101,7 +104,12 @@ class TestSearchStacStatic(unittest.TestCase):
         # if no product_type is provided, product_type should be guessed from properties
         self.assertEqual(items[0].product_type, "S2_MSI_L1C")
 
-    def test_search_stac_static_load_root_not_recursive(self):
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test_search_stac_static_load_root_not_recursive(
+        self, mock_fetch_product_types_list
+    ):
         """load_stac_items from root must provide an empty list when no recursive"""
         items = self.dag.load_stac_items(
             self.root_cat, recursive=False, provider=self.stac_provider
@@ -121,7 +129,10 @@ class TestSearchStacStatic(unittest.TestCase):
             self.assertEqual(item.provider, self.stac_provider)
             self.assertEqual(item.product_type, self.product_type)
 
-    def test_search_stac_static(self):
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test_search_stac_static(self, mock_fetch_product_types_list):
         """Use StaticStacSearch plugin to search all items"""
         items, nb = self.dag.search()
         self.assertEqual(len(items), self.root_cat_len)
@@ -129,7 +140,10 @@ class TestSearchStacStatic(unittest.TestCase):
         for item in items:
             self.assertEqual(item.provider, self.static_stac_provider)
 
-    def test_search_stac_static_load_item(self):
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test_search_stac_static_load_item(self, mock_fetch_product_types_list):
         """load_stac_items from a single item must provide it"""
         item = self.dag.load_stac_items(self.item, provider=self.stac_provider)
         self.assertIsInstance(item, SearchResult)
@@ -138,7 +152,12 @@ class TestSearchStacStatic(unittest.TestCase):
         # if no product_type is provided, product_type should be guessed from properties
         self.assertEqual(item[0].product_type, "S2_MSI_L1C")
 
-    def test_search_stac_static_load_item_updated_provider(self):
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test_search_stac_static_load_item_updated_provider(
+        self, mock_fetch_product_types_list
+    ):
         """load_stac_items from a single item using updated provider"""
         item = self.dag.load_stac_items(self.item, provider=self.stac_provider)
 
@@ -204,7 +223,10 @@ class TestSearchStacStatic(unittest.TestCase):
         for item in filtered_items:
             self.assertIn("2018", item.properties["startTimeFromAscendingNode"])
 
-    def test_search_stac_static_by_date(self):
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test_search_stac_static_by_date(self, mock_fetch_product_types_list):
         """Use StaticStacSearch plugin to search by date"""
         filtered_items, nb = self.dag.search(start="2018-01-01", end="2019-01-01")
         self.assertEqual(len(filtered_items), self.child_cat_len)
@@ -264,7 +286,10 @@ class TestSearchStacStatic(unittest.TestCase):
         )
         self.assertEqual(len(filtered_items), 1)
 
-    def test_search_stac_static_by_geom(self):
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test_search_stac_static_by_geom(self, mock_fetch_product_types_list):
         """Use StaticStacSearch plugin to search by geometry"""
         items, nb = self.dag.search(
             geom=self.extent_big,
@@ -295,13 +320,19 @@ class TestSearchStacStatic(unittest.TestCase):
         )
         self.assertEqual(len(filtered_items), 1)
 
-    def test_search_stac_static_by_property(self):
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test_search_stac_static_by_property(self, mock_fetch_product_types_list):
         """Use StaticStacSearch plugin to search by property"""
         items, nb = self.dag.search(orbitNumber=110)
         self.assertEqual(len(items), 3)
         self.assertEqual(nb, 3)
 
-    def test_search_stac_static_by_cloudcover(self):
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test_search_stac_static_by_cloudcover(self, mock_fetch_product_types_list):
         """Use StaticStacSearch plugin to search by cloud cover"""
         items, nb = self.dag.search(cloudCover=10)
         self.assertEqual(len(items), 1)

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -222,6 +222,9 @@ class TestApisPluginEcmwfApi(BaseApisPluginTest):
         assert auth_dict["url"] == self.api_plugin.config.api_endpoint
         del self.api_plugin.config.credentials
 
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
     @mock.patch("ecmwfapi.api.ECMWFService.execute", autospec=True)
     @mock.patch("ecmwfapi.api.ECMWFDataServer.retrieve", autospec=True)
     @mock.patch("ecmwfapi.api.Connection.call", autospec=True)
@@ -230,6 +233,7 @@ class TestApisPluginEcmwfApi(BaseApisPluginTest):
         mock_connection_call,
         mock_ecmwfdataserver_retrieve,
         mock_ecmwfservice_execute,
+        mock_fetch_product_types_list,
     ):
         """EcmwfApi.download must call the appriate ecmwf api service"""
 
@@ -295,12 +299,16 @@ class TestApisPluginEcmwfApi(BaseApisPluginTest):
         mock_ecmwfservice_execute.assert_not_called()
         mock_ecmwfdataserver_retrieve.assert_not_called()
 
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
     @mock.patch("ecmwfapi.api.ECMWFDataServer.retrieve", autospec=True)
     @mock.patch("ecmwfapi.api.Connection.call", autospec=True)
     def test_plugins_apis_ecmwf_download_all(
         self,
         mock_connection_call,
         mock_ecmwfdataserver_retrieve,
+        mock_fetch_product_types_list,
     ):
         """EcmwfApi.download_all must call the appriate ecmwf api service"""
 
@@ -744,10 +752,13 @@ class TestApisPluginCdsApi(BaseApisPluginTest):
         assert auth_dict["url"] == self.api_plugin.config.api_endpoint
         del self.api_plugin.config.credentials
 
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
     @mock.patch("eodag.plugins.apis.cds.CdsApi.authenticate", autospec=True)
     @mock.patch("cdsapi.api.Client.retrieve", autospec=True)
     def test_plugins_apis_cds_download(
-        self, mock_client_retrieve, mock_cds_authenticate
+        self, mock_client_retrieve, mock_cds_authenticate, mock_fetch_product_types_list
     ):
         """CdsApi.download must call the authenticate function and cdsapi Client retrieve"""
         mock_cds_authenticate.return_value = {
@@ -785,11 +796,18 @@ class TestApisPluginCdsApi(BaseApisPluginTest):
         assert path == expected_path
         assert path_to_uri(expected_path) == eoproduct.location
 
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
     @mock.patch("eodag.plugins.apis.cds.CdsApi.authenticate", autospec=True)
     @mock.patch("eodag.plugins.apis.cds.CdsApi.download", autospec=True)
     @mock.patch("cdsapi.api.Client.retrieve", autospec=True)
     def test_plugins_apis_cds_download_all(
-        self, mock_client_retrieve, mock_cds_download, mock_cds_authenticate
+        self,
+        mock_client_retrieve,
+        mock_cds_download,
+        mock_cds_authenticate,
+        mock_fetch_product_types_list,
     ):
         """CdsApi.download_all must call download on each product"""
         mock_cds_authenticate.return_value = {

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1105,7 +1105,10 @@ class TestCoreSearch(TestCoreBase):
         )
         self.assertGreater(len(guesses), 10)
 
-    def test__prepare_search_no_parameters(self):
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test__prepare_search_no_parameters(self, mock_fetch_product_types_list):
         """_prepare_search must create some kwargs even when no parameter has been provided"""
         prepared_search = self.dag._prepare_search()
         expected = {
@@ -1115,7 +1118,10 @@ class TestCoreSearch(TestCoreBase):
         expected = set(["geometry", "productType", "auth", "search_plugin"])
         self.assertSetEqual(expected, set(prepared_search))
 
-    def test__prepare_search_dates(self):
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test__prepare_search_dates(self, mock_fetch_product_types_list):
         """_prepare_search must handle start & end dates"""
         base = {
             "start": "2020-01-01",
@@ -1127,7 +1133,10 @@ class TestCoreSearch(TestCoreBase):
             prepared_search["completionTimeFromAscendingNode"], base["end"]
         )
 
-    def test__prepare_search_geom(self):
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test__prepare_search_geom(self, mock_fetch_product_types_list):
         """_prepare_search must handle geom, box and bbox"""
         # The default way to provide a geom is through the 'geom' argument.
         base = {"geom": (0, 50, 2, 52)}
@@ -1153,7 +1162,10 @@ class TestCoreSearch(TestCoreBase):
         self.assertNotIn("bbox", prepared_search)
         self.assertIsInstance(prepared_search["geometry"], Polygon)
 
-    def test__prepare_search_locations(self):
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test__prepare_search_locations(self, mock_fetch_product_types_list):
         """_prepare_search must handle a location search"""
         # When locations where introduced they could be passed
         # as regular kwargs. The new and recommended way to provide
@@ -1232,7 +1244,12 @@ class TestCoreSearch(TestCoreBase):
         finally:
             self.dag.set_preferred_provider(prev_fav_provider)
 
-    def test__prepare_search_search_plugin_has_generic_product_properties(self):
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test__prepare_search_search_plugin_has_generic_product_properties(
+        self, mock_fetch_product_types_list
+    ):
         """_prepare_search must be able to attach the generic product properties to the search plugin"""
         prev_fav_provider = self.dag.get_preferred_provider()[0]
         try:

--- a/tests/units/test_eoproduct.py
+++ b/tests/units/test_eoproduct.py
@@ -30,10 +30,10 @@ from shapely import geometry
 from tests import EODagTestCase
 from tests.context import (
     DEFAULT_STREAM_REQUESTS_TIMEOUT,
+    DatasetDriver,
     Download,
     EOProduct,
     HTTPDownload,
-    NoDriver,
     ProgressCallback,
     config,
 )
@@ -85,9 +85,9 @@ class TestEOProduct(EODagTestCase):
         self.assertIsNone(product.search_intersection)
 
     def test_eoproduct_default_driver_unsupported_product_type(self):
-        """EOProduct driver attr must be NoDriver if its product type is not associated with a eodag dataset driver"""  # noqa
+        """EOProduct driver attr must be set even if its product type is not supported"""
         product = self._dummy_product(productType=self.NOT_ASSOCIATED_PRODUCT_TYPE)
-        self.assertIsInstance(product.driver, NoDriver)
+        self.assertIsInstance(product.driver, DatasetDriver)
 
     def test_eoproduct_geointerface(self):
         """EOProduct must provide a geo-interface with a set of specific properties"""

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import json
 import os
 import re
@@ -43,6 +44,10 @@ class RequestTestCase(unittest.TestCase):
         cls.expanduser_mock.start()
 
         # import after having mocked home_dir because it launches http server (and EODataAccessGateway)
+        # reload eodag.rest.utils to prevent eodag_api cache conflicts
+        import eodag.rest.utils
+
+        importlib.reload(eodag.rest.utils)
         from eodag.rest import server as eodag_http_server
 
         cls.eodag_http_server = eodag_http_server

--- a/tests/units/test_safe_build.py
+++ b/tests/units/test_safe_build.py
@@ -19,17 +19,12 @@ import logging
 import os
 import unittest
 from pathlib import Path
-from shutil import copyfile, rmtree
+from shutil import copyfile
+from tempfile import TemporaryDirectory
 
 import yaml
 
-from tests.context import (
-    TEST_RESOURCES_PATH,
-    TESTS_DOWNLOAD_PATH,
-    AwsDownload,
-    EOProduct,
-    NotAvailableError,
-)
+from tests.context import TEST_RESOURCES_PATH, AwsDownload, EOProduct, NotAvailableError
 
 
 class TestSafeBuild(unittest.TestCase):
@@ -39,6 +34,9 @@ class TestSafeBuild(unittest.TestCase):
         self.awsd = AwsDownload("some_provider", {})
         self.logger = logging.getLogger("eodag.plugins.download.aws")
 
+        self.tmp_download_dir = TemporaryDirectory()
+        self.tmp_download_path = self.tmp_download_dir.name
+
         with open(
             os.path.join(TEST_RESOURCES_PATH, "safe_build", "aws_sentinel_chunks.yml"),
             "r",
@@ -46,8 +44,7 @@ class TestSafeBuild(unittest.TestCase):
             self.aws_sentinel_chunks = yaml.load(fh, Loader=yaml.SafeLoader)
 
     def tearDown(self):
-        if os.path.isdir(TESTS_DOWNLOAD_PATH):
-            rmtree(TESTS_DOWNLOAD_PATH)
+        self.tmp_download_dir.cleanup()
 
     def test_safe_build_out_of_pattern(self):
         """Cannot build SAFE product from out of pattern file"""
@@ -104,7 +101,7 @@ class TestSafeBuild(unittest.TestCase):
             productType="S1_SAR_GRD",
         )
 
-        product_path = os.path.join(TESTS_DOWNLOAD_PATH, prod.properties["title"])
+        product_path = os.path.join(self.tmp_download_path, prod.properties["title"])
 
         def chunk():
             return None
@@ -148,7 +145,7 @@ class TestSafeBuild(unittest.TestCase):
             productType="S2_MSI_L2A",
         )
 
-        product_path = os.path.join(TESTS_DOWNLOAD_PATH, prod.properties["title"])
+        product_path = os.path.join(self.tmp_download_path, prod.properties["title"])
 
         def chunk():
             return None
@@ -194,7 +191,7 @@ class TestSafeBuild(unittest.TestCase):
             productType="S2_MSI_L1C",
         )
 
-        product_path = os.path.join(TESTS_DOWNLOAD_PATH, prod.properties["title"])
+        product_path = os.path.join(self.tmp_download_path, prod.properties["title"])
 
         def chunk():
             return None

--- a/tests/units/test_stac_utils.py
+++ b/tests/units/test_stac_utils.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import json
 import os
 import re
@@ -41,6 +42,8 @@ class TestStacUtils(unittest.TestCase):
 
         # import after having mocked home_dir because it launches http server (and EODataAccessGateway)
         import eodag.rest.utils as rest_utils
+
+        importlib.reload(rest_utils)
 
         cls.rest_utils = rest_utils
 

--- a/tests/units/test_stac_utils.py
+++ b/tests/units/test_stac_utils.py
@@ -369,14 +369,15 @@ class TestStacUtils(unittest.TestCase):
             },
         )
         call_args, call_kwargs = mock_do_search.call_args
-        self.assertDictContainsSubset(
+        # check if call_kwargs contains subset
+        self.assertLessEqual(
             {
                 "productType": "S2_MSI_L1C",
                 "cloudCover": 50,
                 "startTimeFromAscendingNode": "2020-02-01T00:00:00",
                 "completionTimeFromAscendingNode": "2021-02-20T00:00:00",
-            },
-            call_kwargs,
+            }.items(),
+            call_kwargs.items(),
         )
         self.assertEqual(call_kwargs["geometry"].bounds, (0.25, 43.2, 2.8, 43.9))
 
@@ -405,14 +406,15 @@ class TestStacUtils(unittest.TestCase):
             stac_formatted=False,
         )
         call_args, call_kwargs = mock_do_search.call_args
-        self.assertDictContainsSubset(
+        # check if call_kwargs contains subset
+        self.assertLessEqual(
             {
                 "productType": "S2_MSI_L1C",
                 "cloudCover": 50,
                 "startTimeFromAscendingNode": "2020-02-01T00:00:00",
                 "completionTimeFromAscendingNode": "2021-02-20T00:00:00",
-            },
-            call_kwargs,
+            }.items(),
+            call_kwargs.items(),
         )
         self.assertEqual(call_kwargs["geometry"].bounds, (0.25, 43.2, 2.8, 43.9))
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,9 @@ python =
 [testenv]
 commands =
     mkdir -p test-reports
-    pytest -v --show-capture=no --cov \
-        --cov-report term-missing \
+    pytest -v --instafail \
+        -n auto --dist loadscope \
+        --cov --cov-report term-missing \
 		--cov-report=html:test-reports/coverage \
 		--cov-report=xml:test-reports/coverage.xml \
 		--junitxml=test-reports/junit-report.xml \

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ python =
 [testenv]
 commands =
     mkdir -p test-reports
-    pytest -v --show-capture=no --cov --cov-report term-missing \
+    pytest -v --show-capture=no --cov \
         --cov-report term-missing \
 		--cov-report=html:test-reports/coverage \
 		--cov-report=xml:test-reports/coverage.xml \


### PR DESCRIPTION
Tests fixes and optimizing:
- check networks calls with [pytest-socket](https://github.com/miketheman/pytest-socket)
- all doctests except the one from `eodag/utils` moved to `tests` folder to better handle environment for these tests
- [pytest-xdist](https://github.com/pytest-dev/pytest-xdist) and [pytest-instafail](https://github.com/pytest-dev/pytest-instafail) usage
- some other fixes

Local tests duration example for a single environment:
- before: 152s
- after: 46s