### PR TITLE
fix: prevent duplicated ODataV4Search custom args

### DIFF
--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -559,7 +559,10 @@ class QueryStringSearch(Search):
                         for k, v in search_param_cfg_parsed.items():
                             if getattr(self.config, k, None):
                                 update_nested_dict(
-                                    getattr(self.config, k), v, extend_list_values=True
+                                    getattr(self.config, k),
+                                    v,
+                                    extend_list_values=True,
+                                    allow_extend_duplicates=False,
                                 )
                             else:
                                 logger.warning(

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -598,7 +598,11 @@ def jsonpath_parse_dict_items(jsonpath_dict, values_dict):
 
 
 def update_nested_dict(
-    old_dict, new_dict, extend_list_values=False, allow_empty_values=False
+    old_dict,
+    new_dict,
+    extend_list_values=False,
+    allow_empty_values=False,
+    allow_extend_duplicates=True,
 ):
     """Update recursively old_dict items with new_dict ones
 
@@ -609,8 +613,16 @@ def update_nested_dict(
     True
     >>> update_nested_dict(
     ...     {"a": {"a.a": [1, 2]}},
-    ...     {"a": {"a.a": [10]}},
-    ...     extend_list_values=True
+    ...     {"a": {"a.a": [10, 2]}},
+    ...     extend_list_values=True,
+    ...     allow_extend_duplicates=True
+    ... ) == {'a': {'a.a': [1, 2, 10, 2]}}
+    True
+    >>> update_nested_dict(
+    ...     {"a": {"a.a": [1, 2]}},
+    ...     {"a": {"a.a": [10, 2]}},
+    ...     extend_list_values=True,
+    ...     allow_extend_duplicates=False
     ... ) == {'a': {'a.a': [1, 2, 10]}}
     True
     >>> update_nested_dict(
@@ -644,13 +656,30 @@ def update_nested_dict(
                     v,
                     extend_list_values=extend_list_values,
                     allow_empty_values=allow_empty_values,
+                    allow_extend_duplicates=allow_extend_duplicates,
                 )
             elif (
                 extend_list_values
                 and isinstance(old_dict[k], list)
                 and isinstance(v, list)
+                and (
+                    # no common elements
+                    set(v).isdisjoint(old_dict[k])
+                    # common elements
+                    or not set(v).isdisjoint(old_dict[k])
+                    and allow_extend_duplicates
+                )
             ):
                 old_dict[k].extend(v)
+            elif (
+                extend_list_values
+                and isinstance(old_dict[k], list)
+                and isinstance(v, list)
+                # common elements
+                and not set(v).isdisjoint(old_dict[k])
+                and not allow_extend_duplicates
+            ):
+                old_dict[k].extend([x for x in v if x not in old_dict[k]])
             elif (v and not allow_empty_values) or allow_empty_values:
                 old_dict[k] = v
         else:


### PR DESCRIPTION
Prevents duplicated `free_text_search_operations` entries in `ODataV4Search` configuration when searching several times using a custom (not already configured) query parameter