### PR TITLE
feat: fetch product types optimization

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -228,7 +228,7 @@ class EODataAccessGateway(object):
 
             product_types_schema = Schema(
                 ID=fields.STORED,
-                abstract=fields.TEXT,
+                abstract=fields.STORED,
                 instrument=fields.IDLIST,
                 platform=fields.ID,
                 platformSerialIdentifier=fields.IDLIST,

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -15,11 +15,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 import logging
 import os
 import tempfile
 
+import orjson
 import requests
 import yaml
 import yaml.constructor
@@ -495,9 +495,9 @@ def get_ext_product_types_conf(conf_uri=EXT_PRODUCT_TYPES_CONF_URI):
 
     # read from local
     try:
-        with open(conf_uri) as f:
-            return json.load(f)
-    except (json.JSONDecodeError, FileNotFoundError) as e:
+        with open(conf_uri, "rb") as f:
+            return orjson.loads(f.read())
+    except (orjson.JSONDecodeError, FileNotFoundError) as e:
         logger.debug(e)
         logger.warning(
             "Could not read local external product types conf from %s", conf_uri

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -17,10 +17,10 @@
 # limitations under the License.
 
 import hashlib
-import json
 import logging
 
 import geojson
+import orjson
 from jsonpath_ng import Fields
 
 from eodag.api.product import EOProduct
@@ -103,7 +103,7 @@ class BuildPostSearchResult(PostJsonSearch):
         ):
             unpaginated_query_params = self.query_params_unpaginated
         elif isinstance(self.config.pagination["next_page_query_obj"], str):
-            next_page_query_obj = json.loads(
+            next_page_query_obj = orjson.loads(
                 self.config.pagination["next_page_query_obj"].format()
             )
             unpaginated_query_params = {

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import logging
 import re
 from urllib.error import HTTPError as urllib_HTTPError
 from urllib.request import Request, urlopen
 
+import orjson
 import requests
 from lxml import etree
 
@@ -491,7 +491,7 @@ class QueryStringSearch(Search):
                     if "{{" in provider_search_key:
                         # json query string (for POST request)
                         update_nested_dict(
-                            query_params, json.loads(formatted_query_param)
+                            query_params, orjson.loads(formatted_query_param)
                         )
                     else:
                         query_params[eodag_search_key] = formatted_query_param
@@ -1239,7 +1239,7 @@ class PostJsonSearch(QueryStringSearch):
                         skip_base_1=(page - 1) * items_per_page + 1,
                     )
                     update_nested_dict(
-                        self.query_params, json.loads(next_page_query_obj)
+                        self.query_params, orjson.loads(next_page_query_obj)
                     )
 
             urls.append(search_endpoint)

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -921,7 +921,7 @@
     discover_product_types:
       fetch_url: 'https://datahub.creodias.eu/stac/collections'
       result_type: json
-      results_entry: 'collections[*]'
+      results_entry: '$.collections[*]'
       generic_product_type_id: '$.id'
       generic_product_type_parsable_properties:
         collection: '$.id'
@@ -2016,7 +2016,7 @@
     api_endpoint: https://earth-search.aws.element84.com/v0/search
     need_auth: false
     discover_product_types:
-      results_entry: 'collections[?id!="sentinel-s2-l2a-cogs"]'
+      results_entry: '$.collections[?id!="sentinel-s2-l2a-cogs"]'
     pagination:
       # Override the default next page url key path of StacSearch because the next link returned
       # by Earth Search is invalid (as of 2021/04/29). Entry set to null (None) to avoid using the

--- a/eodag/resources/stac_provider.yml
+++ b/eodag/resources/stac_provider.yml
@@ -32,7 +32,7 @@ search:
   discover_product_types:
       fetch_url: '{api_endpoint}/../collections'
       result_type: json
-      results_entry: 'collections[*]'
+      results_entry: '$.collections[*]'
       generic_product_type_id: '$.id'
       generic_product_type_parsable_properties:
         productType: '$.id'

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -35,6 +35,7 @@ import types
 import unicodedata
 import warnings
 from collections import defaultdict
+from copy import deepcopy as copy_deepcopy
 from email.message import Message
 from glob import glob
 from itertools import repeat, starmap
@@ -59,6 +60,7 @@ import click
 import orjson
 import shapefile
 import shapely.wkt
+import yaml
 from dateutil.parser import isoparse
 from dateutil.tz import UTC
 from jsonpath_ng import jsonpath
@@ -1207,6 +1209,42 @@ def cached_parse(str_to_parse):
     :rtype: :class:`jsonpath_ng.JSONPath`
     """
     return parse(str_to_parse)
+
+
+@functools.lru_cache()
+def _mutable_cached_yaml_load(config_path):
+    with open(os.path.abspath(os.path.realpath(config_path)), "r") as fh:
+        return yaml.load(fh, Loader=yaml.SafeLoader)
+
+
+def cached_yaml_load(config_path):
+    """Cached yaml.load
+
+    :param config_path: path to the yaml configuration file
+    :type config_path: str
+    :returns: loaded yaml configuration
+    :rtype: dict
+    """
+    return copy_deepcopy(_mutable_cached_yaml_load(config_path))
+
+
+@functools.lru_cache()
+def _mutable_cached_yaml_load_all(config_path):
+    with open(config_path, "r") as fh:
+        return list(yaml.load_all(fh, Loader=yaml.Loader))
+
+
+def cached_yaml_load_all(config_path):
+    """Cached yaml.load_all
+
+    Load all configurations stored in the configuration file as separated yaml documents
+
+    :param config_path: path to the yaml configuration file
+    :type config_path: str
+    :returns: list of configurations
+    :rtype: list
+    """
+    return copy_deepcopy(_mutable_cached_yaml_load_all(config_path))
 
 
 def get_bucket_name_and_prefix(url=None, bucket_path_level=None):

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -26,7 +26,6 @@ import errno
 import functools
 import hashlib
 import inspect
-import json
 import logging as py_logging
 import os
 import re
@@ -57,6 +56,7 @@ from urllib.parse import (  # noqa; noqa
 from urllib.request import url2pathname
 
 import click
+import orjson
 import shapefile
 import shapely.wkt
 from dateutil.parser import isoparse
@@ -1180,7 +1180,7 @@ def obj_md5sum(data):
     :returns: MD5 checksum
     :rtype: str
     """
-    return hashlib.md5(json.dumps(data, sort_keys=True).encode("utf-8")).hexdigest()
+    return hashlib.md5(orjson.dumps(data, option=orjson.OPT_SORT_KEYS)).hexdigest()
 
 
 @functools.lru_cache()

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ install_requires =
     pyshp
     owslib < 0.26;python_version>='3.10'
     owslib;python_version<'3.10'
+    orjson
     geojson
     pyproj >= 2.1.0
     usgs >= 0.3.1

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -297,8 +297,6 @@ class TestCore(TestCoreBase):
 
     def test_list_product_types_for_provider_ok(self):
         """Core api must correctly return the list of supported product types for a given provider"""
-        # raise Exception({p:pc.api.credentials for p,pc in self.dag.providers_config.items() if hasattr(pc, "api")})
-        # raise Exception(self.dag.conf_dir)
         for provider in self.SUPPORTED_PROVIDERS:
             product_types = self.dag.list_product_types(
                 provider=provider, fetch_providers=False

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -380,7 +380,7 @@ class TestSearchPluginPostJsonSearch(BaseSearchPluginTest):
                 responses.POST, self.awseos_url, status=500, body=b"test error message"
             )
 
-            with self.assertLogs(level="DEBUG") as cm:
+            with self.assertLogs("eodag.plugins.search.qssearch", level="DEBUG") as cm:
                 with self.assertRaises(RequestError):
                     products, estimate = self.awseos_search_plugin.query(
                         page=1,


### PR DESCRIPTION
[fetch_product_types_list()](https://eodag.readthedocs.io/en/latest/notebooks/api_user_guide/2_providers_products_available.html#Product-types-discovery) optimization, including:

- `orjson` usage
- `jsonpath.parse()` optimized for nested lists
- `product_types.abstract` type changed in `whoosh` index
- cached `load_config()`

With `planetary_computer` external product types included, `fetch_product_types_list()` goes from 3.04s to 0.49s