### PR TITLE
fix: request-ftp requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ install_requires =
     ecmwf-api-client
     cdsapi
     stream-zip
-    requests_ftp @ https://github.com/Lukasa/requests-ftp/archive/refs/heads/master.zip
+    requests-ftp
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Fixes `request-ftp` requirement breaking pypi package build
```
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         Invalid value for requires_dist. Error: Can't have direct dependency:  
         'requests-ftp @                                                        
         https://github.com/Lukasa/requests-ftp/archive/refs/heads/master.zip'  
```