### PR TITLE
feat: customize requests headers with EODAG version as user agent

### DIFF
--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -31,7 +31,7 @@ from eodag.plugins.download.base import (
     DEFAULT_DOWNLOAD_WAIT,
     DEFAULT_STREAM_REQUESTS_TIMEOUT,
 )
-from eodag.utils import ProgressCallback, get_geometry_from_various
+from eodag.utils import USER_AGENT, ProgressCallback, get_geometry_from_various
 from eodag.utils.exceptions import DownloadError, MisconfiguredError
 
 try:
@@ -437,6 +437,7 @@ class EOProduct(object):
                 self.properties["quicklook"],
                 stream=True,
                 auth=auth,
+                headers=USER_AGENT,
                 timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
             ) as stream:
                 try:

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -28,6 +28,7 @@ import yaml.parser
 from pkg_resources import resource_filename
 
 from eodag.utils import (
+    USER_AGENT,
     dict_items_recursive_apply,
     merge_mappings,
     slugify,
@@ -478,7 +479,9 @@ def get_ext_product_types_conf(conf_uri=EXT_PRODUCT_TYPES_CONF_URI):
     if conf_uri.lower().startswith("http"):
         # read from remote
         try:
-            response = requests.get(conf_uri, timeout=HTTP_REQ_TIMEOUT)
+            response = requests.get(
+                conf_uri, headers=USER_AGENT, timeout=HTTP_REQ_TIMEOUT
+            )
             response.raise_for_status()
             return response.json()
         except requests.RequestException as e:

--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -40,6 +40,7 @@ from eodag.plugins.download.base import (
 )
 from eodag.utils import (
     GENERIC_PRODUCT_TYPE,
+    USER_AGENT,
     ProgressCallback,
     format_dict_items,
     path_to_uri,
@@ -284,6 +285,7 @@ class UsgsApi(Download, Api):
                 with requests.get(
                     req_url,
                     stream=True,
+                    headers=USER_AGENT,
                     timeout=wait * 60,
                 ) as stream:
                     try:

--- a/eodag/plugins/authentication/keycloak.py
+++ b/eodag/plugins/authentication/keycloak.py
@@ -20,6 +20,7 @@ import requests
 
 from eodag.plugins.authentication import Authentication
 from eodag.plugins.authentication.openid_connect import CodeAuthorizedAuth
+from eodag.utils import USER_AGENT
 from eodag.utils.exceptions import AuthenticationError
 from eodag.utils.stac_reader import HTTP_REQ_TIMEOUT
 
@@ -52,6 +53,7 @@ class KeycloakOIDCPasswordAuth(Authentication):
                     "password": self.config.credentials["password"],
                     "grant_type": self.GRANT_TYPE,
                 },
+                headers=USER_AGENT,
                 timeout=HTTP_REQ_TIMEOUT,
             )
             response.raise_for_status()

--- a/eodag/plugins/authentication/openid_connect.py
+++ b/eodag/plugins/authentication/openid_connect.py
@@ -25,7 +25,14 @@ from lxml import etree
 from requests.auth import AuthBase
 
 from eodag.plugins.authentication import Authentication
-from eodag.utils import parse_qs, repeatfunc, urlencode, urlparse, urlunparse
+from eodag.utils import (
+    USER_AGENT,
+    parse_qs,
+    repeatfunc,
+    urlencode,
+    urlparse,
+    urlunparse,
+)
 from eodag.utils.exceptions import AuthenticationError, MisconfiguredError
 from eodag.utils.stac_reader import HTTP_REQ_TIMEOUT
 
@@ -173,7 +180,10 @@ class OIDCAuthorizationCodeFlowAuth(Authentication):
             "redirect_uri": self.config.redirect_uri,
         }
         authorization_response = self.session.get(
-            self.config.authorization_uri, params=params, timeout=HTTP_REQ_TIMEOUT
+            self.config.authorization_uri,
+            params=params,
+            headers=USER_AGENT,
+            timeout=HTTP_REQ_TIMEOUT,
         )
 
         login_document = etree.HTML(authorization_response.text)
