### PR TITLE
fix: remove module from logging and shorten loggers names

### DIFF
--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -44,7 +44,7 @@ except ImportError:
     from shapely.errors import TopologicalError as GEOSException
 
 
-logger = logging.getLogger("eodag.api.product")
+logger = logging.getLogger("eodag.product")
 
 
 class EOProduct:

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -46,7 +46,7 @@ from eodag.utils import (
     update_nested_dict,
 )
 
-logger = logging.getLogger("eodag.api.product.metadata_mapping")
+logger = logging.getLogger("eodag.product.metadata_mapping")
 
 SEP = r"#"
 INGEST_CONVERSION_REGEX = re.compile(

--- a/eodag/plugins/apis/base.py
+++ b/eodag/plugins/apis/base.py
@@ -20,7 +20,7 @@ import logging
 from eodag.plugins.base import PluginTopic
 from eodag.plugins.download.base import DEFAULT_DOWNLOAD_TIMEOUT, DEFAULT_DOWNLOAD_WAIT
 
-logger = logging.getLogger("eodag.plugins.apis.base")
+logger = logging.getLogger("eodag.apis.base")
 
 
 class Api(PluginTopic):

--- a/eodag/plugins/apis/cds.py
+++ b/eodag/plugins/apis/cds.py
@@ -35,7 +35,7 @@ from eodag.utils import datetime_range, get_geometry_from_various, path_to_uri, 
 from eodag.utils.exceptions import AuthenticationError, DownloadError, RequestError
 from eodag.utils.logging import get_logging_verbose
 
-logger = logging.getLogger("eodag.plugins.apis.cds")
+logger = logging.getLogger("eodag.apis.cds")
 
 CDS_KNOWN_FORMATS = {"grib": "grib", "netcdf": "nc"}
 

--- a/eodag/plugins/apis/ecmwf.py
+++ b/eodag/plugins/apis/ecmwf.py
@@ -35,7 +35,7 @@ from eodag.utils import get_geometry_from_various, path_to_uri, urlsplit
 from eodag.utils.exceptions import AuthenticationError, DownloadError
 from eodag.utils.logging import get_logging_verbose
 
-logger = logging.getLogger("eodag.plugins.apis.ecmwf")
+logger = logging.getLogger("eodag.apis.ecmwf")
 
 ECMWF_MARS_KNOWN_FORMATS = {"grib": "grib", "netcdf": "nc"}
 

--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -51,7 +51,7 @@ from eodag.utils.exceptions import (
     RequestError,
 )
 
-logger = logging.getLogger("eodag.plugins.apis.usgs")
+logger = logging.getLogger("eodag.apis.usgs")
 
 
 class UsgsApi(Download, Api):

--- a/eodag/plugins/authentication/keycloak.py
+++ b/eodag/plugins/authentication/keycloak.py
@@ -25,7 +25,7 @@ from eodag.plugins.authentication.openid_connect import CodeAuthorizedAuth
 from eodag.utils import HTTP_REQ_TIMEOUT, USER_AGENT
 from eodag.utils.exceptions import AuthenticationError, MisconfiguredError
 
-logger = logging.getLogger("eodag.plugins.auth.keycloak")
+logger = logging.getLogger("eodag.auth.keycloak")
 
 
 class KeycloakOIDCPasswordAuth(Authentication):

--- a/eodag/plugins/authentication/sas_auth.py
+++ b/eodag/plugins/authentication/sas_auth.py
@@ -25,7 +25,7 @@ from eodag.plugins.authentication.base import Authentication
 from eodag.utils import HTTP_REQ_TIMEOUT, USER_AGENT, deepcopy, format_dict_items
 from eodag.utils.exceptions import AuthenticationError
 
-logger = logging.getLogger("eodag.plugins.auth.sas_auth")
+logger = logging.getLogger("eodag.auth.sas_auth")
 
 
 class RequestsSASAuth(AuthBase):

--- a/eodag/plugins/crunch/filter_date.py
+++ b/eodag/plugins/crunch/filter_date.py
@@ -25,7 +25,7 @@ from dateutil import tz
 
 from eodag.plugins.crunch.base import Crunch
 
-logger = logging.getLogger("eodag.plugins.crunch.filter_date")
+logger = logging.getLogger("eodag.crunch.date")
 
 
 class FilterDate(Crunch):

--- a/eodag/plugins/crunch/filter_latest_intersect.py
+++ b/eodag/plugins/crunch/filter_latest_intersect.py
@@ -25,7 +25,7 @@ from shapely import geometry
 
 from eodag.plugins.crunch.base import Crunch
 
-logger = logging.getLogger("eodag.plugins.crunch.filter_latest_intersect")
+logger = logging.getLogger("eodag.crunch.latest_intersect")
 
 
 class FilterLatestIntersect(Crunch):

--- a/eodag/plugins/crunch/filter_latest_tpl_name.py
+++ b/eodag/plugins/crunch/filter_latest_tpl_name.py
@@ -22,7 +22,7 @@ import re
 from eodag.plugins.crunch.base import Crunch
 from eodag.utils.exceptions import ValidationError
 
-logger = logging.getLogger("eodag.plugins.crunch.filter_latest_tpl_name")
+logger = logging.getLogger("eodag.crunch.latest_tpl_name")
 
 
 class FilterLatestByName(Crunch):

--- a/eodag/plugins/crunch/filter_overlap.py
+++ b/eodag/plugins/crunch/filter_overlap.py
@@ -28,7 +28,7 @@ except ImportError:
     from shapely.errors import TopologicalError as GEOSException
 
 
-logger = logging.getLogger("eodag.plugins.crunch.filter_overlap")
+logger = logging.getLogger("eodag.crunch.overlap")
 
 
 class FilterOverlap(Crunch):

--- a/eodag/plugins/crunch/filter_property.py
+++ b/eodag/plugins/crunch/filter_property.py
@@ -21,7 +21,7 @@ import operator
 
 from eodag.plugins.crunch.base import Crunch
 
-logger = logging.getLogger("eodag.plugins.crunch.filter_property")
+logger = logging.getLogger("eodag.crunch.property")
 
 
 class FilterProperty(Crunch):

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -44,7 +44,7 @@ from eodag.utils import (
 )
 from eodag.utils.exceptions import AuthenticationError, DownloadError, NotAvailableError
 
-logger = logging.getLogger("eodag.plugins.download.aws")
+logger = logging.getLogger("eodag.download.aws")
 
 # AWS chunk path identify patterns
 

--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -35,7 +35,7 @@ from eodag.utils.exceptions import (
 )
 from eodag.utils.notebook import NotebookWidgets
 
-logger = logging.getLogger("eodag.plugins.download.base")
+logger = logging.getLogger("eodag.download.base")
 
 # default wait times in minutes
 DEFAULT_DOWNLOAD_WAIT = 2  # in minutes

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -61,7 +61,7 @@ from eodag.utils.exceptions import (
     NotAvailableError,
 )
 
-logger = logging.getLogger("eodag.plugins.download.http")
+logger = logging.getLogger("eodag.download.http")
 
 
 class HTTPDownload(Download):

--- a/eodag/plugins/download/s3rest.py
+++ b/eodag/plugins/download/s3rest.py
@@ -50,7 +50,7 @@ from eodag.utils.exceptions import (
     RequestError,
 )
 
-logger = logging.getLogger("eodag.plugins.download.s3rest")
+logger = logging.getLogger("eodag.download.s3rest")
 
 
 class S3RestDownload(Download):

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -32,7 +32,7 @@ from eodag.plugins.search.base import Search
 from eodag.utils import GENERIC_PRODUCT_TYPE
 from eodag.utils.exceptions import UnsupportedProvider
 
-logger = logging.getLogger("eodag.plugins.manager")
+logger = logging.getLogger("eodag.manager")
 
 
 class PluginManager:

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -25,7 +25,7 @@ from eodag.api.product.metadata_mapping import (
 from eodag.plugins.base import PluginTopic
 from eodag.utils import GENERIC_PRODUCT_TYPE, format_dict_items
 
-logger = logging.getLogger("eodag.plugins.search.base")
+logger = logging.getLogger("eodag.search.base")
 
 
 class Search(PluginTopic):

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -32,7 +32,7 @@ from eodag.api.product.metadata_mapping import (
 from eodag.plugins.search.qssearch import PostJsonSearch
 from eodag.utils import dict_items_recursive_sort
 
-logger = logging.getLogger("eodag.plugins.search.build_search_result")
+logger = logging.getLogger("eodag.search.build_search_result")
 
 
 class BuildPostSearchResult(PostJsonSearch):

--- a/eodag/plugins/search/csw.py
+++ b/eodag/plugins/search/csw.py
@@ -37,7 +37,7 @@ from eodag.plugins.search.base import Search
 from eodag.utils import DEFAULT_PROJ
 from eodag.utils.import_system import patch_owslib_requests
 
-logger = logging.getLogger("eodag.plugins.search.csw")
+logger = logging.getLogger("eodag.search.csw")
 
 SUPPORTED_REFERENCE_SCHEMES = ["WWW:DOWNLOAD-1.0-http--download"]
 

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -50,7 +50,7 @@ from eodag.utils import (
 )
 from eodag.utils.exceptions import AuthenticationError, MisconfiguredError, RequestError
 
-logger = logging.getLogger("eodag.plugins.search.qssearch")
+logger = logging.getLogger("eodag.search.qssearch")
 
 
 class QueryStringSearch(Search):

--- a/eodag/plugins/search/static_stac_search.py
+++ b/eodag/plugins/search/static_stac_search.py
@@ -28,7 +28,7 @@ from eodag.plugins.search.qssearch import StacSearch
 from eodag.utils import HTTP_REQ_TIMEOUT, MockResponse
 from eodag.utils.stac_reader import fetch_stac_items
 
-logger = logging.getLogger("eodag.plugins.search.static_stac_search")
+logger = logging.getLogger("eodag.search.static_stac_search")
 
 
 class StaticStacSearch(StacSearch):

--- a/eodag/utils/logging.py
+++ b/eodag/utils/logging.py
@@ -92,7 +92,7 @@ def setup_logging(verbose, no_progress_bar=False):
                 "formatters": {
                     "verbose": {
                         "format": (
-                            "%(asctime)-15s %(name)-32s [%(levelname)-8s] (%(module)-17s tid=%(thread)d) %(message)s"
+                            "%(asctime)-15s %(name)-32s [%(levelname)-8s] (tid=%(thread)d) %(message)s"
                         )
                     }
                 },

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -530,8 +530,8 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
                 plugin.orderDownloadStatus(self.product, auth=auth)
                 self.assertEqual(
                     [
-                        f"INFO:eodag.plugins.download.http:{self.product.properties['title']} order status: 50%",
-                        'WARNING:eodag.plugins.download.http:{"progress_percentage": 50, "that": "failed"}',
+                        f"INFO:eodag.download.http:{self.product.properties['title']} order status: 50%",
+                        'WARNING:eodag.download.http:{"progress_percentage": 50, "that": "failed"}',
                     ],
                     cm.output,
                 )

--- a/tests/units/test_eoproduct.py
+++ b/tests/units/test_eoproduct.py
@@ -505,7 +505,7 @@ class TestEOProduct(EODagTestCase):
     def test_eoproduct_register_downloader_resolve_ignored(self):
         """eoproduct.register_donwloader must ignore unresolvable locations and properties"""
 
-        logger = logging.getLogger("eodag.api.product")
+        logger = logging.getLogger("eodag.product")
         with mock.patch.object(logger, "debug") as mock_debug:
 
             downloadable_product = self._dummy_downloadable_product(

--- a/tests/units/test_safe_build.py
+++ b/tests/units/test_safe_build.py
@@ -32,7 +32,7 @@ class TestSafeBuild(unittest.TestCase):
         super(TestSafeBuild, self).setUp()
 
         self.awsd = AwsDownload("some_provider", {})
-        self.logger = logging.getLogger("eodag.plugins.download.aws")
+        self.logger = logging.getLogger("eodag.download.aws")
 
         self.tmp_download_dir = TemporaryDirectory()
         self.tmp_download_path = self.tmp_download_dir.name

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -471,7 +471,7 @@ class TestSearchPluginPostJsonSearch(BaseSearchPluginTest):
                 responses.POST, self.awseos_url, status=500, body=b"test error message"
             )
 
-            with self.assertLogs("eodag.plugins.search.qssearch", level="DEBUG") as cm:
+            with self.assertLogs("eodag.search.qssearch", level="DEBUG") as cm:
                 with self.assertRaises(RequestError):
                     products, estimate = self.awseos_search_plugin.query(
                         page=1,


### PR DESCRIPTION
Fixes #876

- removes duplicate `module` information from `logging` (also in logger name)
- shorten loggers names: remove `plugins`, `api`, `filter_`