### PR TITLE
feat: list provider-specific queryables

### DIFF
--- a/docs/api_reference/core.rst
+++ b/docs/api_reference/core.rst
@@ -80,7 +80,7 @@ Misc
 
    EODataAccessGateway.group_by_extent
    EODataAccessGateway.guess_product_type
-   EODataAccessGateway.get_queryables
+   EODataAccessGateway.list_queryables
 
 .. autoclass:: eodag.api.core.EODataAccessGateway
    :members: set_preferred_provider, get_preferred_provider, update_providers_config, list_product_types,

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -22,10 +22,11 @@ import os
 import re
 import shutil
 from operator import itemgetter
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import geojson
 import pkg_resources
+import requests
 import yaml.parser
 from pkg_resources import resource_filename
 from whoosh import analysis, fields
@@ -34,6 +35,12 @@ from whoosh.index import create_in, exists_in, open_dir
 from whoosh.qparser import QueryParser
 
 from eodag.api.product.metadata_mapping import mtd_cfg_as_conversion_and_querypath
+from eodag.api.queryables import (
+    QueryableProperty,
+    Queryables,
+    format_provider_queryables,
+    format_queryable,
+)
 from eodag.api.search_result import SearchResult
 from eodag.config import (
     SimpleYamlProxyConfig,
@@ -56,6 +63,7 @@ from eodag.utils import (
     DEFAULT_PAGE,
     GENERIC_PRODUCT_TYPE,
     HTTP_REQ_TIMEOUT,
+    USER_AGENT,
     MockResponse,
     _deprecated,
     deepcopy,
@@ -2075,7 +2083,7 @@ class EODataAccessGateway:
 
     def get_queryables(
         self, provider: Optional[str] = None, product_type: Optional[str] = None
-    ) -> Set[str]:
+    ) -> dict[str, QueryableProperty]:
         """Fetch the queryable properties for a given product type and/or provider.
 
         :param product_type: (optional) The EODAG product type.
@@ -2085,11 +2093,12 @@ class EODataAccessGateway:
         :returns: A set containing the EODAG queryable properties.
         :rtype: set
         """
-        default_queryables = {"productType", "start", "end", "geom", "locations", "id"}
+        default_queryables = Queryables().properties
         if provider is None and product_type is None:
             return default_queryables
 
         plugins = self._plugins_manager.get_search_plugins(product_type, provider)
+        provider_plugin = None
 
         # dictionary of the queryable properties of the providers supporting the given product type
         all_queryable_properties = dict()
@@ -2105,7 +2114,7 @@ class EODataAccessGateway:
                     f"{product_type} is not available for provider {provider}"
                 )
 
-            provider_queryables = set(default_queryables)
+            provider_queryables = default_queryables
 
             metadata_mapping = deepcopy(getattr(plugin.config, "metadata_mapping", {}))
 
@@ -2118,12 +2127,141 @@ class EODataAccessGateway:
 
             for key, value in metadata_mapping.items():
                 if isinstance(value, list) and "TimeFromAscendingNode" not in key:
-                    provider_queryables.add(key)
+                    queryable = format_queryable(key)
+                    provider_queryables[key] = queryable
 
             all_queryable_properties[plugin.provider] = provider_queryables
+            if provider and plugin.provider == provider:
+                provider_plugin = plugin
+                break
 
         if provider is None:
-            # intersection of the queryables among the providers
-            return set.intersection(*all_queryable_properties.values())
+            result = {}
+            for queryables in all_queryable_properties.values():
+                result.update(queryables)
+            return result
         else:
-            return all_queryable_properties[provider]
+            if product_type:
+                provider_queryables = self._add_provider_product_type_queryables(
+                    provider_plugin,
+                    provider,
+                    product_type,
+                    all_queryable_properties[provider],
+                )
+            else:
+                provider_queryables = self._add_provider_queryables(
+                    provider_plugin, provider, all_queryable_properties[provider]
+                )
+            return provider_queryables
+
+    def _add_provider_queryables(
+        self, search_plugin: Union[Search, Api], provider: str, queryables: dict
+    ) -> Dict[str, Any]:
+        """Add the queryables fetched from the given provider to the default queryables.
+        If the queryables endpoint is not supported by the provider, the original queryables are returned
+        :param provider: The provider.
+        :type provider: str
+        :param queryables: default queryables to which provider queryables will be added
+        :type queryables: dict
+        :returns queryable_properties: A dict containing the formatted queryable properties
+                                       including queryables fetched from the provider.
+        :rtype dict
+        """
+
+        search_type = search_plugin.config.type
+        if search_type == "StacSearch":
+            queryables_url = search_plugin.config.api_endpoint.replace(
+                "/search", "/queryables"
+            )
+        else:
+            queryables_url = ""
+        if not queryables_url:
+            logger.info(
+                "no url was found for %s provider-specific queryables", provider
+            )
+            return queryables
+        try:
+            headers = USER_AGENT
+            if hasattr(search_plugin, "auth"):
+                res = requests.get(
+                    queryables_url, headers=headers, auth=search_plugin.auth
+                )
+            else:
+                res = requests.get(queryables_url, headers=headers)
+            res.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            if err.response.status_code == 404:
+                logger.info("provider %s does not support queryables", provider)
+                return queryables
+            else:
+                raise RequestError(str(err))
+        else:
+            provider_queryables = res.json()["properties"]
+            return format_provider_queryables(provider_queryables, queryables)
+
+    def _add_provider_product_type_queryables(
+        self,
+        search_plugin: Union[Search, Api],
+        provider: str,
+        product_type: str,
+        queryables: dict,
+    ) -> Dict[str, Any]:
+        """Add the queryables fetched from the given provider for the given product type
+        to the default queryables derived from the metadata mapping.
+        If the queryables endpoint is not supported by the provider, the original queryables are returned.
+        :param provider: The provider.
+        :type provider: str
+        :param product_type: EODAG product type
+        :type product_type: str
+        :param queryables: default queryables to which provider queryables will be added
+        :type queryables: dict
+        :returns queryable_properties: A dict containing the formatted queryable properties
+                                       including queryables fetched from the provider.
+        :rtype dict
+        """
+        search_type = search_plugin.config.type
+        provider_product_type = search_plugin.config.products.get(product_type, {}).get(
+            "productType", None
+        )
+        if not provider_product_type:
+            logger.warning(
+                "provider product type mapping for product type %s not found",
+                product_type,
+            )
+            provider_product_type = product_type
+        if search_type == "StacSearch":
+            api_url = search_plugin.config.api_endpoint.replace("/search", "/")
+            queryables_url = (
+                api_url + "collections/" + provider_product_type + "/queryables"
+            )
+        else:
+            queryables_url = ""
+
+        if not queryables_url:
+            logger.info(
+                "no url was found for %s on %s provider-specific queryables",
+                product_type,
+                provider,
+            )
+            return queryables
+        try:
+            headers = USER_AGENT
+            if hasattr(search_plugin, "auth"):
+                res = requests.get(
+                    queryables_url, headers=headers, auth=search_plugin.auth
+                )
+            else:
+                res = requests.get(queryables_url, headers=headers)
+            res.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            if err.response.status_code == 404:
+                logger.info("provider %s does not support queryables", provider)
+                return queryables
+            else:
+                raise RequestError(str(err))
+        else:
+            if "properties" in res.json():
+                provider_queryables = res.json()["properties"]
+                return format_provider_queryables(provider_queryables, queryables)
+            else:
+                return queryables

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -2081,7 +2081,7 @@ class EODataAccessGateway:
         plugin_conf.update({key.replace("-", "_"): val for key, val in options.items()})
         return self._plugins_manager.get_crunch_plugin(name, **plugin_conf)
 
