### PR TITLE
213 fallback mechanism to search for products with other providers

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -1551,7 +1551,10 @@ class EODataAccessGateway(object):
                     auth_plugins = kwargs.get("auth", None)
                     auth = None
                     if auth_plugins is not None:
-                        auth = auth_plugins.get(search_plugin.provider, None)
+                        if isinstance(auth_plugins, dict):
+                            auth = auth_plugins.get(search_plugin.provider, None)
+                        else:
+                            auth = auth_plugins
                     eo_product.register_downloader(download_plugin, auth)
 
             results.extend(res)

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -839,7 +839,9 @@ class EODataAccessGateway(object):
         The default behaviour is to look for products on the provider with the
         highest priority supporting the requested product type. These priorities
         are configurable through user configuration file or individual
-        environment variable.
+        environment variable. If the request to the provider with the highest priority
+        fails, the data will be request from the provider with the next highest priority.
+        Only if the request fails for all available providers, an error will be thrown.
 
         :param page: (optional) The page number to return
         :type page: int
@@ -979,7 +981,7 @@ class EODataAccessGateway(object):
     def search_iter_page_plugin(
         self, items_per_page=DEFAULT_ITEMS_PER_PAGE, search_plugin=None, **kwargs
     ):
-        """Iterate over the pages of a products search.
+        """Iterate over the pages of a products search using a given search plugin.
 
         :param items_per_page: (optional) The number of results requested per page
         :type items_per_page: int
@@ -1106,6 +1108,8 @@ class EODataAccessGateway(object):
         It iterates over the pages of a search query and collects all the returned
         products into a single :class:`~eodag.api.search_result.SearchResult` instance.
 
+        Requests are attempted to all providers of the product ordered by descending piority.
+
         :param items_per_page: (optional) The number of results requested internally per
                                page. The maximum number of items than can be requested
                                at once to a provider has been configured in EODAG for
@@ -1142,7 +1146,7 @@ class EODataAccessGateway(object):
                           name=country and attr=ISO3
         :type locations: dict
         :param kwargs: Some other criteria that will be used to do the search,
-                       using paramaters compatibles with the provider
+                       using parameters compatible with the provider
         :type kwargs: Union[int, str, bool, dict]
         :returns: An iterator that yields page per page a collection of EO products
                   matching the criteria

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -61,6 +61,7 @@ from eodag.utils.exceptions import (
     MisconfiguredError,
     NoMatchingProductType,
     PluginImplementationError,
+    RequestError,
     UnsupportedProvider,
 )
 from eodag.utils.stac_reader import HTTP_REQ_TIMEOUT, fetch_stac_items
@@ -887,7 +888,7 @@ class EODataAccessGateway(object):
         search_kwargs = self._prepare_search(
             start=start, end=end, geom=geom, locations=locations, **kwargs
         )
-        search_plugin = search_kwargs.pop("search_plugin", None)
+        search_plugins = search_kwargs.pop("search_plugins", [])
         if search_kwargs.get("id"):
             # adds minimal pagination to be able to check only 1 product is returned
             search_kwargs.update(
@@ -901,10 +902,27 @@ class EODataAccessGateway(object):
             page=page,
             items_per_page=items_per_page,
         )
-        search_plugin.clear()
-        return self._do_search(
-            search_plugin, count=True, raise_errors=raise_errors, **search_kwargs
-        )
+        for i, search_plugin in enumerate(search_plugins):
+            search_plugin.clear()
+            try:
+                return self._do_search(
+                    search_plugin,
+                    count=True,
+                    raise_errors=raise_errors,
+                    **search_kwargs,
+                )
+            except RequestError:
+                if i < len(search_plugins) - 1:
+                    logger.warning(
+                        "No result could be obtained from provider %s, "
+                        "we will try to get the data from another provider",
+                        search_plugin.provider,
+                    )
+                else:
+                    logger.error(
+                        "No result could be obtained from any available " "provider"
+                    )
+                    raise
 
     def search_iter_page(
         self,
@@ -954,6 +972,27 @@ class EODataAccessGateway(object):
             start=start, end=end, geom=geom, locations=locations, **kwargs
         )
         search_plugin = search_kwargs.pop("search_plugin")
