### PR TITLE
feat: use `downloadLink` if exists for STAC providers

### DIFF
--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -169,16 +169,15 @@ class AwsDownload(Download):
 
     :param provider: provider name
     :type provider: str
-    :param config: Download plugin configuration
-                   config.requester_pays:
-
     :param config: Download plugin configuration:
 
-                     * ``config.base_uri`` (str) - s3 endpoint url
-                     * ``config.requester_pays`` (bool) - whether download is done from
-                       a requester-pays bucket or not
-                     * ``config.flatten_top_dirs`` (bool) - flatten directory structure
-                     * ``config.products`` (dict) - product_type specific configuration
+        * ``config.base_uri`` (str) - s3 endpoint url
+        * ``config.requester_pays`` (bool) - (optional) whether download is done from a
+          requester-pays bucket or not
+        * ``config.flatten_top_dirs`` (bool) - (optional) flatten directory structure
+        * ``config.products`` (dict) - (optional) product_type specific configuration
+        * ``config.ignore_assets`` (bool) - (optional) ignore assets and download using downloadLink
+
     :type config: :class:`~eodag.config.PluginConfig`
     """
 

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -61,7 +61,30 @@ logger = logging.getLogger("eodag.plugins.download.http")
 
 
 class HTTPDownload(Download):
-    """HTTPDownload plugin. Handles product download over HTTP protocol"""
+    """HTTPDownload plugin. Handles product download over HTTP protocol
+
+    :param provider: provider name
+    :type provider: str
+    :param config: Download plugin configuration:
+
+        * ``config.base_uri`` (str) - default endpoint url
+        * ``config.extract`` (bool) - (optional) extract downloaded archive or not
+        * ``config.auth_error_code`` (int) - (optional) authentication error code
+        * ``config.dl_url_params`` (dict) - (optional) attitional parameters to send in the request
+        * ``config.archive_depth`` (int) - (optional) level in extracted path tree where to find data
+        * ``config.flatten_top_dirs`` (bool) - (optional) flatten directory structure
+        * ``config.ignore_assets`` (bool) - (optional) ignore assets and download using downloadLink
+        * ``config.order_enabled`` (bool) - (optional) wether order is enabled or not if product is `OFFLINE`
+        * ``config.order_method`` (str) - (optional) HTTP request method, GET (default) or POST
+        * ``config.order_headers`` (dict) - (optional) order request headers
+        * ``config.order_on_response`` (dict) - (optional) edit or add new product properties
+        * ``config.order_status_method`` (str) - (optional) status HTTP request method, GET (default) or POST
+        * ``config.order_status_percent`` (str) - (optional) progress percentage key in obtained status response
+        * ``config.order_status_error`` (dict) - (optional) key/value identifying an error status
+
+    :type config: :class:`~eodag.config.PluginConfig`
+
+    """
 
     def __init__(self, provider, config):
         super(HTTPDownload, self).__init__(provider, config)

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -341,19 +341,22 @@ class HTTPDownload(Download):
             return fs_path
 
         # download assets if exist instead of remote_location
-        try:
-            fs_path = self._download_assets(
-                product,
-                fs_path.replace(".zip", ""),
-                record_filename,
-                auth,
-                progress_callback,
-                **kwargs,
-            )
-            product.location = path_to_uri(fs_path)
-            return fs_path
-        except NotAvailableError:
-            pass
+        if hasattr(product, "assets") and not getattr(
+            self.config, "ignore_assets", False
+        ):
+            try:
+                fs_path = self._download_assets(
+                    product,
+                    fs_path.replace(".zip", ""),
+                    record_filename,
+                    auth,
+                    progress_callback,
+                    **kwargs,
+                )
+                product.location = path_to_uri(fs_path)
+                return fs_path
+            except NotAvailableError:
+                pass
 
         # order product if it is offline
         ordered_message = ""

--- a/eodag/plugins/download/s3rest.py
+++ b/eodag/plugins/download/s3rest.py
@@ -59,6 +59,25 @@ class S3RestDownload(Download):
     https://mundiwebservices.com/keystoneapi/uploads/documents/CWS-DATA-MUT-087-EN-Mundi_Download_v1.1.pdf#page=13
 
     Re-use AwsDownload bucket some handling methods
+
+    :param provider: provider name
+    :type provider: str
+    :param config: Download plugin configuration:
+
+        * ``config.base_uri`` (str) - default endpoint url
+        * ``config.extract`` (bool) - (optional) extract downloaded archive or not
+        * ``config.auth_error_code`` (int) - (optional) authentication error code
+        * ``config.bucket_path_level`` (int) - (optional) bucket location index in path.split('/')
+        * ``config.order_enabled`` (bool) - (optional) wether order is enabled or not if product is `OFFLINE`
+        * ``config.order_method`` (str) - (optional) HTTP request method, GET (default) or POST
+        * ``config.order_headers`` (dict) - (optional) order request headers
+        * ``config.order_on_response`` (dict) - (optional) edit or add new product properties
+        * ``config.order_status_method`` (str) - (optional) status HTTP request method, GET (default) or POST
+        * ``config.order_status_percent`` (str) - (optional) progress percentage key in obtained status response
+        * ``config.order_status_success`` (dict) - (optional) key/value identifying an error success
+        * ``config.order_status_on_success`` (dict) - (optional) edit or add new product properties
+
+    :type config: :class:`~eodag.config.PluginConfig`
     """
 
     def __init__(self, provider, config):

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import shutil
 import stat
 import unittest
 from pathlib import Path
