### PR TITLE
fix: stac server catalogs cloud-cover filtering

### DIFF
--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -978,7 +978,7 @@ class StacCatalog(StacCommon):
         self.update_data(parsed_dict)
 
         # update search args
-        self.search_args.update({"cloudCover": cloud_cover})
+        self.search_args.update({"query": {"eo:cloud_cover": {"lte": cloud_cover}}})
 
         return parsed_dict
 


### PR DESCRIPTION
fixes cloud-cover filtering through dynamically built STAC server catalogs (i.e. http://127.0.0.1:5000/S2_MSI_L1C/cloud_cover/10/items)