### PR TITLE
fix: eodag-server docker sigterm

### DIFF
--- a/docker/run-stac-server.sh
+++ b/docker/run-stac-server.sh
@@ -8,4 +8,4 @@ else
     echo "Logging level can be changed using EODAG_LOGGING environment variable [1-3]"
 fi
 # start
-eodag $LOGGING_OPTIONS serve-rest -w
+exec eodag $LOGGING_OPTIONS serve-rest -w


### PR DESCRIPTION
Fixes `eodag-server` dockerfile to have running process with pid 1 and accept SIGTERM signal