### PR TITLE
ci: coverage to distinct pr comments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,17 +89,29 @@ jobs:
       uses: EnricoMi/publish-unit-test-result-action@v2
       continue-on-error: true
       with:
-        files: artifacts/**/*junit-report.xml
-    - name: Publish Coverage Report
+        files: artifacts/*/junit-report.xml
+
+    - name: Publish Coverage Report for Ubuntu
       uses: 5monkeys/cobertura-action@master
       if: ${{ github.event_name == 'pull_request' }}
       with:
-        path: artifacts/**/*python3.11*coverage.xml
+        path: artifacts/unit-test-results-python3.11-ubuntu-latest/coverage.xml
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         minimum_coverage: 70
         fail_below_threshold: false
         only_changed_files: true
-        report_name: Tests Coverage Report for Ubuntu and Windows (python3.11)
+        report_name: Code Coverage (Ubuntu)
+
+    - name: Publish Coverage Report for Windows
+      uses: 5monkeys/cobertura-action@master
+      if: ${{ github.event_name == 'pull_request' }}
+      with:
+        path: artifacts/unit-test-results-python3.11-windows-latest/coverage.xml
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        minimum_coverage: 70
+        fail_below_threshold: false
+        only_changed_files: true
+        report_name: Code Coverage (Windows)
 
   build-docs:
     name: Build the docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -186,6 +186,3 @@ select = D1
 add_ignore = D107,D100,D105
 # Don't require docstrings for tests or setup
 match = (?!test|setup).*\.py
-
-[coverage:run]
-omit = tests/*

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,8 @@ commands =
     mkdir -p test-reports
     pytest -v --instafail \
         -n auto --dist loadscope \
-        --cov --cov-report term-missing \
+        --cov=eodag \
+        --cov-report term-missing \
 		--cov-report=html:test-reports/coverage \
 		--cov-report=xml:test-reports/coverage.xml \
 		--junitxml=test-reports/junit-report.xml \


### PR DESCRIPTION
Code coverage reports for Windows and Ubuntu post in distinct PR comments to avoid duplicate lines bug with github action.

Related to https://github.com/5monkeys/cobertura-action/issues/68