### PR TITLE
docs: extend documentation for guess_product_type and other minor updates

### DIFF
--- a/docs/api_reference/core.rst
+++ b/docs/api_reference/core.rst
@@ -79,6 +79,7 @@ Misc
 .. autosummary::
 
    EODataAccessGateway.group_by_extent
+   EODataAccessGateway.guess_product_type
 
 .. autoclass:: eodag.api.core.EODataAccessGateway
    :members: set_preferred_provider, get_preferred_provider, update_providers_config, list_product_types,

--- a/docs/cli_user_guide.rst
+++ b/docs/cli_user_guide.rst
@@ -106,8 +106,7 @@ string search sent to the provider. For instance, if you want to add foo=1 and b
                      --cruncher-args FilterOverlap minimum_overlap 10 \
                      --query "foo=1&bar=2"
 
-* If the product type is not known, it can also be guessed by EODAG during the search based on parameters in the search request.
-The possible parameters are:
+* If the product type is not known, it can also be guessed by EODAG during the search based on parameters in the search request. The possible parameters are:
 
         * `instrument` (e.g. MSI)
         * `platform` (e.g. SENTINEL2)

--- a/docs/cli_user_guide.rst
+++ b/docs/cli_user_guide.rst
@@ -83,6 +83,26 @@ The request above searches for `S2_MSI_L1C` product types in a given bounding bo
 internally all the products that match these criteria. Without ``--all``, it would only fetch the products found on the
 first result page. It finally saves the results in a GeoJSON file.
 
+If the product type is not known, it can also be guessed by EODAG during the search based on parameters in the search request.
+The possible parameters are:
+
+* `instrument` (e.g. MSI)
+* `platform` (e.g. SENTINEL2)
+* `platformSerialIdentifier` (e.g. S2A)
+* `processingLevel` (e.g. L1)
+* `sensorType` (e.g. OPTICAL)
+* `keywords` (e.g. SENTINEL2 L1C SAFE), which is case insensitive and ignores `-` or `_` characters
+
+For example, the following search request will first search for a product type for platform SENTINEL2 and processingLevel L1
+(there are several product types matching these criteria, e.g., `S2_MSI_L1C`) and then use this product type to execute the actual search.
+
+.. code-block:: console
+        eodag search \
+        --platform SENTINEL2 \
+        --processingLevel L1 \
+        --box 1 43 2 44 \
+        --start 2021-03-01 --end 2021-03-31
+
 You can pass arguments to a cruncher on the command line by doing this (example with using ``FilterOverlap`` cruncher
 which takes ``minimum_overlap`` as argument):
 

--- a/docs/cli_user_guide.rst
+++ b/docs/cli_user_guide.rst
@@ -83,26 +83,6 @@ The request above searches for `S2_MSI_L1C` product types in a given bounding bo
 internally all the products that match these criteria. Without ``--all``, it would only fetch the products found on the
 first result page. It finally saves the results in a GeoJSON file.
 
-If the product type is not known, it can also be guessed by EODAG during the search based on parameters in the search request.
-The possible parameters are:
-
-* `instrument` (e.g. MSI)
-* `platform` (e.g. SENTINEL2)
-* `platformSerialIdentifier` (e.g. S2A)
-* `processingLevel` (e.g. L1)
-* `sensorType` (e.g. OPTICAL)
-* `keywords` (e.g. SENTINEL2 L1C SAFE), which is case insensitive and ignores `-` or `_` characters
-
-For example, the following search request will first search for a product type for platform SENTINEL2 and processingLevel L1
-(there are several product types matching these criteria, e.g., `S2_MSI_L1C`) and then use this product type to execute the actual search.
-
-.. code-block:: console
-        eodag search \
-        --platform SENTINEL2 \
-        --processingLevel L1 \
-        --box 1 43 2 44 \
-        --start 2021-03-01 --end 2021-03-31
-
 You can pass arguments to a cruncher on the command line by doing this (example with using ``FilterOverlap`` cruncher
 which takes ``minimum_overlap`` as argument):
 
