### PR TITLE
fix: search errors handling

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -928,6 +928,8 @@ class EODataAccessGateway(object):
                 products, _ = self._do_search(
                     search_plugin, count=False, raise_errors=True, **search_kwargs
                 )
+            except Exception:
+                products = SearchResult([])
             finally:
                 # we don't want that next(search_iter_page(...)) modifies the plugin
                 # indefinitely. So we reset after each request, but before the generator

--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -45,7 +45,7 @@ from eodag.utils import (
     format_dict_items,
     path_to_uri,
 )
-from eodag.utils.exceptions import AuthenticationError, NotAvailableError
+from eodag.utils.exceptions import AuthenticationError, NotAvailableError, RequestError
 
 logger = logging.getLogger("eodag.plugins.apis.usgs")
 
@@ -192,9 +192,11 @@ class UsgsApi(Download, Api):
                 )
         except USGSError as e:
             logger.warning(
-                f"Product type {usgs_dataset} does not exist on USGS EE catalog"
+                f"Product type {usgs_dataset} may not exist on USGS EE catalog"
             )
-            logger.warning(f"Skipping error: {e}")
+            api.logout()
+            raise RequestError(e)
+
         api.logout()
 
         if final:

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -31,7 +31,6 @@ from eodag.api.product.metadata_mapping import (
 )
 from eodag.plugins.search.qssearch import PostJsonSearch
 from eodag.utils import dict_items_recursive_sort
-from eodag.utils.exceptions import RequestError
 
 logger = logging.getLogger("eodag.plugins.search.build_search_result")
 
@@ -76,17 +75,13 @@ class BuildPostSearchResult(PostJsonSearch):
     def do_search(self, *args, **kwargs):
         """Perform the actual search request, and return result in a single element."""
         search_url = self.search_urls[0]