+        self.search_iter_page_plugin(
+            items_per_page=items_per_page, search_plugin=search_plugin, **search_kwargs
+        )
+
+    def search_iter_page_plugin(
+        self, items_per_page=DEFAULT_ITEMS_PER_PAGE, search_plugin=None, **kwargs
+    ):
+        """Iterate over the pages of a products search.
+
+        :param items_per_page: (optional) The number of results requested per page
+        :type items_per_page: int
+        :param kwargs: Some other criteria that will be used to do the search,
+                       using parameters compatibles with the provider
+        :type kwargs: Union[int, str, bool, dict]
+        :param search_plugin: search plugin to be used
+        :type search_plugin: eodag.plugins.base.Search
+        :returns: An iterator that yields page per page a collection of EO products
+                  matching the criteria
+        :rtype: Iterator[:class:`~eodag.api.search_result.SearchResult`]
+        """
+
         iteration = 1
         # Store the search plugin config pagination.next_page_url_tpl to reset it later
         # since it might be modified if the next_page_url mechanism is used by the
@@ -963,7 +1002,7 @@ class EODataAccessGateway(object):
         prev_next_page_query_obj = pagination_config.get("next_page_query_obj", None)
         # Page has to be set to a value even if use_next is True, this is required
         # internally by the search plugin (see collect_search_urls)
