### PR TITLE
fix(server): properly display next page object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,7 @@ celerybeat-schedule
 .env
 
 # virtualenv
-.venv/
+.venv*/
 venv/
 ENV/
 

--- a/eodag/resources/stac.yml
+++ b/eodag/resources/stac.yml
@@ -153,7 +153,8 @@ items:
       href: '$.search_results.next'
       title: Next page
       type: application/geo+json
-      method: GET
+      method: '$.search_results.method'
+      body: '$.search_results.body'
   # time and date when the response was generated
   timeStamp: '$.search_results.timeStamp'
   # count request result

--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -704,7 +704,11 @@ def stac_search(
     provider = arguments.pop("provider", None)
 
     response = search_stac_items(
-        url=url, arguments=arguments, root=url_root, provider=provider
+        url=url,
+        arguments=arguments,
+        root=url_root,
+        provider=provider,
+        method=request.method,
     )
     resp = ORJSONResponse(
         content=response, status_code=200, media_type="application/json"

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import datetime
 import logging
 import os
-import re
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 from urllib.parse import parse_qs, urlencode, urlparse
@@ -346,22 +345,6 @@ class StacItem(StacCommon):
             for i, _ in enumerate(items_model["links"]):
                 if items_model["links"][i]["rel"] == "self":
                     items_model["links"][i]["href"] = catalog["url"]
-            if "page=" not in self.url:
-                search_results.next = "%s&page=%s" % (
-                    self.url,
-                    search_results.properties["page"] + 1,
-                )
-            else:
-                search_results.next = re.sub(
-                    r"^(.*)(page=[0-9]+)(.*)$",
-                    r"\1page=%s\3" % (search_results.properties["page"] + 1),
-                    self.url,
-                )
-        else:
-            search_results.next = "%s?page=%s" % (
-                self.url,
-                search_results.properties["page"] + 1,
-            )
 
         search_results.timeStamp = (
             datetime.datetime.now(datetime.timezone.utc)

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -37,6 +37,7 @@ from typing import (
     Tuple,
     Union,
 )
+from urllib.parse import urlencode
 
 import dateutil.parser
 from dateutil import tz
@@ -818,6 +819,7 @@ def search_stac_items(
     root: str = "/",
     catalogs: List[str] = [],
     provider: Optional[str] = None,
+    method: Optional[str] = "GET",
 ) -> Dict[str, Any]:
     """Get items collection dict for given catalogs list
 
@@ -831,12 +833,20 @@ def search_stac_items(
     :type catalogs: list
     :param provider: (optional) Chosen provider
     :type provider: str
+    :param method: (optional) search request HTTP method ('GET' or 'POST')
+    :type method: str
     :returns: Catalog dictionnary
     :rtype: dict
     """
     collections = arguments.get("collections", None)
 
     catalog_url = url.replace("/items", "")
+
+    query_args = {
+        key: value for key, value in arguments.copy().items() if value is not None
+    }
+    next_page_id = int(query_args["page"]) + 1 if "page" in query_args else 2
+    query_args["page"] = next_page_id
 
     # use catalogs from path or if it is empty, collections from args
     if catalogs:
@@ -860,7 +870,8 @@ def search_stac_items(
             root=root,
             provider=provider,
             eodag_api=eodag_api,
-            # handle only one collection per request (STAC allows multiple)
+            # handle only one collection
+            # per request (STAC allows multiple)
             catalogs=collections[0:1],
             url=catalog_url.replace("/search", f"/collections/{collections[0]}"),
         )
@@ -956,12 +967,22 @@ def search_stac_items(
                         **{"url": result_catalog.url, "root": result_catalog.root},
                     ),
                 )
+
         search_results = search_products(
             product_type=result_catalog.search_args["product_type"],
             arguments=search_products_arguments,
         )
 
-    return StacItem(
+    search_results.method = method
+    if method == "POST":
+        search_results.next = f"{url}"
+        search_results.body = query_args
+
+    elif method == "GET":
+        next_query_string = urlencode(query_args)
+        search_results.next = f"{url}?{next_query_string}"
+
+    items = StacItem(
         url=url,
         stac_config=stac_config,
         provider=provider,
@@ -974,6 +995,8 @@ def search_stac_items(
             **{"url": result_catalog.url, "root": result_catalog.root},
         ),
     )
+
+    return items
 
 
 def get_stac_extension_oseo(url: str) -> Dict[str, str]:

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -842,11 +842,13 @@ def search_stac_items(
 
     catalog_url = url.replace("/items", "")
 
-    query_args = {
+    next_page_kwargs = {
         key: value for key, value in arguments.copy().items() if value is not None
     }
-    next_page_id = int(query_args["page"]) + 1 if "page" in query_args else 2
-    query_args["page"] = next_page_id
+    next_page_id = (
+        int(next_page_kwargs["page"]) + 1 if "page" in next_page_kwargs else 2
+    )
+    next_page_kwargs["page"] = next_page_id
 
     # use catalogs from path or if it is empty, collections from args
     if catalogs:
@@ -976,10 +978,10 @@ def search_stac_items(
     search_results.method = method
     if method == "POST":
         search_results.next = f"{url}"
-        search_results.body = query_args
+        search_results.body = next_page_kwargs
 
     elif method == "GET":
-        next_query_string = urlencode(query_args)
+        next_query_string = urlencode(next_page_kwargs)
         search_results.next = f"{url}?{next_query_string}"
 
     items = StacItem(

--- a/tests/units/test_stac_utils.py
+++ b/tests/units/test_stac_utils.py
@@ -486,3 +486,69 @@ class TestStacUtils(unittest.TestCase):
         )
         # check that no other asset have also been added to the response
         self.assertEqual(len(response["features"][0]["assets"]), 2)
+
+    @mock.patch(
+        "eodag.plugins.search.qssearch.QueryStringSearch._request",
+        autospec=True,
+    )
+    def test_search_stac_items_get(self, mock__request):
+        """search_stac_items runs with GET method"""
+        # mock the QueryStringSearch request with the S2_MSI_L1C peps response search dictionary
+        mock__request.return_value = mock.Mock()
+        mock__request.return_value.json.return_value = self.peps_resp_search_json
+
+        response = self.rest_utils.search_stac_items(
+            url="http://foo/search",
+            arguments={"collections": "S2_MSI_L1C"},
+            root="http://foo/",
+            method="GET",
+        )
+
+        mock__request.assert_called()
+
+        next_link = [link for link in response["links"] if link["rel"] == "next"][0]
+
+        self.assertEqual(
+            next_link,
+            {
+                "method": "GET",
+                "body": None,
+                "rel": "next",
+                "href": "http://foo/search?collections=S2_MSI_L1C&page=2",
+                "title": "Next page",
+                "type": "application/geo+json",
+            },
+        )
+
+    @mock.patch(
+        "eodag.plugins.search.qssearch.QueryStringSearch._request",
+        autospec=True,
+    )
+    def test_search_stac_items_post(self, mock__request):
+        """search_stac_items runs with GET method"""
+        # mock the QueryStringSearch request with the S2_MSI_L1C peps response search dictionary
+        mock__request.return_value = mock.Mock()
+        mock__request.return_value.json.return_value = self.peps_resp_search_json
+
+        response = self.rest_utils.search_stac_items(
+            url="http://foo/search",
+            arguments={"collections": ["S2_MSI_L1C"]},
+            root="http://foo/",
+            method="POST",
+        )
+
+        mock__request.assert_called()
+
+        next_link = [link for link in response["links"] if link["rel"] == "next"][0]
+
+        self.assertEqual(
+            next_link,
+            {
+                "method": "POST",
+                "rel": "next",
+                "href": "http://foo/search",
+                "title": "Next page",
+                "type": "application/geo+json",
+                "body": {"collections": ["S2_MSI_L1C"], "page": 2},
+            },
+        )

--- a/tests/units/test_stac_utils.py
+++ b/tests/units/test_stac_utils.py
@@ -532,7 +532,7 @@ class TestStacUtils(unittest.TestCase):
 
         response = self.rest_utils.search_stac_items(
             url="http://foo/search",
-            arguments={"collections": ["S2_MSI_L1C"]},
+            arguments={"collections": ["S2_MSI_L1C"], "page": 2},
             root="http://foo/",
             method="POST",
         )
@@ -549,6 +549,6 @@ class TestStacUtils(unittest.TestCase):
                 "href": "http://foo/search",
                 "title": "Next page",
                 "type": "application/geo+json",
-                "body": {"collections": ["S2_MSI_L1C"], "page": 2},
+                "body": {"collections": ["S2_MSI_L1C"], "page": 3},
             },
         )


### PR DESCRIPTION
### Description
This PR fixes the `next` link display in `search` requests (both `GET` and `POST`).
It provides a URL to the next page and the json body in the case of a `POST` request.
