### PR TITLE
fix: flask 2.2.x as max version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     flasgger
     jsonpath-ng
     lxml
-    flask >= 1.0.2, != 2.2.0, != 2.2.1
+    flask >= 1.0.2, != 2.2.0, != 2.2.1, < 2.3.0
     whoosh
     pystac >= 1.0.0b1
     ecmwf-api-client


### PR DESCRIPTION
Set flask `2.2.X` as max version, because of incompatibility with `flasgger`.
See https://github.com/flasgger/flasgger/issues/562