-        search_kwargs.update(
+        kwargs.update(
             page=1,
             items_per_page=items_per_page,
         )
@@ -977,11 +1016,18 @@ class EODataAccessGateway(object):
                 pagination_config["next_page_query_obj"] = next_page_query_obj
             logger.info("Iterate search over multiple pages: page #%s", iteration)
             try:
+                if "raise_errors" in kwargs:
+                    kwargs.pop("raise_errors")
                 products, _ = self._do_search(
-                    search_plugin, count=False, raise_errors=True, **search_kwargs
+                    search_plugin, count=False, raise_errors=True, **kwargs
                 )
             except Exception:
-                products = SearchResult([])
+                logger.warning(
+                    "error at retrieval of data from %s, for params: %s",
+                    search_plugin.provider,
+                    str(kwargs),
+                )
+                raise
             finally:
                 # we don't want that next(search_iter_page(...)) modifies the plugin
                 # indefinitely. So we reset after each request, but before the generator
@@ -1040,7 +1086,7 @@ class EODataAccessGateway(object):
                 last_page_with_products = iteration - 1
                 break
             iteration += 1
-            search_kwargs["page"] = iteration
+            kwargs["page"] = iteration
         logger.debug(
             "Iterate over pages: last products found on page %s",
             last_page_with_products,
@@ -1121,36 +1167,48 @@ class EODataAccessGateway(object):
                 )
                 self.fetch_product_types_list()
 
-        search_plugin = next(
-            self._plugins_manager.get_search_plugins(product_type=product_type)
+        search_kwargs = self._prepare_search(
+            start=start, end=end, geom=geom, locations=locations, **kwargs
         )
-        if items_per_page is None:
-            items_per_page = search_plugin.config.pagination.get(
-                "max_items_per_page", DEFAULT_MAX_ITEMS_PER_PAGE
-            )
+        search_plugins = search_kwargs.get("search_plugins", [])
+        for i, search_plugin in enumerate(search_plugins):
+            if items_per_page is None:
+                items_per_page = search_plugin.config.pagination.get(
+                    "max_items_per_page", DEFAULT_MAX_ITEMS_PER_PAGE
+                )
 
-        logger.debug(
-            "Searching for all the products with provider %s and a maximum of %s "
-            "items per page.",
-            search_plugin.provider,
-            items_per_page,
-        )
-        all_results = SearchResult([])
-        for page_results in self.search_iter_page(
-            items_per_page=items_per_page,
-            start=start,
-            end=end,
-            geom=geom,
-            locations=locations,
-            **kwargs,
-        ):
-            all_results.data.extend(page_results.data)
-        logger.info(
-            "Found %s result(s) on provider '%s'",
-            len(all_results),
-            search_plugin.provider,
-        )
-        return all_results
+            logger.debug(
+                "Searching for all the products with provider %s and a maximum of %s "
+                "items per page.",
+                search_plugin.provider,
+                items_per_page,
+            )
+            all_results = SearchResult([])
+            try:
+                for page_results in self.search_iter_page_plugin(
+                    items_per_page=items_per_page,
+                    search_plugin=search_plugin,
+                    **search_kwargs,
+                ):
+                    all_results.data.extend(page_results.data)
+                logger.info(
+                    "Found %s result(s) on provider '%s'",
+                    len(all_results),
+                    search_plugin.provider,
+                )
+                return all_results
+            except RequestError:
+                if i < len(search_plugins) - 1:
+                    logger.warning(
+                        "No result could be obtained from provider %s, "
+                        "we will try to get the data from another provider",
+                        search_plugin.provider,
+                    )
+                else:
+                    logger.error(
+                        "No result could be obtained from any available " "provider"
+                    )
+                    raise
 
     def _search_by_id(self, uid, provider=None, **kwargs):
         """Internal method that enables searching a product by its id.
@@ -1305,59 +1363,65 @@ class EODataAccessGateway(object):
             )
             self.fetch_product_types_list()
 
-        search_plugin = next(
-            self._plugins_manager.get_search_plugins(product_type=product_type)
-        )
-        if search_plugin.provider != self.get_preferred_provider()[0]:
+        search_plugins = []
+        for plugin in self._plugins_manager.get_search_plugins(
+            product_type=product_type
+        ):
+            search_plugins.append(plugin)
+
+        if search_plugins[0].provider != self.get_preferred_provider()[0]:
             logger.warning(
                 "Product type '%s' is not available with provider '%s'. "
                 "Searching it on provider '%s' instead.",
                 product_type,
                 self.get_preferred_provider()[0],
-                search_plugin.provider,
+                search_plugins[0].provider,
             )
         else:
             logger.info(
                 "Searching product type '%s' on provider: %s",
                 product_type,
-                search_plugin.provider,
+                search_plugins[0].provider,
             )
         # Add product_types_config to plugin config. This dict contains product
         # type metadata that will also be stored in each product's properties.
-        try:
-            search_plugin.config.product_type_config = dict(
-                [
-                    p
-                    for p in self.list_product_types(
-                        search_plugin.provider, fetch_providers=False
-                    )
-                    if p["ID"] == product_type
-                ][0],
-                **{"productType": product_type},
+        auth_plugins = []
+        for search_plugin in search_plugins:
+            try:
+                search_plugin.config.product_type_config = dict(
+                    [
+                        p
+                        for p in self.list_product_types(
+                            search_plugin.provider, fetch_providers=False
+                        )
+                        if p["ID"] == product_type
+                    ][0],
+                    **{"productType": product_type},
+                )
+                # If the product isn't in the catalog, it's a generic product type.
+            except IndexError:
+                # Construct the GENERIC_PRODUCT_TYPE metadata
+                search_plugin.config.product_type_config = dict(
+                    ID=GENERIC_PRODUCT_TYPE,
+                    **self.product_types_config[GENERIC_PRODUCT_TYPE],
+                    productType=product_type,
+                )
+            # Remove the ID since this is equal to productType.
+            search_plugin.config.product_type_config.pop("ID", None)
+
+            logger.debug(
+                "Using plugin class for search: %s", search_plugin.__class__.__name__
             )
-        # If the product isn't in the catalog, it's a generic product type.
-        except IndexError:
-            # Construct the GENERIC_PRODUCT_TYPE metadata
-            search_plugin.config.product_type_config = dict(
-                ID=GENERIC_PRODUCT_TYPE,
-                **self.product_types_config[GENERIC_PRODUCT_TYPE],
-                productType=product_type,
-            )
-        # Remove the ID since this is equal to productType.
-        search_plugin.config.product_type_config.pop("ID", None)
+            auth_plugin = self._plugins_manager.get_auth_plugin(search_plugin.provider)
+            auth_plugins.append(auth_plugin)
 
-        logger.debug(
-            "Using plugin class for search: %s", search_plugin.__class__.__name__
-        )
-        auth_plugin = self._plugins_manager.get_auth_plugin(search_plugin.provider)
+            # append auth to search plugin if needed
+            if getattr(search_plugin.config, "need_auth", False) and callable(
+                getattr(auth_plugin, "authenticate", None)
+            ):
+                search_plugin.auth = auth_plugin.authenticate()
 
-        # append auth to search plugin if needed
-        if getattr(search_plugin.config, "need_auth", False) and callable(
-            getattr(auth_plugin, "authenticate", None)
-        ):
-            search_plugin.auth = auth_plugin.authenticate()
-
-        return dict(search_plugin=search_plugin, auth=auth_plugin, **kwargs)
+        return dict(search_plugins=search_plugins, auth=auth_plugins, **kwargs)
 
     def _do_search(self, search_plugin, count=True, raise_errors=False, **kwargs):
         """Internal method that performs a search on a given provider.

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -393,6 +393,7 @@ def search_products(product_type, arguments, stac_formatted=True):
     try:
         arg_product_type = arguments.pop("product_type", None)
         unserialized = arguments.pop("unserialized", None)
+        id = arguments.pop("id", None)
 
         page, items_per_page = get_pagination_info(arguments)
         dtstart, dtend = get_datetime(arguments)
@@ -406,6 +407,7 @@ def search_products(product_type, arguments, stac_formatted=True):
             "start": dtstart,
             "end": dtend,
             "geom": geom,
+            "id": id,
         }
 
         if stac_formatted:

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1193,7 +1193,7 @@ class TestCoreSearch(TestCoreBase):
             "geometry": None,
             "productType": None,
         }
