### PR TITLE
refactor: metadata parsing

### DIFF
--- a/eodag/plugins/authentication/keycloak.py
+++ b/eodag/plugins/authentication/keycloak.py
@@ -62,7 +62,10 @@ class KeycloakOIDCPasswordAuth(Authentication):
             auth_errors = getattr(self.config, "auth_error_code", [None])
             if not isinstance(auth_errors, list):
                 auth_errors = [auth_errors]
-            if e.response.status_code in auth_errors:
+            if (
+                hasattr(e.response, "status_code")
+                and e.response.status_code in auth_errors
+            ):
                 raise AuthenticationError(
                     "HTTP Error %s returned, %s\nPlease check your credentials for %s"
                     % (e.response.status_code, e.response.text.strip(), self.provider)

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -28,7 +28,7 @@ from botocore.handlers import disable_signing
 from lxml import etree
 
 from eodag.api.product.metadata_mapping import (
-    mtd_cfg_as_jsonpath,
+    mtd_cfg_as_conversion_and_querypath,
     properties_from_json,
     properties_from_xml,
 )
@@ -256,7 +256,7 @@ class AwsDownload(Download):
             )
             logger.info("Fetching extra metadata from %s" % fetch_url)
             resp = requests.get(fetch_url, headers=USER_AGENT, timeout=HTTP_REQ_TIMEOUT)
-            update_metadata = mtd_cfg_as_jsonpath(update_metadata)
+            update_metadata = mtd_cfg_as_conversion_and_querypath(update_metadata)
             if fetch_format == "json":
                 json_resp = resp.json()
                 update_metadata = properties_from_json(json_resp, update_metadata)

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -30,7 +30,7 @@ from requests import HTTPError, RequestException
 from eodag.api.product.metadata_mapping import (
     OFFLINE_STATUS,
     ONLINE_STATUS,
-    mtd_cfg_as_jsonpath,
+    mtd_cfg_as_conversion_and_querypath,
     properties_from_json,
     properties_from_xml,
 )
@@ -139,7 +139,7 @@ class HTTPDownload(Download):
         if order_metadata_mapping:
             logger.debug("Parsing order response to update product metada-mapping")
             order_metadata_mapping_jsonpath = {}
