### PR TITLE
fix: CdsApi default dates and refactor

### DIFF
--- a/eodag/plugins/apis/cds.py
+++ b/eodag/plugins/apis/cds.py
@@ -15,35 +15,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import hashlib
 import logging
 from datetime import datetime
 
 import cdsapi
+import geojson
 import requests
 
-from eodag import EOProduct
-from eodag.api.product.metadata_mapping import NOT_AVAILABLE, properties_from_json
 from eodag.plugins.apis.base import Api
 from eodag.plugins.download.base import (
     DEFAULT_DOWNLOAD_TIMEOUT,
     DEFAULT_DOWNLOAD_WAIT,
     Download,
 )
-from eodag.plugins.search.qssearch import QueryStringSearch
-from eodag.utils import (
-    datetime_range,
-    get_geometry_from_various,
-    parse_qsl,
-    path_to_uri,
-    urlsplit,
-)
-from eodag.utils.exceptions import (
-    AuthenticationError,
-    DownloadError,
-    RequestError,
-    ValidationError,
-)
+from eodag.plugins.search.base import Search
+from eodag.plugins.search.build_search_result import BuildPostSearchResult
+from eodag.rest.stac import DEFAULT_MISSION_START_DATE
+from eodag.utils import datetime_range, get_geometry_from_various, path_to_uri, urlsplit
+from eodag.utils.exceptions import AuthenticationError, DownloadError, RequestError
 from eodag.utils.logging import get_logging_verbose
 
 logger = logging.getLogger("eodag.plugins.apis.cds")
@@ -51,7 +40,7 @@ logger = logging.getLogger("eodag.plugins.apis.cds")
 CDS_KNOWN_FORMATS = {"grib": "grib", "netcdf": "nc"}
 
 