-    def get_queryables(
+    def list_queryables(
         self,
         provider: Optional[str] = None,
         product_type: Optional[str] = None,
@@ -2161,7 +2161,6 @@ class EODataAccessGateway:
                     all_queryable_properties[provider],
                     base,
                 )
-                print(provider_queryables)
             else:
                 provider_queryables = self._add_provider_queryables(
                     provider_plugin, provider, all_queryable_properties[provider], base

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -2126,7 +2126,11 @@ class EODataAccessGateway:
             )
 
             for key, value in metadata_mapping.items():
-                if isinstance(value, list) and "TimeFromAscendingNode" not in key:
+                if (
+                    isinstance(value, list)
+                    and "TimeFromAscendingNode" not in key
+                    and key not in provider_queryables
+                ):
                     queryable = format_queryable(key)
                     provider_queryables[key] = queryable
 

--- a/eodag/api/queryables.py
+++ b/eodag/api/queryables.py
@@ -151,7 +151,10 @@ def format_provider_queryables(
 
     """
     for queryable, data in provider_queryables.items():
-        attributes = {"description": queryable}
+        titled_name = re.sub(
+            CAMEL_TO_SPACE_TITLED, " ", queryable.split(":")[-1]
+        ).title()
+        attributes = {"description": titled_name}
         if "type" in data:
             if isinstance(data["type"], list):
                 attributes["type"] = data["type"]

--- a/eodag/api/queryables.py
+++ b/eodag/api/queryables.py
@@ -1,0 +1,163 @@
+import re
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+
+from eodag.api.product.metadata_mapping import OSEO_METADATA_MAPPING
+from eodag.config import load_stac_config
+
+CAMEL_TO_SPACE_TITLED = re.compile(r"[:_-]|(?<=[a-z])(?=[A-Z])")
+
+
+def rename_to_stac_standard(key: str) -> str:
+    """Fetch the queryable properties for a collection.
+
+    :param key: The camelCase key name obtained from a collection's metadata mapping.
+    :type key: str
+    :returns: The STAC-standardized property name if it exists, else the default camelCase queryable name
+    :rtype: str
+    """
+    # Load the stac config properties for renaming the properties
+    # to their STAC standard
+    stac_config = load_stac_config()
+    stac_config_properties: Dict[str, Any] = stac_config["item"]["properties"]
+
+    for stac_property, value in stac_config_properties.items():
+        if isinstance(value, list):
+            value = value[0]
+        if str(value).endswith(key):
+            return stac_property
+
+    if key in OSEO_METADATA_MAPPING:
+        return "oseo:" + key
+
+    return key
+
+
+class QueryableProperty(BaseModel):
+    """A class representing a queryable property.
+
+    :param description: The description of the queryables property
+    :type description: str
+    :param ref: (optional) A reference link to the schema of the property.
+    :type ref: str
+    """
+
+    description: str
+    ref: Optional[str] = Field(default=None, serialization_alias="$ref")
+    type: Optional[list] = None
+
+
+class Queryables(BaseModel):
+    """A class representing queryable properties for the STAC API.
+
+    :param json_schema: The URL of the JSON schema.
+    :type json_schema: str
+    :param q_id: (optional) The identifier of the queryables.
+    :type q_id: str
+    :param q_type: The type of the object.
+    :type q_type: str
+    :param title: The title of the queryables.
+    :type title: str
+    :param description: The description of the queryables
+    :type description: str
+    :param properties: A dictionary of queryable properties.
+    :type properties: dict
+    :param additional_properties: Whether additional properties are allowed.
+    :type additional_properties: bool
+    """
+
+    json_schema: str = Field(
+        default="https://json-schema.org/draft/2019-09/schema",
+        serialization_alias="$schema",
+    )
+    q_id: Optional[str] = Field(default=None, serialization_alias="$id")
+    q_type: str = Field(default="object", serialization_alias="type")
+    title: str = Field(default="Queryables for EODAG STAC API")
+    description: str = Field(
+        default="Queryable names for the EODAG STAC API Item Search filter."
+    )
+    properties: Dict[str, QueryableProperty] = Field(
+        default={
+            "id": QueryableProperty(
+                description="ID",
+                ref="https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/id",
+            ),
+            "collection": QueryableProperty(
+                description="Collection",
+                ref="https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/collection",
+            ),
+            "geometry": QueryableProperty(
+                description="Geometry",
+                ref="https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/geometry",
+            ),
+            "bbox": QueryableProperty(
+                description="Bbox",
+                ref="https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/bbox",
+            ),
+            "datetime": QueryableProperty(
+                description="Datetime",
+                ref="https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/datetime.json#/properties/datetime",
+            ),
+        }
+    )
+    additional_properties: bool = Field(
+        default=True, serialization_alias="additionalProperties"
+    )
+
+    def get_properties(self) -> Dict[str, QueryableProperty]:
+        """Get the queryable properties.
+
+        :returns: A dictionary containing queryable properties.
+        :rtype: typing.Dict[str, QueryableProperty]
+        """
+        return self.properties
+
+    def __contains__(self, name: str) -> bool:
+        return name in self.properties
+
+    def __setitem__(self, name: str, qprop: QueryableProperty) -> None:
+        self.properties[name] = qprop
+
+
+def format_queryable(queryable_key: str) -> QueryableProperty:
+    """
+    creates a queryable property from a property key
+    :param queryable_key: key of the property for which the queryable property shall be created
+    :type queryable_key: str
+    :returns: queryable property for the given key
+    :rtype: QueryableProperty
+    """
+    if queryable_key not in ["start", "end", "geom", "locations", "id"]:
+        stac_key = rename_to_stac_standard(queryable_key)
+    else:
+        stac_key = queryable_key
+    titled_name = re.sub(CAMEL_TO_SPACE_TITLED, " ", stac_key.split(":")[-1]).title()
+    return QueryableProperty(description=titled_name)
+
+
+def format_provider_queryables(
+    provider_queryables: dict, queryables: dict
+) -> Dict[str, Any]:
+    """
+    formats the provider queryables and adds them to the existing queryables
+    :param provider_queryables: queryables fetched from the provider
+    :type provider_queryables: dict
+    :param queryables: default queryables to which provider queryables will be added
+    :type queryables: dict
+    :returns queryable_properties: A dict containing the formatted queryable properties
+                                       including queryables fetched from the provider.
+    :rtype dict
+
+    """
+    for queryable, data in provider_queryables.items():
+        attributes = {"description": queryable}
+        if "type" in data:
+            if isinstance(data["type"], list):
+                attributes["type"] = data["type"]
+            else:
+                attributes["type"] = [data["type"]]
+        if "ref" in data:
+            attributes["ref"] = data["ref"]
+        queryables[queryable] = QueryableProperty(**attributes)
+    return queryables

--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -673,7 +673,8 @@ def stac_catalogs(catalogs: str, request: Request) -> Any:
     "/queryables",
     tags=["Capabilities"],
     response_model_exclude_none=True,
-    include_in_schema=False)
+    include_in_schema=False,
+)
 def list_queryables(request: Request, provider: Optional[str] = None) -> Queryables:
     """Returns the list of terms available for use when writing filter expressions.
 
@@ -733,7 +734,6 @@ def stac_search(
         content=response, status_code=200, media_type="application/json"
     )
     return resp
-
 
 
 app.include_router(router)

--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -483,7 +483,7 @@ def list_collection_queryables(
             provider, collection_id, queryables
         )
 
-    return queryables
+    return jsonable_encoder(queryables)
 
 
 @router.get(
@@ -692,7 +692,7 @@ def list_queryables(request: Request, provider: Optional[str] = None) -> Queryab
     if provider:
         queryables = add_provider_queryables(provider, queryables)
 
-    return queryables
+    return jsonable_encoder(queryables)
 
 
 @router.get(

--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -449,7 +449,7 @@ def stac_collections_items(collection_id: str, request: Request) -> Any:
 )
 def list_collection_queryables(
     request: Request, collection_id: str, provider: Optional[str] = None
-) -> Queryables:
+) -> Any:
     """Returns the list of queryable properties for a specific collection.
 
     This endpoint provides a list of properties that can be used as filters when querying
@@ -462,8 +462,8 @@ def list_collection_queryables(
     :type collection_id: str
     :param provider: (optional) The provider for which to retrieve additional properties.
     :type provider: str
-    :returns: An object containing the list of available queryable properties for the specified collection.
-    :rtype: eodag.rest.utils.Queryables
+    :returns: A json object containing the list of available queryable properties for the specified collection.
+    :rtype: Any
     """
     logger.debug(f"URL: {request.url}")
 
@@ -675,7 +675,7 @@ def stac_catalogs(catalogs: str, request: Request) -> Any:
     response_model_exclude_none=True,
     include_in_schema=False,
 )
-def list_queryables(request: Request, provider: Optional[str] = None) -> Queryables:
+def list_queryables(request: Request, provider: Optional[str] = None) -> Any:
     """Returns the list of terms available for use when writing filter expressions.
 
     This endpoint provides a list of terms that can be used as filters when querying
@@ -684,8 +684,8 @@ def list_queryables(request: Request, provider: Optional[str] = None) -> Queryab
 
     :param request: The incoming request object.
     :type request: fastapi.Request
-    :returns: An object containing the list of available queryable terms.
-    :rtype: eodag.rest.utils.Queryables
+    :returns: A json object containing the list of available queryable terms.
+    :rtype: Any
     """
     logger.debug(f"URL: {request.url}")
     queryables = Queryables(q_id=request.state.url)

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -1216,7 +1216,7 @@ def add_provider_queryables(provider: str, queryables: dict):
     else:
         queryables_url = getattr(search_plugin.config, "queryables_endpoint", "")
     if not queryables_url:
-        logger.warning("no url for queryables found for provider %s", provider)
+        logger.info("no url was found for %s provider-specific queryables", provider)
         return queryables
     try:
         if hasattr(search_plugin, "auth"):

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -1214,7 +1214,7 @@ def add_provider_queryables(provider: str, queryables: dict):
             "/search", "/queryables"
         )
     else:
