### PR TITLE
fix: update STAC browser catalogUrl param name

### DIFF
--- a/docker/stac-browser.dockerfile
+++ b/docker/stac-browser.dockerfile
@@ -15,7 +15,7 @@ WORKDIR /stac-browser
 RUN npm install
 
 # start application
-RUN npm run build -- --CATALOG_URL=http://localhost:5000
+RUN npm run build -- --catalogUrl=http://localhost:5000
 
 # production stage, self describing
 FROM nginx:stable-alpine as production-stage


### PR DESCRIPTION
Updates STAC browser catalog url parameter name from `CATALOG_URL` to `catalogUrl`. See https://github.com/radiantearth/stac-browser#migrate-from-old-versions