### PR TITLE
fix: use refresh token to get access token in keycloak auth

### DIFF
--- a/eodag/plugins/authentication/keycloak.py
+++ b/eodag/plugins/authentication/keycloak.py
@@ -119,6 +119,7 @@ class KeycloakOIDCPasswordAuth(Authentication):
                 >= self.token_info["access_token_expiration"]
             )
         ):
+            # Request new TOKEN on first attempt or if token expired
             res = self._request_new_token()
             self.token_info["token_time"] = current_time
             self.token_info["access_token_expiration"] = res["expires_in"]
@@ -132,6 +133,7 @@ class KeycloakOIDCPasswordAuth(Authentication):
             and (current_time - self.token_info["refresh_time"]).seconds
             >= self.token_info["access_token_expiration"]
         ):
+            # Use refresh token
             res = self._get_token_with_refresh_token()
             self.token_info["refresh_token"] = res["refresh_token"]
             self.token_info["refresh_time"] = current_time

--- a/eodag/plugins/authentication/keycloak.py
+++ b/eodag/plugins/authentication/keycloak.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+from datetime import datetime
 from typing import Optional
 
 import requests
@@ -73,6 +74,7 @@ class KeycloakOIDCPasswordAuth(Authentication):
     REQUIRED_PARAMS = ["auth_base_uri", "client_id", "client_secret", "token_provision"]
     # already retrieved token store, to be used if authenticate() fails (OTP use-case)
     retrieved_token: Optional[str] = None
+    token_info: Optional[dict] = {}
 
     def __init__(self, provider, config):
         super(KeycloakOIDCPasswordAuth, self).__init__(provider, config)
@@ -94,6 +96,51 @@ class KeycloakOIDCPasswordAuth(Authentication):
         Makes authentication request
         """
         self.validate_config_credentials()
+        access_token = self._get_access_token()
+        self.retrieved_token = access_token
+        return CodeAuthorizedAuth(
+            self.retrieved_token,
+            self.config.token_provision,
+            key=getattr(self.config, "token_qs_key", None),
+        )
+
+    def _get_access_token(self):
+        current_time = datetime.now()
+        if (
+            not self.token_info
+            or (
+                "refresh_token" in self.token_info
+                and (current_time - self.token_info["token_time"]).seconds
+                >= self.token_info["refresh_token_expiration"]
+            )
+            or (
+                "refresh_token" not in self.token_info
+                and (current_time - self.token_info["token_time"]).seconds
+                >= self.token_info["access_token_expiration"]
+            )
+        ):
+            res = self._request_new_token()
+            self.token_info["token_time"] = current_time
+            self.token_info["access_token_expiration"] = res["expires_in"]
+            if "refresh_token" in res:
+                self.token_info["refresh_time"] = current_time
+                self.token_info["refresh_token_expiration"] = res["refresh_expires_in"]
+                self.token_info["refresh_token"] = res["refresh_token"]
+            return res["access_token"]
+        elif (
+            "refresh_token" in self.token_info
+            and (current_time - self.token_info["refresh_time"]).seconds
+            >= self.token_info["access_token_expiration"]
+        ):
+            res = self._get_token_with_refresh_token()
+            self.token_info["refresh_token"] = res["refresh_token"]
+            self.token_info["refresh_time"] = current_time
+            return res["access_token"]
+        logger.debug("using already retrieved access token")
+        return self.retrieved_token
+
+    def _request_new_token(self):
+        logger.debug("fetching new access token")
         req_data = {
             "client_id": self.config.client_id,
             "client_secret": self.config.client_secret,
@@ -144,10 +191,31 @@ class KeycloakOIDCPasswordAuth(Authentication):
                         tb.format_exc()
                     )
                 )
+        return response.json()
 
-        self.retrieved_token = response.json()["access_token"]
-        return CodeAuthorizedAuth(
-            self.retrieved_token,
-            self.config.token_provision,
-            key=getattr(self.config, "token_qs_key", None),
-        )
+    def _get_token_with_refresh_token(self):
+        logger.debug("fetching access token with refresh token")
+        req_data = {
+            "client_id": self.config.client_id,
+            "client_secret": self.config.client_secret,
+            "grant_type": "refresh_token",
+            "refresh_token": self.token_info["refresh_token"],
+        }
+        try:
+            response = self.session.post(
+                self.TOKEN_URL_TEMPLATE.format(
+                    auth_base_uri=self.config.auth_base_uri.rstrip("/"),
+                    realm=self.config.realm,
+                ),
+                data=req_data,
+                headers=USER_AGENT,
+                timeout=HTTP_REQ_TIMEOUT,
+            )
+            response.raise_for_status()
+        except requests.RequestException as e:
+            logger.error(
+                "could not fetch access token with refresh token, executing new token request, error: %s",
+                getattr(e.response, "text", ""),
+            )
+            return self._request_new_token()
+        return response.json()


### PR DESCRIPTION
For keycloak authentication it is now checked if the access token is still valid before a new token request is done. If available, the refresh token is used to request a new access token.