-        queryables_url = getattr(search_plugin.config, "queryables_endpoint", "")
+        queryables_url = ""
     if not queryables_url:
         logger.info("no url was found for %s provider-specific queryables", provider)
         return queryables
@@ -1271,12 +1271,14 @@ def add_provider_product_type_queryables(
             api_url + "collections/" + provider_product_type + "/queryables"
         )
     else:
-        queryables_url = getattr(
-            search_plugin.config, "queryables_endpoint", ""
-        ).format(product_type=provider_product_type)
+        queryables_url = ""
 
     if not queryables_url:
-        logger.info("no url was found for %s on %s provider-specific queryables", product_type, provider)
+        logger.info(
+            "no url was found for %s on %s provider-specific queryables",
+            product_type,
+            provider,
+        )
         return {}
     try:
         if hasattr(search_plugin, "auth"):

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -1278,7 +1278,7 @@ def add_provider_product_type_queryables(
             product_type,
             provider,
         )
-        return {}
+        return queryables
     try:
         headers = USER_AGENT
         if hasattr(search_plugin, "auth"):
@@ -1289,7 +1289,7 @@ def add_provider_product_type_queryables(
     except requests.exceptions.HTTPError as err:
         if err.response.status_code == 404:
             logger.info("provider %s does not support queryables", provider)
-            return {}
+            return queryables
         else:
             raise RequestError(str(err))
     else:
@@ -1297,7 +1297,7 @@ def add_provider_product_type_queryables(
             provider_queryables = res.json()["properties"]
             return _format_provider_queryables(provider_queryables, queryables)
         else:
-            return {}
+            return queryables
 
 
 def _format_provider_queryables(

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -46,7 +46,7 @@ from shapely.geometry import Polygon, shape
 import eodag
 from eodag import EOProduct
 from eodag.api.product.metadata_mapping import OSEO_METADATA_MAPPING
-from eodag.api.queryables import QueryableProperty
+from eodag.api.queryables import BaseQueryableProperty
 from eodag.api.search_result import SearchResult
 from eodag.config import load_stac_config, load_stac_provider_config
 from eodag.plugins.crunch.filter_latest_intersect import FilterLatestIntersect
@@ -1055,7 +1055,7 @@ def get_stac_extension_oseo(url: str) -> Dict[str, str]:
 
 def fetch_collection_queryable_properties(
     collection_id: Optional[str] = None, provider: Optional[str] = None
-) -> Dict[str, QueryableProperty]:
+) -> Dict[str, BaseQueryableProperty]:
     """Fetch the queryable properties for a collection.
 
     :param collection_id: The ID of the collection.
@@ -1066,7 +1066,7 @@ def fetch_collection_queryable_properties(
     :rtype queryable_properties: set
     """
     # Fetch the metadata mapping for collection-specific queryables
-    kwargs = {}
+    kwargs = {"base": False}
     if collection_id is not None:
         kwargs["product_type"] = collection_id
     if provider is not None:

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -1302,7 +1302,7 @@ def add_provider_product_type_queryables(
             return {}
 
 
-def _format_provider_queryables(provider_queryables: dict, queryables: dict):
+def _format_provider_queryables(provider_queryables: dict, queryables: dict) -> Dict[str, Any]:
     for queryable, data in provider_queryables.items():
         attributes = {"description": queryable}
         if "type" in data:

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -1071,7 +1071,7 @@ def fetch_collection_queryable_properties(
         kwargs["product_type"] = collection_id
     if provider is not None:
         kwargs["provider"] = provider
-    return eodag_api.get_queryables(**kwargs)
+    return eodag_api.list_queryables(**kwargs)
 
 
 def eodag_api_init() -> None:

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -40,6 +40,7 @@ from typing import (
 from urllib.parse import urlencode
 
 import dateutil.parser
+import requests
 from dateutil import tz
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
@@ -58,6 +59,7 @@ from eodag.utils import (
     DEFAULT_ITEMS_PER_PAGE,
     DEFAULT_PAGE,
     GENERIC_PRODUCT_TYPE,
+    USER_AGENT,
     _deprecated,
     dict_items_recursive_apply,
     string_to_jsonpath,
@@ -66,6 +68,7 @@ from eodag.utils.exceptions import (
     MisconfiguredError,
     NoMatchingProductType,
     NotAvailableError,
+    RequestError,
     UnsupportedProductType,
     ValidationError,
 )
@@ -1065,6 +1068,7 @@ class QueryableProperty(BaseModel):
 
     description: str
     ref: Optional[str] = Field(default=None, serialization_alias="$ref")
+    type: Optional[list] = None
 
 
 class Queryables(BaseModel):
@@ -1188,6 +1192,124 @@ def fetch_collection_queryable_properties(
         if prop not in ["start", "end", "geom", "locations", "id"]:
             queryable_properties.add(rename_to_stac_standard(prop))
     return queryable_properties
+
+
+def add_provider_queryables(provider: str, queryables: dict):
+    """Add the queryables fetched from the given provider to the default queryables.
+    If the queryables endpoint is not supported by the provider, the original queryables are returned
+    :param provider: The provider.
+    :type provider: str
+    :param queryables: default queryables to which provider queryables will be added
+    :type queryables: dict
+    :returns queryable_properties: A dict containing the formatted queryable properties
+                                   including queryables fetched from the provider.
+    :rtype dict
+    """
+    search_plugin = next(
+        eodag_api._plugins_manager.get_search_plugins(provider=provider)
+    )
+    search_type = search_plugin.config.type
+    if search_type == "StacSearch":
+        queryables_url = search_plugin.config.api_endpoint.replace(
+            "/search", "/queryables"
+        )
+    else:
+        queryables_url = getattr(search_plugin.config, "queryables_endpoint", "")
+    if not queryables_url:
+        logger.warning("no url for queryables found for provider %s", provider)
+        return queryables
+    try:
+        if hasattr(search_plugin, "auth"):
+            headers = getattr(search_plugin.auth, "headers", USER_AGENT)
+        else:
+            headers = USER_AGENT
+        res = requests.get(queryables_url, headers=headers)
+        res.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        if err.response.status_code == 404:
+            logger.info("provider %s does not support queryables", provider)
+            return queryables
+        else:
+            raise RequestError(str(err))
+    else:
+        provider_queryables = res.json()["properties"]
+        return _format_provider_queryables(provider_queryables, queryables)
+
+
+def add_provider_product_type_queryables(
+    provider: str, product_type: str, queryables: dict
+):
+    """Add the queryables fetched from the given provider for the given product type
+    to the default queryables derived from the metadata mapping.
+    If the queryables endpoint is not supported by the provider, the original queryables are returned.
+    :param provider: The provider.
+    :type provider: str
+    :param product_type: EODAG product type
+    :type product_type: str
+    :param queryables: default queryables to which provider queryables will be added
+    :type queryables: dict
+    :returns queryable_properties: A dict containing the formatted queryable properties
+                                   including queryables fetched from the provider.
+    :rtype dict
+    """
+    search_plugin = next(
+        eodag_api._plugins_manager.get_search_plugins(provider=provider)
+    )
+    search_type = search_plugin.config.type
+    provider_product_type = search_plugin.config.products.get(product_type, {}).get(
+        "productType", None
+    )
+    if not provider_product_type:
+        logger.warning(
+            "provider product type mapping for product type %s not found", product_type
+        )
+        provider_product_type = product_type
+    if search_type == "StacSearch":
+        api_url = search_plugin.config.api_endpoint.replace("/search", "/")
+        queryables_url = (
+            api_url + "collections/" + provider_product_type + "/queryables"
+        )
+    else:
+        queryables_url = getattr(
+            search_plugin.config, "queryables_endpoint", ""
+        ).format(product_type=provider_product_type)
+
+    if not queryables_url:
+        logger.warning("no url for queryables found for provider %s", provider)
+        return {}
+    try:
+        if hasattr(search_plugin, "auth"):
+            headers = getattr(search_plugin.auth, "headers", USER_AGENT)
+        else:
+            headers = USER_AGENT
+        res = requests.get(queryables_url, headers=headers)
+        res.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        if err.response.status_code == 404:
+            logger.info("provider %s does not support queryables", provider)
+            return {}
+        else:
+            raise RequestError(str(err))
+    else:
+        if "properties" in res.json():
+            provider_queryables = res.json()["properties"]
+            return _format_provider_queryables(provider_queryables, queryables)
+        else:
+            return {}
+
+
+def _format_provider_queryables(provider_queryables: dict, queryables: dict):
+    for queryable, data in provider_queryables.items():
+        attributes = {"description": queryable}
+        if "type" in data:
+            if isinstance(data["type"], list):
+                attributes["type"] = data["type"]
+            else:
+                attributes["type"] = [data["type"]]
+        if "ref" in data:
+            attributes["ref"] = data["ref"]
+        queryables[queryable] = QueryableProperty(**attributes)
+    return queryables
 
 
 def eodag_api_init() -> None:

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -1194,7 +1194,7 @@ def fetch_collection_queryable_properties(
     return queryable_properties
 
 
-def add_provider_queryables(provider: str, queryables: dict):
+def add_provider_queryables(provider: str, queryables: dict) -> Dict[str, Any]:
     """Add the queryables fetched from the given provider to the default queryables.
     If the queryables endpoint is not supported by the provider, the original queryables are returned
     :param provider: The provider.

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -1220,7 +1220,8 @@ def add_provider_queryables(provider: str, queryables: dict):
         return queryables
     try:
         if hasattr(search_plugin, "auth"):
-            headers = getattr(search_plugin.auth, "headers", USER_AGENT)
+            headers = getattr(search_plugin.auth, "headers", {})
+            headers.update(USER_AGENT)
         else:
             headers = USER_AGENT
         res = requests.get(queryables_url, headers=headers)
@@ -1279,7 +1280,8 @@ def add_provider_product_type_queryables(
         return {}
     try:
         if hasattr(search_plugin, "auth"):
-            headers = getattr(search_plugin.auth, "headers", USER_AGENT)
+            headers = getattr(search_plugin.auth, "headers", {})
+            headers.update(USER_AGENT)
         else:
             headers = USER_AGENT
         res = requests.get(queryables_url, headers=headers)

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -1219,12 +1219,11 @@ def add_provider_queryables(provider: str, queryables: dict) -> Dict[str, Any]:
         logger.info("no url was found for %s provider-specific queryables", provider)
         return queryables
     try:
+        headers = USER_AGENT
         if hasattr(search_plugin, "auth"):
-            headers = getattr(search_plugin.auth, "headers", {})
-            headers.update(USER_AGENT)
+            res = requests.get(queryables_url, headers=headers, auth=search_plugin.auth)
         else:
-            headers = USER_AGENT
-        res = requests.get(queryables_url, headers=headers)
+            res = requests.get(queryables_url, headers=headers)
         res.raise_for_status()
     except requests.exceptions.HTTPError as err:
         if err.response.status_code == 404:
@@ -1281,12 +1280,11 @@ def add_provider_product_type_queryables(
         )
         return {}
     try:
+        headers = USER_AGENT
         if hasattr(search_plugin, "auth"):
-            headers = getattr(search_plugin.auth, "headers", {})
-            headers.update(USER_AGENT)
+            res = requests.get(queryables_url, headers=headers, auth=search_plugin.auth)
         else:
-            headers = USER_AGENT
-        res = requests.get(queryables_url, headers=headers)
+            res = requests.get(queryables_url, headers=headers)
         res.raise_for_status()
     except requests.exceptions.HTTPError as err:
         if err.response.status_code == 404:
@@ -1302,7 +1300,9 @@ def add_provider_product_type_queryables(
             return {}
 
 
-def _format_provider_queryables(provider_queryables: dict, queryables: dict) -> Dict[str, Any]:
+def _format_provider_queryables(
+    provider_queryables: dict, queryables: dict
+) -> Dict[str, Any]:
     for queryable, data in provider_queryables.items():
         attributes = {"description": queryable}
         if "type" in data:

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -1239,7 +1239,7 @@ def add_provider_queryables(provider: str, queryables: dict) -> Dict[str, Any]:
 
 def add_provider_product_type_queryables(
     provider: str, product_type: str, queryables: dict
-):
+) -> Dict[str, Any]:
     """Add the queryables fetched from the given provider for the given product type
     to the default queryables derived from the metadata mapping.
     If the queryables endpoint is not supported by the provider, the original queryables are returned.

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -1276,7 +1276,7 @@ def add_provider_product_type_queryables(
         ).format(product_type=provider_product_type)
 
     if not queryables_url:
-        logger.warning("no url for queryables found for provider %s", provider)
+        logger.info("no url was found for %s on %s provider-specific queryables", product_type, provider)
         return {}
     try:
         if hasattr(search_plugin, "auth"):

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -80,6 +80,7 @@ from dateutil.tz import UTC
 from jsonpath_ng import jsonpath
 from jsonpath_ng.ext import parse
 from jsonpath_ng.jsonpath import Child, Fields, Index, Root, Slice
+from requests import HTTPError
 from shapely.geometry import Polygon, shape
 from shapely.geometry.base import BaseGeometry
 from tqdm.auto import tqdm
@@ -1179,6 +1180,11 @@ class MockResponse:
     def json(self) -> Any:
         """Return json data"""
         return self.json_data
+
+    def raise_for_status(self):
+        """raises an exception when the status is not ok"""
+        if self.status_code != 200:
+            raise HTTPError()
 
 
 def md5sum(file_path: str) -> str:

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -1181,7 +1181,7 @@ class MockResponse:
         """Return json data"""
         return self.json_data
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         """raises an exception when the status is not ok"""
         if self.status_code != 200:
             raise HTTPError()

--- a/tests/resources/stac/queryables.json
+++ b/tests/resources/stac/queryables.json
@@ -1,0 +1,36 @@
+{
+  "$id": "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-1-grd/queryables",
+  "type": "object",
+  "title": "STAC Queryables.",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "id": {
+      "$ref": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/definitions/core/allOf/2/properties/id",
+      "title": "Item ID",
+      "description": "Item identifier"
+    },
+    "datetime": {
+      "type": "string",
+      "title": "Acquired",
+      "format": "date-time",
+      "pattern": "(\\+00:00|Z)$",
+      "description": "Datetime"
+    },
+    "geometry": {
+      "$ref": "https://geojson.org/schema/Feature.json",
+      "title": "Item Geometry",
+      "description": "Item Geometry"
+    },
+    "platform": {
+      "enum": [
+        "SENTINEL-1A",
+        "SENTINEL-1B"
+      ],
+      "type": "string",
+      "title": "Platform"
+    },
+    "s1:processing_level":{
+      "type":"string"
+    }
+  }
+}

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -32,6 +32,7 @@ from shapely import wkt
 from shapely.geometry import LineString, MultiPolygon, Polygon
 
 from eodag import __version__ as eodag_version
+from eodag.api.queryables import QueryableProperty, Queryables
 from eodag.utils import GENERIC_PRODUCT_TYPE
 from tests import TEST_RESOURCES_PATH
 from tests.context import (
@@ -1010,85 +1011,71 @@ class TestCore(TestCoreBase):
         with self.assertRaises(UnsupportedProductType):
             self.dag.get_queryables(product_type="not_existing_product_type")
 
-        expected_result = {"productType", "start", "end", "geom", "locations", "id"}
+        expected_result = Queryables().properties
         queryables = self.dag.get_queryables()
-        self.assertSetEqual(queryables, expected_result)
+        self.assertDictEqual(expected_result, queryables)
 
-        expected_result = {
-            "start",
-            "end",
-            "geom",
-            "locations",
-            "productType",
-            "platformSerialIdentifier",
-            "instrument",
-            "processingLevel",
-            "resolution",
-            "organisationName",
-            "parentIdentifier",
-            "orbitNumber",
-            "orbitDirection",
-            "swathIdentifier",
-            "cloudCover",
-            "snowCover",
-            "sensorMode",
-            "polarizationMode",
-            "id",
-            "tileIdentifier",
-            "geometry",
+        expected_properties = {
+            "Product Type",
+            "Organisation Name",
+            "Parent Identifier",
+            "Swath Identifier",
+            "Cloud Cover",
+            "Snow Cover",
+            "Polarization Mode",
+            "Tile Identifier",
         }
-        queryables = self.dag.get_queryables(provider="peps")
-        self.assertSetEqual(queryables, expected_result)
-
-        expected_result = {
-            "start",
-            "end",
-            "geom",
-            "locations",
-            "productType",
-            "platformSerialIdentifier",
-            "instrument",
-            "processingLevel",
-            "resolution",
-            "organisationName",
-            "parentIdentifier",
-            "orbitNumber",
-            "orbitDirection",
-            "swathIdentifier",
-            "snowCover",
-            "sensorMode",
-            "polarizationMode",
-            "id",
-            "tileIdentifier",
-            "geometry",
-        }
-        queryables = self.dag.get_queryables(provider="peps", product_type="S1_SAR_GRD")
-        self.assertSetEqual(queryables, expected_result)
-
-        expected_result = {"productType", "start", "end", "geom", "locations", "id"}
-        queryables = self.dag.get_queryables(product_type="S2_MSI_L1C")
-        self.assertSetEqual(queryables, expected_result)
-
-        expected_result = {
-            "productType",
-            "start",
-            "end",
-            "geom",
-            "locations",
-            "geometry",
-            "platformSerialIdentifier",
-            "title",
-            "cloudCover",
-            "illuminationAzimuthAngle",
-            "illuminationZenithAngle",
-            "awsPath",
-            "productPath",
-            "id",
-        }
-        queryables = self.dag.get_queryables(
-            provider="aws_eos", product_type="S2_MSI_L1C"
+        for property in expected_properties:
+            key_parts = property.split(" ")
+            key = key_parts[0].lower()
+            if len(key_parts) > 1:
+                key += key_parts[1]
+            expected_result[key] = QueryableProperty(description=property)
+        expected_result["platformSerialIdentifier"] = QueryableProperty(
+            description="Platform"
         )
-        self.assertSetEqual(queryables, expected_result)
+        expected_result["resolution"] = QueryableProperty(description="Gsd")
+        expected_result["orbitNumber"] = QueryableProperty(description="Absolute Orbit")
+        expected_result["orbitDirection"] = QueryableProperty(description="Orbit State")
+        expected_result["processingLevel"] = QueryableProperty(description="Level")
+        expected_result["instrument"] = QueryableProperty(description="Instruments")
+        expected_result["sensorMode"] = QueryableProperty(description="Instrument Mode")
+        queryables = self.dag.get_queryables(provider="peps")
+        self.assertDictEqual(expected_result, queryables)
+
+        expected_properties = {
+            "Product Type",
+            "Organisation Name",
+            "Parent Identifier",
+            "Swath Identifier",
+            "Snow Cover",
+            "Polarization Mode",
+            "Tile Identifier",
+        }
+        expected_result = Queryables().properties
+        for property in expected_properties:
+            key_parts = property.split(" ")
+            key = key_parts[0].lower()
+            if len(key_parts) > 1:
+                key += key_parts[1]
+            expected_result[key] = QueryableProperty(description=property)
+        expected_result["platformSerialIdentifier"] = QueryableProperty(
+            description="Platform"
+        )
+        expected_result["resolution"] = QueryableProperty(description="Gsd")
+        expected_result["orbitNumber"] = QueryableProperty(description="Absolute Orbit")
+        expected_result["orbitDirection"] = QueryableProperty(description="Orbit State")
+        expected_result["processingLevel"] = QueryableProperty(description="Level")
+        expected_result["instrument"] = QueryableProperty(description="Instruments")
+        expected_result["sensorMode"] = QueryableProperty(description="Instrument Mode")
+
+        queryables = self.dag.get_queryables(provider="peps", product_type="S1_SAR_GRD")
+        self.assertDictEqual(queryables, expected_result)
+
+        queryables = self.dag.get_queryables(product_type="S2_MSI_L1C")
+        self.assertIn("awsPath", queryables.keys())
+        self.assertIn("id", queryables.keys())
+        self.assertIn("illuminationAzimuthAngle", queryables.keys())
 
 
 class TestCoreConfWithEnvVar(TestCoreBase):

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1006,13 +1006,13 @@ class TestCore(TestCoreBase):
     def test_get_queryables(self):
         """get_queryables must return queryables list adapted to provider and product-type"""
         with self.assertRaises(UnsupportedProvider):
-            self.dag.get_queryables(provider="not_existing_provider")
+            self.dag.list_queryables(provider="not_existing_provider")
 
         with self.assertRaises(UnsupportedProductType):
-            self.dag.get_queryables(product_type="not_existing_product_type")
+            self.dag.list_queryables(product_type="not_existing_product_type")
 
         expected_result = Queryables().get_base_properties()
-        queryables = self.dag.get_queryables()
+        queryables = self.dag.list_queryables()
         self.assertDictEqual(expected_result, queryables)
 
         expected_properties = {
@@ -1046,7 +1046,7 @@ class TestCore(TestCoreBase):
         expected_result["sensorMode"] = BaseQueryableProperty(
             description="Instrument Mode"
         )
-        queryables = self.dag.get_queryables(provider="peps")
+        queryables = self.dag.list_queryables(provider="peps")
         self.assertDictEqual(expected_result, queryables)
 
         expected_properties = {
@@ -1081,10 +1081,12 @@ class TestCore(TestCoreBase):
             description="Instrument Mode"
         )
 
-        queryables = self.dag.get_queryables(provider="peps", product_type="S1_SAR_GRD")
+        queryables = self.dag.list_queryables(
+            provider="peps", product_type="S1_SAR_GRD"
+        )
         self.assertDictEqual(queryables, expected_result)
 
-        queryables = self.dag.get_queryables(product_type="S2_MSI_L1C")
+        queryables = self.dag.list_queryables(product_type="S2_MSI_L1C")
         self.assertIn("awsPath", queryables.keys())
         self.assertIn("id", queryables.keys())
         self.assertIn("illuminationAzimuthAngle", queryables.keys())

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -32,7 +32,7 @@ from shapely import wkt
 from shapely.geometry import LineString, MultiPolygon, Polygon
 
 from eodag import __version__ as eodag_version
-from eodag.api.queryables import QueryableProperty, Queryables
+from eodag.api.queryables import BaseQueryableProperty, Queryables
 from eodag.utils import GENERIC_PRODUCT_TYPE
 from tests import TEST_RESOURCES_PATH
 from tests.context import (
@@ -1011,7 +1011,7 @@ class TestCore(TestCoreBase):
         with self.assertRaises(UnsupportedProductType):
             self.dag.get_queryables(product_type="not_existing_product_type")
 
-        expected_result = Queryables().properties
+        expected_result = Queryables().get_base_properties()
         queryables = self.dag.get_queryables()
         self.assertDictEqual(expected_result, queryables)
 
@@ -1030,16 +1030,22 @@ class TestCore(TestCoreBase):
             key = key_parts[0].lower()
             if len(key_parts) > 1:
                 key += key_parts[1]
-            expected_result[key] = QueryableProperty(description=property)
-        expected_result["platformSerialIdentifier"] = QueryableProperty(
+            expected_result[key] = BaseQueryableProperty(description=property)
+        expected_result["platformSerialIdentifier"] = BaseQueryableProperty(
             description="Platform"
         )
-        expected_result["resolution"] = QueryableProperty(description="Gsd")
-        expected_result["orbitNumber"] = QueryableProperty(description="Absolute Orbit")
-        expected_result["orbitDirection"] = QueryableProperty(description="Orbit State")
-        expected_result["processingLevel"] = QueryableProperty(description="Level")
-        expected_result["instrument"] = QueryableProperty(description="Instruments")
-        expected_result["sensorMode"] = QueryableProperty(description="Instrument Mode")
+        expected_result["resolution"] = BaseQueryableProperty(description="Gsd")
+        expected_result["orbitNumber"] = BaseQueryableProperty(
+            description="Absolute Orbit"
+        )
+        expected_result["orbitDirection"] = BaseQueryableProperty(
+            description="Orbit State"
+        )
+        expected_result["processingLevel"] = BaseQueryableProperty(description="Level")
+        expected_result["instrument"] = BaseQueryableProperty(description="Instruments")
+        expected_result["sensorMode"] = BaseQueryableProperty(
+            description="Instrument Mode"
+        )
         queryables = self.dag.get_queryables(provider="peps")
         self.assertDictEqual(expected_result, queryables)
 
@@ -1052,22 +1058,28 @@ class TestCore(TestCoreBase):
             "Polarization Mode",
             "Tile Identifier",
         }
-        expected_result = Queryables().properties
+        expected_result = Queryables().get_base_properties()
         for property in expected_properties:
             key_parts = property.split(" ")
             key = key_parts[0].lower()
             if len(key_parts) > 1:
                 key += key_parts[1]
-            expected_result[key] = QueryableProperty(description=property)
-        expected_result["platformSerialIdentifier"] = QueryableProperty(
+            expected_result[key] = BaseQueryableProperty(description=property)
+        expected_result["platformSerialIdentifier"] = BaseQueryableProperty(
             description="Platform"
         )
-        expected_result["resolution"] = QueryableProperty(description="Gsd")
-        expected_result["orbitNumber"] = QueryableProperty(description="Absolute Orbit")
-        expected_result["orbitDirection"] = QueryableProperty(description="Orbit State")
-        expected_result["processingLevel"] = QueryableProperty(description="Level")
-        expected_result["instrument"] = QueryableProperty(description="Instruments")
-        expected_result["sensorMode"] = QueryableProperty(description="Instrument Mode")
+        expected_result["resolution"] = BaseQueryableProperty(description="Gsd")
+        expected_result["orbitNumber"] = BaseQueryableProperty(
+            description="Absolute Orbit"
+        )
+        expected_result["orbitDirection"] = BaseQueryableProperty(
+            description="Orbit State"
+        )
+        expected_result["processingLevel"] = BaseQueryableProperty(description="Level")
+        expected_result["instrument"] = BaseQueryableProperty(description="Instruments")
+        expected_result["sensorMode"] = BaseQueryableProperty(
+            description="Instrument Mode"
+        )
 
         queryables = self.dag.get_queryables(provider="peps", product_type="S1_SAR_GRD")
         self.assertDictEqual(queryables, expected_result)

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -1061,7 +1061,10 @@ class RequestTestCase(unittest.TestCase):
         mock_requests_get.return_value = MockResponse(
             provider_queryables, status_code=200
         )
-
+        res_no_provider = self._request_valid(
+            "collections/S1_SAR_GRD/queryables",
+            check_links=False,
+        )
         res = self._request_valid(
             "collections/S1_SAR_GRD/queryables?provider=planetary_computer",
             check_links=False,
@@ -1071,7 +1074,7 @@ class RequestTestCase(unittest.TestCase):
             "sentinel-1-grd/queryables",
             headers=USER_AGENT,
         )
-        self.assertEqual(30, len(res["properties"]))
+        assert len(res["properties"]) > len(res_no_provider["properties"])
         # property added from provider queryables
         self.assertIn("s1:processing_level", res["properties"])
         # property updated with info from provider queryables

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -1063,12 +1063,12 @@ class RequestTestCase(unittest.TestCase):
         )
 
         res = self._request_valid(
-            f"collections/{self.tested_product_type}/queryables?provider=planetary_computer",
+            "collections/S1_SAR_GRD/queryables?provider=planetary_computer",
             check_links=False,
         )
         mock_requests_get.assert_called_once_with(
-            url=f"https://planetarycomputer.microsoft.com/api/stac/v1/collections/"
-            f"{self.tested_product_type}/queryables",
+            url="https://planetarycomputer.microsoft.com/api/stac/v1/collections/"
+            "sentinel-1-grd/queryables",
             headers=USER_AGENT,
         )
         self.assertEqual(30, len(res["properties"]))

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -1038,7 +1038,7 @@ class RequestTestCase(unittest.TestCase):
         """Request to /queryables should return a valid response."""
         self._request_valid("queryables", check_links=False)
 
-    @mock.patch("eodag.rest.utils.requests.get", autospec=True)
+    @mock.patch("eodag.api.core.requests.get", autospec=True)
     def test_queryables_with_provider(self, mock_requests_get):
         self._request_valid("queryables?provider=planetary_computer", check_links=False)
         mock_requests_get.assert_called_once_with(
@@ -1052,7 +1052,7 @@ class RequestTestCase(unittest.TestCase):
             f"collections/{self.tested_product_type}/queryables", check_links=False
         )
 
-    @mock.patch("eodag.rest.utils.requests.get", autospec=True)
+    @mock.patch("eodag.api.core.requests.get", autospec=True)
     def test_product_type_queryables_with_provider(self, mock_requests_get):
         """Request a collection-specific list of queryables for a given provider."""
         queryables_path = os.path.join(TEST_RESOURCES_PATH, "stac/queryables.json")
@@ -1074,9 +1074,9 @@ class RequestTestCase(unittest.TestCase):
             "sentinel-1-grd/queryables",
             headers=USER_AGENT,
         )
-        assert len(res["properties"]) > len(res_no_provider["properties"])
         # property added from provider queryables
         self.assertIn("s1:processing_level", res["properties"])
+        self.assertNotIn("s1:processing_level", res_no_provider["properties"])
         # property updated with info from provider queryables
         self.assertIn("platform", res["properties"])
         self.assertEqual("string", res["properties"]["platform"]["type"][0])

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -29,7 +29,7 @@ from fastapi.testclient import TestClient
 from shapely.geometry import box
 
 from eodag.utils import USER_AGENT, MockResponse
-from tests import TEST_RESOURCES_PATH, mock
+from tests import mock
 from tests.context import (
     DEFAULT_ITEMS_PER_PAGE,
     TEST_RESOURCES_PATH,

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -28,6 +28,7 @@ import geojson
 from fastapi.testclient import TestClient
 from shapely.geometry import box
 
+from eodag.utils import USER_AGENT
 from tests import mock
 from tests.context import (
     DEFAULT_ITEMS_PER_PAGE,
@@ -1037,16 +1038,29 @@ class RequestTestCase(unittest.TestCase):
         """Request to /queryables should return a valid response."""
         self._request_valid("queryables", check_links=False)
 
+    @mock.patch("eodag.rest.utils.requests.get", autospec=True)
+    def test_queryables_with_provider(self, mock_requests_get):
+        self._request_valid("queryables?provider=planetary_computer", check_links=False)
+        mock_requests_get.assert_called_once_with(
+            url="https://planetarycomputer.microsoft.com/api/stac/v1/queryables",
+            headers=USER_AGENT,
+        )
+
     def test_product_type_queryables(self):
         """Request to /collections/{collection_id}/queryables should return a valid response."""
         self._request_valid(
             f"collections/{self.tested_product_type}/queryables", check_links=False
         )
 
-    def test_product_type_queryables_with_provider(self):
+    @mock.patch("eodag.rest.utils.requests.get", autospec=True)
+    def test_product_type_queryables_with_provider(self, mock_requests_get):
         """Request a collection-specific list of queryables for a given provider."""
-
         self._request_valid(
-            f"collections/{self.tested_product_type}/queryables?provider=peps",
+            f"collections/{self.tested_product_type}/queryables?provider=planetary_computer",
             check_links=False,
+        )
+        mock_requests_get.assert_called_once_with(
+            url=f"https://planetarycomputer.microsoft.com/api/stac/v1/collections/"
+            f"{self.tested_product_type}/queryables",
+            headers=USER_AGENT,
         )


### PR DESCRIPTION
- When the queryables are fetched for a specific provider, we try to call the queryables endpoint of the provider (currently only available for planetary_computer) to retrieve additional queryables from the provider.
- renamed `core.get_queryables()` to `core.list_queryables()`
- some queryables refactoring