### PR TITLE
feat: provider group

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -23,18 +23,7 @@ import re
 import shutil
 import tempfile
 from operator import itemgetter
-from typing import (
-    TYPE_CHECKING,
-    AbstractSet,
-    Any,
-    Dict,
-    Iterator,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Set, Tuple, Union
 
 import geojson
 import pkg_resources
@@ -553,7 +542,7 @@ class EODataAccessGateway:
                 if product_type_id == GENERIC_PRODUCT_TYPE:
                     continue
                 config = self.product_types_config[product_type_id]
-                config["_id"] = product_type_id 
+                config["_id"] = product_type_id
                 if "alias" in config:
                     product_type_id = config["alias"]
                 product_type = {"ID": product_type_id, **config}
@@ -2147,9 +2136,7 @@ class EODataAccessGateway:
         return self._plugins_manager.get_crunch_plugin(name, **plugin_conf)
 
     def list_queryables(
-        self,
-        provider: Optional[str] = None,
-        **kwargs: Any,
+        self, provider: Optional[str] = None, **kwargs: Any
     ) -> Dict[str, Annotated[Any, FieldInfo]]:
         """Fetch the queryable properties for a given product type and/or provider.
 
@@ -2158,11 +2145,14 @@ class EODataAccessGateway:
         :param kwargs: additional filters for queryables (`productType` or other search
                        arguments)
         :type kwargs: Any
+
+        :raises UnsupportedProductType: If the specified product type is not available for the
+                                        provider.
+
         :returns: A dict containing the EODAG queryable properties, associating
                   parameters to their annotated type
         :rtype: Dict[str, Annotated[Any, FieldInfo]]
         """
-        # unknown product type
         available_product_types = [
             pt["ID"] for pt in self.list_product_types(fetch_providers=False)
         ]
@@ -2170,101 +2160,28 @@ class EODataAccessGateway:
         if product_type is not None and product_type not in available_product_types:
             self.fetch_product_types_list()
 
-        # dictionary of the queryable properties of the providers supporting the given product type
-        providers_available_queryables: Dict[
-            str, Dict[str, Annotated[Any, FieldInfo]]
-        ] = dict()
-
-        if provider is None and product_type is None:
-            return model_fields_to_annotated(CommonQueryables.model_fields)
-        elif provider is None:
-            for plugin in self._plugins_manager.get_search_plugins(
-                product_type, provider
-            ):
-                providers_available_queryables[plugin.provider] = self.list_queryables(
-                    provider=plugin.provider, **kwargs
-                )
-
-            # return providers queryables intersection
-            queryables_keys: AbstractSet[str] = set()
-            for queryables in providers_available_queryables.values():
-                queryables_keys = (
-                    queryables_keys & queryables.keys()
-                    if queryables_keys
-                    else queryables.keys()
-                )
-            return {
-                k: v
-                for k, v in providers_available_queryables.popitem()[1].items()
-                if k in queryables_keys
-            }
-
-        all_queryables = copy_deepcopy(
-            model_fields_to_annotated(Queryables.model_fields)
-        )
-
-        try:
-            plugin = next(
-                self._plugins_manager.get_search_plugins(product_type, provider)
-            )
-        except StopIteration:
-            # return default queryables if no plugin is found
+        if not provider and not product_type:
             return model_fields_to_annotated(CommonQueryables.model_fields)
 
-        providers_available_queryables[plugin.provider] = dict()
+        providers_queryables: Dict[str, Dict[str, Annotated[Any, FieldInfo]]] = {}
 
-        # unknown product type: try again after fetch_product_types_list()
-        if (
-            product_type
-            and product_type not in plugin.config.products.keys()
-            and provider is None
-        ):
-            raise UnsupportedProductType(product_type)
-        elif product_type and product_type not in plugin.config.products.keys():
-            raise UnsupportedProductType(
-                f"{product_type} is not available for provider {provider}"
+        for plugin in self._plugins_manager.get_search_plugins(product_type, provider):
+            if product_type and product_type not in plugin.config.products.keys():
+                raise UnsupportedProductType(
+                    f"{product_type} is not available for provider {plugin.provider}"
+                )
+            providers_queryables[plugin.provider] = _list_plugin_queryables(
+                plugin, kwargs, product_type
             )
 
-        metadata_mapping = deepcopy(getattr(plugin.config, "metadata_mapping", {}))
-
-        # product_type-specific metadata-mapping
-        metadata_mapping.update(
-            getattr(plugin.config, "products", {})
-            .get(product_type, {})
-            .get("metadata_mapping", {})
+        queryable_keys: Set[str] = set.intersection(  # type: ignore
+            *[set(q.keys()) for q in providers_queryables.values()]
         )
-
-        # default values
-        default_values = deepcopy(
-            getattr(plugin.config, "products", {}).get(product_type, {})
-        )
-        default_values.pop("metadata_mapping", None)
-        kwargs = dict(default_values, **kwargs)
-
-        # remove not mapped parameters or non-queryables
-        for param in list(metadata_mapping.keys()):
-            if NOT_MAPPED in metadata_mapping[param] or not isinstance(
-                metadata_mapping[param], list
-            ):
-                del metadata_mapping[param]
-
-        for key, value in all_queryables.items():
-            annotated_args = get_args(value)
-            if len(annotated_args) < 1:
-                continue
-            field_info = annotated_args[1]
-            if not isinstance(field_info, FieldInfo):
-                continue
-            if key in kwargs:
-                field_info.default = kwargs[key]
-            if field_info.is_required() or (
-                (field_info.alias or key) in metadata_mapping
-            ):
-                providers_available_queryables[plugin.provider][key] = value
-
-        provider_queryables = plugin.discover_queryables(**kwargs) or dict()
-        # use EODAG configured queryables by default
-        provider_queryables.update(providers_available_queryables[provider])
+        queryables = {
+            k: v
+            for k, v in list(providers_queryables.values())[0].items()
+            if k in queryable_keys
+        }
 
         # always keep at least CommonQueryables
         common_queryables = copy_deepcopy(CommonQueryables.model_fields)
@@ -2272,9 +2189,9 @@ class EODataAccessGateway:
             if key in kwargs:
                 queryable.default = kwargs[key]
 
-        provider_queryables.update(model_fields_to_annotated(common_queryables))
+        queryables.update(model_fields_to_annotated(common_queryables))
 
-        return provider_queryables
+        return queryables
 
     def available_sortables(self) -> Dict[str, Optional[ProviderSortables]]:
         """For each provider, gives its available sortable parameter(s) and its maximum
@@ -2308,3 +2225,61 @@ class EODataAccessGateway:
                 ],
             }
         return sortables
+
+
+def _list_plugin_queryables(
+    plugin: Union[Search, Api],
+    filters: Dict[str, Any],
+    product_type: Optional[str] = None,
+) -> Dict[str, Annotated[Any, FieldInfo]]:
+    """
+    Get queryables for a specific search plugin.
+
+    :param plugin: The search plugin (either Search or Api).
+    :type plugin: Union[Search, Api]
+    :param filters: Additional filters for queryables.
+    :type filters: Dict[str, Any]
+    :param product_type: (optional) The product type.
+    :type product_type: Optional[str]
+
+    :return: A dictionary containing the queryable properties, associating parameters to their
+             annotated type.
+    :rtype: Dict[str, Annotated[Any, FieldInfo]]
+    """
+    default_values: Dict[str, Any] = deepcopy(
+        getattr(plugin.config, "products", {}).get(product_type, {})
+    )
+    default_values.pop("metadata_mapping", None)
+
+    queryables: Dict[str, Annotated[Any, FieldInfo]] = (
+        plugin.discover_queryables(**{**default_values, **filters}) or {}
+    )
+
+    metadata_mapping: Dict[str, Any] = deepcopy(
+        getattr(plugin.config, "metadata_mapping", {})
+    )
+    metadata_mapping.update(
+        getattr(plugin.config, "products", {})
+        .get(product_type, {})
+        .get("metadata_mapping", {})
+    )
+
+    for param in list(metadata_mapping.keys()):
+        if NOT_MAPPED in metadata_mapping[param] or not isinstance(
+            metadata_mapping[param], list
+        ):
+            del metadata_mapping[param]
+
+    eoadag_queryables = copy_deepcopy(
+        model_fields_to_annotated(Queryables.model_fields)
+    )
+    for k, v in eoadag_queryables.items():
+        field_info = get_args(v)[1] if len(get_args(v)) > 1 else None
+        if not isinstance(field_info, FieldInfo):
+            continue
+        if k in filters:
+            field_info.default = filters[k]
+        if field_info.is_required() or ((field_info.alias or k) in metadata_mapping):
+            queryables[k] = v
+
+    return queryables

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -532,9 +532,19 @@ class EODataAccessGateway:
             self.fetch_product_types_list(provider=provider)
 
         product_types: List[Dict[str, Any]] = []
-        if provider is not None:
-            if provider in self.providers_config:
-                provider_supported_products = self.providers_config[provider].products
+
+        if provider:
+            providers = [
+                p
+                for p in self.providers_config.values()
+                if provider in [p.name, getattr(p, "group", None)]
+            ]
+            if len(providers) == 0:
+                raise UnsupportedProvider(
+                    f"The requested provider is not (yet) supported: {provider}"
+                )
+            for p in providers:
+                provider_supported_products = p.products
                 for product_type_id in provider_supported_products:
                     if product_type_id == GENERIC_PRODUCT_TYPE:
                         continue
@@ -545,10 +555,8 @@ class EODataAccessGateway:
                     product_type = dict(ID=product_type_id, **config)
                     if product_type_id not in product_types:
                         product_types.append(product_type)
-                return sorted(product_types, key=itemgetter("ID"))
-            raise UnsupportedProvider(
-                f"invalid requested provider: {provider} is not (yet) supported"
-            )
+            return sorted(product_types, key=itemgetter("ID"))
+
         # Only get the product types supported by the available providers
         for provider in self.available_providers():
             current_product_type_ids = [pt["ID"] for pt in product_types]
@@ -849,23 +857,48 @@ class EODataAccessGateway:
         # rebuild index after product types list update
         self.build_index()
 
-    def available_providers(self, product_type: Optional[str] = None) -> List[str]:
-        """Gives the sorted list of the available providers
+    def available_providers(
+        self, product_type: Optional[str] = None, by_group: bool = False
+    ) -> List[str]:
+        """Gives the sorted list of the available providers or groups
+
+        The providers or groups are sorted first by their priority level in descending order,
+        and then alphabetically in ascending order for providers or groups with the same
+        priority level.
 
         :param product_type: (optional) Only list providers configured for this product_type
-        :type product_type: str
-        :returns: the sorted list of the available providers
-        :rtype: list
+        :type product_type: Optional[str]
+        :param by_group: (optional) If set to True, list groups instead of providers
+        :type by_group: bool
+        :returns: the sorted list of the available providers or groups
+        :rtype: List[str]
         """
 
         if product_type:
-            return sorted(
-                k
+            providers = [
+                (v.group if by_group and hasattr(v, "group") else k, v.priority)
                 for k, v in self.providers_config.items()
                 if product_type in getattr(v, "products", {}).keys()
-            )
+            ]
         else:
-            return sorted(tuple(self.providers_config.keys()))
+            providers = [
+                (v.group if by_group and hasattr(v, "group") else k, v.priority)
+                for k, v in self.providers_config.items()
+            ]
+
+        # If by_group is True, keep only the highest priority for each group
+        if by_group:
+            group_priority: Dict[str, int] = {}
+            for name, priority in providers:
+                if name not in group_priority or priority > group_priority[name]:
+                    group_priority[name] = priority
+            providers = list(group_priority.items())
+
+        # Sort by priority (descending) and then by name (ascending)
+        providers.sort(key=lambda x: (-x[1], x[0]))
+
+        # Return only the names of the providers or groups
+        return [name for name, _ in providers]
 
     def get_product_type_from_alias(self, alias_or_id: str) -> str:
         """Return the ID of a product type by either its ID or alias

--- a/eodag/cli.py
+++ b/eodag/cli.py
@@ -446,8 +446,6 @@ def list_pt(ctx: Context, **kwargs: Any) -> None:
                     provider=provider, fetch_providers=fetch_providers
                 )
                 if pt["ID"] in guessed_product_types
-                or "alias" in pt
-                and pt["alias"] in guessed_product_types
             ]
         else:
             product_types = dag.list_product_types(

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -128,7 +128,11 @@ class ProviderConfig(yaml.YAMLObject):
     """
 
     name: str
+    group: str
     priority: int = 0  # Set default priority to 0
+    roles: List[str]
+    description: str
+    url: str
     api: PluginConfig
     search: PluginConfig
     products: Dict[str, Any]
@@ -141,7 +145,7 @@ class ProviderConfig(yaml.YAMLObject):
     yaml_tag = "!provider"
 
     @classmethod
-    def from_yaml(cls, loader: yaml.Loader, node: Any) -> ProviderConfig:
+    def from_yaml(cls, loader: yaml.Loader, node: Any) -> Iterator[ProviderConfig]:
         """Build a :class:`~eodag.config.ProviderConfig` from Yaml"""
         cls.validate(tuple(node_key.value for node_key, _ in node.value))
         for node_key, node_value in node.value:
@@ -376,7 +380,7 @@ def load_config(config_path: str) -> Dict[str, ProviderConfig]:
     :returns: The default provider's configuration
     :rtype: dict
     """
-    logger.debug(f"Loading configuration from {config_path}")
+    logger.debug("Loading configuration from %s", config_path)
     config: Dict[str, ProviderConfig] = {}
     try:
         # Providers configs are stored in this file as separated yaml documents

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -43,7 +43,7 @@ from eodag.plugins.crunch.base import Crunch
 from eodag.plugins.download.base import Download
 from eodag.plugins.search.base import Search
 from eodag.utils import GENERIC_PRODUCT_TYPE
-from eodag.utils.exceptions import UnsupportedProvider
+from eodag.utils.exceptions import MisconfiguredError, UnsupportedProvider
 
 if TYPE_CHECKING:
     from eodag.api.product import EOProduct
@@ -72,6 +72,8 @@ class PluginManager:
     """
 
     supported_topics = {"search", "download", "crunch", "auth", "api"}
+
+    product_type_to_provider_config_map: Dict[str, List[ProviderConfig]]
 
     def __init__(self, providers_config: Dict[str, ProviderConfig]) -> None:
         self.providers_config = providers_config
@@ -116,7 +118,7 @@ class PluginManager:
                         self.providers_config = plugin_providers_config
         self.rebuild()
 
-    def rebuild(self, providers_config=None):
+    def rebuild(self, providers_config: Optional[Dict[str, ProviderConfig]] = None):
         """(Re)Build plugin manager mapping and cache"""
         if providers_config is not None:
             self.providers_config = providers_config
@@ -126,13 +128,13 @@ class PluginManager:
 
     def build_product_type_to_provider_config_map(self) -> None:
         """Build mapping conf between product types and providers"""
-        self.product_type_to_provider_config_map: Dict[str, List[ProviderConfig]] = {}
+        self.product_type_to_provider_config_map = {}
         for provider in list(self.providers_config):
             provider_config = self.providers_config[provider]
             if not hasattr(provider_config, "products") or not provider_config.products:
                 logger.info(
-                    "%s: provider has no product configured and will be skipped"
-                    % provider
+                    "%s: provider has no product configured and will be skipped",
+                    provider,
                 )
                 self.providers_config.pop(provider)
                 continue
@@ -159,47 +161,49 @@ class PluginManager:
         :param product_type: (optional) The product type that the constructed plugins
                              must support
         :type product_type: str
-        :param provider: (optional) The provider on which to get the search plugin
+        :param provider: (optional) The provider or the provider group on which to get
+            the search plugins
         :type provider: str
         :returns: All the plugins supporting the product type, one by one (a generator
                   object)
-        :rtype: types.GeneratorType(:class:`~eodag.plugins.search.Search` or :class:`~eodag.plugins.download.Api`)
+        :rtype: types.GeneratorType(:class:`~eodag.plugins.search.Search`
+            or :class:`~eodag.plugins.download.Api`)
         :raises: :class:`~eodag.utils.exceptions.UnsupportedProvider`
         :raises: :class:`~eodag.utils.exceptions.UnsupportedProductType`
         """
 
         def get_plugin() -> Union[Search, Api]:
             plugin: Union[Search, Api]
-            try:
+            if search := getattr(config, "search", None):
                 config.search.products = config.products
                 config.search.priority = config.priority
-                plugin = cast(
-                    Search, self._build_plugin(config.name, config.search, Search)
-                )
-            except AttributeError:
+                plugin = cast(Search, self._build_plugin(config.name, search, Search))
+            elif api := getattr(config, "api", None):
                 config.api.products = config.products
                 config.api.priority = config.priority
-                plugin = cast(Api, self._build_plugin(config.name, config.api, Api))
+                plugin = cast(Api, self._build_plugin(config.name, api, Api))
+            else:
+                raise MisconfiguredError(
+                    f"No search plugin configureed for {config.name}."
+                )
             return plugin
 
-        if provider is not None:
-            try:
-                config = self.providers_config[provider]
-            except KeyError:
-                raise UnsupportedProvider
-            yield get_plugin()
-            # Signal the end of iteration as we already have what we wanted (see PEP-479)
-            return
+        configs: List[ProviderConfig] = list(self.providers_config.values())
+        if provider:
+            configs = [
+                c
+                for c in self.providers_config.values()
+                if provider in [getattr(c, "group", None), c.name]  # type: ignore
+            ]
 
-        if product_type is None:
-            for config in sorted(
-                self.providers_config.values(), key=attrgetter("priority"), reverse=True
-            ):
-                yield get_plugin()
-            # Signal the end of iteration as we already have what we wanted (see PEP-479)
-            return
+        if product_type:
+            configs = self.product_type_to_provider_config_map[product_type]
+
+        if not configs:
+            raise UnsupportedProvider
+
         try:
-            for config in self.product_type_to_provider_config_map[product_type]:
+            for config in sorted(configs, key=attrgetter("priority"), reverse=True):
                 yield get_plugin()
         except KeyError:
             logger.info(
@@ -220,19 +224,20 @@ class PluginManager:
         :rtype: :class:`~eodag.plugins.download.Download` or :class:`~eodag.plugins.download.Api`
         """
         plugin_conf = self.providers_config[product.provider]
-        try:
+        if download := getattr(plugin_conf, "download", None):
             plugin_conf.download.priority = plugin_conf.priority
             plugin = cast(
                 Download,
-                self._build_plugin(product.provider, plugin_conf.download, Download),
+                self._build_plugin(product.provider, download, Download),
             )
-            return plugin
-        except AttributeError:
+        elif api := getattr(plugin_conf, "api", None):
             plugin_conf.api.priority = plugin_conf.priority
-            plugin = cast(
-                Api, self._build_plugin(product.provider, plugin_conf.api, Api)
+            plugin = cast(Api, self._build_plugin(product.provider, api, Api))
+        else:
+            raise MisconfiguredError(
+                f"No download plugin configured for provider {plugin_conf.name}."
             )
-            return plugin
+        return plugin
 
     def get_auth_plugin(self, provider: str) -> Optional[Authentication]:
         """Build and return the authentication plugin for the given product_type and
@@ -244,17 +249,17 @@ class PluginManager:
         :rtype: :class:`~eodag.plugins.authentication.Authentication`
         """
         plugin_conf = self.providers_config[provider]
-        try:
-            plugin_conf.auth.priority = plugin_conf.priority
-            plugin = cast(
-                Authentication,
-                self._build_plugin(provider, plugin_conf.auth, Authentication),
-            )
-            return plugin
-        except AttributeError:
+        auth = getattr(plugin_conf, "auth", None)
+        if not auth:
             # We guess the plugin being built is of type Api, therefore no need
             # for an Auth plugin.
             return None
+        auth.priority = plugin_conf.priority
+        plugin = cast(
+            Authentication,
+            self._build_plugin(provider, auth, Authentication),
+        )
+        return plugin
 
     @staticmethod
     def get_crunch_plugin(name: str, **options: Any) -> Crunch:
@@ -268,8 +273,8 @@ class PluginManager:
         :returns: The cruncher named `name`
         :rtype: :class:`~eodag.plugins.crunch.Crunch`
         """
-        Klass = Crunch.get_plugin_by_class_name(name)
-        return Klass(options)
+        klass = Crunch.get_plugin_by_class_name(name)
+        return klass(options)
 
     def sort_providers(self) -> None:
         """Sort providers taking into account current priority order"""

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -206,7 +206,13 @@ class PluginManager:
             ]
 
         if not configs:
-            raise UnsupportedProvider
+            if product_type:
+                raise UnsupportedProvider(
+                    f"The product type {product_type} is not available with provider {provider}"
+                )
+            raise UnsupportedProvider(
+                f"The requested provider is not (yet) supported: {provider}"
+            )
 
         for config in sorted(configs, key=attrgetter("priority"), reverse=True):
             yield get_plugin()

--- a/eodag/resources/stac.yml
+++ b/eodag/resources/stac.yml
@@ -134,14 +134,6 @@ collection:
       - '$.product_type.instrument'
     processing:level: '$.product_type.processingLevel'
 
-provider:
-  name: '$.provider.name'
-  description: '$.provider.description'
-  # one or more of "producer" "licensor" "processor" "host"
-  roles: '$.provider.roles'
-  url: '$.provider.url'
-  priority: '$.provider.priority'
-
 # Data ------------------------------------------------------------------------
 
 # https://stacspec.org/STAC-api.html#operation/getFeatures

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -21,7 +21,6 @@ import logging
 import os
 from collections import defaultdict
 from datetime import datetime, timezone
-from operator import itemgetter
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, cast
 from urllib.parse import parse_qs, urlencode, urlparse
 
@@ -669,14 +668,18 @@ class StacCollection(StacCommon):
         collection_list: List[Dict[str, Any]] = []
         for product_type in product_types:
             # get available providers for each product_type
-            providers = [self.provider] if self.provider else [
-                plugin.provider
-                for plugin in self.eodag_api._plugins_manager.get_search_plugins(
-                    product_type=(
-                        product_type.get("_id", None) or product_type["ID"]
+            providers = (
+                [self.provider]
+                if self.provider
+                else [
+                    plugin.provider
+                    for plugin in self.eodag_api._plugins_manager.get_search_plugins(
+                        product_type=(
+                            product_type.get("_id", None) or product_type["ID"]
+                        )
                     )
-                )
-            ]
+                ]
+            )
 
             # parse jsonpath
             product_type_collection = jsonpath_parse_dict_items(

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -173,13 +173,16 @@ class StacCommon:
             for p in self.eodag_api.providers_config.values()
             if provider in [p.name, getattr(p, "group", None)]
         ][0]
-        return {
+        provider_dict = {
             "name": getattr(provider_config, "group", provider_config.name),
-            "description": provider_config.description,
             "roles": provider_config.roles,
-            "url": provider_config.url,
             "priority": provider_config.priority,
         }
+        if hasattr(provider_config, "description"):
+            provider_dict["description"] = provider_config.description
+        if hasattr(provider_config, "url"):
+            provider_dict["url"] = provider_config.url
+        return provider_dict
 
 
 class StacItem(StacCommon):

--- a/tests/integration/test_core_search.py
+++ b/tests/integration/test_core_search.py
@@ -225,7 +225,7 @@ class TestCoreSearch(unittest.TestCase):
         available_providers = self.dag.available_providers(product_type)
         self.assertListEqual(
             available_providers,
-            ["cop_dataspace", "creodias", "onda", "peps", "sara", "wekeo"],
+            ["peps", "cop_dataspace", "creodias", "onda", "sara", "wekeo"],
         )
 
         products, count = self.dag.search(productType="S1_SAR_SLC")
@@ -253,7 +253,7 @@ class TestCoreSearch(unittest.TestCase):
         available_providers = self.dag.available_providers(product_type)
         self.assertListEqual(
             available_providers,
-            ["cop_dataspace", "creodias", "onda", "peps", "sara", "wekeo"],
+            ["peps", "cop_dataspace", "creodias", "onda", "sara", "wekeo"],
         )
 
         self.assertRaises(
@@ -280,7 +280,7 @@ class TestCoreSearch(unittest.TestCase):
         available_providers = self.dag.available_providers(product_type)
         self.assertListEqual(
             available_providers,
-            ["cop_dataspace", "creodias", "onda", "peps", "sara", "wekeo"],
+            ["peps", "cop_dataspace", "creodias", "onda", "sara", "wekeo"],
         )
 
         # peps comes 1st by priority
@@ -327,7 +327,7 @@ class TestCoreSearch(unittest.TestCase):
         available_providers = self.dag.available_providers(product_type)
         self.assertListEqual(
             available_providers,
-            ["cop_dataspace", "creodias", "onda", "peps", "sara", "wekeo"],
+            ["peps", "cop_dataspace", "creodias", "onda", "sara", "wekeo"],
         )
 
         # onda comes 3rd by priority
@@ -362,7 +362,7 @@ class TestCoreSearch(unittest.TestCase):
         available_providers = self.dag.available_providers(product_type)
         self.assertListEqual(
             available_providers,
-            ["cop_dataspace", "creodias", "onda", "peps", "sara", "wekeo"],
+            ["peps", "cop_dataspace", "creodias", "onda", "sara", "wekeo"],
         )
 
         mock_query.side_effect = [
@@ -389,7 +389,7 @@ class TestCoreSearch(unittest.TestCase):
         available_providers = self.dag.available_providers(product_type)
         self.assertListEqual(
             available_providers,
-            ["cop_dataspace", "creodias", "onda", "peps", "sara", "wekeo"],
+            ["peps", "cop_dataspace", "creodias", "onda", "sara", "wekeo"],
         )
 
         mock_query.return_value = ([], 0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -615,9 +615,7 @@ class TestEodagCli(unittest.TestCase):
         self.assertEqual(result.exit_code, 1)
         self.assertIn("Unsupported provider. You may have a typo", result.output)
         self.assertIn(
-            "Available providers: {}".format(
-                ", ".join(sorted(test_core.TestCore.SUPPORTED_PROVIDERS))
-            ),
+            f"Available providers: {', '.join(test_core.TestCore.SUPPORTED_PROVIDERS)}",
             result.output,
         )
 

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -27,6 +27,7 @@ import unittest
 import uuid
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import Mock
 
 from pkg_resources import resource_filename
 from shapely import wkt
@@ -1082,8 +1083,8 @@ class TestCore(TestCoreBase):
         "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
     )
     def test_list_queryables(
-        self, mock_discover_queryables, mock_fetch_product_types_list
-    ):
+        self, mock_discover_queryables: Mock, mock_fetch_product_types_list: Mock
+    ) -> None:
         """list_queryables must return queryables list adapted to provider and product-type"""
         with self.assertRaises(UnsupportedProvider):
             self.dag.list_queryables(provider="not_supported_provider")
@@ -1120,7 +1121,7 @@ class TestCore(TestCoreBase):
                 self.assertEqual(str(expected_longer_result[key]), str(queryable))
 
     @mock.patch("eodag.plugins.apis.cds.CdsApi.discover_queryables", autospec=True)
-    def test_list_queryables_with_constraints(self, mock_discover_queryables):
+    def test_list_queryables_with_constraints(self, mock_discover_queryables: Mock):
         plugin = next(
             self.dag._plugins_manager.get_search_plugins(
                 provider="cop_cds", product_type="ERA5_SL"

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -413,26 +413,26 @@ class TestCore(TestCoreBase):
     }
     SUPPORTED_PROVIDERS = [
         "peps",
-        "usgs",
-        "theia",
-        "creodias",
-        "onda",
-        "aws_eos",
         "astraea_eod",
-        "usgs_satapi_aws",
+        "aws_eos",
+        "cop_ads",
+        "cop_cds",
+        "cop_dataspace",
+        "creodias",
+        "creodias_s3",
         "earth_search",
         "earth_search_cog",
         "earth_search_gcs",
         "ecmwf",
-        "cop_ads",
-        "cop_cds",
-        "sara",
-        "meteoblue",
-        "cop_dataspace",
-        "planetary_computer",
         "hydroweb_next",
+        "meteoblue",
+        "onda",
+        "planetary_computer",
+        "sara",
+        "theia",
+        "usgs",
+        "usgs_satapi_aws",
         "wekeo",
-        "creodias_s3",
     ]
 
     def setUp(self):
@@ -1409,7 +1409,8 @@ class TestCoreInvolvingConfDir(unittest.TestCase):
     def execution_involving_conf_dir(self, inspect=None, conf_dir=None):
         """Check that the path(s) inspected (str, list) are created after the instantation
         of EODataAccessGateway. If they were already there, rename them (.old), instantiate,
-        check, delete the new files, and restore the existing files to there previous name."""
+        check, delete the new files, and restore the existing files to there previous name.
+        """
         if inspect is not None:
             if conf_dir is None:
                 conf_dir = os.path.join(os.path.expanduser("~"), ".config", "eodag")
@@ -2091,6 +2092,7 @@ class TestCoreSearch(TestCoreBase):
 
     def test__do_search_does_not_raise_by_default(self):
         """_do_search must not raise any error by default"""
+
         # provider attribute required internally by __do_search for logging purposes.
         class DummyConfig:
             pagination = {}


### PR DESCRIPTION
in EODAG library:
- add a `by_group` option on `core.available_providers`. If set, we return the unique list of groups instead of the list of provider names.
- update `list_product_types` to accept group name as provider names. Calling `list_product_types` with a group name set in the provider name will return the union of product types from all the providers of this group.
- update `get_search_plugin` to accept group names as provider names. Calling `get_search_plugin` with a group name as provider name will yield all the plugins belonging to the group.

in EODAG server:
- use group when set instead of provider name

> `group` is an optional field

Example:

I have 2 provider configuration in EODAG:

- earth_search
- earth_search_cog

I configure both with `group` **earth_search**. 

- [x] When I `list  the product types` for provider **earth_search**, EODAG return the merged list of product types from earth_search and earth_search_cog. 
- [x] In server mode, the returned product types display **earth_search** as provider name.

- [x] When I `search` for products with provider **earth_search**, EDOAG search on both provider using the existing fallback mechanism.

- [x] When I ask for `queryables `with provider **earth_search** the response is the intersect of queryables from earth_search and earth_search_cog. 
- [x] `available_providers` returns only one entry for both: **earth_search**.