### PR TITLE
fix: flatten_top_directories on single file

### DIFF
--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -1148,6 +1148,9 @@ def flatten_top_directories(nested_dir_root, common_subdirs_path=None):
         subpaths_list = [p for p in Path(nested_dir_root).glob("**/*") if p.is_file()]
         common_subdirs_path = os.path.commonpath(subpaths_list)
 
+    if Path(common_subdirs_path).is_file():
+        common_subdirs_path = os.path.dirname(common_subdirs_path)
+
     if nested_dir_root != common_subdirs_path:
         logger.debug(f"Flatten {common_subdirs_path} to {nested_dir_root}")
         tmp_path = mkdtemp()

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -487,7 +487,7 @@ class TestDownloadPluginHttpRetry(BaseDownloadPluginTest):
                 self.plugin.download(
                     self.product,
                     outputs_prefix=self.output_dir,
-                    wait=0.1 / 60,
+                    wait=0.01 / 60,
                     timeout=0.2 / 60,
                 )
 

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -241,6 +241,20 @@ class TestUtils(unittest.TestCase):
             self.assertIn(Path(nested_dir_root) / "c2" / "bar", dir_content)
             self.assertIn(Path(nested_dir_root) / "c2" / "baz", dir_content)
 
+    def test_flatten_top_dirs_single_file(self):
+        """flatten_top_dirs must flatten directory structure containing a single file"""
+        with TemporaryDirectory() as nested_dir_root:
+            os.makedirs(os.path.join(nested_dir_root, "a", "b", "c1"))
+            # create empty file
+            open(os.path.join(nested_dir_root, "a", "b", "c1", "foo"), "a").close()
+
+            flatten_top_directories(nested_dir_root)
+
+            dir_content = list(Path(nested_dir_root).glob("**/*"))
+
+            self.assertEqual(len(dir_content), 1)
+            self.assertIn(Path(nested_dir_root) / "foo", dir_content)
+
     def test_flatten_top_dirs_given_subdir(self):
         """flatten_top_dirs must flatten directory structure using given subdirectory"""
         with TemporaryDirectory() as nested_dir_root:


### PR DESCRIPTION
Fixes #633 
Prevents error raised when trying to use `flatten_top_directories()` on a directory containing a single file or when downloading a product having a single asset with download plugin configured with `flatten_top_dirs: true`.