### PR TITLE
feat: server mode collections search

### DIFF
--- a/docs/notebooks/api_user_guide/4_search.ipynb
+++ b/docs/notebooks/api_user_guide/4_search.ipynb
@@ -2228,7 +2228,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the previous request we made use of the whoosh query language which can be used to do complex text search. It supports the boolean operators AND, OR and NOT to combine the search terms. If a space is given between two words as in the example above, this corresponds to the operator AND. Brackets '()' can also be used. The example above also shows the use of the wildcard operator '*' which can represent any numer of characters. The wildcard operator '?' always represents only one character. It is also possible to match a range of terms by using square brackets '[]' and TO, e.g. [A TO D] will match all words in the lexical range between A and D. Below you can find some examples for the different operators."
+    "In the previous request we made use of the [whoosh query language](https://whoosh.readthedocs.io/en/latest/querylang.html#the-default-query-language) which can be used to do complex text search. It supports the boolean operators `AND`, `OR` and `NOT` to combine the search terms. If a space is given between two words as in the example above, this corresponds to the operator AND. Brackets `()` can also be used. The example above also shows the use of the wildcard operator `*` which can represent any numer of characters. The wildcard operator `?` always represents only one character. It is also possible to match a range of terms by using square brackets `[]` and TO, e.g. `[A TO D]` will match all words in the lexical range between A and D. Below you can find some examples for the different operators."
    ]
   },
   {
@@ -2274,9 +2274,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "returns all product types where the platform is either LANDSAT or SENTINEL1:\n",
-    "\n",
-    "['L57_REFLECTANCE', 'LANDSAT_C2L1', 'LANDSAT_C2L2', 'LANDSAT_C2L2ALB_BT', 'LANDSAT_C2L2ALB_SR', 'LANDSAT_C2L2ALB_ST', 'LANDSAT_C2L2ALB_TA', 'LANDSAT_C2L2_SR', 'LANDSAT_C2L2_ST', 'LANDSAT_ETM_C1', 'LANDSAT_ETM_C2L1', 'LANDSAT_ETM_C2L2', 'LANDSAT_TM_C1', 'LANDSAT_TM_C2L1', 'LANDSAT_TM_C2L2', 'S1_SAR_GRD', 'S1_SAR_OCN', 'S1_SAR_RAW', 'S1_SAR_SLC']"
+    "returns all product types where the platform is either LANDSAT or SENTINEL1."
    ]
   },
   {
@@ -2319,9 +2317,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "returns all product types which contain either the keywords LANDSAT and collection2 or the keyword SAR:\n",
-    "\n",
-    "['LANDSAT_C2L1', 'LANDSAT_C2L2', 'LANDSAT_C2L2ALB_BT', 'LANDSAT_C2L2ALB_SR', 'LANDSAT_C2L2ALB_ST', 'LANDSAT_C2L2ALB_TA', 'LANDSAT_C2L2_SR', 'LANDSAT_C2L2_ST', 'LANDSAT_ETM_C2L1', 'LANDSAT_ETM_C2L2', 'LANDSAT_TM_C2L1', 'LANDSAT_TM_C2L2', 'S1_SAR_GRD', 'S1_SAR_OCN', 'S1_SAR_RAW', 'S1_SAR_SLC']"
+    "returns all product types which contain either the keywords LANDSAT and collection2 or the keyword SAR."
    ]
   },
   {
@@ -2366,9 +2362,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "returns all product types where the platformSerialIdentifier is composed of 'L' and one other character:\n",
-    "\n",
-    "['L57_REFLECTANCE', 'L8_OLI_TIRS_C1L1', 'L8_REFLECTANCE', 'LANDSAT_C2L1', 'LANDSAT_C2L2', 'LANDSAT_C2L2ALB_BT', 'LANDSAT_C2L2ALB_SR', 'LANDSAT_C2L2ALB_ST', 'LANDSAT_C2L2ALB_TA', 'LANDSAT_C2L2_SR', 'LANDSAT_C2L2_ST', 'LANDSAT_ETM_C1', 'LANDSAT_ETM_C2L1', 'LANDSAT_ETM_C2L2', 'LANDSAT_TM_C1', 'LANDSAT_TM_C2L1', 'LANDSAT_TM_C2L2']"
+    "returns all product types where the platformSerialIdentifier is composed of 'L' and one other character."
    ]
   },
   {
@@ -2439,9 +2433,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "returns all product types where the platform is SENTINEL1, SENTINEL2 or SENTINEL3:\n",
-    "\n",
-    "['S1_SAR_GRD', 'S1_SAR_OCN', 'S1_SAR_RAW', 'S1_SAR_SLC', 'S2_MSI_L1C', 'S2_MSI_L2A', 'S2_MSI_L2A_COG', 'S2_MSI_L2A_MAJA', 'S2_MSI_L2B_MAJA_SNOW', 'S2_MSI_L2B_MAJA_WATER', 'S2_MSI_L3A_WASP', 'S3_EFR', 'S3_ERR', 'S3_LAN', 'S3_OLCI_L2LFR', 'S3_OLCI_L2LRR', 'S3_OLCI_L2WFR', 'S3_OLCI_L2WRR', 'S3_RAC', 'S3_SLSTR_L1RBT', 'S3_SLSTR_L2AOD', 'S3_SLSTR_L2FRP', 'S3_SLSTR_L2LST', 'S3_SLSTR_L2WST', 'S3_SRA', 'S3_SRA_A', 'S3_SRA_BS', 'S3_SY_AOD', 'S3_SY_SYN', 'S3_SY_V10', 'S3_SY_VG1', 'S3_SY_VGP', 'S3_WAT']"
+    "returns all product types where the platform is SENTINEL1, SENTINEL2 or SENTINEL3."
    ]
   },
   {
@@ -2454,7 +2446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -2477,7 +2469,7 @@
        " 'LANDSAT_TM_C2L2']"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2491,29 +2483,68 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "['LANDSAT_C2L1', \n",
-    "'L57_REFLECTANCE', \n",
-    "'LANDSAT_C2L2', \n",
-    "'LANDSAT_C2L2ALB_BT', \n",
-    "'LANDSAT_C2L2ALB_SR', \n",
-    "'LANDSAT_C2L2ALB_ST', \n",
-    "'LANDSAT_C2L2ALB_TA', \n",
-    "'LANDSAT_C2L2_SR', \n",
-    "'LANDSAT_C2L2_ST', \n",
-    "'LANDSAT_ETM_C1', \n",
-    "'LANDSAT_ETM_C2L1', \n",
-    "'LANDSAT_ETM_C2L2', \n",
-    "'LANDSAT_TM_C1', \n",
-    "'LANDSAT_TM_C2L1', \n",
-    "'LANDSAT_TM_C2L2']"
+    "The product types in the result are ordered by how well they match the criteria. In the example above only the first product type (LANDSAT_C2L1) matches the second parameter (platformSerialIdentifier=\"L1\"), all other product types only match the first criterion. Therefore, it is usually best to use the first product type in the list as it will be the one that fits best."
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The product types in the result are ordered by how well they match the criteria. In the example above only the first product type (LANDSAT_C2L1) matches the second parameter (platformSerialIdentifier=\"L1\"), all other product types only match the first criterion. Therefore, it is usually best to use the first product type in the list as it will be the one that fits best."
+    "Per paramater guesses are joined using a `UNION` by default (`intersect=False`). This can also be changed to an intersection:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['LANDSAT_C2L1']"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dag.guess_product_type(platform=\"LANDSAT\", platformSerialIdentifier=\"L1\", intersect=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Whoosh query language](https://whoosh.readthedocs.io/en/latest/querylang.html#the-default-query-language) *free text search* can also be passed to the method, it will be used to search in `title`, `abstract` and `keywords` fields:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['ERA5_SL_MONTHLY',\n",
+       " 'ERA5_PL_MONTHLY',\n",
+       " 'ERA5_LAND_MONTHLY',\n",
+       " 'ERA5_SL',\n",
+       " 'ERA5_PL',\n",
+       " 'GLOFAS_SEASONAL_REFORECAST',\n",
+       " 'SEASONAL_MONTHLY_PL',\n",
+       " 'SEASONAL_MONTHLY_SL']"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dag.guess_product_type(\"ECMWF AND MONTHLY\")"
    ]
   },
   {

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -607,11 +607,10 @@ class EODataAccessGateway:
                     query = QueryParser(
                         search_key, self._product_types_index.schema
                     ).parse(term)
-                    partial_result = searcher.search(query, limit=None)
                     if results is None:
-                        results = partial_result
+                        results = searcher.search(query, limit=None)
                     else:
-                        results.upgrade_and_extend(partial_result)
+                        results.upgrade_and_extend(searcher.search(query, limit=None))
             if results is None:
                 # no result found -> intersection is empty set
                 return []

--- a/eodag/resources/stac.yml
+++ b/eodag/resources/stac.yml
@@ -62,6 +62,7 @@ conformance:
     - https://api.stacspec.org/v1.0.0/ogcapi-features#query
     - https://api.stacspec.org/v1.0.0/ogcapi-features#sort
     - https://api.stacspec.org/v1.0.0/collections
+    - https://api.stacspec.org/v1.0.0/collection-search#free-text
     - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core
     - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30
     - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson

--- a/eodag/resources/stac_api.yml
+++ b/eodag/resources/stac_api.yml
@@ -174,9 +174,12 @@ paths:
       operationId: getCollections
       parameters:
         - $ref: '#/components/parameters/provider'
+        - $ref: '#/components/parameters/q'
       responses:
         '200':
           $ref: '#/components/responses/Collections'
+        '202':
+          $ref: '#/components/responses/Accepted'
         '500':
           $ref: '#/components/responses/ServerError'
   /collections/{collectionId}:
@@ -1913,6 +1916,12 @@ components:
         text/html:
           schema:
             type: string
+    Accepted:
+      description: The request has been accepted, but the data is not yet ready. Please wait a few minutes before trying again.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/exception'
     Collections:
       description: >-
         The feature collections shared by this API.

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -637,22 +637,37 @@ class StacCollection(StacCommon):
         """
         if filters is None:
             filters = {}
+        free_text_filter = filters.pop("q", None)
+
+        # product types matching filters
         try:
-            guessed_product_types = self.eodag_api.guess_product_type(**filters)
+            guessed_product_types = (
+                self.eodag_api.guess_product_type(**filters) if filters else []
+            )
         except NoMatchingProductType:
             guessed_product_types = []
+
+        # product types matching free text filter
+        if free_text_filter and not guessed_product_types:
+            whooshable_filter = " OR ".join(
+                [f"({x})" for x in free_text_filter.split(",")]
+            )
+            try:
+                guessed_product_types = self.eodag_api.guess_product_type(
+                    whooshable_filter
+                )
+            except NoMatchingProductType:
+                guessed_product_types = []
+
+        # list product types with all metadata using guessed ids
         if guessed_product_types:
             product_types = [
                 pt
-                for pt in self.eodag_api.list_product_types(
-                    provider=self.provider, filter=filters.get("q", None)
-                )
+                for pt in self.eodag_api.list_product_types(provider=self.provider)
                 if pt["ID"] in guessed_product_types
             ]
         else:
-            product_types = self.eodag_api.list_product_types(
-                provider=self.provider, filter=filters.get("q", None)
-            )
+            product_types = self.eodag_api.list_product_types(provider=self.provider)
         return product_types
 
     def __get_collection_list(

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -644,49 +644,16 @@ class StacCollection(StacCommon):
         if guessed_product_types:
             product_types = [
                 pt
-                for pt in self.eodag_api.list_product_types(provider=self.provider)
+                for pt in self.eodag_api.list_product_types(
+                    provider=self.provider, filter=filters.get("q", None)
+                )
                 if pt["ID"] in guessed_product_types
             ]
         else:
-            product_types = self.eodag_api.list_product_types(provider=self.provider)
+            product_types = self.eodag_api.list_product_types(
+                provider=self.provider, filter=filters.get("q", None)
+            )
         return product_types
-
-    def __filter_collection_free_text_search(
-        self,
-        search_terms: List[str],
-        collection: Dict[str, Any],
-        keys: List[str] = ["title", "description", "keywords"],
-    ):
-        """Implements STAC Collection free-text search
-
-        :param search_terms: Terms to search in the collection
-        :type search_terms: list
-        :param collection: Collection to be filtered
-        :type collection: dict
-        :param keys List of keys of the collection to which the filter is applied
-        :type keys: list
-        :returns: True if the collection matches the filter criteria, False otherwise
-        :rtype: bool
-        """
-
-        def check_recursively(term: str, obj: Any) -> bool:
-            ret = False
-            if type(obj) is str:
-                if term in obj.lower():
-                    ret = True
-            elif type(obj) is list:
-                for i in obj:  # type: ignore
-                    ret = check_recursively(term, i)
-                    if ret:
-                        break
-            return ret
-
-        search_terms = [t.strip().lower() for t in search_terms]
-        for term in search_terms:
-            for key in keys:
-                if check_recursively(term, collection[key]):
-                    return True
-        return False
 
     def __get_collection_list(
         self, filters: Optional[Dict[str, Any]] = None
@@ -745,15 +712,6 @@ class StacCollection(StacCommon):
             )
 
             collection_list.append(product_type_collection)
-
-        if "q" in filters:
-            # STAC Collection free-text search
-            search_terms = filters["q"].split(",")
-            new_collection_list = []
-            for collection in collection_list:
-                if self.__filter_collection_free_text_search(search_terms, collection):
-                    new_collection_list.append(collection)
-            collection_list = new_collection_list
 
         return collection_list
 

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -677,6 +677,8 @@ class StacCollection(StacCommon):
             elif type(obj) is list:
                 for i in obj:  # type: ignore
                     ret = check_recursively(term, i)
+                    if ret:
+                        break
             return ret
 
         search_terms = [t.strip().lower() for t in search_terms]

--- a/tests/resources/ext_product_types_free_text_search.json
+++ b/tests/resources/ext_product_types_free_text_search.json
@@ -1,0 +1,59 @@
+{
+  "astraea_eod": {
+    "providers_config": {
+      "foo": {
+        "productType": "foo",
+        "metadata_mapping": {
+          "cloudCover": "$.null"
+        }
+      },
+      "bar": {
+        "productType": "bar",
+        "metadata_mapping": {
+          "cloudCover": "$.null"
+        }
+      },
+      "foobar": {
+        "productType": "foobar",
+        "metadata_mapping": {
+          "cloudCover": "$.null"
+        }
+      }
+    },
+    "product_types_config": {
+      "foo": {
+        "abstract": "abstractFOO - This is FOO. FooAndBar",
+        "instrument": "Not Available",
+        "platform": "Not Available",
+        "platformSerialIdentifier": "Not Available",
+        "processingLevel": "Not Available",
+        "keywords": "suspendisse",
+        "license": "WTFPL",
+        "title": "titleFOO - Lorem FOO collection",
+        "missionStartDate": "2012-12-12T00:00:00.000Z"
+      },
+      "bar": {
+        "abstract": "abstractBAR - This is BAR",
+        "instrument": "Not Available",
+        "platform": "Not Available",
+        "platformSerialIdentifier": "Not Available",
+        "processingLevel": "Not Available",
+        "keywords": "lectus,lectus_bar_key",
+        "license": "WTFPL",
+        "title": "titleBAR - Lorem BAR collection (FooAndBar)",
+        "missionStartDate": "2012-12-12T00:00:00.000Z"
+      },
+      "foobar": {
+        "abstract": "abstract FOOBAR - This is FOOBAR",
+        "instrument": "Not Available",
+        "platform": "Not Available",
+        "platformSerialIdentifier": "Not Available",
+        "processingLevel": "Not Available",
+        "keywords": "tortor",
+        "license": "WTFPL",
+        "title": "titleFOOBAR - Lorem FOOBAR collection",
+        "missionStartDate": "2012-12-12T00:00:00.000Z"
+      }
+    }
+  }
+}

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -517,6 +517,69 @@ class TestCore(TestCoreBase):
         self.dag.list_product_types(provider="peps", fetch_providers=True)
         mock_fetch_product_types_list.assert_called_once_with(self.dag, provider="peps")
 
+    def test_list_product_types_with_free_text_filter_ok(self):
+        """Core api must correctly return the list of supported product types"""
+
+        product_types = self.dag.list_product_types(
+            fetch_providers=False, filter="ABSTRACTFOO"
+        )
+        self.assertIsInstance(product_types, list)
+        for product_type in product_types:
+            self.assertListProductTypesRightStructure(product_type)
+        # There should be no repeated product type in the output
+        self.assertEqual(len(product_types), len(set(pt["ID"] for pt in product_types)))
+
+    def test_list_product_types_with_free_text_filter(self):
+        """Testing the search terms"""
+
+        with open(
+            os.path.join(TEST_RESOURCES_PATH, "ext_product_types_free_text_search.json")
+        ) as f:
+            ext_product_types_conf = json.load(f)
+        self.dag.update_product_types_list(ext_product_types_conf)
+
+        # match in the abstract
+        product_types = self.dag.list_product_types(
+            fetch_providers=False, filter="ABSTRACTFOO"
+        )
+        product_types_ids = [r["ID"] for r in product_types or []]
+        self.assertListEqual(product_types_ids, ["foo"])
+
+        # passing the provider
+        product_types = self.dag.list_product_types(
+            provider="astraea_eod", fetch_providers=False, filter="ABSTRACTFOO"
+        )
+        product_types_ids = [r["ID"] for r in product_types or []]
+        self.assertListEqual(product_types_ids, ["foo"])
+
+        # match in the abstract
+        product_types = self.dag.list_product_types(
+            fetch_providers=False, filter=" FOO  THIS  IS "
+        )
+        product_types_ids = [r["ID"] for r in product_types or []]
+        self.assertListEqual(product_types_ids, ["foo"])
+
+        # match in the keywords
+        product_types = self.dag.list_product_types(
+            fetch_providers=False, filter="LECTUS_BAR_KEY"
+        )
+        product_types_ids = [r["ID"] for r in product_types or []]
+        self.assertListEqual(product_types_ids, ["bar"])
+
+        # match in the title
+        product_types = self.dag.list_product_types(
+            fetch_providers=False, filter="COLLECTION FOOBAR"
+        )
+        product_types_ids = [r["ID"] for r in product_types or []]
+        self.assertListEqual(product_types_ids, ["foobar"])
+
+        # multiple terms
+        product_types = self.dag.list_product_types(
+            fetch_providers=False, filter="FOOANDBAR,FOOBAR"
+        )
+        product_types_ids = [r["ID"] for r in product_types or []]
+        self.assertListEqual(product_types_ids, ["bar", "foo", "foobar"])
+
     def test_update_product_types_list(self):
         """Core api.update_product_types_list must update eodag product types list"""
         with open(os.path.join(TEST_RESOURCES_PATH, "ext_product_types.json")) as f:

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -964,7 +964,6 @@ class RequestTestCase(unittest.TestCase):
         """A simple request for product types with(out) a provider must succeed"""
         for url in ("/collections",):
             r = self.app.get(url)
-            self.assertTrue(guess_pt.called)
             self.assertTrue(list_pt.called)
             self.assertEqual(200, r.status_code)
             self.assertListEqual(
@@ -1379,10 +1378,12 @@ class RequestTestCase(unittest.TestCase):
         )
 
     @mock.patch("eodag.rest.core.eodag_api.list_product_types", autospec=True)
-    def test_collection_free_text_search(self, list_pt: Mock):
+    @mock.patch("eodag.rest.core.eodag_api.guess_product_type", autospec=True)
+    def test_collection_free_text_search(self, guess_pt: Mock, list_pt: Mock):
         """Test STAC Collection free-text search"""
 
         url = "/collections?q=TERM1,TERM2"
         r = self.app.get(url)
-        list_pt.assert_called_once_with(provider=None, filter="TERM1,TERM2")
+        list_pt.assert_called_once_with(provider=None)
+        guess_pt.assert_called_once_with("(TERM1) OR (TERM2)")
         self.assertEqual(200, r.status_code)

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -1378,7 +1378,7 @@ class RequestTestCase(unittest.TestCase):
             },
         )
 
-    @mock.patch("eodag.rest.utils.eodag_api.list_product_types", autospec=True)
+    @mock.patch("eodag.rest.core.eodag_api.list_product_types", autospec=True)
     def test_collection_free_text_search(self, list_pt: Mock):
         """Test STAC Collection free-text search"""
 

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -1377,3 +1377,105 @@ class RequestTestCase(unittest.TestCase):
                 }
             },
         )
+
+    @mock.patch(
+        "eodag.rest.utils.eodag_api.guess_product_type", autospec=True, return_value=[]
+    )
+    @mock.patch(
+        "eodag.rest.utils.eodag_api.list_product_types",
+        autospec=True,
+        return_value=[
+            {
+                "ID": "S2_MSI_L1C",
+                "abstract": "The Level-1C product is composed of 100x100 km2 tiles "
+                "(ortho-images in UTM/WGS84 projection). [...]",
+                "instrument": "MSI",
+                "platform": "SENTINEL2",
+                "platformSerialIdentifier": ["S2A", "S2B"],
+                "processingLevel": "L1",
+                "sensorType": "OPTICAL",
+                "title": "SENTINEL2 Level - 1C",
+            },
+            {
+                "ID": "S2_MSI_L2A",
+                "abstract": "The Level-2A product provides Bottom Of Atmosphere (BOA) "
+                "reflectance images derived from the associated Level-1C "
+                "products. [...]",
+                "instrument": "MSI",
+                "platform": "SENTINEL2",
+                "platformSerialIdentifier": ["S2A", "S2B"],
+                "processingLevel": "L2",
+                "sensorType": "OPTICAL",
+                "title": "SENTINEL2 Level-2A",
+            },
+            {
+                "ID": "L57_REFLECTANCE",
+                "abstract": "Landsat 5,7,8 L2A data (old format) distributed by Theia "
+                "(2014 to 2017-03-20) using MUSCATE prototype, Lamber 93 "
+                "projection.",
+                "instrument": ["OLI", "TIRS"],
+                "platform": "LANDSAT",
+                "platformSerialIdentifier": ["L5", "L7", "L8"],
+                "processingLevel": "L2A",
+                "sensorType": "OPTICAL",
+                "title": "Landsat 5,7,8 Level-2A",
+            },
+        ],
+    )
+    def test_collection_free_text_search(self, list_pt: Mock, guess_pt: Mock):
+        """Test STAC Collection free-text search"""
+
+        url = "/collections?q=NOT FOUND"
+        r = self.app.get(url)
+        self.assertTrue(guess_pt.called)
+        self.assertTrue(list_pt.called)
+        self.assertEqual(200, r.status_code)
+        self.assertFalse(
+            [
+                it["title"]
+                for it in json.loads(r.content.decode("utf-8")).get("links", [])
+                if it["rel"] == "child"
+            ],
+        )
+
+        url = "/collections?q= LEVEL - 1C  "
+        r = self.app.get(url)
+        self.assertTrue(guess_pt.called)
+        self.assertTrue(list_pt.called)
+        self.assertEqual(200, r.status_code)
+        self.assertListEqual(
+            ["S2_MSI_L1C"],
+            [
+                it["title"]
+                for it in json.loads(r.content.decode("utf-8")).get("links", [])
+                if it["rel"] == "child"
+            ],
+        )
+
+        url = "/collections?q=projection,atmosphere"
+        r = self.app.get(url)
+        self.assertTrue(guess_pt.called)
+        self.assertTrue(list_pt.called)
+        self.assertEqual(200, r.status_code)
+        self.assertListEqual(
+            ["S2_MSI_L1C", "S2_MSI_L2A", "L57_REFLECTANCE"],
+            [
+                it["title"]
+                for it in json.loads(r.content.decode("utf-8")).get("links", [])
+                if it["rel"] == "child"
+            ],
+        )
+
+        url = "/collections?q=l7"
+        r = self.app.get(url)
+        self.assertTrue(guess_pt.called)
+        self.assertTrue(list_pt.called)
+        self.assertEqual(200, r.status_code)
+        self.assertListEqual(
+            ["L57_REFLECTANCE"],
+            [
+                it["title"]
+                for it in json.loads(r.content.decode("utf-8")).get("links", [])
+                if it["rel"] == "child"
+            ],
+        )


### PR DESCRIPTION
Implements server-mode free text search of collections https://github.com/stac-api-extensions/collection-search#free-text-search.

Uses updated [guess_product_type](https://eodag.readthedocs.io/en/latest/api_reference/core.html#eodag.api.core.EODataAccessGateway.guess_product_type) method that now accepts `free_text_filter` and `intersect` parameters.
See updated examples on [how to guess a product type](https://eodag.readthedocs.io/en/latest/notebooks/api_user_guide/4_search.html#Guess-a-product-type).
