### PR TITLE
fix: shapely transform inverted xy and warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     owslib < 0.26;python_version>='3.10'
     owslib;python_version<'3.10'
     geojson
-    pyproj
+    pyproj >= 2.1.0
     usgs >= 0.3.1
     boto3
     flasgger

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -568,7 +568,7 @@ class TestDownloadPluginHttpRetry(BaseDownloadPluginTest):
                 self.plugin.download(
                     self.product,
                     outputs_prefix=self.output_dir,
-                    wait=0.01 / 60,
+                    wait=0.02 / 60,
                     timeout=0.2 / 60,
                 )
 

--- a/tests/units/test_metadata_mapping.py
+++ b/tests/units/test_metadata_mapping.py
@@ -131,8 +131,8 @@ class TestMetadataFormatter(unittest.TestCase):
             to_format, fieldname="SRID=3857;POINT (321976 5390999)"
         )
         geom = wkt.loads(wkt_str)
-        self.assertEqual(round(geom.x, 1), 43.5)
-        self.assertEqual(round(geom.y, 1), 2.9)
+        self.assertEqual(round(geom.x, 1), 2.9)
+        self.assertEqual(round(geom.y, 1), 43.5)
 
     def test_convert_to_ewkt(self):
         to_format = "{fieldname#to_ewkt}"
@@ -175,11 +175,11 @@ class TestMetadataFormatter(unittest.TestCase):
         sub_multipolygon.attrib["srsName"] = "EPSG:3857"
         sub_polygon1 = etree.SubElement(sub_multipolygon, "foo")
         sub_polygon1.text = (
-            "4833492 136933 4871341 136933 4871341 187044 4833492 187044 4833492 136933"
+            "136923 5376120 136923 5428376 187017 5428376 187017 5376120 136923 5376120"
         )
         sub_polygon2 = etree.SubElement(sub_multipolygon, "bar")
         sub_polygon2.text = (
-            "4833492 248305 4871341 248305 4871341 409938 4833492 409938 4833492 248305"
+            "248242 5376120 248242 5428376 409655 5428376 409655 5376120 248242 5376120"
         )
         wkt_str = format_metadata(to_format, fieldname=georss)
         geom = wkt.loads(wkt_str)


### PR DESCRIPTION
Fixes inverted x/y when using `shapely.ops.transform()` in `convert_from_ewkt()` and `convert_from_georss()`, and supresses deprecation warning following https://shapely.readthedocs.io/en/latest/manual.html#other-transformations guidelines