### PR TITLE
ci: latest pandoc version in gh actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,8 +146,8 @@ jobs:
         key: ${{ runner.os }}-pip-${{ steps.get-week.outputs.WEEK }}-${{ hashFiles('setup.cfg') }}
     - name: Install pandoc
       run: |
-        sudo apt update
-        sudo apt install -y make pandoc
+        curl -s https://api.github.com/repos/jgm/pandoc/releases/latest | grep -o "https.*amd64.deb" | wget -O pandoc.deb -qi -
+        sudo dpkg -i pandoc.deb && rm pandoc.deb
     - name: Install tox
       run: |
         python -m pip install tox


### PR DESCRIPTION
Fixes warning displayed in the `Build the docs` job in github actions:
> /home/runner/work/eodag/eodag/.tox/docs/lib/python3.7/site-packages/nbsphinx/__init__.py:1058: RuntimeWarning: You are using an unsupported version of pandoc (2.9.2.1).
Your version must be at least (2.14.2) but less than (4.0.0).