@@ -125,6 +105,27 @@ string search sent to the provider. For instance, if you want to add foo=1 and b
                      --cruncher FilterOverlap \
                      --cruncher-args FilterOverlap minimum_overlap 10 \
                      --query "foo=1&bar=2"
+
+* If the product type is not known, it can also be guessed by EODAG during the search based on parameters in the search request.
+The possible parameters are:
+
+        * `instrument` (e.g. MSI)
+        * `platform` (e.g. SENTINEL2)
+        * `platformSerialIdentifier` (e.g. S2A)
+        * `processingLevel` (e.g. L1)
+        * `sensorType` (e.g. OPTICAL)
+        * `keywords` (e.g. SENTINEL2 L1C SAFE), which is case insensitive and ignores `-` or `_` characters
+
+For example, the following search request will first search for a product type for platform SENTINEL2 and processingLevel L1
+(there are several product types matching these criteria, e.g., `S2_MSI_L1C`) and then use this product type to execute the actual search.
+
+.. code-block:: console
+
+        eodag search \
+        --platform SENTINEL2 \
+        --processingLevel L1 \
+        --box 1 43 2 44 \
+        --start 2021-03-01 --end 2021-03-31
 
 * To download the result of a previous call to ``search``:
 

--- a/docs/getting_started_guide/configure.rst
+++ b/docs/getting_started_guide/configure.rst
@@ -136,7 +136,7 @@ API: Dynamic configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``eodag`` 's configuration can be altered directly from using Python. See this
-`dedicated page <../notebooks/api_uder_guide/3_configuration.ipynb>`_ in the Python API user guide.
+`dedicated page <../notebooks/api_user_guide/3_configuration.ipynb>`_ in the Python API user guide.
 
 Priority setting
 ^^^^^^^^^^^^^^^^

--- a/docs/getting_started_guide/register.rst
+++ b/docs/getting_started_guide/register.rst
@@ -54,7 +54,7 @@ to each provider supported by ``eodag``:
 
   * Create an account on `EOS <https://auth.eos.com>`__
 
-  * Get your EOS api key from `here <https://console.eos.com>`__
+  * Get your EOS api key from `here <https://api-connect.eos.com/user-dashboard/statistics>`__
 
   * Create an account on `AWS <https://aws.amazon.com/>`__
 
@@ -97,3 +97,5 @@ to each provider supported by ``eodag``:
     none exists).
 
   * Add these credentials to the user configuration file.
+
+* ``earth_search_cog``: no authentication needed.

--- a/docs/notebooks/api_user_guide/4_search.ipynb
+++ b/docs/notebooks/api_user_guide/4_search.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -8,6 +9,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -15,6 +17,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -45,6 +48,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -66,6 +70,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -73,6 +78,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -82,6 +88,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -89,6 +96,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -96,6 +104,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -103,6 +112,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -202,6 +212,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -218,6 +229,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -281,6 +293,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -322,6 +335,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -329,6 +343,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -379,6 +394,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -408,6 +424,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -415,6 +432,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -422,6 +440,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -480,6 +499,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -487,6 +507,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -515,6 +536,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -543,6 +565,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -666,6 +689,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -696,6 +720,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -727,6 +752,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -734,6 +760,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -756,6 +783,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -763,6 +791,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -777,6 +806,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -784,6 +814,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -791,6 +822,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -826,6 +858,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -833,6 +866,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -840,6 +874,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -847,6 +882,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -854,6 +890,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -867,6 +904,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -883,6 +921,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -890,6 +929,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -923,6 +963,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -951,6 +992,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1157,6 +1199,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1164,6 +1207,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1250,6 +1294,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1303,6 +1348,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1533,6 +1579,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1546,6 +1593,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1553,6 +1601,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1569,6 +1618,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1576,6 +1626,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1872,6 +1923,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1879,6 +1931,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1886,6 +1939,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1914,6 +1968,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1952,6 +2007,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1959,10 +2015,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`eodag` has an internal product type catalog which stores a number of metadata for each product type (see [this page](../../getting_started_guide/product_types.rst) for more information). It is actually possible to search for products by using some of these metadata. In that case, `eodag` will query its own catalog and use **the product type that best matches the query**. The supported kwargs are:\n",
+    "`eodag` has an internal product type catalog which stores a number of metadata for each product type (see [this page](../../getting_started_guide/product_types.rst) for more information). It is actually possible to search for products by using some of these metadata. In that case, `eodag` will query its own catalog and use **the product type that best matches the query** among the available product types (i.e. all product types offered by providers where the necessary credentials are provided). The supported kwargs are:\n",
     "\n",
     "* `instrument` (e.g. *MSI*)\n",
     "* `platform` (e.g. *SENTINEL2*)\n",
