### PR TITLE
docs: ref to dockerhub eodag-server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,7 @@ check the `Python API User Guide <https://eodag.readthedocs.io/en/latest/api_use
 STAC REST API
 -------------
 
-An eodag installation can be exposed through a STAC compliant REST api from the command line:
+An eodag instance can be exposed through a STAC compliant REST api from the command line:
 
 .. code-block:: bash
 
@@ -173,6 +173,12 @@ An eodag installation can be exposed through a STAC compliant REST api from the 
     # download
     $ wget "http://127.0.0.1:5000/S2_MSI_L1C/country/FRA/year/2021/month/01/day/25/cloud_cover/10/items/S2A_MSIL1C_20210125T105331_N0209_R051_T31UCR_20210125T130733/download"
 
+
+``eodag-server`` is available on `https://hub.docker.com/r/csspace/eodag-server <https://hub.docker.com/r/csspace/eodag-server>`_:
+
+.. code-block:: bash
+
+    docker run -p 5000:5000 --rm csspace/eodag-server:2.9.2
 
 You can also browse over your STAC API server using `STAC Browser <https://github.com/radiantearth/stac-browser>`_.
 Simply run:

--- a/docs/stac_rest.rst
+++ b/docs/stac_rest.rst
@@ -74,7 +74,7 @@ Example URL:
 * http://127.0.0.1:5000/search?collections=S2_MSI_L1C&bbox=0,43,1,44&datetime=2018-01-20/2018-01-25&cloudCover=20
 
 Browsing
----------
+--------
 
 EODAG provides additional catalogs that extend browsing/filtering capabilities:
 
@@ -109,6 +109,16 @@ And browse http://127.0.0.1:5001:
 .. image:: _static/stac_browser_example.png
    :width: 800
    :alt: STAC browser example
+
+docker
+------
+
+In addition of the *docker-compose* configuration included in sources and described just above, ``eodag-server`` is
+available on `https://hub.docker.com/r/csspace/eodag-server <https://hub.docker.com/r/csspace/eodag-server>`_:
+
+.. code-block:: bash
+
+    $ docker run -p 5000:5000 --rm csspace/eodag-server:2.9.2
 
 Example
 -------


### PR DESCRIPTION
Adds links to `eodag-server`, [eodag STAC API server](https://eodag.readthedocs.io/en/latest/stac_rest.html) docker image on https://hub.docker.com/r/csspace/eodag-server