### PR TITLE
feat: implement new core method get_queryables

### DIFF
--- a/docs/api_reference/core.rst
+++ b/docs/api_reference/core.rst
@@ -80,6 +80,7 @@ Misc
 
    EODataAccessGateway.group_by_extent
    EODataAccessGateway.guess_product_type
+   EODataAccessGateway.get_queryables
 
 .. autoclass:: eodag.api.core.EODataAccessGateway
    :members: set_preferred_provider, get_preferred_provider, update_providers_config, list_product_types,

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -1999,7 +1999,7 @@ class EODataAccessGateway:
         return self._plugins_manager.get_crunch_plugin(name, **plugin_conf)
 
     def get_queryables(
-        self, product_type: Optional[str] = None, provider: Optional[str] = None
+        self, provider: Optional[str] = None, product_type: Optional[str] = None
     ) -> Set[str]:
         """Fetch the queryable properties for a given product type and/or provider.
 

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -2033,6 +2033,11 @@ class EODataAccessGateway:
 
             provider_queryables = set(default_queryables)
 
+            # add provider queryables
+            for key, value in getattr(plugin.config, "metadata_mapping", {}).items():
+                if isinstance(value, list) and "TimeFromAscendingNode" not in key:
+                    provider_queryables.add(key)
+
             if product_type:
                 # list of all product_type-specific queryables
                 mapping = dict(

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -2033,23 +2033,16 @@ class EODataAccessGateway:
 
             provider_queryables = set(default_queryables)
 
-            # add provider queryables
-            for key, value in getattr(plugin.config, "metadata_mapping", {}).items():
-                if isinstance(value, list) and "TimeFromAscendingNode" not in key:
-                    provider_queryables.add(key)
+            metadata_mapping = deepcopy(getattr(plugin.config, "metadata_mapping", {}))
 
-            if product_type:
-                # list of all product_type-specific queryables
-                mapping = dict(
-                    plugin.config.products.get(product_type, {}).get(
-                        "metadata_mapping", {}
-                    )
-                )
-            else:
-                # list of all provider-specific queryables
-                mapping = dict(plugin.config.metadata_mapping)
+            # product_type-specific metadata-mapping
+            metadata_mapping.update(
+                getattr(plugin.config, "products", {})
+                .get(product_type, {})
+                .get("metadata_mapping", {})
+            )
 
-            for key, value in mapping.items():
+            for key, value in metadata_mapping.items():
                 if isinstance(value, list) and "TimeFromAscendingNode" not in key:
                     provider_queryables.add(key)
 

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -2020,8 +2020,16 @@ class EODataAccessGateway:
         # dictionary of the queryable properties of the providers supporting the given product type
         all_queryable_properties = dict()
         for plugin in plugins:
-            if product_type and product_type not in plugin.config.products.keys():
+            if (
+                product_type
+                and product_type not in plugin.config.products.keys()
+                and provider is None
+            ):
                 raise UnsupportedProductType(product_type)
+            elif product_type and product_type not in plugin.config.products.keys():
+                raise UnsupportedProductType(
+                    f"{product_type} is not available for provider {provider}"
+                )
 
             provider_queryables = set(default_queryables)
 

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -2013,10 +2013,10 @@ class EODataAccessGateway:
         if provider is None and product_type is None:
             return {"productType", "start", "end", "geom", "locations", "id"}
 
-        if provider in self._plugins_manager.providers_config:
-            providers = [self._plugins_manager.providers_config[provider]]
+        if provider in self.providers_config:
+            providers = [self.providers_config[provider]]
         else:
-            providers = self._plugins_manager.providers_config.values()
+            providers = self.providers_config.values()
         queryable_properties: Set[str] = set()
         for provider_config in providers:
             # if a product_type is given then search all the providers providing it,
@@ -2028,8 +2028,10 @@ class EODataAccessGateway:
                 continue
             if hasattr(provider_config, "search"):
                 plugin_config = provider_config.search
-            else:
+            elif hasattr(provider_config, "api"):
                 plugin_config = provider_config.api
+            else:
+                continue
             # list of all provider-specific queryables
             mapping = dict(plugin_config.metadata_mapping)
             for key, value in mapping.items():

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -2014,7 +2014,7 @@ class EODataAccessGateway:
         default_queryables = {"productType", "start", "end", "geom", "locations", "id"}
         if provider is None and product_type is None:
             return default_queryables
-        
+
         plugins = self._plugins_manager.get_search_plugins(product_type, provider)
 
         # dictionary of the queryable properties of the providers supporting the given product type
@@ -2022,7 +2022,6 @@ class EODataAccessGateway:
         for plugin in plugins:
             if product_type and product_type not in plugin.config.products.keys():
                 raise UnsupportedProductType(product_type)
-            
 
             provider_queryables = set(default_queryables)
 

--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -467,8 +467,8 @@ def list_collection_queryables(
         fetch_collection_queryable_properties(*conf_args)
     )
 
-    for prop in provider_properties:
-        titled_name = re.sub(CAMEL_TO_SPACE_TITLED, " ", prop).title()
+    for prop in sorted(provider_properties):
+        titled_name = re.sub(CAMEL_TO_SPACE_TITLED, " ", prop.split(":")[-1]).title()
         queryables[prop] = QueryableProperty(description=titled_name)
 
     return queryables

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -1121,8 +1121,10 @@ def fetch_collection_queryable_properties(
     :rtype queryable_properties: set
     """
     # Fetch the metadata mapping for collection-specific queryables
