### PR TITLE
fix: limit jsonpath-ng version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     boto3
     fastapi >= 0.93.0
     uvicorn
-    jsonpath-ng
+    jsonpath-ng < 1.6.0
     lxml
     whoosh
     pystac >= 1.0.0b1


### PR DESCRIPTION
Temporary limit `jsonpath-ng` under latest 1.6.0 until tests are fixed