### PR TITLE
feat: restore pruned providers when configuration is updated

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -305,13 +305,11 @@ class EODataAccessGateway(object):
         for provider, provider_conf in conf_update.items():
             if (
                 provider in self.providers_config
-                and provider_conf.get("search", {}) is not None
                 and "metadata_mapping" in provider_conf.get("search", {})
             ):
                 search_plugin_key = "search"
             elif (
                 provider in self.providers_config
-                and provider_conf.get("api", {}) is not None
                 and "metadata_mapping" in provider_conf.get("api", {})
             ):
                 search_plugin_key = "api"

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -305,11 +305,13 @@ class EODataAccessGateway(object):
         for provider, provider_conf in conf_update.items():
             if (
                 provider in self.providers_config
+                and provider_conf.get("search", {}) is not None
                 and "metadata_mapping" in provider_conf.get("search", {})
             ):
                 search_plugin_key = "search"
             elif (
                 provider in self.providers_config
+                and provider_conf.get("api", {}) is not None
                 and "metadata_mapping" in provider_conf.get("api", {})
             ):
                 search_plugin_key = "api"
@@ -334,15 +336,27 @@ class EODataAccessGateway(object):
                     conf_update[provider][search_plugin_key]["metadata_mapping"],
                 )
 
+        # restore the pruned configuration
+        for provider, pruned_conf in self._pruned_providers_config.items():
+            logger.info(
+                "%s: provider restored from the pruned configurations",
+                provider,
+            )
+            self.providers_config[provider] = pruned_conf
         override_config_from_mapping(self.providers_config, conf_update)
+
         stac_provider_config = load_stac_provider_config()
         for provider in conf_update.keys():
             provider_config_init(self.providers_config[provider], stac_provider_config)
         # re-create _plugins_manager using up-to-date providers_config
         self._plugins_manager.build_product_type_to_provider_config_map()
 
+        # filter out providers needing auth that have no credentials set
+        self._prune_providers_list()
+
     def _prune_providers_list(self):
         """Removes from config providers needing auth that have no credentials set."""
+        self._pruned_providers_config = {}
         update_needed = False
         for provider in list(self.providers_config.keys()):
             conf = self.providers_config[provider]
@@ -356,6 +370,9 @@ class EODataAccessGateway(object):
                 )
                 if not credentials_exist:
                     # credentials needed but not found
