### PR TITLE
fix: not-downloaded products warning

### DIFF
--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -513,8 +513,8 @@ class Download(PluginTopic):
                     sleep(wait_seconds + 1)
                 elif len(products) > 0 and datetime.now() >= stop_time:
                     logger.warning(
-                        f"{len(products)} products could not be downloaded:"
-                        f"{' ' + [prod.properties['title'] for prod in products]}",
+                        f"{len(products)} products could not be downloaded: "
+                        + str([prod.properties["title"] for prod in products])
                     )
                     break
                 elif len(products) == 0:


### PR DESCRIPTION
Fixes issue in the warning message following a download timeout (that could be caused by a network issue):
```
File /path/to/lib/python3.9/site-packages/eodag/plugins/download/base.py:517, in Download.download_all(self, products, auth, downloaded_callback, progress_callback, wait, timeout, **kwargs)
513 sleep(wait_seconds + 1)
514 elif len(products) > 0 and datetime.now() >= stop_time:
515 logger.warning(
516 f"{len(products)} products could not be downloaded:"
--> 517 f"{' ' + [prod.properties['title'] for prod in products]}",
518 )
TypeError: can only concatenate str (not "list") to str
```