-        expected = set(["geometry", "productType", "auth", "search_plugin"])
+        expected = set(["geometry", "productType", "auth", "search_plugins"])
         self.assertSetEqual(expected, set(prepared_search))
 
     @mock.patch(
@@ -1316,7 +1316,9 @@ class TestCoreSearch(TestCoreBase):
             # abstract, platform, etc.) but this is sufficient to check that the
             # product_type_config dict has been created and populated.
             self.assertEqual(
-                prepared_search["search_plugin"].config.product_type_config["title"],
+                prepared_search["search_plugins"][0].config.product_type_config[
+                    "title"
+                ],
                 "SENTINEL2 Level-1C",
             )
         finally:
@@ -1337,7 +1339,9 @@ class TestCoreSearch(TestCoreBase):
             # product_type_config is still created if the product is not known to eodag
             # however it contains no data.
             self.assertIsNone(
-                prepared_search["search_plugin"].config.product_type_config["title"],
+                prepared_search["search_plugins"][0].config.product_type_config[
+                    "title"
+                ],
             )
         finally:
             self.dag.set_preferred_provider(prev_fav_provider)
@@ -1349,8 +1353,8 @@ class TestCoreSearch(TestCoreBase):
             self.dag.set_preferred_provider("peps")
             base = {"productType": "S2_MSI_L1C"}
             prepared_search = self.dag._prepare_search(**base)
-            self.assertEqual(prepared_search["search_plugin"].provider, "peps")
-            self.assertEqual(prepared_search["auth"].provider, "peps")
+            self.assertEqual(prepared_search["search_plugins"][0].provider, "peps")
+            self.assertEqual(prepared_search["auth"]["peps"].provider, "peps")
         finally:
             self.dag.set_preferred_provider(prev_fav_provider)
 
@@ -1358,7 +1362,7 @@ class TestCoreSearch(TestCoreBase):
         """_prepare_search must not return the search and auth plugins for a search by id"""
         base = {"id": "some_id", "provider": "some_provider"}
         prepared_search = self.dag._prepare_search(**base)
-        self.assertNotIn("search_plugin", prepared_search)
+        self.assertNotIn("search_plugins", prepared_search)
         self.assertNotIn("auth", prepared_search)
 
     def test__prepare_search_peps_plugins_product_not_available(self):
@@ -1373,8 +1377,8 @@ class TestCoreSearch(TestCoreBase):
             self.dag.set_preferred_provider("theia")
             base = {"productType": "S2_MSI_L1C"}
             prepared_search = self.dag._prepare_search(**base)
-            self.assertEqual(prepared_search["search_plugin"].provider, "peps")
-            self.assertEqual(prepared_search["auth"].provider, "peps")
+            self.assertEqual(prepared_search["search_plugins"][0].provider, "peps")
+            self.assertEqual(prepared_search["auth"]["peps"].provider, "peps")
         finally:
             self.dag.set_preferred_provider(prev_fav_provider)
 
@@ -1659,7 +1663,9 @@ class TestCoreSearch(TestCoreBase):
 
         search_plugin.config = DummyConfig()
         prepare_seach.return_value = dict(search_plugin=search_plugin)
-        page_iterator = self.dag.search_iter_page(items_per_page=2)
+        page_iterator = self.dag.search_iter_page_plugin(
+            items_per_page=2, search_plugin=search_plugin
+        )
         first_result_page = next(page_iterator)
         self.assertIsInstance(first_result_page, SearchResult)
         self.assertEqual(len(first_result_page), self.search_results_size)
@@ -1684,7 +1690,9 @@ class TestCoreSearch(TestCoreBase):
 
         search_plugin.config = DummyConfig()
         prepare_seach.return_value = dict(search_plugin=search_plugin)
-        page_iterator = self.dag.search_iter_page(items_per_page=2)
+        page_iterator = self.dag.search_iter_page_plugin(
+            items_per_page=2, search_plugin=search_plugin
+        )
         all_page_results = list(page_iterator)
         self.assertEqual(len(all_page_results), 2)
         self.assertIsInstance(all_page_results[0], SearchResult)
@@ -1707,7 +1715,9 @@ class TestCoreSearch(TestCoreBase):
 
         search_plugin.config = DummyConfig()
         prepare_seach.return_value = dict(search_plugin=search_plugin)
-        page_iterator = self.dag.search_iter_page(items_per_page=2)
+        page_iterator = self.dag.search_iter_page_plugin(
+            items_per_page=2, search_plugin=search_plugin
+        )
         all_page_results = list(page_iterator)
         self.assertEqual(len(all_page_results), 2)
         self.assertIsInstance(all_page_results[0], SearchResult)
@@ -1721,7 +1731,7 @@ class TestCoreSearch(TestCoreBase):
         search_plugin.provider = "peps"
         search_plugin.query.side_effect = AttributeError()
         prepare_seach.return_value = dict(search_plugin=search_plugin)
-        page_iterator = self.dag.search_iter_page()
+        page_iterator = self.dag.search_iter_page_plugin()
         with self.assertRaises(AttributeError):
             next(page_iterator)
 
@@ -1766,8 +1776,6 @@ class TestCoreSearch(TestCoreBase):
         dag.update_providers_config(dummy_provider_config)
         dag.set_preferred_provider("dummy_provider")
 
-        page_iterator = dag.search_iter_page(productType="S2_MSI_L1C")
-        next(page_iterator)
         search_plugin = next(
             dag._plugins_manager.get_search_plugins(product_type="S2_MSI_L1C")
         )
@@ -1798,14 +1806,16 @@ class TestCoreSearch(TestCoreBase):
         # mocked return value. Later calls would then break
         def yield_search_plugin():
             while True:
-                yield {"search_plugin": search_plugin}
+                yield {"search_plugins": [search_plugin]}
 
         prepare_seach.side_effect = yield_search_plugin()
         all_results = self.dag.search_all(items_per_page=2)
         self.assertIsInstance(all_results, SearchResult)
         self.assertEqual(len(all_results), 3)
 
-    @mock.patch("eodag.api.core.EODataAccessGateway.search_iter_page", autospec=True)
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.search_iter_page_plugin", autospec=True
+    )
     def test_search_all_use_max_items_per_page(self, mocked_search_iter_page):
         """search_all must use the configured parameter max_items_per_page if available"""
         dag = EODataAccessGateway()
