### PR TITLE
build(docker): correct PYTHONPATH

### DIFF
--- a/docker/stac-server.dockerfile
+++ b/docker/stac-server.dockerfile
@@ -55,7 +55,7 @@ COPY ./eodag /eodag/eodag
 RUN python -m pip install .
 
 # add python path
-ENV PYTHONPATH="${PYTHONPATH}:/eodag/eodag"
+ENV PYTHONPATH="${PYTHONPATH}:/eodag/eodag/resources"
 
 # copy start-stac script
 COPY ./docker/run-stac-server.sh /eodag/run-stac-server.sh


### PR DESCRIPTION
Fixes `PYTHONPATH` in server Dockerfile, causing the following error on build:
```
stac_server | Traceback (most recent call last):
stac_server |   File "/usr/local/bin/eodag", line 3, in <module>
stac_server |     import re
stac_server |   File "/usr/local/lib/python3.9/re.py", line 124, in <module>
stac_server |     import enum
stac_server |   File "/usr/local/lib/python3.9/enum.py", line 2, in <module>
stac_server |     from types import MappingProxyType, DynamicClassAttribute
stac_server |   File "/eodag/eodag/types/__init__.py", line 21, in <module>
stac_server |     from typing import Any, Dict, List, Literal, Optional, Tuple, Union
stac_server |   File "/usr/local/lib/python3.9/typing.py", line 23, in <module>
stac_server |     import contextlib
stac_server |   File "/usr/local/lib/python3.9/contextlib.py", line 6, in <module>
stac_server |     from functools import wraps
stac_server |   File "/usr/local/lib/python3.9/functools.py", line 22, in <module>
stac_server |     from types import GenericAlias
stac_server | ImportError: cannot import name 'GenericAlias' from partially initialized module 'types' (most likely due to a circular import) (/eodag/eodag/types/__init__.py)
```