### PR TITLE
fix: set responses max version lt 0.24.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ dev =
     wheel
     flake8
     pre-commit
-    responses
+    responses < 0.24.0
     fastapi[all]
 notebook = tqdm[notebook]
 tutorials =


### PR DESCRIPTION
Set `responses` max version to less than `0.24.0`, to prevent conflicts with `pytest-socket`.

See https://github.com/getsentry/responses/issues/691