@@ -195,7 +205,9 @@ class OIDCAuthorizationCodeFlowAuth(Authentication):
             auth_uri = login_form.xpath(
                 self.config.login_form_xpath.rstrip("/") + "/@action"
             )[0]
-        return self.session.post(auth_uri, data=login_data, timeout=HTTP_REQ_TIMEOUT)
+        return self.session.post(
+            auth_uri, data=login_data, headers=USER_AGENT, timeout=HTTP_REQ_TIMEOUT
+        )
 
     def grant_user_consent(self, authentication_response):
         """Grant user consent"""
@@ -211,6 +223,7 @@ class OIDCAuthorizationCodeFlowAuth(Authentication):
         return self.session.post(
             self.config.authorization_uri,
             data=user_consent_data,
+            headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
         )
 
@@ -251,7 +264,10 @@ class OIDCAuthorizationCodeFlowAuth(Authentication):
             self.config.token_exchange_post_data_method: token_exchange_data
         }
         r = self.session.post(
-            self.config.token_uri, timeout=HTTP_REQ_TIMEOUT, **post_request_kwargs
+            self.config.token_uri,
+            headers=USER_AGENT,
+            timeout=HTTP_REQ_TIMEOUT,
+            **post_request_kwargs
         )
         return r.json()[self.config.token_key]
 

--- a/eodag/plugins/authentication/qsauth.py
+++ b/eodag/plugins/authentication/qsauth.py
@@ -22,6 +22,7 @@ import requests.auth
 from requests.exceptions import RequestException
 
 from eodag.plugins.authentication import Authentication
+from eodag.utils import USER_AGENT
 from eodag.utils.exceptions import AuthenticationError
 from eodag.utils.stac_reader import HTTP_REQ_TIMEOUT
 
@@ -66,6 +67,7 @@ class HttpQueryStringAuth(Authentication):
                 response = requests.get(
                     auth_uri,
                     timeout=HTTP_REQ_TIMEOUT,
+                    headers=USER_AGENT,
                     auth=auth,
                 )
                 response.raise_for_status()

--- a/eodag/plugins/authentication/token.py
+++ b/eodag/plugins/authentication/token.py
@@ -20,7 +20,7 @@ import requests
 from requests import RequestException
 
 from eodag.plugins.authentication.base import Authentication
-from eodag.utils import RequestsTokenAuth
+from eodag.utils import USER_AGENT, RequestsTokenAuth
 from eodag.utils.exceptions import AuthenticationError, MisconfiguredError
 from eodag.utils.stac_reader import HTTP_REQ_TIMEOUT
 
@@ -52,7 +52,9 @@ class TokenAuth(Authentication):
 
         # append headers to req if some are specified in config
         req_kwargs = (
-            {"headers": self.config.headers} if hasattr(self.config, "headers") else {}
+            {"headers": dict(self.config.headers, **USER_AGENT)}
+            if hasattr(self.config, "headers")
+            else {"headers": USER_AGENT}
         )
         try:
             # First get the token

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -34,6 +34,7 @@ from eodag.api.product.metadata_mapping import (
 )
 from eodag.plugins.download.base import Download
 from eodag.utils import (
+    USER_AGENT,
     ProgressCallback,
     flatten_top_directories,
     get_bucket_name_and_prefix,
@@ -254,7 +255,7 @@ class AwsDownload(Download):
                 **product.properties
             )
             logger.info("Fetching extra metadata from %s" % fetch_url)
-            resp = requests.get(fetch_url, timeout=HTTP_REQ_TIMEOUT)
+            resp = requests.get(fetch_url, headers=USER_AGENT, timeout=HTTP_REQ_TIMEOUT)
             update_metadata = mtd_cfg_as_jsonpath(update_metadata)
             if fetch_format == "json":
                 json_resp = resp.json()

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -42,6 +42,7 @@ from eodag.plugins.download.base import (
     Download,
 )
 from eodag.utils import (
+    USER_AGENT,
     ProgressCallback,
     flatten_top_directories,
     path_to_uri,
@@ -117,7 +118,7 @@ class HTTPDownload(Download):
             method=order_method,
             url=order_url,
             auth=auth,
-            headers=getattr(self.config, "order_headers", {}),
+            headers=dict(getattr(self.config, "order_headers", {}), **USER_AGENT),
             **order_kwargs,
         ) as response:
             try:
