### PR TITLE
fix: update server body model to search by ids

### DIFF
--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -308,6 +308,7 @@ class SearchBody(BaseModel):
     limit: Union[int, None] = 20
     page: Union[int, None] = 1
     query: Union[dict, None] = None
+    ids: Union[List[str], None] = None
 
 
 @router.get("/search", tags=["STAC"])


### PR DESCRIPTION
Update server body model to search by ids (missing `ids` parameter)

Related to #776 