### PR TITLE
fix: remove `step` parameter in CAMS_EAC4 configuration

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -2714,7 +2714,6 @@
       stream: oper
       class: mc
       expver: '0001'
-      step: 0
       variable:
         - dust_aerosol_0.03-0.55um_mixing_ratio
         - dust_aerosol_0.55-0.9um_mixing_ratio

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -640,7 +640,6 @@ class TestApisPluginCdsApi(BaseApisPluginTest):
             "stream": "oper",
             "class": "mc",
             "expver": "0001",
-            "step": 0,
             "variable": [
                 "dust_aerosol_0.03-0.55um_mixing_ratio",
                 "dust_aerosol_0.55-0.9um_mixing_ratio",


### PR DESCRIPTION
Fixes #747 

Products `CAMS_EAC4` download works once again by removing the parameter `step` in its configuration for `cop_ads`.