### PR TITLE
feat: add static type information

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,7 @@ try:
 except ImportError:  # pragma: no cover
     # for python < 3.8
     from importlib_metadata import metadata  # type: ignore
+from typing import Dict
 
 # -- General configuration ------------------------------------------------
 
@@ -188,7 +189,7 @@ htmlhelp_basename = "eodagdoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
-latex_elements = {
+latex_elements: Dict[str, str] = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',

--- a/eodag/plugins/authentication/keycloak.py
+++ b/eodag/plugins/authentication/keycloak.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+from typing import Optional
 
 import requests
 
@@ -71,7 +72,7 @@ class KeycloakOIDCPasswordAuth(Authentication):
     TOKEN_URL_TEMPLATE = "{auth_base_uri}/realms/{realm}/protocol/openid-connect/token"
     REQUIRED_PARAMS = ["auth_base_uri", "client_id", "client_secret", "token_provision"]
     # already retrieved token store, to be used if authenticate() fails (OTP use-case)
-    retrieved_token = None
+    retrieved_token: Optional[str] = None
 
     def __init__(self, provider, config):
         super(KeycloakOIDCPasswordAuth, self).__init__(provider, config)

--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -162,7 +162,7 @@ def eodag_openapi():
     return app.openapi_schema
 
 
-app.openapi = eodag_openapi
+app.__setattr__("openapi", eodag_openapi)
 
 # Cross-Origin Resource Sharing
 allowed_origins = os.getenv("EODAG_CORS_ALLOWED_ORIGINS")
@@ -316,7 +316,7 @@ class SearchBody(BaseModel):
 
 @router.get("/search", tags=["STAC"])
 @router.post("/search", tags=["STAC"])
-def stac_search(request: Request, search_body: SearchBody = None):
+def stac_search(request: Request, search_body: Optional[SearchBody] = None):
     """STAC collections items"""
     logger.debug(f"URL: {request.url}")
     logger.debug(f"Body: {search_body}")

--- a/eodag/utils/notebook.py
+++ b/eodag/utils/notebook.py
@@ -17,6 +17,9 @@
 # limitations under the License.
 
 
+from typing import Any
+
+
 def check_ipython():
     """Check if called from ipython"""
     try:
@@ -44,9 +47,9 @@ class NotebookWidgets(object):
     """Display / handle ipython widgets"""
 
     is_notebook = False
-    html_box = None
+    html_box: Any = None
     html_box_shown = False
-    display = None
+    display: Any = None
 
     def __init__(self):
         self.is_notebook = check_notebook()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,30 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 fallback_version = "2.11.0b2.dev0"
+
+[[tool.mypy.overrides]]
+module = [
+    "boto3",
+    "botocore.*",
+    "cdsapi",
+    "click",
+    "click.*",
+    "ecmwfapi",
+    "ecmwfapi.*",
+    "eodag_cube.*",
+    "geojson",
+    "IPython.display",
+    "owslib.*",
+    "requests_ftp",
+    "shapefile",
+    "shapely",
+    "shapely.*",
+    "stream_zip",
+    "jsonpath_ng",
+    "jsonpath_ng.*",
+    "usgs",
+    "usgs.*",
+    "whoosh",
+    "whoosh.*"
+]
+ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -113,6 +113,7 @@ exclude =
 * =
     LICENSE
     NOTICE
+    py.typed
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
### Description
This PR addresses #387 and adds basic type information for eodag.

### Further comments
Usage of eodag has been tested in a `mypy`-enabled environment and does no longer result in a warning about missing type information.