@@ -170,6 +171,71 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             headers=USER_AGENT,
             timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
         )
+
+    @mock.patch("eodag.plugins.download.http.requests.request", autospec=True)
+    @mock.patch("eodag.plugins.download.http.requests.head", autospec=True)
+    @mock.patch("eodag.plugins.download.http.requests.get", autospec=True)
+    def test_plugins_download_http_ignore_assets(
+        self, mock_requests_get, mock_requests_head, mock_requests_request
+    ):
+        """HTTPDownload.download() must ignore assets if configured to"""
+
+        plugin = self.get_download_plugin(self.product)
+        self.product.location = (
+            self.product.remote_location
+        ) = "http://somewhere/dowload_from_location"
+        self.product.properties["id"] = "someproduct"
+        self.product.assets = {"foo": {"href": "http://somewhere/download_asset"}}
+
+        # download asset if ignore_assets = False
+        plugin.config.ignore_assets = False
+        path = plugin.download(self.product, outputs_prefix=self.output_dir)
+        mock_requests_get.assert_called_once_with(
+            self.product.assets["foo"]["href"],
+            stream=True,
+            auth=None,
+            params=plugin.config.dl_url_params,
+            headers=USER_AGENT,
+            timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
+        )
+        mock_requests_request.assert_not_called()
+        # re-enable product download
+        self.product.location = self.product.remote_location
+        shutil.rmtree(path)
+        mock_requests_get.reset_mock()
+        mock_requests_request.reset_mock()
+
+        # download using remote_location if ignore_assets = True
+        plugin.config.ignore_assets = True
+        path = plugin.download(self.product, outputs_prefix=self.output_dir)
+        mock_requests_get.assert_not_called()
+        mock_requests_request.assert_called_once_with(
+            "get",
+            self.product.remote_location,
+            stream=True,
+            auth=None,
+            params=plugin.config.dl_url_params,
+            headers=USER_AGENT,
+            timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
+        )
+        # re-enable product download
+        self.product.location = self.product.remote_location
+        os.remove(path)
+        mock_requests_get.reset_mock()
+        mock_requests_request.reset_mock()
+
+        # download asset if ignore_assets unset
+        del plugin.config.ignore_assets
+        plugin.download(self.product, outputs_prefix=self.output_dir)
+        mock_requests_get.assert_called_once_with(
+            self.product.assets["foo"]["href"],
+            stream=True,
+            auth=None,
+            params=plugin.config.dl_url_params,
+            headers=USER_AGENT,
+            timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
+        )
+        mock_requests_request.assert_not_called()
 
     @mock.patch("eodag.plugins.download.http.requests.head", autospec=True)
     @mock.patch("eodag.plugins.download.http.requests.get", autospec=True)


### PR DESCRIPTION
Fixes #728 

While downloading a product with a STAC provider, we use the `downloadLink` property if exists instead of downloading every asset.

The `ignore_assets` attribute had already been implemented for AWS download plugin, now it is also operational for HTTP download plugin so every STAC provider can use it.