### PR TITLE
feat[server]: offline products order handling

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -175,8 +175,9 @@ class BuildPostSearchResult(PostJsonSearch):
 
         query_hash = hashlib.sha1(str(qs).encode("UTF-8")).hexdigest()
 
-        # update result with search args if not None (and not auth)
+        # update result with product_type_def_params and search args if not None (and not auth)
         kwargs.pop("auth", None)
+        result.update(self.product_type_def_params)
         result = dict(result, **{k: v for k, v in kwargs.items() if v is not None})
 
         # parse porperties

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -1144,6 +1144,11 @@ class PostJsonSearch(QueryStringSearch):
         if _dc_qs is not None:
             qs = unquote_plus(unquote_plus(_dc_qs))
             qp = geojson.loads(qs)
+
+            # provider product type specific conf
+            self.product_type_def_params = self.get_product_type_def_params(
+                product_type, **kwargs
+            )
         else:
             keywords = {
                 k: v for k, v in kwargs.items() if k != "auth" and v is not None

--- a/eodag/rest/core.py
+++ b/eodag/rest/core.py
@@ -23,7 +23,7 @@ from typing import Any, Callable, Dict, List, Optional, cast
 
 import dateutil
 from fastapi import Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import ORJSONResponse, StreamingResponse
 from pydantic import ValidationError as pydanticValidationError
 
 import eodag
@@ -263,9 +263,11 @@ def download_stac_item(
         download_stream = file_to_stream(
             eodag_api.download(product, extract=False, asset=asset)
         )
-    except NotAvailableError:
-        download_stream.content = (i for i in range(0))
-        download_stream.status_code = 202
+    except NotAvailableError as e:
+        return ORJSONResponse(
+            status_code=202,
+            content={"description": str(e)},
+        )
 
     return StreamingResponse(
         content=download_stream.content,

--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -39,7 +39,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
-from fastapi.responses import ORJSONResponse, StreamingResponse
+from fastapi.responses import ORJSONResponse
 from pydantic import ValidationError as pydanticValidationError
 from pygeofilter.backends.cql2_json import to_cql2
 from pygeofilter.parsers.cql2_text import parse as parse_cql2_text
@@ -79,6 +79,8 @@ from eodag.utils.exceptions import (
 if TYPE_CHECKING:
     from fastapi.types import DecoratedCallable
     from requests import Response
+
+from starlette.responses import Response as StarletteResponse
 
 logger = logging.getLogger("eodag.rest.server")
 ERRORS_WITH_500_STATUS_CODE = {
@@ -385,7 +387,7 @@ def stac_extension_oseo(request: Request) -> Any:
 )
 def stac_collections_item_download(
     collection_id: str, item_id: str, request: Request
-) -> StreamingResponse:
+) -> StarletteResponse:
     """STAC collection item download"""
     logger.debug("URL: %s", request.url)
 
@@ -393,7 +395,11 @@ def stac_collections_item_download(
     provider = arguments.pop("provider", None)
 
     return download_stac_item(
-        catalogs=[collection_id], item_id=item_id, provider=provider, **arguments
+        request=request,
+        catalogs=[collection_id],
+        item_id=item_id,
+        provider=provider,
+        **arguments,
     )
 
 
@@ -412,6 +418,7 @@ def stac_collections_item_download_asset(
     provider = arguments.pop("provider", None)
 
     return download_stac_item(
+        request=request,
         catalogs=[collection_id],
         item_id=item_id,
         provider=provider,
@@ -575,7 +582,7 @@ def collections(request: Request) -> Any:
 )
 def stac_catalogs_item_download(
     catalogs: str, item_id: str, request: Request
-) -> StreamingResponse:
+) -> StarletteResponse:
     """STAC Catalog item download"""
     logger.debug("URL: %s", request.url)
 
@@ -585,7 +592,11 @@ def stac_catalogs_item_download(
     list_catalog = catalogs.strip("/").split("/")
 
     return download_stac_item(
-        catalogs=list_catalog, item_id=item_id, provider=provider, **arguments
+        request=request,
+        catalogs=list_catalog,
+        item_id=item_id,
+        provider=provider,
+        **arguments,
     )
 
 
@@ -606,6 +617,7 @@ def stac_catalogs_item_download_asset(
     list_catalog = catalogs.strip("/").split("/")
 
     return download_stac_item(
+        request=request,
         catalogs=list_catalog,
         item_id=item_id,
         provider=provider,

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -1433,6 +1433,7 @@ class StreamResponse:
     content: Iterator[bytes]
     headers: Optional[Mapping[str, str]] = None
     media_type: Optional[str] = None
+    status_code: Optional[int] = None
 
 
 def guess_file_type(file: str) -> Optional[str]:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -335,6 +335,7 @@ class EODagTestCase(unittest.TestCase):
                     response.__zip_buffer = io.BytesIO(fh.read())
                 cl = response.__zip_buffer.getbuffer().nbytes
                 response.headers = {"content-length": cl}
+                response.url = "http://foo.bar"
 
             def __enter__(response):
                 return response

--- a/tests/context.py
+++ b/tests/context.py
@@ -33,6 +33,7 @@ from eodag.api.product.metadata_mapping import (
     format_metadata,
     OFFLINE_STATUS,
     ONLINE_STATUS,
+    STAGING_STATUS,
     properties_from_json,
     NOT_AVAILABLE,
 )

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -172,6 +172,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
                     self.__zip_buffer = io.BytesIO(fh.read())
                 cl = self.__zip_buffer.getbuffer().nbytes
                 self.headers = {"content-length": cl}
+                self.url = "http://foo.bar"
 
             def __enter__(self):
                 return self

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -1009,12 +1009,12 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         # empty product download directory should have been removed
         self.assertFalse(Path(os.path.join(self.output_dir, "dummy_product")).exists())
 
-    def test_plugins_download_http_order_download_cds(
+    def test_plugins_download_http_order_download_cop_ads(
         self,
     ):
         """HTTPDownload.download must order the product if needed"""
 
-        self.product.provider = "cop_cds"
+        self.product.provider = "cop_ads"
         self.product.product_type = "CAMS_EAC4"
         product_dataset = "cams-global-reanalysis-eac4"
 
@@ -1076,6 +1076,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
 
             # expected values
             expected_remote_location = "http://somewhere/download/dummy_request_id"
+            expected_order_status_link = f"{endpoint}/tasks/dummy_request_id"
             expected_path = os.path.join(
                 output_data_path, self.product.properties["title"]
             )
@@ -1086,6 +1087,12 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
                 timeout=0.2 / 60,
             )
             self.assertEqual(self.product.remote_location, expected_remote_location)
+            self.assertEqual(
+                self.product.properties["downloadLink"], expected_remote_location
+            )
+            self.assertEqual(
+                self.product.properties["orderStatusLink"], expected_order_status_link
+            )
             self.assertEqual(path, expected_path)
             self.assertEqual(self.product.location, path_to_uri(expected_path))
 

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -514,7 +514,7 @@ class RequestTestCase(unittest.TestCase):
     def _request_accepted(self, url, mock_search):
         response = self.app.get(url, follow_redirects=True)
         self.assertEqual(202, response.status_code)
-        self.assertEquals(response.content, b"")
+        self.assertEqual(response.content, b"")
 
     def test_request_params(self):
         self._request_not_valid(f"search?collections={self.tested_product_type}&bbox=1")

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -513,8 +513,9 @@ class RequestTestCase(unittest.TestCase):
     )
     def _request_accepted(self, url, mock_search):
         response = self.app.get(url, follow_redirects=True)
+        response_content = json.loads(response.content.decode("utf-8"))
         self.assertEqual(202, response.status_code)
-        self.assertEqual(response.content, b"")
+        self.assertIn("description", response_content)
 
     def test_request_params(self):
         self._request_not_valid(f"search?collections={self.tested_product_type}&bbox=1")
@@ -1160,7 +1161,7 @@ class RequestTestCase(unittest.TestCase):
     @mock.patch(
         "eodag.plugins.download.http.HTTPDownload._stream_download",
         autospec=True,
-        side_effect=NotAvailableError(),
+        side_effect=NotAvailableError("Product offline. Try again later."),
     )
     def test_download_offline_item_from_catalog(self, mock_download, mock_auth):
         """Download an offline item through eodag server catalog should return a


### PR DESCRIPTION
When downloading an OFFLINE product in server mode:

- return HTTP Status 202 with new download link containing order status check information as query parameters
- don't retry to download the product again

Closes #871 

Also fixes missing `dataset` parameter after `BuildSearchResult` search-by-id in server mode