@@ -197,7 +198,9 @@ class HTTPDownload(Download):
             method=status_method,
             url=status_url,
             auth=auth,
-            headers=getattr(self.config, "order_status_headers", {}),
+            headers=dict(
+                getattr(self.config, "order_status_headers", {}), **USER_AGENT
+            ),
             **status_kwargs,
         ) as response:
             try:
@@ -401,6 +404,7 @@ class HTTPDownload(Download):
                 stream=True,
                 auth=auth,
                 params=params,
+                headers=USER_AGENT,
                 timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
                 **req_kwargs,
             ) as self.stream:
@@ -547,7 +551,10 @@ class HTTPDownload(Download):
             if not asset["href"].startswith("file:"):
                 # HEAD request for size & filename
                 asset_headers = requests.head(
-                    asset["href"], auth=auth, timeout=HTTP_REQ_TIMEOUT
+                    asset["href"],
+                    auth=auth,
+                    headers=USER_AGENT,
+                    timeout=HTTP_REQ_TIMEOUT,
                 ).headers
                 header_content_disposition_dict = {}
 
@@ -576,6 +583,7 @@ class HTTPDownload(Download):
                         stream=True,
                         auth=auth,
                         params=params,
+                        headers=USER_AGENT,
                         timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
                     ) as stream:
                         # size from GET header / Content-length
@@ -610,6 +618,7 @@ class HTTPDownload(Download):
                 stream=True,
                 auth=auth,
                 params=params,
+                headers=USER_AGENT,
                 timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
             ) as stream:
                 try:

--- a/eodag/plugins/download/s3rest.py
+++ b/eodag/plugins/download/s3rest.py
@@ -35,6 +35,7 @@ from eodag.plugins.download.base import (
 )
 from eodag.plugins.download.http import HTTPDownload
 from eodag.utils import (
+    USER_AGENT,
     ProgressCallback,
     get_bucket_name_and_prefix,
     path_to_uri,
@@ -149,7 +150,7 @@ class S3RestDownload(Download):
             # get nodes/files list contained in the bucket
             logger.debug("Retrieving product content from %s", nodes_list_url)
             bucket_contents = requests.get(
-                nodes_list_url, auth=auth, timeout=HTTP_REQ_TIMEOUT
+                nodes_list_url, auth=auth, headers=USER_AGENT, timeout=HTTP_REQ_TIMEOUT
             )
             try:
                 bucket_contents.raise_for_status()
@@ -275,6 +276,7 @@ class S3RestDownload(Download):
                     node_url,
                     stream=True,
                     auth=auth,
+                    headers=USER_AGENT,
                     timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
                 ) as stream:
                     try:

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -70,11 +70,20 @@ from tqdm.auto import tqdm
 
 from eodag.utils import logging as eodag_logging
 
+try:
+    from importlib.metadata import metadata  # type: ignore
+except ImportError:  # pragma: no cover
+    # for python < 3.8
+    from importlib_metadata import metadata  # type: ignore
+
 DEFAULT_PROJ = "EPSG:4326"
 
 logger = py_logging.getLogger("eodag.utils")
 
 GENERIC_PRODUCT_TYPE = "GENERIC_PRODUCT_TYPE"
+
+eodag_version = metadata("eodag")["Version"]
+USER_AGENT = {"User-Agent": f"eodag/{eodag_version}"}
 
 
 def _deprecated(reason="", version=None):