-class CdsApi(Download, Api, QueryStringSearch):
+class CdsApi(Download, Api, BuildPostSearchResult):
     """A plugin that enables to build download-request and download data on CDS API.
 
     Builds a single ready-to-download :class:`~eodag.api.product._product.EOProduct`
@@ -65,90 +54,54 @@ class CdsApi(Download, Api, QueryStringSearch):
 
     def __init__(self, provider, config):
         # init self.config.metadata_mapping using Search Base plugin
-        super(QueryStringSearch, self).__init__(provider, config)
+        Search.__init__(self, provider, config)
 
         # needed by QueryStringSearch.build_query_string / format_free_text_search
         self.config.__dict__.setdefault("free_text_search_operations", {})
         # needed for compatibility
-        self.config.__dict__.setdefault("pagination", {})
+        self.config.__dict__.setdefault("pagination", {"next_page_query_obj": "{{}}"})
+
+    def do_search(self, *args, **kwargs):
+        """Should perform the actual search request."""
+        return [{}]
 
     def query(
         self, product_type=None, items_per_page=None, page=None, count=True, **kwargs
     ):
         """Build ready-to-download SearchResult"""
 
-        # check some mandatory parameters
+        # check productType, dates, geometry, use defaults if not specified
+        # productType
+        if not kwargs.get("productType"):
+            kwargs["productType"] = kwargs.get("dataset", None)
         # start date
         if "startTimeFromAscendingNode" not in kwargs:
-            raise ValidationError("Required start date is missing")
+            kwargs["startTimeFromAscendingNode"] = (
+                getattr(self.config, "product_type_config", {}).get(
+                    "missionStartDate", None
+                )
+                or DEFAULT_MISSION_START_DATE
+            )
         # end date
         if "completionTimeFromAscendingNode" not in kwargs:
-            raise ValidationError("Required end date is missing")
-
-        product_type = kwargs.get("productType")
-
-        # Map query args to properties
-        product_properties = kwargs
-        product_properties.pop("auth", None)
+            kwargs["completionTimeFromAscendingNode"] = getattr(
+                self.config, "product_type_config", {}
+            ).get("missionEndDate", None) or datetime.utcnow().isoformat(
+                timespec="seconds"
+            )
         # geometry
-        search_geometry = product_properties.get("geometry", None) or [
-            -180,
-            -90,
-            180,
-            90,
-        ]
-        product_geometry = get_geometry_from_various(geometry=search_geometry)
-        product_properties["geometry"] = product_geometry
+        if not kwargs.get("geometry", None):
+            kwargs["geometry"] = [
+                -180,
+                -90,
+                180,
+                90,
+            ]
+        kwargs["geometry"] = get_geometry_from_various(geometry=kwargs["geometry"])
 
-        # add product_type specific properties from provider configuration (overriden by query args)
-        product_properties = dict(
-            self.config.products.get(product_type, {}), **product_properties
+        return BuildPostSearchResult.query(
+            self, items_per_page=items_per_page, page=page, count=count, **kwargs
         )
-
-        # properties mapped using provider configuration
-        product_properties = properties_from_json(
-            product_properties, self.config.metadata_mapping
-        )
-
-        # build query string & parameters dict using from available mapped properties
-        product_available_properties = {
-            k: v for (k, v) in product_properties.items() if v != NOT_AVAILABLE
-        }
-        qp, qs = self.build_query_string(product_type, **product_available_properties)
-
-        # query hash, will be used to build a product id
-        query_hash = hashlib.sha1(str(qs).encode("UTF-8")).hexdigest()
-
-        # build product id
-        if product_type is not None:
-            id_prefix = product_type
-        else:
-            id_prefix = ("%s" % (qp.get("dataset", ""))).upper()
-
-        product_id = "%s_%s_%s" % (
-            id_prefix,
-            qp["date"][0].split("/")[0].replace("-", ""),
-            query_hash,
-        )
-        product_properties["id"] = product_properties["title"] = product_id
-
-        # update downloadLink
-        product_properties["downloadLink"] += f"?{qs}"
-
-        product = EOProduct(
-            provider=self.provider,
-            productType=product_type,
-            properties=product_properties,
-        )
-        # use product_type_config as default properties
-        product.properties = dict(
-            getattr(self.config, "product_type_config", {}), **product.properties
-        )
-
-        results_count = 1
-        return [
-            product,
-        ], results_count
 
     def _get_cds_client(self, **auth_dict):
         """Returns cdsapi client."""
@@ -227,8 +180,9 @@ class CdsApi(Download, Api, QueryStringSearch):
             return fs_path
 
         # get download request dict from product.location/downloadLink url query string
+        # separate url & parameters
         query_str = "".join(urlsplit(product.location).fragment.split("?", 1)[1:])
-        download_request = dict(parse_qsl(query_str))
+        download_request = geojson.loads(query_str)
 
         date_range = download_request.pop("date_range", False)
         if date_range:

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -1201,7 +1201,7 @@ class PostJsonSearch(QueryStringSearch):
             self.need_count = True
             self.total_items_nb = None
 
-        if hasattr(kwargs["auth"], "config"):
+        if "auth" in kwargs and hasattr(kwargs["auth"], "config"):
             auth_conf_dict = getattr(kwargs["auth"].config, "credentials", {})
         else:
             auth_conf_dict = {}

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -50,7 +50,7 @@ from eodag.utils.exceptions import (
 
 logger = logging.getLogger("eodag.rest.stac")
 
-default_min_date = "2015-01-01"
+DEFAULT_MISSION_START_DATE = "2015-01-01T00:00:00Z"
 
 
 class StacCommon(object):
@@ -888,7 +888,9 @@ class StacCatalog(StacCommon):
         :returns: Start & stop dates
         :rtype: tuple
         """
-        extent_date_min = dateutil.parser.parse(default_min_date).replace(tzinfo=tz.UTC)
+        extent_date_min = dateutil.parser.parse(DEFAULT_MISSION_START_DATE).replace(
+            tzinfo=tz.UTC
+        )
         extent_date_max = datetime.datetime.now(datetime.timezone.utc).replace(
             tzinfo=tz.UTC
         )

--- a/tests/context.py
+++ b/tests/context.py
@@ -63,6 +63,7 @@ from eodag.plugins.download.base import (
 from eodag.plugins.download.http import HTTPDownload
 from eodag.plugins.manager import PluginManager
 from eodag.plugins.search.base import Search
+from eodag.rest.stac import DEFAULT_MISSION_START_DATE
 from eodag.utils import (
     USER_AGENT,
     get_bucket_name_and_prefix,


### PR DESCRIPTION
Default dates usage with [CdsApi](https://eodag.readthedocs.io/en/latest/plugins_reference/generated/eodag.plugins.apis.cds.CdsApi.html) (`cop_ads` and `cop_cds` providers).
Refactored `CdsApi` plugin using `BuildPostSearchResult` plugin.