### PR TITLE
fix(server): correct links in stac model

### DIFF
--- a/eodag/resources/stac.yml
+++ b/eodag/resources/stac.yml
@@ -29,7 +29,7 @@ landing_page:
   links:
     - rel: self
       type: "application/json"
-      href: "{catalog[root]}"
+      href: "{catalog[root]}/"
     - rel: service-desc
       type: "application/vnd.oai.openapi+json;version=3.0"
       href: "{catalog[root]}/api"
@@ -66,11 +66,11 @@ collections:
   links:
     - rel: self
       title: collections
-      href: /collections
+      href: "{collections[url]}"
     - rel: root
-      href: /
+      href: "{collections[root]}/"
     - rel: parent
-      href: /
+      href: "{collections[root]}/"
   collections:
     - "{collection}"
   stac_version: "{stac_version}"
@@ -84,12 +84,12 @@ collection:
   links:
     - rel: self
       title: "{collection[id]}"
-      href: "{collection[root]}/collections/{collection[id]}"
+      href: "{collection[url]}"
     - rel: root
-      href: "{collection[root]}"
+      href: "{collection[root]}/"
     - rel: items
       title: "items"
-      href: "{collection[root]}/collections/{collection[id]}/items"
+      href: "{collection[url]}/items"
   extent:
     spatial:
       bbox:
@@ -140,7 +140,7 @@ items:
       title: "items"
       href: "{catalog[url]}/items"
     - rel: root
-      href: /
+      href: "{catalog[root]}/"
     - rel: parent
       title: "{catalog[id]}"
       href: "{catalog[url]}"
@@ -208,13 +208,13 @@ item:
       title: "{item[id]}"
       href: "{catalog[url]}/items/{item[id]}"
     - rel: root
-      href: /
+      href: "{catalog[root]}/"
     - rel: parent
       title: "{catalog[id]}"
       href: "{catalog[url]}"
     - rel: collection
       title: "{item[collection]}"
-      href: "/collections/{item[collection]}"
+      href: "{catalog[url]}"
   assets:
     downloadLink:
         title: 'Download link'

--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -380,7 +380,7 @@ def stac_collections_items(collection_id, request: Request):
 @router.get("/collections/{collection_id}", tags=["Capabilities"])
 def collection_by_id(collection_id, request: Request):
     """STAC collection by id"""
-    url = request.state.url
+    url = request.state.url_root + "/collections"
     url_root = request.state.url_root
 
     body = {}

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -578,7 +578,8 @@ class StacCollection(StacCommon):
             # parse f-strings
             format_args = deepcopy(self.stac_config)
             format_args["collection"] = dict(
-                product_type_collection, **{"url": self.url, "root": self.root}
+                product_type_collection,
+                **{"url": f"{self.url}/{product_type['ID']}", "root": self.root},
             )
             product_type_collection = format_dict_items(
                 product_type_collection, **format_args
@@ -598,6 +599,14 @@ class StacCollection(StacCommon):
         """
         collections = deepcopy(self.stac_config["collections"])
         collections["collections"] = self.__get_collection_list(filters)
+
+        # # parse f-strings
+        format_args = deepcopy(self.stac_config)
+        format_args["collections"].update({"url": self.url, "root": self.root})
+
+        collections["links"] = [
+            format_dict_items(link, **format_args) for link in collections["links"]
+        ]
 
         collections["links"] += [
             {

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -91,14 +91,14 @@ class RequestTestCase(unittest.TestCase):
         response = self.app.get("/", follow_redirects=True)
         self.assertEqual(200, response.status_code)
         resp_json = json.loads(response.content.decode("utf-8"))
-        self.assertEqual(resp_json["links"][0]["href"], "http://testserver")
+        self.assertEqual(resp_json["links"][0]["href"], "http://testserver/")
 
         response = self.app.get(
             "/", follow_redirects=True, headers={"Forwarded": "host=foo;proto=https"}
         )
         self.assertEqual(200, response.status_code)
         resp_json = json.loads(response.content.decode("utf-8"))
-        self.assertEqual(resp_json["links"][0]["href"], "https://foo")
+        self.assertEqual(resp_json["links"][0]["href"], "https://foo/")
 
         response = self.app.get(
             "/",
@@ -107,7 +107,7 @@ class RequestTestCase(unittest.TestCase):
         )
         self.assertEqual(200, response.status_code)
         resp_json = json.loads(response.content.decode("utf-8"))
-        self.assertEqual(resp_json["links"][0]["href"], "httpz://bar")
+        self.assertEqual(resp_json["links"][0]["href"], "httpz://bar/")
 
     @mock.patch(
         "eodag.rest.utils.eodag_api.search",


### PR DESCRIPTION
Correct the links in the STAC model. It fix the links on the following endpoints:
- /collections
- /collections/{collection_id}
- /collections/{collection_id}/items
- /collections/{collection_id}/items/{item_id}