### PR TITLE
test: static type checking

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,13 @@ dev =
     pre-commit
     responses < 0.24.0
     fastapi[all]
+    # static type checking
+    mypy
+    types-tqdm
+    lxml-stubs
+    types-python-dateutil
+    types-requests
+    types-setuptools
 notebook = tqdm[notebook]
 tutorials =
     eodag-cube >= 0.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 [tox]
-envlist = py38, py39, py310, py311, py312, docs, pypi, linters
+envlist = py38, py39, py310, py311, py312, docs, pypi, linters, mypy
 skipdist = true
 
 # Mapping required by tox-gh-actions, only used in CI
@@ -87,3 +87,7 @@ basepython = python3
 skip_install = true
 deps = pre-commit
 commands = pre-commit run --all-files
+
+[testenv:mypy]
+commands = mypy -p eodag
+deps = -r{toxinidir}/requirements-dev.txt


### PR DESCRIPTION
Adds `mypy` static type checking to tests through `tox`.

Related to #863 and #880