### PR TITLE
fix: guess_product_type should return given productType if specified

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -787,6 +787,8 @@ class EODataAccessGateway(object):
         :rtype: list[str]
         :raises: :class:`~eodag.utils.exceptions.NoMatchingProductType`
         """
+        if kwargs.get("productType", None):
+            return [kwargs["productType"]]
         supported_params = {
             param
             for param in (

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1157,6 +1157,10 @@ class TestCoreSearch(TestCoreBase):
         ]
         self.assertEqual(actual, expected)
 
+        # with product type specified
+        actual = self.dag.guess_product_type(productType="foo")
+        self.assertEqual(actual, ["foo"])
+
     def test_guess_product_type_without_kwargs(self):
         """guess_product_type must raise an exception when no kwargs are provided"""
         with self.assertRaises(NoMatchingProductType):


### PR DESCRIPTION
`guess_product_type()` should return given `productType` if specified