### PR TITLE
fix: update creodias auth to Creodias-new

### DIFF
--- a/docs/getting_started_guide/configure.rst
+++ b/docs/getting_started_guide/configure.rst
@@ -246,3 +246,62 @@ Or with the CLI:
                 -p S2_MSI_L1C \
                 --storage my_search.geojson
    eodag download -f my_config.yml --search-results my_search.geojson
+
+Authenticate using an OTP / One Time Password (Two-Factor authentication)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use OTP through Python code
+"""""""""""""""""""""""""""
+
+``creodias`` needs a temporary 6-digits code to authenticate in addition of the ``username`` and ``password``. Check
+`Creodias documentation <https://creodias.docs.cloudferro.com/en/latest/gettingstarted/Two-Factor-Authentication-for-Creodias-Site.html>`_
+to see how to get this code once you are registered. This OTP code will only be valid for a few seconds, so you will
+better set it dynamically in your python code instead of storing it statically in your user configuration file.
+
+Set the OTP by updating ``creodias`` credentials for ``totp`` entry, using one of the two following configuration update
+commands:
+
+.. code-block:: python
+
+   dag.providers_config["creodias"].auth.credentials["totp"] = "PLEASE_CHANGE_ME"
+
+   # OR
+
+   dag.update_providers_config(
+      """
+      creodias:
+         auth:
+            credentials:
+               totp: PLEASE_CHANGE_ME
+      """
+   )
+
+Then quickly authenticate as this OTP has a few seconds only lifetime. First authentication will retrieve a token that
+will be stored and used if further authentication tries fail:
+
+.. code-block:: python
+
+   dag._plugins_manager.get_auth_plugin("creodias").authenticate()
+
+Please note that authentication mechanism is already included in
+`download methods <https://eodag.readthedocs.io/en/stable/notebooks/api_user_guide/7_download.html>`_ , so you could also directly execute a
+download to retrieve the token while the OTP is still valid.
+
+Use OTP through CLI
+"""""""""""""""""""
+
+To download through CLI a product on a provider that needs a One Time Password,  e.g. ``creodias``, first search on this
+provider (increase the provider priotity to make eodag search on it):
+
+.. code-block:: console
+
+        EODAG__CREODIAS__PRIORITY=2 eodag search -b 1 43 2 44 -s 2018-01-01 -e 2018-01-31 -p S2_MSI_L1C --items 1
+
+Then download using the OTP (``creodias`` needs it as ``totp`` parameter):
+
+.. code-block:: console
+
+        EODAG__CREODIAS__AUTH__CREDENTIALS__TOTP=PLEASE_CHANGE_ME eodag download --search-results search_results.geojson
+
+If needed, check in the documentation how to
+`use environment variables to configure EODAG <#environment-variable-configuration>`_.

--- a/docs/getting_started_guide/register.rst
+++ b/docs/getting_started_guide/register.rst
@@ -15,7 +15,12 @@ to each provider supported by ``eodag``:
 
 * ``peps``: create an account `here <https://peps.cnes.fr/rocket/#/register>`__, then use your email as `username` in eodag credentials.
 
-* ``creodias``: create an account `here <https://portal.creodias.eu/register.php>`__
+* ``creodias``: create an account `here <https://portal.creodias.eu/register.php>`__, then use your `username`, `password` in eodag credentials. You will also
+  need `totp` in credentials, a temporary 6-digits OTP (One Time Password, see
+  `Creodias documentation <https://creodias.docs.cloudferro.com/en/latest/gettingstarted/Two-Factor-Authentication-for-Creodias-Site.html>`__)
+  to be able to authenticate and download. Check
+  `Authenticate using an OTP <https://eodag.readthedocs.io/en/latest/getting_started_guide/configure.html#authenticate-using-an-otp-one-time-password-two-factor-authentication>`__
+  to see how to proceed.
 
 * ``onda``: create an account `here: <https://www.onda-dias.eu/cms/>`__
 

--- a/eodag/plugins/authentication/keycloak.py
+++ b/eodag/plugins/authentication/keycloak.py
@@ -69,11 +69,7 @@ class KeycloakOIDCPasswordAuth(Authentication):
     TOKEN_URL_TEMPLATE = "{auth_base_uri}/realms/{realm}/protocol/openid-connect/token"
     REQUIRED_PARAMS = ["auth_base_uri", "client_id", "client_secret", "token_provision"]
     # already retrieved token store, to be used if authenticate() fails (OTP use-case)
-<<<<<<< HEAD
     retrieved_token = None
-=======
-    retrived_token = None
->>>>>>> 903e058... docs: KeycloakOIDCPasswordAuth docstring update
 
     def __init__(self, provider, config):
         super(KeycloakOIDCPasswordAuth, self).__init__(provider, config)

--- a/eodag/plugins/authentication/keycloak.py
+++ b/eodag/plugins/authentication/keycloak.py
@@ -26,13 +26,54 @@ from eodag.utils.stac_reader import HTTP_REQ_TIMEOUT
 
 
 class KeycloakOIDCPasswordAuth(Authentication):
-    """Authentication plugin using Keycloak and OpenId Connect"""
+    """Authentication plugin using Keycloak and OpenId Connect.
+
+    This plugin request a token and use it through a query-string or a header.
+
+    Using :class:`~eodag.plugins.download.http.HTTPDownload` a download link
+    `http://example.com?foo=bar` will become
+    `http://example.com?foo=bar&my-token=obtained-token` if associated to the following
+    configuration::
+
+        provider:
+            ...
+            auth:
+                plugin: KeycloakOIDCPasswordAuth
+                auth_base_uri: 'https://somewhere/auth'
+                realm: 'the-realm'
+                client_id: 'SOME_ID'
+                client_secret: '01234-56789'
+                token_provision: qs
+                token_qs_key: 'my-token'
+                ...
+            ...
+
+    If configured to send the token through the header, the download request header will
+    be updated with `Authorization: "Bearer obtained-token"` if associated to the
+    following configuration::
+
+        provider:
+            ...
+            auth:
+                plugin: KeycloakOIDCPasswordAuth
+                auth_base_uri: 'https://somewhere/auth'
+                realm: 'the-realm'
+                client_id: 'SOME_ID'
+                client_secret: '01234-56789'
+                token_provision: header
+                ...
+            ...
+    """
 
     GRANT_TYPE = "password"
     TOKEN_URL_TEMPLATE = "{auth_base_uri}/realms/{realm}/protocol/openid-connect/token"
     REQUIRED_PARAMS = ["auth_base_uri", "client_id", "client_secret", "token_provision"]
     # already retrieved token store, to be used if authenticate() fails (OTP use-case)
+<<<<<<< HEAD
     retrieved_token = None
+=======
+    retrived_token = None
+>>>>>>> 903e058... docs: KeycloakOIDCPasswordAuth docstring update
 
     def __init__(self, provider, config):
         super(KeycloakOIDCPasswordAuth, self).__init__(provider, config)

--- a/eodag/plugins/authentication/keycloak.py
+++ b/eodag/plugins/authentication/keycloak.py
@@ -40,19 +40,19 @@ class KeycloakOIDCPasswordAuth(Authentication):
         Makes authentication request
         """
         self.validate_config_credentials()
