### PR TITLE
fix: astraea_eod product-type specific metadata-mapping

### DIFF
--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -276,15 +276,24 @@ class QueryStringSearch(Search):
                 )
                 if other_product_for_mapping:
                     other_product_type_def_params = self.get_product_type_def_params(
-                        other_product_for_mapping,  # **kwargs
+                        other_product_for_mapping,
                     )
-                    product_type_metadata_mapping.update(
-                        other_product_type_def_params.get("metadata_mapping", {})
+                    other_product_type_mtd_mapping = (
+                        mtd_cfg_as_conversion_and_querypath(
+                            other_product_type_def_params.get("metadata_mapping", {})
+                        )
                     )
-                # from current product
-                product_type_metadata_mapping.update(
-                    self.config.products[product_type]["metadata_mapping"]
-                )
+                    # updated mapping at the end
+                    for metadata, mapping in other_product_type_mtd_mapping.items():
+                        product_type_metadata_mapping.pop(metadata, None)
+                        product_type_metadata_mapping[metadata] = mapping
+
+                # from current product, updated mapping at the end
+                for metadata, mapping in self.config.products[product_type][
+                    "metadata_mapping"
+                ].items():
+                    product_type_metadata_mapping.pop(metadata, None)
+                    product_type_metadata_mapping[metadata] = mapping
 
                 self.config.products[product_type][
                     "metadata_mapping"

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -1233,6 +1233,42 @@ class TestSearchPluginStacSearch(BaseSearchPluginTest):
         )
         self.assertNotIn("bar", products[0].properties)
 
+    @mock.patch("eodag.plugins.search.qssearch.StacSearch._request", autospec=True)
+    def test_plugins_search_stacsearch_distinct_product_type_mtd_mapping_astraea_eod(
+        self, mock__request
+    ):
+        """The metadata mapping for a astraea_eod should correctly build assets"""
+        mock__request.return_value = mock.Mock()
+        result = {
+            "features": [
+                {
+                    "id": "foo",
+                    "geometry": None,
+                    "assets": {
+                        "productInfo": {"href": "s3://foo.bar/baz/productInfo.json"}
+                    },
+                },
+            ],
+        }
+        product_type = "S1_SAR_GRD"
+        mock__request.return_value.json.side_effect = [result]
+        search_plugin = self.get_search_plugin(product_type, "astraea_eod")
+
+        products, _ = search_plugin.query(
+            productType=product_type,
+            auth=None,
+        )
+        self.assertIn("productInfo", products[0].assets)
+        self.assertEqual(
+            products[0].assets["productInfo"]["href"],
+            "s3://foo.bar/baz/productInfo.json",
+        )
+        self.assertIn("manifest.safe", products[0].assets)
+        self.assertEqual(
+            products[0].assets["manifest.safe"]["href"],
+            "s3://foo.bar/baz/manifest.safe",
+        )
+
 
 class TestSearchPluginBuildPostSearchResult(BaseSearchPluginTest):
     @mock.patch("eodag.plugins.authentication.qsauth.requests.get", autospec=True)


### PR DESCRIPTION
Fixes issue when searching `S1_SAR_GRD` on `astraea_eod`, caused by a problem when parsing its product-type specific metadata-mapping:
```
KeyError: 'aswPath'
```