### PR TITLE
feat: EOProduct defaultGeometry property

### DIFF
--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -92,7 +92,17 @@ class EOProduct(object):
             for key, value in properties.items()
             if key != "geometry" and value not in [NOT_MAPPED, NOT_AVAILABLE]
         }
-        product_geometry = properties["geometry"]
+        if "geometry" not in properties or (
+            properties["geometry"] == NOT_AVAILABLE
+            and "defaultGeometry" not in properties
+        ):
+            raise MisconfiguredError(
+                f"No geometry available to build EOProduct(id={properties.get('id', None)}, provider={provider})"
+            )
+        elif properties["geometry"] == NOT_AVAILABLE:
+            product_geometry = properties["defaultGeometry"]
+        else:
+            product_geometry = properties["geometry"]
         # Let's try 'latmin lonmin latmax lonmax'
         if isinstance(product_geometry, str):
             bbox_pattern = re.compile(


### PR DESCRIPTION
Better handle missing geometry when building [EOProduct](https://eodag.readthedocs.io/en/stable/api_reference/eoproduct.html#eodag.api.product._product.EOProduct):
- raises `MisconfiguredError` with explicit message on missing geometry and no `defaultGeometry` configured
- uses `properties["defaultGeometry"]` as default geometry if exists