@@ -1828,7 +1838,9 @@ class TestCoreSearch(TestCoreBase):
         dag.search_all(productType="S2_MSI_L1C")
         self.assertEqual(mocked_search_iter_page.call_args[1]["items_per_page"], 2)
 
-    @mock.patch("eodag.api.core.EODataAccessGateway.search_iter_page", autospec=True)
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.search_iter_page_plugin", autospec=True
+    )
     def test_search_all_use_default_value(self, mocked_search_iter_page):
         """search_all must use the DEFAULT_MAX_ITEMS_PER_PAGE if the provider's one wasn't configured"""
         dag = EODataAccessGateway()
@@ -1852,7 +1864,9 @@ class TestCoreSearch(TestCoreBase):
             DEFAULT_MAX_ITEMS_PER_PAGE,
         )
 
-    @mock.patch("eodag.api.core.EODataAccessGateway.search_iter_page", autospec=True)
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.search_iter_page_plugin", autospec=True
+    )
     def test_search_all_user_items_per_page(self, mocked_search_iter_page):
         """search_all must use the value of items_per_page provided by the user"""
         dag = EODataAccessGateway()
@@ -1876,8 +1890,9 @@ class TestCoreSearch(TestCoreBase):
     @mock.patch(
         "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
     )
-    def test_search_all_request_error(self, mocked_request):
-        """search_all must stop iteration if a request exception is raised"""
+    @mock.patch("eodag.plugins.apis.usgs.UsgsApi.authenticate", autospec=True)
+    def test_search_all_request_error(self, mocked_request, mocked_authenticate):
+        """search_all must stop iteration and move to next provider when error occurs"""
         dag = EODataAccessGateway()
         dummy_provider_config = """
         dummy_provider:
@@ -1896,20 +1911,22 @@ class TestCoreSearch(TestCoreBase):
         mocked_request.side_effect = RequestError()
         dag.update_providers_config(dummy_provider_config)
         dag.set_preferred_provider("dummy_provider")
-        results = dag.search_all(productType="S2_MSI_L1C")
-        self.assertEqual(len(results), 0)
+        dag.search_all(productType="S2_MSI_L1C")
+        mocked_authenticate.assert_called_once()
 
-    @mock.patch("eodag.api.core.EODataAccessGateway.search_iter_page", autospec=True)
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.search_iter_page_plugin", autospec=True
+    )
     @mock.patch(
         "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
     )
     def test_search_all_unknown_product_type(
-        self, mock_fetch_product_types_list, mock_search_iter_page
+        self, mock_fetch_product_types_list, mock_search_iter_page_plugin
     ):
         """search_all must fetch product types if product_type is unknown"""
         self.dag.search_all(productType="foo")
-        mock_fetch_product_types_list.assert_called_once_with(self.dag)
-        mock_search_iter_page.assert_called_once()
+        mock_fetch_product_types_list.assert_called_with(self.dag)
+        mock_search_iter_page_plugin.assert_called_once()
 
 
 class TestCoreDownload(TestCoreBase):

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1928,6 +1928,31 @@ class TestCoreSearch(TestCoreBase):
         mock_fetch_product_types_list.assert_called_with(self.dag)
         mock_search_iter_page_plugin.assert_called_once()
 
+    @mock.patch("eodag.api.core.EODataAccessGateway._do_search", autospec=True)
+    def test_search_request_error(self, mocked_do_search):
+        """search must retry with the next provider when error occurs"""
+        """when it fails for all providers an exception is raiased"""
+        dag = EODataAccessGateway()
+        dummy_provider_config = """
+        dummy_provider:
+            search:
+                type: QueryStringSearch
+                api_endpoint: https://api.my_new_provider/search
+                pagination:
+                    next_page_url_tpl: 'dummy_next_page_url_tpl'
+                    next_page_url_key_path: '$.links[?(@.rel="next")].href'
+                metadata_mapping:
+                    dummy: 'dummy'
+            products:
+                S2_MSI_L1C:
+                    productType: '{productType}'
+        """
+        mocked_do_search.side_effect = RequestError()
+        dag.update_providers_config(dummy_provider_config)
+        dag.set_preferred_provider("dummy_provider")
+        self.assertRaises(RequestError, dag.search, productType="S2_MSI_L1C")
+        assert mocked_do_search.call_count >= 2
+
 
 class TestCoreDownload(TestCoreBase):
     @classmethod


### PR DESCRIPTION
Adds a fallback mechanism for the search of products. If the search request fails with the preferred providers, the provider with next highest priority will be used. The requests continue until a request is successful or until no more provider offering the desired product is found. In the latter case an error is raised.

Furthermore, the bug, that searching by ids via the /search endpoint was not working, is fixed. The parameter ids is now taken into consideration (however, only the first id is used as searching with multiple ids is currently not supported).