-        try:
-            response = self._request(
-                search_url,
-                info_message=f"Sending search request: {search_url}",
-                exception_message=f"Skipping error while searching for {self.provider} "
-                f"{self.__class__.__name__} instance:",
-            )
-        except RequestError:
-            return []
-        else:
-            return [response.json()]
+        response = self._request(
+            search_url,
+            info_message=f"Sending search request: {search_url}",
+            exception_message=f"Skipping error while searching for {self.provider} "
+            f"{self.__class__.__name__} instance:",
+        )
+        return [response.json()]
 
     def normalize_results(self, results, **kwargs):
         """Build :class:`~eodag.api.product._product.EOProduct` from provider result

--- a/tests/integration/test_core_search_errors.py
+++ b/tests/integration/test_core_search_errors.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018, CS GROUP - France, https://www.csgroup.eu/
+#
+# This file is part of EODAG project
+#     https://www.github.com/CS-SI/EODAG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+import unittest
+
+from requests.exceptions import RequestException
+
+from tests import TEST_RESOURCES_PATH
+from tests.context import EODataAccessGateway, RequestError, USGSError
+from tests.utils import mock
+
+
+class TestCoreSearchErrors(unittest.TestCase):
+    def setUp(self):
+        super(TestCoreSearchErrors, self).setUp()
+        # Mock home and eodag conf directory to tmp dir
+        self.tmp_home_dir = tempfile.TemporaryDirectory()
+        self.expanduser_mock = mock.patch(
+            "os.path.expanduser", autospec=True, return_value=self.tmp_home_dir.name
+        )
+        self.expanduser_mock.start()
+        # load fake credentials to prevent providers needing auth for search to be pruned
+        config_path = os.path.join(TEST_RESOURCES_PATH, "wrong_credentials_conf.yml")
+        self.dag = EODataAccessGateway(user_conf_file_path=config_path)
+
+    def tearDown(self):
+        super(TestCoreSearchErrors, self).tearDown()
+        # stop Mock and remove tmp config dir
+        self.expanduser_mock.stop()
+        self.tmp_home_dir.cleanup()
+
+    @mock.patch(
+        "eodag.plugins.search.qssearch.requests.get",
+        autospec=True,
+        side_effect=RequestException,
+    )
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test_core_search_errors_qssearch(self, mock_fetch_product_types_list, mock_get):
+
+        # QueryStringSearch (peps)
+        self.dag.set_preferred_provider("peps")
+        products, count = self.dag.search()
+        self.assertEqual(count, 0)
+        self.assertEqual(len(products), 0)
+        self.assertRaises(RequestError, self.dag.search, raise_errors=True)
+        # search iterator
+        self.assertRaises(StopIteration, next, self.dag.search_iter_page())
+        # search_all
+        self.assertEqual(len(self.dag.search_all()), 0)
+
+    @mock.patch(
+        "eodag.plugins.search.qssearch.requests.post",
+        autospec=True,
+        side_effect=RequestException,
+    )
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test_core_search_errors_stacsearch(
+        self, mock_fetch_product_types_list, mock_post
+    ):
+        # StacSearch (astraea_eod)
+        self.dag.set_preferred_provider("astraea_eod")
+        products, count = self.dag.search()
+        self.assertEqual(count, 0)
+        self.assertEqual(len(products), 0)
+        self.assertRaises(RequestError, self.dag.search, raise_errors=True)
+        # search iterator
+        self.assertRaises(StopIteration, next, self.dag.search_iter_page())
+        # search_all
+        self.assertEqual(len(self.dag.search_all()), 0)
+
+    @mock.patch(
+        "eodag.plugins.search.qssearch.requests.post",
+        autospec=True,
+        side_effect=RequestException,
+    )
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test_core_search_errors_postjson(
+        self, mock_fetch_product_types_list, mock_post
+    ):
+        # PostJsonSearch (aws_eos)
+        self.dag.set_preferred_provider("aws_eos")
+        products, count = self.dag.search()
+        self.assertEqual(count, 0)
+        self.assertEqual(len(products), 0)
+        self.assertRaises(RequestError, self.dag.search, raise_errors=True)
+        # search iterator
+        self.assertRaises(StopIteration, next, self.dag.search_iter_page())
+        # search_all
+        self.assertEqual(len(self.dag.search_all()), 0)
+
+    @mock.patch(
+        "eodag.plugins.search.qssearch.urlopen",
+        autospec=True,
+        side_effect=RequestException,
+    )
+    @mock.patch(
+        "eodag.plugins.search.qssearch.requests.get",
+        autospec=True,
+        side_effect=RequestException,
+    )
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test_core_search_errors_odata(
+        self, mock_fetch_product_types_list, mock_get, mock_urlopen
+    ):
+        # ODataV4Search (onda)
+        self.dag.set_preferred_provider("onda")
+        products, count = self.dag.search()
+        self.assertEqual(count, 0)
+        self.assertEqual(len(products), 0)
+        self.assertRaises(RequestError, self.dag.search, raise_errors=True)
+        # search iterator
+        self.assertRaises(StopIteration, next, self.dag.search_iter_page())
+        # search_all
+        self.assertEqual(len(self.dag.search_all()), 0)
+
+    @mock.patch(
+        "eodag.plugins.apis.usgs.api.scene_search", autospec=True, side_effect=USGSError
+    )
+    @mock.patch("eodag.plugins.apis.usgs.api.login", autospec=True)
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test_core_search_errors_usgs(
+        self, mock_fetch_product_types_list, mock_login, mock_scene_search
+    ):
+        # UsgsApi (usgs)
+        self.dag.set_preferred_provider("usgs")
+        products, count = self.dag.search(productType="foo")
+        self.assertEqual(count, 0)
+        self.assertEqual(len(products), 0)
+        self.assertRaises(
+            RequestError, self.dag.search, productType="foo", raise_errors=True
+        )
+        # search iterator
+        self.assertRaises(StopIteration, next, self.dag.search_iter_page())
+        # search_all
+        self.assertEqual(len(self.dag.search_all()), 0)
+
+    @mock.patch(
+        "eodag.plugins.search.qssearch.requests.post",
+        autospec=True,
+        side_effect=RequestException,
+    )
+    @mock.patch(
+        "eodag.plugins.authentication.qsauth.HttpQueryStringAuth.authenticate",
+        autospec=True,
+    )
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
+    )
+    def test_core_search_errors_buildpost(
+        self, mock_fetch_product_types_list, mock_authenticate, mock_post
+    ):
+        # BuildPostSearchResult (meteoblue)
+        self.dag.set_preferred_provider("meteoblue")
+        products, count = self.dag.search()
+        self.assertEqual(count, 0)
+        self.assertEqual(len(products), 0)
+        self.assertRaises(RequestError, self.dag.search, raise_errors=True)
+        # search iterator
+        self.assertRaises(StopIteration, next, self.dag.search_iter_page())
+        # search_all
+        self.assertEqual(len(self.dag.search_all()), 0)

--- a/tests/resources/wrong_credentials_conf.yml
+++ b/tests/resources/wrong_credentials_conf.yml
@@ -57,3 +57,8 @@ cop_dataspace:
         credentials:
             username: "wrong_username"
             password: "wrong_password"
+
+meteoblue:
+    auth:
+        credentials:
+            apikey: "wrong_apikey"

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1002,3 +1002,17 @@ class TestEODagEndToEndWrongCredentials(EndToEndBase):
                     )
                 ),
             )
+
+    def test_end_to_end_wrong_credentials_search_meteoblue(self):
+        # It should already fail while searching for the products.
+        self.eodag.set_preferred_provider(METEOBLUE_SEARCH_ARGS[0])
+        with self.assertRaises(AuthenticationError):
+            results, _ = self.eodag.search(
+                raise_errors=True,
+                **dict(
+                    zip(
+                        ["productType", "start", "end", "geom"],
+                        METEOBLUE_SEARCH_ARGS[1:],
+                    )
+                ),
+            )


### PR DESCRIPTION
Fixes [search](https://eodag.readthedocs.io/en/latest/notebooks/api_user_guide/4_search.html#Search-methods) error handling, broken since `v2.9.0` and #632, and adds associated tests