-    args = [collection_id, provider] if provider else [collection_id]
-    eodag_queryable_properties = eodag_api.get_queryables(*args)
+    kwargs = {"product_type": collection_id}
+    if provider is not None:
+        kwargs["provider"] = provider
+    eodag_queryable_properties = eodag_api.get_queryables(**kwargs)
     # list of all the STAC standardized collection-specific queryables
     queryable_properties: Set[str] = set()
     for prop in eodag_queryable_properties:

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -1122,14 +1122,11 @@ def fetch_collection_queryable_properties(
     """
     # Fetch the metadata mapping for collection-specific queryables
     args = [collection_id, provider] if provider else [collection_id]
-    search_plugin = next(eodag_api._plugins_manager.get_search_plugins(*args))
-    search_plugin.config
-    mapping: Dict[str, Any] = dict(search_plugin.config.metadata_mapping)
+    eodag_queryable_properties = eodag_api.get_queryables(*args)
     # list of all the STAC standardized collection-specific queryables
     queryable_properties: Set[str] = set()
-    for key, value in mapping.items():
-        if isinstance(value, list) and "TimeFromAscendingNode" not in key:
-            queryable_properties.add(rename_to_stac_standard(key))
+    for prop in eodag_queryable_properties:
+        queryable_properties.add(rename_to_stac_standard(prop))
     return queryable_properties
 
 

--- a/tests/context.py
+++ b/tests/context.py
@@ -97,6 +97,7 @@ from eodag.utils.exceptions import (
     PluginImplementationError,
     RequestError,
     UnsupportedDatasetAddressScheme,
+    UnsupportedProductType,
     UnsupportedProvider,
     ValidationError,
     STACOpenerError,

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1008,55 +1008,51 @@ class TestCore(TestCoreBase):
         self.assertSetEqual(queryables, expected_result)
 
         expected_result = {
+            "geometry",
+            "platformSerialIdentifier",
+            "title",
+            "awsPath",
+            "id",
+            "productType",
+            "doi",
+            "processingLevel",
             "platform",
+            "instrument",
             "resolution",
             "publicationDate",
-            "acquisitionStation",
-            "productType",
-            "availabilityTime",
-            "sensorMode",
+            "orbitNumber",
             "orbitDirection",
-            "dopplerFrequency",
             "cloudCover",
+            "sensorMode",
             "creationDate",
-            "tileIdentifier",
-            "id",
+            "modificationDate",
+            "productVersion",
+            "availabilityTime",
+            "acquisitionStation",
             "acquisitionSubType",
             "illuminationAzimuthAngle",
             "illuminationElevationAngle",
-            "platformSerialIdentifier",
-            "modificationDate",
             "polarizationChannels",
-            "orbitNumber",
-            "doi",
-            "productVersion",
-            "geometry",
-            "instrument",
-            "processingLevel",
+            "dopplerFrequency",
+            "tileIdentifier",
         }
-        queryables = self.dag.get_queryables(product_type="LANDSAT_C2L1")
+        queryables = self.dag.get_queryables(product_type="NAIP")
         self.assertSetEqual(queryables, expected_result)
 
         expected_result = {
-            "productType",
-            "platformSerialIdentifier",
-            "instrument",
-            "processingLevel",
-            "resolution",
-            "organisationName",
-            "parentIdentifier",
-            "orbitNumber",
-            "orbitDirection",
-            "swathIdentifier",
-            "cloudCover",
-            "snowCover",
-            "sensorMode",
-            "polarizationMode",
-            "id",
-            "tileIdentifier",
             "geometry",
+            "platformSerialIdentifier",
+            "title",
+            "cloudCover",
+            "illuminationAzimuthAngle",
+            "illuminationZenithAngle",
+            "awsPath",
+            "productPath",
+            "id",
         }
-        queryables = self.dag.get_queryables(provider="peps", product_type="S2_MSI_L1C")
+        queryables = self.dag.get_queryables(
+            provider="aws_eos", product_type="S2_MSI_L1C"
+        )
         self.assertSetEqual(queryables, expected_result)
 
 

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -43,6 +43,7 @@ from tests.context import (
     ProviderConfig,
     RequestError,
     SearchResult,
+    UnsupportedProductType,
     UnsupportedProvider,
     get_geometry_from_various,
     load_default_config,
@@ -981,6 +982,12 @@ class TestCore(TestCoreBase):
         self.dag.update_providers_config(new_config)
 
     def test_get_queryables(self):
+        with self.assertRaises(UnsupportedProvider):
+            self.dag.get_queryables(provider="not_existing_provider")
+
+        with self.assertRaises(UnsupportedProductType):
+            self.dag.get_queryables(product_type="not_existing_product_type")
+
         expected_result = {"productType", "start", "end", "geom", "locations", "id"}
         queryables = self.dag.get_queryables()
         self.assertSetEqual(queryables, expected_result)
@@ -1011,32 +1018,17 @@ class TestCore(TestCoreBase):
             "geometry",
             "platformSerialIdentifier",
             "title",
-            "awsPath",
-            "id",
-            "productType",
-            "doi",
-            "processingLevel",
-            "platform",
-            "instrument",
-            "resolution",
-            "publicationDate",
-            "orbitNumber",
-            "orbitDirection",
             "cloudCover",
-            "sensorMode",
-            "creationDate",
-            "modificationDate",
-            "productVersion",
-            "availabilityTime",
-            "acquisitionStation",
-            "acquisitionSubType",
             "illuminationAzimuthAngle",
-            "illuminationElevationAngle",
-            "polarizationChannels",
-            "dopplerFrequency",
-            "tileIdentifier",
+            "illuminationZenithAngle",
+            "awsPath",
+            "productPath",
+            "id",
         }
-        queryables = self.dag.get_queryables(product_type="NAIP")
+        preferred_provider, _ = self.dag.get_preferred_provider()
+        self.dag.set_preferred_provider("aws_eos")
+        queryables = self.dag.get_queryables(product_type="S2_MSI_L1C")
+        self.dag.set_preferred_provider(preferred_provider)
         self.assertSetEqual(queryables, expected_result)
 
         expected_result = {

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -980,6 +980,85 @@ class TestCore(TestCoreBase):
         # run a 2nd time: check that it does not raise an error
         self.dag.update_providers_config(new_config)
 
+    def test_get_queryables(self):
+        expected_result = {"productType", "start", "end", "geom", "locations", "id"}
+        queryables = self.dag.get_queryables()
+        self.assertSetEqual(queryables, expected_result)
+
+        expected_result = {
+            "productType",
+            "platformSerialIdentifier",
+            "instrument",
+            "processingLevel",
+            "resolution",
+            "organisationName",
+            "parentIdentifier",
+            "orbitNumber",
+            "orbitDirection",
+            "swathIdentifier",
+            "cloudCover",
+            "snowCover",
+            "sensorMode",
+            "polarizationMode",
+            "id",
+            "tileIdentifier",
+            "geometry",
+        }
+        queryables = self.dag.get_queryables(provider="peps")
+        self.assertSetEqual(queryables, expected_result)
+
+        expected_result = {
+            "platform",
+            "resolution",
+            "publicationDate",
+            "acquisitionStation",
+            "productType",
+            "availabilityTime",
+            "sensorMode",
+            "orbitDirection",
+            "dopplerFrequency",
+            "cloudCover",
+            "creationDate",
+            "tileIdentifier",
+            "id",
+            "acquisitionSubType",
+            "illuminationAzimuthAngle",
+            "illuminationElevationAngle",
+            "platformSerialIdentifier",
+            "modificationDate",
+            "polarizationChannels",
+            "orbitNumber",
+            "doi",
+            "productVersion",
+            "geometry",
+            "instrument",
+            "processingLevel",
+        }
+        queryables = self.dag.get_queryables(product_type="LANDSAT_C2L1")
+        self.assertSetEqual(queryables, expected_result)
+
+        expected_result = {
+            "productType",
+            "platformSerialIdentifier",
+            "instrument",
+            "processingLevel",
+            "resolution",
+            "organisationName",
+            "parentIdentifier",
+            "orbitNumber",
+            "orbitDirection",
+            "swathIdentifier",
+            "cloudCover",
+            "snowCover",
+            "sensorMode",
+            "polarizationMode",
+            "id",
+            "tileIdentifier",
+            "geometry",
+        }
+        queryables = self.dag.get_queryables(provider="peps", product_type="S2_MSI_L1C")
+        self.assertSetEqual(queryables, expected_result)
+
 
 class TestCoreConfWithEnvVar(TestCoreBase):
     @classmethod

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -993,6 +993,10 @@ class TestCore(TestCoreBase):
         self.assertSetEqual(queryables, expected_result)
 
         expected_result = {
+            "start",
+            "end",
+            "geom",
+            "locations",
             "productType",
             "platformSerialIdentifier",
             "instrument",
@@ -1014,24 +1018,16 @@ class TestCore(TestCoreBase):
         queryables = self.dag.get_queryables(provider="peps")
         self.assertSetEqual(queryables, expected_result)
 
-        expected_result = {
-            "geometry",
-            "platformSerialIdentifier",
-            "title",
-            "cloudCover",
-            "illuminationAzimuthAngle",
-            "illuminationZenithAngle",
-            "awsPath",
-            "productPath",
-            "id",
-        }
-        preferred_provider, _ = self.dag.get_preferred_provider()
-        self.dag.set_preferred_provider("aws_eos")
+        expected_result = {"productType", "start", "end", "geom", "locations", "id"}
         queryables = self.dag.get_queryables(product_type="S2_MSI_L1C")
-        self.dag.set_preferred_provider(preferred_provider)
         self.assertSetEqual(queryables, expected_result)
 
         expected_result = {
+            "productType",
+            "start",
+            "end",
+            "geom",
+            "locations",
             "geometry",
             "platformSerialIdentifier",
             "title",

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -982,6 +982,7 @@ class TestCore(TestCoreBase):
         self.dag.update_providers_config(new_config)
 
     def test_get_queryables(self):
+        """get_queryables must return queryables list adapted to provider and product-type"""
         with self.assertRaises(UnsupportedProvider):
             self.dag.get_queryables(provider="not_existing_provider")
 
@@ -1016,6 +1017,31 @@ class TestCore(TestCoreBase):
             "geometry",
         }
         queryables = self.dag.get_queryables(provider="peps")
+        self.assertSetEqual(queryables, expected_result)
+
+        expected_result = {
+            "start",
+            "end",
+            "geom",
+            "locations",
+            "productType",
+            "platformSerialIdentifier",
+            "instrument",
+            "processingLevel",
+            "resolution",
+            "organisationName",
+            "parentIdentifier",
+            "orbitNumber",
+            "orbitDirection",
+            "swathIdentifier",
+            "snowCover",
+            "sensorMode",
+            "polarizationMode",
+            "id",
+            "tileIdentifier",
+            "geometry",
+        }
+        queryables = self.dag.get_queryables(provider="peps", product_type="S1_SAR_GRD")
         self.assertSetEqual(queryables, expected_result)
 
         expected_result = {"productType", "start", "end", "geom", "locations", "id"}


### PR DESCRIPTION
Implements a new core method `def get_queryables(provider=None, product_type=None) -> List[str]`:

- If no `provider` and no `product_type` are passed, then returns default search method queryable parameters: `["productType", "start", "end", "geom", "locations", "id"]`
- If a `provider` is passed (but no `product_type`), then returns its queryable parameters from provider's config
- If a `product_type` is passed (but no `provider`), then return the intersection of the queryables of all the providers supporting it
- If both a `product_type` and a `provider` are passed, then returns the queryable parameters from provider's config and the queryable parameters for that product type

The following exceptions are raised:
- `UnsupportedProvider()` if the given `provider` is not found
- `UnsupportedProductType()` if the given `product_type` is not found
