### PR TITLE
docs: deserialize documentation typo

### DIFF
--- a/docs/notebooks/api_user_guide/5_serialize_deserialize.ipynb
+++ b/docs/notebooks/api_user_guide/5_serialize_deserialize.ipynb
@@ -192,7 +192,7 @@
    "source": [
     "There are two methods offered by [EODataAccessGateway](../../api_reference/core.rst#eodag.api.core.EODataAccessGateway) to load a search result saved as a GeoJSON:\n",
     "\n",
-    "* [serialize()](../../api_reference/core.rst#eodag.api.core.EODataAccessGateway.deserialize): it  simply recreates a [SearchResult](../../api_reference/searchresult.rst#eodag.api.search_result.SearchResult) and the [EOProduct](../../api_reference/eoproduct.rst#eodag.api.product._product.EOProduct) it contained\n",
+    "* [deserialize()](../../api_reference/core.rst#eodag.api.core.EODataAccessGateway.deserialize): it  simply recreates a [SearchResult](../../api_reference/searchresult.rst#eodag.api.search_result.SearchResult) and the [EOProduct](../../api_reference/eoproduct.rst#eodag.api.product._product.EOProduct) it contained\n",
     "* [deserialize_and_register()](../../api_reference/core.rst#eodag.api.core.EODataAccessGateway.deserialize_and_register): it also recreates a [SearchResult](../../api_reference/searchresult.rst#eodag.api.search_result.SearchResult) but additionally registers for each [EOProduct](../../api_reference/eoproduct.rst#eodag.api.product._product.EOProduct) the information it requires to download itself"
    ],
    "cell_type": "markdown",


### PR DESCRIPTION
Corrected typo in the "Serialize/Deserialize" page of the documentation.

Fixes #900 