### PR TITLE
fix(server): missing intersects parameter in request body model

### DIFF
--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -288,6 +288,7 @@ class SearchBody(BaseModel):
     collections: Union[List[str], str]
     datetime: Union[str, None] = None
     bbox: Union[list, str, None] = None
+    intersects: Union[dict, None] = None
     limit: Union[int, None] = 20
     page: Union[int, None] = 1
     query: Union[dict, None] = None

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -263,13 +263,13 @@ def get_geometry(arguments):
             )
         )
 
-    if "intersects" in arguments and geom:
+    if "intersects" in arguments and arguments["intersects"] is not None and geom:
         new_geom = shape(arguments.pop("intersects"))
         if new_geom.intersects(geom):
             geom = new_geom.intersection(geom)
         else:
             geom = new_geom
-    elif "intersects" in arguments:
+    elif "intersects" in arguments and arguments["intersects"] is not None:
         geom = shape(arguments.pop("intersects"))
 
     if "geom" in arguments and geom:

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -546,6 +546,28 @@ class RequestTestCase(unittest.TestCase):
             ),
         )
 
+    def test_intersects_post_search(self):
+        """POST search with intersects filtering through eodag server should return a valid response"""
+        self._request_valid(
+            "search",
+            protocol="POST",
+            post_data={
+                "collections": [self.tested_product_type],
+                "intersects": {
+                    "type": "Polygon",
+                    "coordinates": [[[0, 43], [0, 44], [1, 44], [1, 43], [0, 43]]],
+                },
+            },
+            expected_search_kwargs=dict(
+                provider="peps",
+                productType=self.tested_product_type,
+                page=1,
+                items_per_page=DEFAULT_ITEMS_PER_PAGE,
+                raise_errors=True,
+                geom=box(0, 43, 1, 44, ccw=False),
+            ),
+        )
+
     def test_ids_post_search(self):
         """POST search with ids filtering through eodag server should return a valid response"""
         self._request_valid(


### PR DESCRIPTION
Fixes server mode missing `intersects` parameter in pydantic request model. This caused lacking geometry filtering using this parameter