### PR TITLE
fix: readthedocs git fetch unshallow

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,6 +4,17 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  jobs:
+    post_checkout:
+      - git fetch --unshallow
+      - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+      - git fetch origin
+
+    # Uncomment to debug
+    # pre_install:
+    #   - pip install -U pip
+    #   - pip install setuptools>=45 setuptools_scm[toml]>=6.2
+    #   - SETUPTOOLS_SCM_DEBUG=1 python -m setuptools_scm
 
 # Build from the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Fixes issues when building readthedocs image: RTD performs a shallow git fetch with the last 50 commits, which prevented `setuptools_scm` to get `eodag` version and breaked its installation.
It is now configured to perform an unshallow git fetch