### PR TITLE
feat: return all available providers for collection

### DIFF
--- a/eodag/resources/stac.yml
+++ b/eodag/resources/stac.yml
@@ -111,12 +111,7 @@ collection:
     - '$.product_type.processingLevel'
     - '$.product_type.sensorType'
   license: '$.product_type.license'
-  providers:
-    - name: '$.provider.name'
-      description: '$.provider.description'
-      # one or more of "producer" "licensor" "processor" "host"
-      roles: '$.provider.roles'
-      url: '$.provider.url'
+  providers: '$.providers'
   summaries:
     constellation:
       - '$.product_type.platform'
@@ -125,6 +120,14 @@ collection:
     intruments:
       - '$.product_type.instrument'
     processing:level: '$.product_type.processingLevel'
+
+provider:
+  name: '$.provider.name'
+  description: '$.provider.description'
+  # one or more of "producer" "licensor" "processor" "host"
+  roles: '$.provider.roles'
+  url: '$.provider.url'
+  priority: '$.provider.priority'
 
 # Data ------------------------------------------------------------------------
 

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -551,16 +551,16 @@ class StacCollection(StacCommon):
 
         collection_list = []
         for product_type in product_types:
-            # get available providers each product_type
-            providers = [
-                plugin.provider
-                for plugin in self.eodag_api._plugins_manager.get_search_plugins(
-                    product_type=product_type["ID"]
-                )
-            ]
-            if self.provider and self.provider in providers:
-                providers.remove(self.provider)
-                providers.insert(0, self.provider)
+            if self.provider:
+                providers = [self.provider]
+            else:
+                # get available providers for each product_type
+                providers = [
+                    plugin.provider
+                    for plugin in self.eodag_api._plugins_manager.get_search_plugins(
+                        product_type=product_type["ID"]
+                    )
+                ]
             providers_models = []
             for provider in providers:
                 provider_m = jsonpath_parse_dict_items(

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -545,29 +545,36 @@ class StacCollection(StacCommon):
         :rtype: list
         """
         collection_model = deepcopy(self.stac_config["collection"])
+        provider_model = deepcopy(self.stac_config["provider"])
 
         product_types = self.__get_product_types(filters)
 
         collection_list = []
         for product_type in product_types:
-            # get default provider for each product_type
-            product_type_provider = (
-                self.provider
-                or next(
-                    self.eodag_api._plugins_manager.get_search_plugins(
-                        product_type=product_type["ID"]
-                    )
-                ).provider
-            )
+            # get available providers each product_type
+            providers = [
+                plugin.provider
+                for plugin in self.eodag_api._plugins_manager.get_search_plugins(
+                    product_type=product_type["ID"]
+                )
+            ]
+            if self.provider and self.provider in providers:
+                providers.remove(self.provider)
+                providers.insert(0, self.provider)
+            providers_models = []
+            for provider in providers:
+                provider_m = jsonpath_parse_dict_items(
+                    provider_model,
+                    {"provider": self.eodag_api.providers_config[provider].__dict__},
+                )
+                providers_models.append(provider_m)
 
             # parse jsonpath
             product_type_collection = jsonpath_parse_dict_items(
                 collection_model,
                 {
                     "product_type": product_type,
-                    "provider": self.eodag_api.providers_config[
-                        product_type_provider
-                    ].__dict__,
+                    "providers": providers_models,
                 },
             )
             # parse f-strings
@@ -622,7 +629,7 @@ class StacCollection(StacCommon):
 
         :param collection_id: Product type as collection ID
         :type collection_id: str
-        :returns: Collection dictionnary
+        :returns: Collection dictionary
         :rtype: dict
         """
         collection_list = self.__get_collection_list()

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -538,7 +538,7 @@ def get_stac_collection_by_id(url, root, collection_id, provider=None):
     :type collection_id: str
     :param provider: (optional) Chosen provider
     :type provider: str
-    :returns: Collection dictionnary
+    :returns: Collection dictionary
     :rtype: dict
     """
     return StacCollection(

--- a/tests/units/test_stac_utils.py
+++ b/tests/units/test_stac_utils.py
@@ -290,9 +290,12 @@ class TestStacUtils(unittest.TestCase):
 
     def test_get_stac_collection_by_id(self):
         """get_stac_collection_by_id runs without any error"""
-        self.rest_utils.get_stac_collection_by_id(
+        r = self.rest_utils.get_stac_collection_by_id(
             url="", root="", collection_id="S2_MSI_L1C"
         )
+        self.assertIsNotNone(r)
+        self.assertEqual(9, len(r["providers"]))
+        self.assertEqual(1, r["providers"][0]["priority"])
 
     def test_get_stac_collections(self):
         """get_stac_collections runs without any error"""

--- a/tests/units/test_stac_utils.py
+++ b/tests/units/test_stac_utils.py
@@ -296,6 +296,14 @@ class TestStacUtils(unittest.TestCase):
         self.assertIsNotNone(r)
         self.assertEqual(9, len(r["providers"]))
         self.assertEqual(1, r["providers"][0]["priority"])
+        self.assertEqual("peps", r["providers"][0]["name"])
+        self.assertEqual(["host"], r["providers"][0]["roles"])
+        self.assertEqual("https://peps.cnes.fr", r["providers"][0]["url"])
+        self.assertTrue(
+            r["providers"][0]["description"].startswith(
+                'The PEPS platform, the French "mirror site"'
+            )
+        )
 
     def test_get_stac_collections(self):
         """get_stac_collections runs without any error"""


### PR DESCRIPTION
In server mode all available providers of a collection sorted by priority are no returned at the collections endpoint (GET /collections, GET /collections/id)
