### PR TITLE
fix: extract USGS tarfiles

### DIFF
--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -338,7 +338,7 @@ class Download(PluginTopic):
                 shutil.move(extraction_dir, outputs_dir)
 
             elif fs_path.endswith(".tar.gz"):
-                with tarfile.open(fs_path, "r:gz") as zfile:
+                with tarfile.open(fs_path, "r") as zfile:
                     progress_callback.reset(total=1)
                     zfile.extractall(path=extraction_dir)
                     progress_callback(1)


### PR DESCRIPTION
Fixes #758 

The command prompt shows products are indeed not gzip compressed archives:

```
file /home/anesson/workspace/eodag-debug/downloads/LC09_L1TP_198030_20230310_20230310_02_T1.tar.gz

/home/anesson/workspace/eodag-debug/downloads/LC09_L1TP_198030_20230310_20230310_02_T1.tar.gz: POSIX tar archive (GNU)
```

`r` must replace `r:gz` for `tarfile.open()` compression mode during archive extractions then.
