### PR TITLE
docs: pin sphinx-book-theme version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -91,7 +91,7 @@ tutorials =
     netcdf4
 docs =
     sphinx
-    sphinx-book-theme >= 0.1.0
+    sphinx-book-theme < 1.0.0
     sphinx-copybutton
     sphinxcontrib-jquery
     nbsphinx


### PR DESCRIPTION
Pin `sphinx-book-theme` version to the latest stable before `v1.0.0`. 
`v1.0.0` was just released and theme settings need to be adapted: https://sphinx-book-theme.readthedocs.io/en/latest/changelog.html#v1-0-0-2023-03-01