--- a/tests/context.py
+++ b/tests/context.py
@@ -64,6 +64,7 @@ from eodag.plugins.download.http import HTTPDownload
 from eodag.plugins.manager import PluginManager
 from eodag.plugins.search.base import Search
 from eodag.utils import (
+    USER_AGENT,
     get_bucket_name_and_prefix,
     get_geometry_from_various,
     get_timestamp,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,6 +30,7 @@ from tests.context import (
     EXT_PRODUCT_TYPES_CONF_URI,
     HTTP_REQ_TIMEOUT,
     TEST_RESOURCES_PATH,
+    USER_AGENT,
     EODataAccessGateway,
     ValidationError,
     config,
@@ -472,7 +473,7 @@ class TestConfigFunctions(unittest.TestCase):
 
         ext_product_types_conf = get_ext_product_types_conf()
         mock_get.assert_called_once_with(
-            EXT_PRODUCT_TYPES_CONF_URI, timeout=HTTP_REQ_TIMEOUT
+            EXT_PRODUCT_TYPES_CONF_URI, headers=USER_AGENT, timeout=HTTP_REQ_TIMEOUT
         )
         self.assertEqual(ext_product_types_conf, {"some_parameter": "a_value"})
 

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -29,6 +29,7 @@ from shapely.geometry import shape
 from tests.context import (
     DEFAULT_DOWNLOAD_WAIT,
     ONLINE_STATUS,
+    USER_AGENT,
     AuthenticationError,
     EODataAccessGateway,
     EOProduct,
@@ -556,6 +557,9 @@ class TestApisPluginUsgsApi(BaseApisPluginTest):
             )
 
             self.assertEqual(len(responses.calls), 1)
+            self.assertIn(
+                list(USER_AGENT.items())[0], responses.calls[0].request.headers.items()
+            )
             responses.calls.reset()
 
             self.assertEqual(

--- a/tests/units/test_eoproduct.py
+++ b/tests/units/test_eoproduct.py
@@ -31,6 +31,7 @@ from tests import EODagTestCase
 from tests.context import (
     DEFAULT_STREAM_REQUESTS_TIMEOUT,
     NOT_AVAILABLE,
+    USER_AGENT,
     DatasetDriver,
     Download,
     EOProduct,
@@ -179,6 +180,7 @@ class TestEOProduct(EODagTestCase):
             "https://fake.url.to/quicklook",
             stream=True,
             auth=None,
+            headers=USER_AGENT,
             timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
         )
         self.assertEqual(quicklook_file_path, "")
@@ -202,6 +204,7 @@ class TestEOProduct(EODagTestCase):
             "https://fake.url.to/quicklook",
             stream=True,
             auth=None,
+            headers=USER_AGENT,
             timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
         )
         self.assertEqual(
@@ -219,6 +222,7 @@ class TestEOProduct(EODagTestCase):
             "https://fake.url.to/quicklook",
             stream=True,
             auth=None,
+            headers=USER_AGENT,
             timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
         )
         self.assertEqual(self.requests_http_get.call_count, 2)
@@ -307,6 +311,7 @@ class TestEOProduct(EODagTestCase):
                 stream=True,
                 auth=None,
                 params={},
+                headers=USER_AGENT,
                 timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
             )
             download_records_dir = pathlib.Path(product_dir_path).parent / ".downloaded"
@@ -358,6 +363,7 @@ class TestEOProduct(EODagTestCase):
                 stream=True,
                 auth=None,
                 params={},
+                headers=USER_AGENT,
                 timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
             )
             # Check that the product's directory exists.
@@ -430,6 +436,7 @@ class TestEOProduct(EODagTestCase):
                 stream=True,
                 auth=None,
                 params={"fakeparam": "dummy"},
+                headers=USER_AGENT,
                 timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
             )
             # Check that "outputs_prefix" is respected.

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -715,7 +715,7 @@ class TestSearchPluginODataV4Search(BaseSearchPluginTest):
     @mock.patch(
         "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
     )
-    def test_plugins_search_odatav4search_count_and_search_onda__per_product_metadata_query_request_error(
+    def test_plugins_search_odatav4search_count_and_search_onda_per_product_metadata_query_request_error(
         self, mock__request, mock_requests_get
     ):
         """A query with a ODataV4Search (here onda) must handle requests errors for query per product metadata"""  # noqa


### PR DESCRIPTION
fixes #614

Requests headers are now customized as follows: `{"User-Agent": <EODAG_VERSION>}`