@@ -1970,6 +2027,14 @@
     "* `processingLevel` (e.g. *L1*)\n",
     "* `sensorType` (e.g. *OPTICAL*)\n",
     "* `keywords` (e.g. *SENTINEL2 L1C SAFE*), which is case insensitive and ignores `-` or `_` characters"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example if we call the method with platform=\"SENTINEL1\", all the product types offering products from this platform will be returned."
    ]
   },
   {
@@ -1990,6 +2055,14 @@
    ],
    "source": [
     "dag.guess_product_type(platform=\"SENTINEL1\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By passing the following argument we can get all collections that contain the keyword collection2 and a keyword that starts with \"LANDSAT\"."
    ]
   },
   {
@@ -2024,10 +2097,142 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A search is made without specifying `productType`, however hints are passed with following supported kwargs. `guess_product_type()` will internally be used to get the best matching product type."
+    "In the previous request we made use of the whoosh query language which can be used to do complex text search. It supports the boolean operators AND, OR and NOT to combine the search terms. If a space is given between two words as in the example above, this corresponds to the operator AND. Brackets '()' can also be used. The example above also shows the use of the wildcard operator '*' which can represent any numer of characters. The wildcard operator '?' always represents only one character. It is also possible to match a range of terms by using square brackets '[]' and TO, e.g. [A TO D] will match all words in the lexical range between A and D. Below you can find some examples for the different operators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dag.guess_product_type(platform=\"LANDSAT OR SENTINEL1\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "returns all product types where the platform is either LANDSAT or SENTINEL1:\n",
+    "\n",
+    "['L57_REFLECTANCE', 'LANDSAT_C2L1', 'LANDSAT_C2L2', 'LANDSAT_C2L2ALB_BT', 'LANDSAT_C2L2ALB_SR', 'LANDSAT_C2L2ALB_ST', 'LANDSAT_C2L2ALB_TA', 'LANDSAT_C2L2_SR', 'LANDSAT_C2L2_ST', 'LANDSAT_ETM_C1', 'LANDSAT_ETM_C2L1', 'LANDSAT_ETM_C2L2', 'LANDSAT_TM_C1', 'LANDSAT_TM_C2L1', 'LANDSAT_TM_C2L2', 'S1_SAR_GRD', 'S1_SAR_OCN', 'S1_SAR_RAW', 'S1_SAR_SLC']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dag.guess_product_type(keywords=\"(LANDSAT AND collection2) OR SAR\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "returns all product types which contain either the keywords LANDSAT and collection2 or the keyword SAR:\n",
+    "\n",
+    "['LANDSAT_C2L1', 'LANDSAT_C2L2', 'LANDSAT_C2L2ALB_BT', 'LANDSAT_C2L2ALB_SR', 'LANDSAT_C2L2ALB_ST', 'LANDSAT_C2L2ALB_TA', 'LANDSAT_C2L2_SR', 'LANDSAT_C2L2_ST', 'LANDSAT_ETM_C2L1', 'LANDSAT_ETM_C2L2', 'LANDSAT_TM_C2L1', 'LANDSAT_TM_C2L2', 'S1_SAR_GRD', 'S1_SAR_OCN', 'S1_SAR_RAW', 'S1_SAR_SLC']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dag.guess_product_type(platformSerialIdentifier=\"L?\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "returns all product types where the platformSerialIdentifier is composed of 'L' and one other character:\n",
+    "\n",
+    "['L57_REFLECTANCE', 'L8_OLI_TIRS_C1L1', 'L8_REFLECTANCE', 'LANDSAT_C2L1', 'LANDSAT_C2L2', 'LANDSAT_C2L2ALB_BT', 'LANDSAT_C2L2ALB_SR', 'LANDSAT_C2L2ALB_ST', 'LANDSAT_C2L2ALB_TA', 'LANDSAT_C2L2_SR', 'LANDSAT_C2L2_ST', 'LANDSAT_ETM_C1', 'LANDSAT_ETM_C2L1', 'LANDSAT_ETM_C2L2', 'LANDSAT_TM_C1', 'LANDSAT_TM_C2L1', 'LANDSAT_TM_C2L2']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dag.guess_product_type(platform=\"[SENTINEL1 TO SENTINEL3]\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "returns all product types where the platform is SENTINEL1, SENTINEL2 or SENTINEL3:\n",
+    "\n",
+    "['S1_SAR_GRD', 'S1_SAR_OCN', 'S1_SAR_RAW', 'S1_SAR_SLC', 'S2_MSI_L1C', 'S2_MSI_L2A', 'S2_MSI_L2A_COG', 'S2_MSI_L2A_MAJA', 'S2_MSI_L2B_MAJA_SNOW', 'S2_MSI_L2B_MAJA_WATER', 'S2_MSI_L3A_WASP', 'S3_EFR', 'S3_ERR', 'S3_LAN', 'S3_OLCI_L2LFR', 'S3_OLCI_L2LRR', 'S3_OLCI_L2WFR', 'S3_OLCI_L2WRR', 'S3_RAC', 'S3_SLSTR_L1RBT', 'S3_SLSTR_L2AOD', 'S3_SLSTR_L2FRP', 'S3_SLSTR_L2LST', 'S3_SLSTR_L2WST', 'S3_SRA', 'S3_SRA_A', 'S3_SRA_BS', 'S3_SY_AOD', 'S3_SY_SYN', 'S3_SY_V10', 'S3_SY_VG1', 'S3_SY_VGP', 'S3_WAT']"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also pass several parameters at the same time, e.g.:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dag.guess_product_type(platform=\"LANDSAT\", platformSerialIdentifier=\"L1\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "['LANDSAT_C2L1', \n",
+    "'L57_REFLECTANCE', \n",
+    "'LANDSAT_C2L2', \n",
+    "'LANDSAT_C2L2ALB_BT', \n",
+    "'LANDSAT_C2L2ALB_SR', \n",
+    "'LANDSAT_C2L2ALB_ST', \n",
+    "'LANDSAT_C2L2ALB_TA', \n",
+    "'LANDSAT_C2L2_SR', \n",
+    "'LANDSAT_C2L2_ST', \n",
+    "'LANDSAT_ETM_C1', \n",
+    "'LANDSAT_ETM_C2L1', \n",
+    "'LANDSAT_ETM_C2L2', \n",
+    "'LANDSAT_TM_C1', \n",
+    "'LANDSAT_TM_C2L1', \n",
+    "'LANDSAT_TM_C2L2']"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The product types in the result are ordered by how well they match the criteria. In the example above only the first product type (LANDSAT_C2L1) matches the second parameter (platformSerialIdentifier=\"L1\"), all other product types only match the first criterion. Therefore, it is usually best to use the first product type in the list as it will be the one that fits best."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If a search is made without specifying `productType` but hints are passed with following supported kwargs, `guess_product_type()` will internally be used to get the best matching product type."
    ]
   },
   {
@@ -2105,10 +2310,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`eodag` searched through its metadata catalog and the product type that best matched the hints happend to be `S2_MSI_L1C`. Internally it used that product type to search for products."
+    "`eodag` searches through its metadata catalog and checks which product type corresponds to tge given parameters. There is a product type called `S2_MSI_L1C`, for the platform SENTINEL2 with the platformSerialIdentifiers S2A and S2B using the instrument MSI and the sensorType OPTICAL. Thus, all parameters of the product type `S2_MSI_L1C` are matching to the given search criteria and it is chosen to be internally used to search for products. If no product type is matching all the criteria, the one with the most matches is chosen, if several product types match all the given criteria, the first one is chosen."
    ]
   },
   {
@@ -2132,6 +2338,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2139,6 +2346,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2146,6 +2354,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2159,6 +2368,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2191,6 +2401,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2218,6 +2429,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2225,6 +2437,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2255,6 +2468,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/notebooks/api_user_guide/4_search.ipynb
+++ b/docs/notebooks/api_user_guide/4_search.ipynb
@@ -587,9 +587,7 @@
    "outputs": [
     {
      "data": {
-      "image/svg+xml": [
-       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"100.0\" height=\"100.0\" viewBox=\"1.44996527605046 43.21336996886716 0.4785046887226798 1.0742476656826767\" preserveAspectRatio=\"xMinYMin meet\"><g transform=\"matrix(1,0,0,-1,0,87.500987603417)\"><g><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"0.021484953313653535\" opacity=\"0.6\" d=\"M 1.4897522266313,43.253156919448 L 1.8886830141923,43.259391910537 L 1.8702372867615,44.247830683969 L 1.8166844329605,44.246978608269 L 1.8115531485622,44.231531984313 L 1.7625666172723,44.084918382335 L 1.7143540280423,43.938123829876 L 1.6656909244209,43.791387494216 L 1.6175634104158,43.644454837603 L 1.5693024790492,43.497542376303 L 1.521405582652,43.350555612604 L 1.4897522266313,43.253156919448 z\" /></g></g></svg>"
-      ],
+      "image/svg+xml": "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"100.0\" height=\"100.0\" viewBox=\"1.44996527605046 43.21336996886716 0.4785046887226798 1.0742476656826767\" preserveAspectRatio=\"xMinYMin meet\"><g transform=\"matrix(1,0,0,-1,0,87.500987603417)\"><g><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"0.021484953313653535\" opacity=\"0.6\" d=\"M 1.4897522266313,43.253156919448 L 1.8886830141923,43.259391910537 L 1.8702372867615,44.247830683969 L 1.8166844329605,44.246978608269 L 1.8115531485622,44.231531984313 L 1.7625666172723,44.084918382335 L 1.7143540280423,43.938123829876 L 1.6656909244209,43.791387494216 L 1.6175634104158,43.644454837603 L 1.5693024790492,43.497542376303 L 1.521405582652,43.350555612604 L 1.4897522266313,43.253156919448 z\" /></g></g></svg>",
       "text/plain": [
        "<shapely.geometry.multipolygon.MultiPolygon at 0x7fa7ea210bb0>"
       ]
@@ -2314,7 +2312,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`eodag` searches through its metadata catalog and checks which product type corresponds to tge given parameters. There is a product type called `S2_MSI_L1C`, for the platform SENTINEL2 with the platformSerialIdentifiers S2A and S2B using the instrument MSI and the sensorType OPTICAL. Thus, all parameters of the product type `S2_MSI_L1C` are matching to the given search criteria and it is chosen to be internally used to search for products. If no product type is matching all the criteria, the one with the most matches is chosen, if several product types match all the given criteria, the first one is chosen."
+    "`eodag` searches through its metadata catalog and checks which product type corresponds to the given parameters. There is a product type called `S2_MSI_L1C`, for the platform SENTINEL2 with the platformSerialIdentifiers S2A and S2B using the instrument MSI and the sensorType OPTICAL. Thus, all parameters of the product type `S2_MSI_L1C` are matching to the given search criteria and it is chosen to be internally used to search for products. If no product type is matching all the criteria, the one with the most matches is chosen, if several product types match all the given criteria, the first one is chosen."
    ]
   },
   {


### PR DESCRIPTION
Fixes #315 
- gives more examples for the use of guess_product_type
- explains the use of whoosh query language
- adds documentation for using search with product type guessing in the cli

Also fixes #719 and #732: typos, dead links, and minor updates