+                    self._pruned_providers_config[provider] = self.providers_config[
+                        provider
+                    ]
                     del self.providers_config[provider]
                     update_needed = True
                     logger.info(
@@ -365,6 +382,9 @@ class EODataAccessGateway(object):
             elif hasattr(conf, "search") and getattr(conf.search, "need_auth", False):
                 if not hasattr(conf, "auth"):
                     # credentials needed but no auth plugin was found
+                    self._pruned_providers_config[provider] = self.providers_config[
+                        provider
+                    ]
                     del self.providers_config[provider]
                     update_needed = True
                     logger.info(
@@ -380,6 +400,9 @@ class EODataAccessGateway(object):
                 )
                 if not credentials_exist:
                     # credentials needed but not found
+                    self._pruned_providers_config[provider] = self.providers_config[
+                        provider
+                    ]
                     del self.providers_config[provider]
                     update_needed = True
                     logger.info(
@@ -388,6 +411,9 @@ class EODataAccessGateway(object):
                     )
             elif not hasattr(conf, "api") and not hasattr(conf, "search"):
                 # provider should have at least an api or search plugin
+                self._pruned_providers_config[provider] = self.providers_config[
+                    provider
+                ]
                 del self.providers_config[provider]
                 logger.info(
                     "%s: provider has been pruned because no api or search plugin could be found",

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -356,7 +356,9 @@ class EODataAccessGateway(object):
 
     def _prune_providers_list(self):
         """Removes from config providers needing auth that have no credentials set."""
-        self._pruned_providers_config = {}
+        # store pruned providers configs
+        if not hasattr(self, "_pruned_providers_config"):
+            self._pruned_providers_config = {}
         update_needed = False
         for provider in list(self.providers_config.keys()):
             conf = self.providers_config[provider]

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -301,6 +301,15 @@ class EODataAccessGateway(object):
         :type yaml_conf: str
         """
         conf_update = yaml.safe_load(yaml_conf)
+
+        # restore the pruned configuration
+        for provider, pruned_conf in self._pruned_providers_config.items():
+            logger.info(
+                "%s: provider restored from the pruned configurations",
+                provider,
+            )
+            self.providers_config[provider] = pruned_conf
+
         # check if metada-mapping as already been built as jsonpath in providers_config
         for provider, provider_conf in conf_update.items():
             if (
@@ -334,13 +343,6 @@ class EODataAccessGateway(object):
                     conf_update[provider][search_plugin_key]["metadata_mapping"],
                 )
 
-        # restore the pruned configuration
-        for provider, pruned_conf in self._pruned_providers_config.items():
-            logger.info(
-                "%s: provider restored from the pruned configurations",
-                provider,
-            )
-            self.providers_config[provider] = pruned_conf
         override_config_from_mapping(self.providers_config, conf_update)
 
         stac_provider_config = load_stac_provider_config()

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -1013,17 +1013,24 @@ def mtd_cfg_as_conversion_and_querypath(src_dict, dest_dict={}, result_type="jso
     :returns: dest_dict
     :rtype: dict
     """
+    # check if the configuration has already been converted
+    some_configured_value = (
+        next(iter(dest_dict.values())) if dest_dict else next(iter(src_dict.values()))
+    )
+    if (
+        isinstance(some_configured_value, list)
+        and isinstance(some_configured_value[1], tuple)
+        or isinstance(some_configured_value, tuple)
+    ):
+        return dest_dict or src_dict
+
     if not dest_dict:
         dest_dict = deepcopy(src_dict)
     for metadata in src_dict:
         if metadata not in dest_dict:
             dest_dict[metadata] = (None, NOT_MAPPED)
         else:
-            try:
-                conversion, path = get_metadata_path(dest_dict[metadata])
-            except TypeError:
-                logger.warning("Skipping metadata '%s'" % str(metadata))
-                continue
+            conversion, path = get_metadata_path(dest_dict[metadata])
             if result_type == "json":
                 parsed_path = string_to_jsonpath(path)
                 if isinstance(parsed_path, str):

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -1019,7 +1019,11 @@ def mtd_cfg_as_conversion_and_querypath(src_dict, dest_dict={}, result_type="jso
         if metadata not in dest_dict:
             dest_dict[metadata] = (None, NOT_MAPPED)
         else:
-            conversion, path = get_metadata_path(dest_dict[metadata])
+            try:
+                conversion, path = get_metadata_path(dest_dict[metadata])
+            except TypeError:
+                logger.warning("Skipping metadata '%s'" % str(metadata))
+                continue
             if result_type == "json":
                 parsed_path = string_to_jsonpath(path)
                 if isinstance(parsed_path, str):

--- a/tests/integration/test_core_config.py
+++ b/tests/integration/test_core_config.py
@@ -119,6 +119,21 @@ class TestCoreProvidersConfig(TestCase):
             self.dag.providers_config["foo_provider"].auth.type, "GenericAuth"
         )
 
+        # update pruned provider with credentials
+        self.dag.update_providers_config(
+            """
+            usgs:
+                api:
+                    credentials:
+                        username: foo
+                        password: bar
+            """
+        )
+        self.assertIsInstance(self.dag.providers_config["usgs"].api, PluginConfig)
+        self.assertEqual(
+            self.dag.providers_config["usgs"].api.credentials["username"], "foo"
+        )
+
         # add new provider that requires auth but without credentials
         self.dag.update_providers_config(
             """
@@ -132,7 +147,7 @@ class TestCoreProvidersConfig(TestCase):
                         productType: '{productType}'
             """
         )
-        self.assertNotIn("bar_provider", self.dag.providers_config)
+        self.assertIn("bar_provider", self.dag.providers_config)
 
         # update provider with credentials
         self.dag.update_providers_config(

--- a/tests/integration/test_core_config.py
+++ b/tests/integration/test_core_config.py
@@ -119,6 +119,39 @@ class TestCoreProvidersConfig(TestCase):
             self.dag.providers_config["foo_provider"].auth.type, "GenericAuth"
         )
 
+        # add new provider that requires auth but without credentials
+        self.dag.update_providers_config(
+            """
+            bar_provider:
+                search:
+                    type: StacSearch
+                    api_endpoint: https://foo.bar/search
+                    need_auth: True
+                products:
+                    GENERIC_PRODUCT_TYPE:
+                        productType: '{productType}'
+            """
+        )
+        self.assertNotIn("bar_provider", self.dag.providers_config)
+
+        # update provider with credentials
+        self.dag.update_providers_config(
+            """
+            bar_provider:
+                auth:
+                    credentials:
+                        username: bar
+                        password: foo
+            """
+        )
+        self.assertIsInstance(
+            self.dag.providers_config["bar_provider"].auth, PluginConfig
+        )
+        self.assertEqual(
+            self.dag.providers_config["bar_provider"].auth.credentials["username"],
+            "bar",
+        )
+
 
 class TestCoreProductTypesConfig(TestCase):
     def setUp(self):

--- a/tests/integration/test_core_config.py
+++ b/tests/integration/test_core_config.py
@@ -120,6 +120,7 @@ class TestCoreProvidersConfig(TestCase):
         )
 
         # update pruned provider with credentials
+        self.assertNotIn("usgs", self.dag.providers_config)
         self.dag.update_providers_config(
             """
             usgs:


### PR DESCRIPTION
The pruned providers are saved in `EODataAccessGateway._pruned_providers_config` and restored when the configuration is updated.