### PR TITLE
fix: cloud cover disabled for radar product types and onda queryable params

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1424,14 +1424,22 @@
         - '$.Metadata.sensorOperationalMode'
 
       # OpenSearch Parameters for Acquistion Parameters Search (Table 6)
-      startTimeFromAscendingNode: '$.beginPosition'
-      completionTimeFromAscendingNode: '$.endPosition'
+      startTimeFromAscendingNode:
+        - null
+        - '$.beginPosition'
+      completionTimeFromAscendingNode:
+        - null
+        - '$.endPosition'
       polarizationChannels: '{$.Metadata.polarisationChannels#replace_str(","," ")}'
 
       # Custom parameters (not defined in the base document referenced above)
-      id: '{$.Metadata.filename#remove_extension}'
+      id:
+        - null
+        - '{$.Metadata.filename#remove_extension}'
       # The geographic extent of the product
-      geometry: '$.footprint'
+      geometry:
+        - null
+        - '$.footprint'
       # The url of the quicklook
       quicklook: '$.quicklook'
       # The url to download the product "as is" (literal or as a template to be completed either after the search result


### PR DESCRIPTION
Related to #389 
- Fixes cloud cover disabled for radar product types
- Fixes `onda` queryable paramaters configuration