-            order_metadata_mapping_jsonpath = mtd_cfg_as_jsonpath(
+            order_metadata_mapping_jsonpath = mtd_cfg_as_conversion_and_querypath(
                 order_metadata_mapping, order_metadata_mapping_jsonpath
             )
             properties_update = properties_from_json(
@@ -276,9 +276,11 @@ class HTTPDownload(Download):
                                 self.config.order_status_on_success["metadata_mapping"]
                             )
                             order_metadata_mapping_jsonpath = {}
-                            order_metadata_mapping_jsonpath = mtd_cfg_as_jsonpath(
-                                new_search_metadata_mapping,
-                                order_metadata_mapping_jsonpath,
+                            order_metadata_mapping_jsonpath = (
+                                mtd_cfg_as_conversion_and_querypath(
+                                    new_search_metadata_mapping,
+                                    order_metadata_mapping_jsonpath,
+                                )
                             )
                             properties_update = properties_from_xml(
                                 result,

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -18,7 +18,7 @@
 
 from eodag.api.product.metadata_mapping import (
     DEFAULT_METADATA_MAPPING,
-    mtd_cfg_as_jsonpath,
+    mtd_cfg_as_conversion_and_querypath,
 )
 from eodag.plugins.base import PluginTopic
 
@@ -40,14 +40,10 @@ class Search(PluginTopic):
         # Update the defaults with the mapping value. This will add any new key
         # added by the provider mapping that is not in the default metadata
         metas.update(self.config.metadata_mapping)
-        # common_jsonpath usage to optimize jsonpath build process
-        mtd_cfg_as_jsonpath_options = {}
-        if hasattr(self.config, "common_metadata_mapping_path"):
-            mtd_cfg_as_jsonpath_options[
-                "common_jsonpath"
-            ] = self.config.common_metadata_mapping_path
-        self.config.metadata_mapping = mtd_cfg_as_jsonpath(
-            metas, self.config.metadata_mapping, **mtd_cfg_as_jsonpath_options
+        self.config.metadata_mapping = mtd_cfg_as_conversion_and_querypath(
+            metas,
+            self.config.metadata_mapping,
+            result_type=getattr(self.config, "result_type", "json"),
         )
 
     def clear(self):

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -30,9 +30,8 @@ from eodag.api.product.metadata_mapping import (
     NOT_AVAILABLE,
     NOT_MAPPED,
     format_metadata,
-    get_metadata_path_value,
     get_search_param,
-    mtd_cfg_as_jsonpath,
+    mtd_cfg_as_conversion_and_querypath,
     properties_from_json,
     properties_from_xml,
 )
@@ -40,10 +39,11 @@ from eodag.plugins.search.base import Search
 from eodag.utils import (
     GENERIC_PRODUCT_TYPE,
     USER_AGENT,
-    cached_parse,
+    _deprecated,
     dict_items_recursive_apply,
     format_dict_items,
     quote,
+    string_to_jsonpath,
     update_nested_dict,
     urlencode,
 )
@@ -166,6 +166,79 @@ class QueryStringSearch(Search):
         self.next_page_url = None
         self.next_page_query_obj = None
         self.next_page_merge = None
+        # parse jsonpath on init: pagination
+        if (
+            self.config.result_type == "json"
+            and "total_items_nb_key_path" in self.config.pagination
+        ):
+            self.config.pagination["total_items_nb_key_path"] = string_to_jsonpath(
+                self.config.pagination["total_items_nb_key_path"]
+            )
+        if (
+            self.config.result_type == "json"
+            and "next_page_url_key_path" in self.config.pagination
+        ):
+            self.config.pagination["next_page_url_key_path"] = string_to_jsonpath(
+                self.config.pagination.get("next_page_url_key_path", None)
+            )
+        if (
+            self.config.result_type == "json"
+            and "next_page_query_obj_key_path" in self.config.pagination
+        ):
+            self.config.pagination["next_page_query_obj_key_path"] = string_to_jsonpath(
+                self.config.pagination.get("next_page_query_obj_key_path", None)
+            )
+        if (
+            self.config.result_type == "json"
+            and "next_page_merge_key_path" in self.config.pagination
+        ):
+            self.config.pagination["next_page_merge_key_path"] = string_to_jsonpath(
+                self.config.pagination.get("next_page_merge_key_path", None)
+            )
+
+        # parse jsonpath on init: product types discovery
+        if (
+            getattr(self.config, "discover_product_types", {}).get(
+                "results_entry", None
+            )
+            and getattr(self.config, "discover_product_types", {}).get(
+                "result_type", None
+            )
+            == "json"
+        ):
+            self.config.discover_product_types["results_entry"] = string_to_jsonpath(
+                self.config.discover_product_types["results_entry"], force=True
+            )
+            self.config.discover_product_types[
+                "generic_product_type_id"
+            ] = mtd_cfg_as_conversion_and_querypath(
+                {"foo": self.config.discover_product_types["generic_product_type_id"]}
+            )[
+                "foo"
+            ]
+            self.config.discover_product_types[
+                "generic_product_type_parsable_properties"
+            ] = mtd_cfg_as_conversion_and_querypath(
+                self.config.discover_product_types[
+                    "generic_product_type_parsable_properties"
+                ]
+            )
+            self.config.discover_product_types[
+                "generic_product_type_parsable_metadata"
+            ] = mtd_cfg_as_conversion_and_querypath(
+                self.config.discover_product_types[
+                    "generic_product_type_parsable_metadata"
+                ]
+            )
+
+        # parse jsonpath on init: product type specific metadata-mapping
+        for product_type in self.config.products.keys():
+            if "metadata_mapping" in self.config.products[product_type].keys():
+                self.config.products[product_type][
+                    "metadata_mapping"
+                ] = mtd_cfg_as_conversion_and_querypath(
+                    self.config.products[product_type]["metadata_mapping"]
+                )
 
     def clear(self):
         """Clear search context"""
@@ -203,9 +276,9 @@ class QueryStringSearch(Search):
                     # extract results from response json
                     result = [
                         match.value
-                        for match in cached_parse(
-                            self.config.discover_product_types["results_entry"]
-                        ).find(resp_as_json)
+                        for match in self.config.discover_product_types[
+                            "results_entry"
+                        ].find(resp_as_json)
                     ]
 
                     conf_update_dict = {
@@ -215,8 +288,8 @@ class QueryStringSearch(Search):
 
                     for product_type_result in result:
                         # providers_config extraction
-                        mapping_config = {}
-                        mapping_config = mtd_cfg_as_jsonpath(
+                        extracted_mapping = properties_from_json(
+                            product_type_result,
                             dict(
                                 self.config.discover_product_types[
                                     "generic_product_type_parsable_properties"
@@ -227,11 +300,6 @@ class QueryStringSearch(Search):
                                     ]
                                 },
                             ),
-                            mapping_config,
-                        )
-
-                        extracted_mapping = properties_from_json(
-                            product_type_result, mapping_config
                         )
                         generic_product_type_id = extracted_mapping.pop(
                             "generic_product_type_id"
@@ -245,16 +313,14 @@ class QueryStringSearch(Search):
                             ),
                         )
                         # product_types_config extraction
-                        mapping_config = {}
-                        mapping_config = mtd_cfg_as_jsonpath(
+                        conf_update_dict["product_types_config"][
+                            generic_product_type_id
+                        ] = properties_from_json(
+                            product_type_result,
                             self.config.discover_product_types[
                                 "generic_product_type_parsable_metadata"
                             ],
-                            mapping_config,
                         )
-                        conf_update_dict["product_types_config"][
-                            generic_product_type_id
-                        ] = properties_from_json(product_type_result, mapping_config)
 
                         # update keywords
                         keywords_fields = [
@@ -351,18 +417,14 @@ class QueryStringSearch(Search):
             other_product_type_def_params = self.get_product_type_def_params(
                 other_product_for_mapping, **kwargs
             )
-            self.update_metadata_mapping(
+            self.config.metadata_mapping.update(
                 other_product_type_def_params.get("metadata_mapping", {})
             )
         # from current product
-        self.update_metadata_mapping(
+        self.config.metadata_mapping.update(
             self.product_type_def_params.get("metadata_mapping", {})
         )
 
-        # Add to the query, the queryable parameters set in the provider product type definition
-        self.product_type_def_params = self.get_product_type_def_params(
-            product_type, **kwargs
-        )
         # if product_type_def_params is set, remove product_type as it may conflict with this conf
         if self.product_type_def_params:
             keywords.pop("productType", None)
@@ -395,27 +457,13 @@ class QueryStringSearch(Search):
         total_items = len(eo_products) if total_items == 0 else total_items
         return eo_products, total_items
 
+    @_deprecated(
+        reason="Simply run `self.config.metadata_mapping.update(metadata_mapping)` instead",
+        version="2.10.0",
+    )
     def update_metadata_mapping(self, metadata_mapping):
         """Update plugin metadata_mapping with input metadata_mapping configuration"""
         self.config.metadata_mapping.update(metadata_mapping)
-        unparsed_metadata = {
-            k: v
-            for k, v in metadata_mapping.items()
-            if isinstance(get_metadata_path_value(self.config.metadata_mapping[k]), str)
-        }
-        # common_jsonpath usage to optimize jsonpath build process
-        # On error, assume the mapping is to be passed as is. Ignore any transformation specified.
-        #   If a value is to be passed as is, we don't want to transform it further
-        mtd_cfg_as_jsonpath_options = {"keep_conversion": False}
-        if hasattr(self.config, "common_metadata_mapping_path"):
-            mtd_cfg_as_jsonpath_options[
-                "common_jsonpath"
-            ] = self.config.common_metadata_mapping_path
-        self.config.metadata_mapping = mtd_cfg_as_jsonpath(
-            unparsed_metadata,
-            self.config.metadata_mapping,
-            **mtd_cfg_as_jsonpath_options,
-        )
 
     def build_query_string(self, product_type, **kwargs):
         """Build The query string using the search parameters"""
@@ -630,9 +678,9 @@ class QueryStringSearch(Search):
             # extract total_items_nb from search results
             total_items_nb = 0
             if self.config.result_type == "json":
-                total_items_nb_key_path_parsed = cached_parse(
-                    self.config.pagination["total_items_nb_key_path"]
-                )
+                total_items_nb_key_path_parsed = self.config.pagination[
+                    "total_items_nb_key_path"
+                ]
 
         results = []
         for search_url in self.search_urls:
@@ -687,7 +735,7 @@ class QueryStringSearch(Search):
             else:
                 resp_as_json = response.json()
                 if next_page_url_key_path:
-                    path_parsed = cached_parse(next_page_url_key_path)
+                    path_parsed = next_page_url_key_path
                     try:
                         self.next_page_url = path_parsed.find(resp_as_json)[0].value
                         logger.debug(
@@ -696,7 +744,7 @@ class QueryStringSearch(Search):
                     except IndexError:
                         logger.debug("Next page URL could not be collected")
                 if next_page_query_obj_key_path:
-                    path_parsed = cached_parse(next_page_query_obj_key_path)
+                    path_parsed = next_page_query_obj_key_path
                     try:
                         self.next_page_query_obj = path_parsed.find(resp_as_json)[
                             0
@@ -707,7 +755,7 @@ class QueryStringSearch(Search):
                     except IndexError:
                         logger.debug("Next page Query-object could not be collected")
                 if next_page_merge_key_path:
-                    path_parsed = cached_parse(next_page_merge_key_path)
+                    path_parsed = next_page_merge_key_path
                     try:
                         self.next_page_merge = path_parsed.find(resp_as_json)[0].value
                         logger.debug(
@@ -792,9 +840,7 @@ class QueryStringSearch(Search):
         else:
             count_results = response.json()
             if isinstance(count_results, dict):
-                path_parsed = cached_parse(
-                    self.config.pagination["total_items_nb_key_path"]
-                )
+                path_parsed = self.config.pagination["total_items_nb_key_path"]
                 total_results = path_parsed.find(count_results)[0].value
             else:  # interpret the result as a raw int
                 total_results = int(count_results)
@@ -855,7 +901,7 @@ class QueryStringSearch(Search):
             return self.config.products[product_type]
         elif GENERIC_PRODUCT_TYPE in self.config.products.keys():
             logger.debug(
-                "Getting genric provider product type definition parameters for %s",
+                "Getting generic provider product type definition parameters for %s",
                 product_type,
             )
             return {
@@ -962,6 +1008,19 @@ class ODataV4Search(QueryStringSearch):
     """A specialisation of a QueryStringSearch that does a two step search to retrieve
     all products metadata"""
 
+    def __init__(self, provider, config):
+        super(ODataV4Search, self).__init__(provider, config)
+
+        # parse jsonpath on init
+        metadata_pre_mapping = getattr(self.config, "metadata_pre_mapping", {})
+        metadata_path = metadata_pre_mapping.get("metadata_path", None)
+        metadata_path_id = metadata_pre_mapping.get("metadata_path_id", None)
+        metadata_path_value = metadata_pre_mapping.get("metadata_path_value", None)
+        if metadata_path and metadata_path_id and metadata_path_value:
+            self.config.metadata_pre_mapping["metadata_path"] = string_to_jsonpath(
+                metadata_path
+            )
+
     def do_search(self, *args, **kwargs):
         """A two step search can be performed if the metadata are not given into the search result"""
 
@@ -1009,7 +1068,8 @@ class ODataV4Search(QueryStringSearch):
         metadata_path_value = metadata_pre_mapping.get("metadata_path_value", None)
 
         if metadata_path and metadata_path_id and metadata_path_value:
-            parsed_metadata_path = cached_parse(metadata_path)
+            # metadata_path already parsed on init
+            parsed_metadata_path = metadata_path
             for result in results:
                 found_metadata = parsed_metadata_path.find(result)
                 if found_metadata:
@@ -1056,11 +1116,11 @@ class PostJsonSearch(QueryStringSearch):
             other_product_type_def_params = self.get_product_type_def_params(
                 other_product_for_mapping, **kwargs
             )
-            self.update_metadata_mapping(
+            self.config.metadata_mapping.update(
                 other_product_type_def_params.get("metadata_mapping", {})
             )
         # from current product
-        self.update_metadata_mapping(
+        self.config.metadata_mapping.update(
             self.product_type_def_params.get("metadata_mapping", {})
         )
 

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -30,7 +30,6 @@
     pagination:
       max_items_per_page: 5000
       total_items_nb_key_path: '$.totalHits'
-    common_metadata_mapping_path: '$'
     metadata_mapping:
       id: '$.displayId'
       geometry: '$.spatialBounds'
@@ -110,7 +109,6 @@
       metadata_pattern: '^[a-zA-Z0-9_]+$'
       search_param: '{{{{"search":{{{{"{metadata}":"{{{metadata}}}" }}}} }}}}'
       metadata_path: '$.*'
-    common_metadata_mapping_path: '$'
     metadata_mapping:
       # landsat8_downloadLink : 's3://landsat-pds/c{storedInCollection}/L8/{path}/{row}/{productID}'
       geometry:
@@ -560,7 +558,6 @@
       metadata_pattern: '^(?!collection)[a-zA-Z0-9_]+$'
       search_param: '{metadata}={{{metadata}}}'
       metadata_path: '$.properties.*'
-    common_metadata_mapping_path: '$'
     metadata_mapping:
       # Opensearch resource identifier within the search engine context (in our case
       # within the context of the data provider)
@@ -736,7 +733,6 @@
       metadata_pattern: '^(?!collection)[a-zA-Z0-9_]+$'
       search_param: '{metadata}={{{metadata}}}'
       metadata_path: '$.properties.*'
-    common_metadata_mapping_path: '$'
     metadata_mapping:
       # Opensearch resource identifier within the search engine context (in our case
       # within the context of the data provider)
@@ -922,7 +918,6 @@
               and:
                 -  "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq '{metadata}' and att/OData.CSC.StringAttribute/Value eq '{{{metadata}}}')"
       metadata_path: '$.Attributes.*'
-    common_metadata_mapping_path: '$'
     discover_product_types:
       fetch_url: 'https://datahub.creodias.eu/stac/collections'
       result_type: json
@@ -1625,7 +1620,6 @@
       metadata_path: '$.Metadata'
       metadata_path_id: 'id'
       metadata_path_value: 'value'
-    common_metadata_mapping_path: '$'
     metadata_mapping:
       # Opensearch resource identifier within the search engine context (in our case
       # within the context of the data provider)
@@ -2177,7 +2171,6 @@
     type: EcmwfApi
     api_endpoint: https://api.ecmwf.int/v1
     extract: false
-    common_metadata_mapping_path: '$'
     metadata_mapping:
       productType: '$.productType'
       title: '$.id'
@@ -2400,7 +2393,6 @@
     type: CdsApi
     api_endpoint: https://ads.atmosphere.copernicus.eu/api/v2
     extract: false
-    common_metadata_mapping_path: '$'
     metadata_mapping:
       productType: '$.productType'
       title: '$.id'
@@ -2718,7 +2710,6 @@
     type: CdsApi
     api_endpoint: https://cds.climate.copernicus.eu/api/v2
     extract: false
-    common_metadata_mapping_path: '$'
     metadata_mapping:
       productType: '$.productType'
       title: '$.id'
@@ -2970,7 +2961,6 @@
       metadata_pattern: '^(?!collection)[a-zA-Z0-9_]+$'
       search_param: '{metadata}={{{metadata}}}'
       metadata_path: '$.properties.*'
-    common_metadata_mapping_path: '$'
     metadata_mapping:
       # Opensearch resource identifier within the search engine context (in our case
       # within the context of the data provider)
@@ -3234,7 +3224,6 @@
       metadata_pattern: '^[a-zA-Z0-9_]+$'
       search_param: '{{{{"{metadata}":{{{metadata}#to_geojson}} }}}}'
       metadata_path: '$.*'
-    common_metadata_mapping_path: '$'
     metadata_mapping:
       startTimeFromAscendingNode: '{$.startTimeFromAscendingNode#to_iso_utc_datetime}'
       completionTimeFromAscendingNode:
@@ -3355,7 +3344,6 @@
               and:
                 -  "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq '{metadata}' and att/OData.CSC.StringAttribute/Value eq '{{{metadata}}}')"
       metadata_path: '$.Attributes.*'
-    common_metadata_mapping_path: '$'
     per_product_metadata_query: false
     metadata_pre_mapping:
       metadata_path: '$.Attributes'

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -21,7 +21,7 @@ from eodag.plugins.crunch.filter_latest_intersect import FilterLatestIntersect
 from eodag.plugins.crunch.filter_latest_tpl_name import FilterLatestByName
 from eodag.plugins.crunch.filter_overlap import FilterOverlap
 from eodag.rest.stac import StacCatalog, StacCollection, StacCommon, StacItem
-from eodag.utils import _deprecated, cached_parse, dict_items_recursive_apply
+from eodag.utils import _deprecated, dict_items_recursive_apply, string_to_jsonpath
 from eodag.utils.exceptions import (
     MisconfiguredError,
     NoMatchingProductType,
@@ -317,9 +317,9 @@ def get_metadata_query_paths(metadata_mapping):
                 # We check if our query path pattern matches one or more of the dict path
                 matches = [
                     (str(match.full_path))
-                    for match in cached_parse(STAC_QUERY_PATTERN).find(
-                        metadata_query_dict
-                    )
+                    for match in string_to_jsonpath(
+                        STAC_QUERY_PATTERN, force=True
+                    ).find(metadata_query_dict)
                 ]
                 if matches:
                     metadata_query_path = matches[0]
@@ -343,7 +343,7 @@ def get_arguments_query_paths(arguments):
     """
     return dict(
         (str(match.full_path), match.value)
-        for match in cached_parse(STAC_QUERY_PATTERN).find(arguments)
+        for match in string_to_jsonpath(STAC_QUERY_PATTERN, force=True).find(arguments)
     )
 
 

--- a/tests/context.py
+++ b/tests/context.py
@@ -79,6 +79,7 @@ from eodag.utils import (
     GENERIC_PRODUCT_TYPE,
     flatten_top_directories,
     deepcopy,
+    cached_parse,
 )
 from eodag.utils.exceptions import (
     AddressNotFound,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,7 +17,6 @@
 # limitations under the License.
 
 import os
-import re
 import tempfile
 import unittest
 from io import StringIO
@@ -245,20 +244,15 @@ class TestConfigFunctions(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestConfigFunctions, cls).setUpClass()
-        # backup os.environ as it will be modified by tests
-        cls.eodag_env_pattern = re.compile(r"EODAG_\w+")
-        cls.eodag_env_backup = {
-            k: v for k, v in os.environ.items() if cls.eodag_env_pattern.match(k)
-        }
+        # mock os.environ to empty env
+        cls.mock_os_environ = mock.patch.dict(os.environ, {}, clear=True)
+        cls.mock_os_environ.start()
 
     @classmethod
     def tearDownClass(cls):
         super(TestConfigFunctions, cls).tearDownClass()
-        # restore os.environ
-        for k, v in os.environ.items():
-            if cls.eodag_env_pattern.match(k):
-                os.environ.pop(k)
-        os.environ.update(cls.eodag_env_backup)
+        # stop os.environ
+        cls.mock_os_environ.stop()
 
     def test_load_default_config(self):
         """Default config must be successfully loaded"""

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -33,6 +33,7 @@ from tests.context import (
     EOProduct,
     PluginManager,
     RequestError,
+    cached_parse,
     get_geometry_from_various,
     load_default_config,
 )
@@ -278,9 +279,9 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
 
         # change onfiguration for this test to filter out some collections
         results_entry = search_plugin.config.discover_product_types["results_entry"]
-        search_plugin.config.discover_product_types[
-            "results_entry"
-        ] = 'collections[?billing=="free"]'
+        search_plugin.config.discover_product_types["results_entry"] = cached_parse(
+            'collections[?billing=="free"]'
+        )
 
         mock__request.return_value = mock.Mock()
         mock__request.return_value.json.return_value = {
@@ -535,7 +536,7 @@ class TestSearchPluginODataV4Search(BaseSearchPluginTest):
         self.assertDictEqual(
             self.onda_search_plugin.config.metadata_pre_mapping,
             {
-                "metadata_path": "$.Metadata",
+                "metadata_path": cached_parse("$.Metadata"),
                 "metadata_path_id": "id",
                 "metadata_path_value": "value",
             },

--- a/tests/units/test_stac_utils.py
+++ b/tests/units/test_stac_utils.py
@@ -19,7 +19,6 @@
 import importlib
 import json
 import os
-import re
 import unittest
 from tempfile import TemporaryDirectory
 
@@ -70,11 +69,9 @@ class TestStacUtils(unittest.TestCase):
         cls.empty_arguments = {}
         cls.empty_criterias = {}
 
-        # backup os.environ as it will be modified by tests
-        cls.eodag_env_pattern = re.compile(r"EODAG_\w+")
-        cls.eodag_env_backup = {
-            k: v for k, v in os.environ.items() if cls.eodag_env_pattern.match(k)
-        }
+        # mock os.environ to empty env
+        cls.mock_os_environ = mock.patch.dict(os.environ, {}, clear=True)
+        cls.mock_os_environ.start()
 
         # disable product types fetch
         os.environ["EODAG_EXT_PRODUCT_TYPES_CFG_FILE"] = ""
@@ -82,15 +79,11 @@ class TestStacUtils(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         super(TestStacUtils, cls).tearDownClass()
-        # restore os.environ
-        for k, v in os.environ.items():
-            if cls.eodag_env_pattern.match(k):
-                os.environ.pop(k)
-        os.environ.update(cls.eodag_env_backup)
-
         # stop Mock and remove tmp config dir
         cls.expanduser_mock.stop()
         cls.tmp_home_dir.cleanup()
+        # stop os.environ
+        cls.mock_os_environ.stop()
 
     def test_download_stac_item_by_id(self):
         pass  # TODO


### PR DESCRIPTION
Refactors metadata-mapping to perform `jsonpath` build/parse during search plugins init step.

Related to #628

Also changes environment variables mocking during tests.