### PR TITLE
fix: ewkt extraction for creodias and cop_dataspace

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3339,6 +3339,7 @@
   search: !plugin
     type: ODataV4Search
     api_endpoint: 'https://catalogue.dataspace.copernicus.eu/odata/v1/Products'
+    timeout: 60
     need_auth: false
     dont_quote:
       - '['

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1013,7 +1013,7 @@
       # The geographic extent of the product
       geometry:
         - null
-        - '{$.Footprint.`sub(/.*(SRID=[0-9]+;.*)/, \\1)`#from_ewkt}'
+        - '{$.Footprint.`sub(/.*(SRID=[0-9]+;[A-Z0-9 \(\),\.]+).*/, \\1)`#from_ewkt}'
       # The url to download the product "as is" (literal or as a template to be completed either after the search result
       # is obtained from the provider or during the eodag download phase)
       downloadLink: 'https://zipper.creodias.eu/odata/v1/Products({uid})/$value'
@@ -3454,7 +3454,7 @@
       # The geographic extent of the product
       geometry:
         - null
-        - '{$.Footprint.`sub(/.*(SRID=[0-9]+;.*)/, \\1)`#from_ewkt}'
+        - '{$.Footprint.`sub(/.*(SRID=[0-9]+;[A-Z0-9 \(\),\.]+).*/, \\1)`#from_ewkt}'
       # The url to download the product "as is" (literal or as a template to be completed either after the search result
       # is obtained from the provider or during the eodag download phase)
       downloadLink: 'https://catalogue.dataspace.copernicus.eu/odata/v1/Products({uid})/$value'


### PR DESCRIPTION
Fixes #845 

- EWKT geometries extraction for `creodias` and `cop_dataspace` (thanks @gasparakos)
- add greater search timeout (60s) on `cop_dataspace`