+        req_data = {
+            "client_id": self.config.client_id,
+            "client_secret": self.config.client_secret,
+            "grant_type": self.GRANT_TYPE,
+        }
+        credentials = {k: v for k, v in self.config.credentials.items()}
         try:
             response = self.session.post(
                 self.TOKEN_URL_TEMPLATE.format(
                     auth_base_uri=self.config.auth_base_uri.rstrip("/"),
                     realm=self.config.realm,
                 ),
-                data={
-                    "client_id": self.config.client_id,
-                    "client_secret": self.config.client_secret,
-                    "username": self.config.credentials["username"],
-                    "password": self.config.credentials["password"],
-                    "grant_type": self.GRANT_TYPE,
-                },
+                data=dict(req_data, **credentials),
                 headers=USER_AGENT,
                 timeout=HTTP_REQ_TIMEOUT,
             )

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1032,7 +1032,7 @@
   auth: !plugin
     type: KeycloakOIDCPasswordAuth
     auth_base_uri: 'https://identity.cloudferro.com/auth'
-    realm: 'dias'
+    realm: 'Creodias-new'
     client_id: 'CLOUDFERRO_PUBLIC'
     client_secret: 'dc0aca03-2dc6-4798-a5de-fc5aeb6c8ee1'
     token_provision: qs

--- a/eodag/resources/user_conf_template.yml
+++ b/eodag/resources/user_conf_template.yml
@@ -69,6 +69,7 @@ creodias:
         credentials:
             username:
             password:
+            totp: # set totp dynamically, see https://eodag.readthedocs.io/en/latest/getting_started_guide/configure.html#authenticate-using-an-otp-one-time-password-two-factor-authentication
 mundi:
     priority: # Lower value means lower priority (Default: 0)
     search:   # Search parameters configuration

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -423,6 +423,9 @@ class TestEODagEndToEnd(EndToEndBase):
 
     def test_end_to_end_search_download_creodias(self):
         product = self.execute_search(*CREODIAS_SEARCH_ARGS)
+        self.eodag.providers_config["creodias"].auth.credentials[
+            "totp"
+        ] = "PLEASE_CHANGE_ME"
         expected_filename = "{}.zip".format(product.properties["title"])
         self.execute_download(product, expected_filename)
 


### PR DESCRIPTION
Fixes #752

Updates `creodias` configuration to use its new [Two-Factor authentication mechanism](https://creodias.docs.cloudferro.com/en/latest/gettingstarted/Two-Factor-Authentication-for-Creodias-Site.html), using a *One Time Password*.

Documentation updated with:
- [provider registration for creodias](https://eodag--763.org.readthedocs.build/en/763/getting_started_guide/register.html)
- [Authenticate using an OTP / One Time Password (Two-Factor authentication)](https://eodag--763.org.readthedocs.build/en/763/getting_started_guide/configure.html#authenticate-using-an-otp-one-time-password-two-factor-authentication)