### PR TITLE
fix: set creodias search timeout to 20s

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -880,6 +880,7 @@
     type: QueryStringSearch
     api_endpoint: 'http://datahub.creodias.eu/resto/api/collections/{collection}/search.json'
     need_auth: false
+    timeout: 20
     pagination:
       next_page_url_tpl: '{url}?{search}&maxRecords={items_per_page}&page={page}'
       total_items_nb_key_path: '$.properties.totalResults'


### PR DESCRIPTION
Set `creodias` search timeout to 20s. Needed for _search-by-id_ that can last for more than 10s on this provider