### PR TITLE
fix: server-mode download for ext api providers

### DIFF
--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -589,8 +589,6 @@ def download_stac_item_by_id(catalogs, item_id, provider=None):
 
     product = search_product_by_id(item_id, product_type=catalogs[0])[0]
 
-    eodag_api.providers_config[product.provider].download.extract = False
-
     product_path = eodag_api.download(product, extract=False)
 
     if os.path.isdir(product_path):

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -627,13 +627,18 @@ class RequestTestCase(unittest.TestCase):
         "eodag.rest.utils.eodag_api.download",
         autospec=True,
     )
-    def test_download_item_from_collection(self, mock_download):
+    def test_download_item_from_collection_api_plugin(self, mock_download):
         """Download through eodag server catalog should return a valid response"""
         # download returns a file that must be returned as is
         tmp_dl_dir = TemporaryDirectory()
         expected_file = f"{tmp_dl_dir.name}.tar"
         Path(expected_file).touch()
         mock_download.return_value = expected_file
+
+        # use an external python API provider for this test
+        self._request_valid_raw.patchings[0].kwargs["return_value"][0][
+            0
+        ].provider = "cop_cds"
 
         response = self._request_valid_raw(
             f"collections/{self.tested_product_type}/items/foo/download"


### PR DESCRIPTION
Fixes #733

In server mode, products download with python external api providers works once again by removing the set up of `extract` attribute of the plugin `download` because this plugin is not theirs by their nature. 

It does not have an impact on extraction process because `extraction` is directly set in `download` method call parameters and it takes priority on providers configuration.