### PR TITLE
feat: Python 3.12 update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, "3.11"]
+        python-version: [3.8, "3.12"]
         os: [ubuntu-latest, windows-latest]
     steps:
     - name: Checkout the repo
@@ -95,7 +95,7 @@ jobs:
       uses: 5monkeys/cobertura-action@master
       if: ${{ github.event_name == 'pull_request' }}
       with:
-        path: artifacts/unit-test-results-python3.11-ubuntu-latest/coverage.xml
+        path: artifacts/unit-test-results-python3.12-ubuntu-latest/coverage.xml
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         pull_request_number: ${{ github.pull_request.number }}
         minimum_coverage: 70
@@ -107,7 +107,7 @@ jobs:
       uses: 5monkeys/cobertura-action@master
       if: ${{ github.event_name == 'pull_request' }}
       with:
-        path: artifacts/unit-test-results-python3.11-windows-latest/coverage.xml
+        path: artifacts/unit-test-results-python3.12-windows-latest/coverage.xml
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         pull_request_number: ${{ github.pull_request.number }}
         minimum_coverage: 70

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     -   id: check-merge-conflict
 
 -   repo: 'https://github.com/PyCQA/flake8'
-    rev: 5.0.4 # needed for py < 3.8.1
+    rev: 6.1.0 # needed for py < 3.8.1
     hooks:
     -   id: flake8
         additional_dependencies:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -75,7 +75,7 @@ To run the entire tests (units, integration and end-to-end):
       you, please `install <https://pandoc.org/installing.html>`_ pandoc and try
       again.
 
-    * eodag is tested against python versions 3.8, 3.9, 3.10 and 3.11. Ensure you have
+    * eodag is tested against python versions 3.8, 3.9, 3.10, 3.11 and 3.12. Ensure you have
       these versions installed before you run tox. You can use
       `pyenv <https://github.com/pyenv/pyenv>`_ to manage many different versions
       of python

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Internet :: WWW/HTTP :: Indexing/Search
     Topic :: Scientific/Engineering :: GIS

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 [tox]
-envlist = py38, py39, py310, py311, docs, pypi, linters
+envlist = py38, py39, py310, py311, py312, docs, pypi, linters
 skipdist = true
 
 # Mapping required by tox-gh-actions, only used in CI
@@ -26,6 +26,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 commands =


### PR DESCRIPTION
Update python max version to 3.12

> `tox -e docs` fails cause the wheel for netCDF4 is not available for Python 3.12 yet.
> See https://github.com/Unidata/netcdf4-python/issues/1282

edit: can be merged now that netCDF4 is available for py312