### PR TITLE
fix: cast loaded env vars type using config type-hints

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -83,6 +83,7 @@ from eodag.utils.exceptions import (
 from eodag.utils.stac_reader import fetch_stac_items
 
 if TYPE_CHECKING:
+    from pydantic.fields import FieldInfo
     from shapely.geometry.base import BaseGeometry
     from whoosh.index import Index
 
@@ -2086,7 +2087,7 @@ class EODataAccessGateway:
         self,
         provider: Optional[str] = None,
         product_type: Optional[str] = None,
-    ) -> Dict[str, Tuple[Annotated, Any]]:
+    ) -> Dict[str, Tuple[Annotated[Any, FieldInfo], Any]]:
         """Fetch the queryable properties for a given product type and/or provider.
 
         :param provider: (optional) The provider.
@@ -2096,7 +2097,7 @@ class EODataAccessGateway:
         :returns: A dict containing the EODAG queryable properties, associating
                   parameters to a tuple containing their annotaded type and default
                   value
-        :rtype: Dict[str, Tuple[Annotated, Any]]
+        :rtype: Dict[str, Tuple[Annotated[Any, FieldInfo], Any]]
         """
         # unknown product type
         if product_type is not None and product_type not in self.list_product_types(
@@ -2106,7 +2107,7 @@ class EODataAccessGateway:
 
         # dictionary of the queryable properties of the providers supporting the given product type
         providers_available_queryables: Dict[
-            str, Dict[str, Tuple[Annotated, Any]]
+            str, Dict[str, Tuple[Annotated[Any, FieldInfo], Any]]
         ] = dict()
 
         if provider is None and product_type is None:

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -250,7 +250,7 @@ class PluginConfig(yaml.YAMLObject):
     need_auth: bool
     result_type: str
     results_entry: str
-    pagination: Pagination
+    pagination: PluginConfig.Pagination
     query_params_key: str
     discover_metadata: Dict[str, str]
     discover_product_types: Dict[str, Any]
@@ -275,7 +275,7 @@ class PluginConfig(yaml.YAMLObject):
     order_enabled: bool  # HTTPDownload
     order_method: str  # HTTPDownload
     order_headers: Dict[str, str]  # HTTPDownload
-    order_status_on_success: OrderStatusOnSuccess
+    order_status_on_success: PluginConfig.OrderStatusOnSuccess
     bucket_path_level: int  # S3RestDownload
 
     # auth -----------------------------------------------------------------------------

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
+from inspect import isclass
 from typing import (
-    TYPE_CHECKING,
     Any,
     Dict,
     ItemsView,
@@ -32,6 +32,7 @@ from typing import (
     TypedDict,
     Union,
     ValuesView,
+    get_type_hints,
 )
 
 import orjson
@@ -39,13 +40,16 @@ import requests
 import yaml
 import yaml.constructor
 import yaml.parser
+from jsonpath_ng import JSONPath
 from pkg_resources import resource_filename
+from requests.auth import AuthBase
 
 from eodag.utils import (
     HTTP_REQ_TIMEOUT,
     USER_AGENT,
     cached_yaml_load,
     cached_yaml_load_all,
+    cast_scalar_value,
     deepcopy,
     dict_items_recursive_apply,
     merge_mappings,
@@ -55,10 +59,6 @@ from eodag.utils import (
     uri_to_path,
 )
 from eodag.utils.exceptions import ValidationError
-
-if TYPE_CHECKING:
-    from jsonpath_ng import JSONPath
-    from requests.auth import AuthBase
 
 logger = logging.getLogger("eodag.config")
 
@@ -266,7 +266,7 @@ class PluginConfig(yaml.YAMLObject):
     merge_responses: bool  # PostJsonSearch for aws_eos
     collection: bool  # PostJsonSearch for aws_eos
     max_connections: int  # StaticStacSearch
-    timeout: int  # StaticStacSearch
+    timeout: float  # StaticStacSearch
 
     # download -------------------------------------------------------------------------
     base_uri: str
@@ -471,13 +471,38 @@ def override_config_from_env(config: Dict[str, Any]) -> None:
         :type mapping: dict
         """
         parts = env_var.split("__")
-        if len(parts) == 1:
+        iter_parts = iter(parts)
+        env_type = get_type_hints(PluginConfig).get(next(iter_parts, ""), str)
+        child_env_type = (
+            get_type_hints(env_type).get(next(iter_parts, ""), None)
+            if isclass(env_type)
+            else None
+        )
+        if len(parts) == 2 and child_env_type:
+            # for nested config (pagination, ...)
+            # try converting env_value type from type hints
+            try:
+                env_value = cast_scalar_value(env_value, child_env_type)
+            except TypeError:
+                logger.warning(
+                    f"Could not convert {parts} value {env_value} to {child_env_type}"
+                )
+            mapping.setdefault(parts[0], {})
+            mapping[parts[0]][parts[1]] = env_value
+        elif len(parts) == 1:
+            # try converting env_value type from type hints
+            try:
+                env_value = cast_scalar_value(env_value, env_type)
+            except TypeError:
+                logger.warning(
+                    f"Could not convert {parts[0]} value {env_value} to {env_type}"
+                )
             mapping[parts[0]] = env_value
         else:
             new_map = mapping.setdefault(parts[0], {})
             build_mapping_from_env("__".join(parts[1:]), env_value, new_map)
 
-    mapping_from_env = {}
+    mapping_from_env: Dict[str, Any] = {}
     for env_var in os.environ:
         if env_var.startswith("EODAG__"):
             build_mapping_from_env(
@@ -500,7 +525,6 @@ def override_config_from_mapping(
     :type mapping: dict
     """
     for provider, new_conf in mapping.items():
-        new_conf: Dict[str, Any]
         old_conf: Optional[Dict[str, Any]] = config.get(provider)
         if old_conf is not None:
             old_conf.update(new_conf)

--- a/eodag/plugins/apis/base.py
+++ b/eodag/plugins/apis/base.py
@@ -21,6 +21,8 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:
+    from pydantic.fields import FieldInfo
+
     from eodag.api.product import EOProduct
     from eodag.api.search_result import SearchResult
     from eodag.config import PluginConfig
@@ -95,7 +97,7 @@ class Api(PluginTopic):
 
     def discover_queryables(
         self, product_type: Optional[str] = None
-    ) -> Optional[Dict[str, Tuple[Annotated, Any]]]:
+    ) -> Optional[Dict[str, Tuple[Annotated[Any, FieldInfo], Any]]]:
         """Fetch queryables list from provider using `discover_queryables` conf"""
         return None
 

--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -327,7 +327,9 @@ class UsgsApi(Download, Api):
                         stream.raise_for_status()
                     except RequestException as e:
                         if e.response and hasattr(e.response, "content"):
-                            error_message = f"{e.response.content} - {e}"
+                            error_message = (
+                                f"{e.response.content.decode('utf-8')} - {e}"
+                            )
                         else:
                             error_message = str(e)
                         raise NotAvailableError(error_message)
@@ -341,7 +343,7 @@ class UsgsApi(Download, Api):
                                     progress_callback(len(chunk))
             except requests.exceptions.Timeout as e:
                 if e.response and hasattr(e.response, "content"):
-                    error_message = f"{e.response.content} - {e}"
+                    error_message = f"{e.response.content.decode('utf-8')} - {e}"
                 else:
                     error_message = str(e)
                 raise NotAvailableError(error_message)

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -33,6 +33,8 @@ from eodag.utils import (
 )
 
 if TYPE_CHECKING:
+    from pydantic.fields import FieldInfo
+
     from eodag.api.product import EOProduct
     from eodag.config import PluginConfig
     from eodag.utils import Annotated
@@ -90,7 +92,7 @@ class Search(PluginTopic):
 
     def discover_queryables(
         self, product_type: Optional[str] = None
-    ) -> Optional[Dict[str, Tuple[Annotated, Any]]]:
+    ) -> Optional[Dict[str, Tuple[Annotated[Any, FieldInfo], Any]]]:
         """Fetch queryables list from provider using `discover_queryables` conf"""
         return None
 

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -1270,7 +1270,7 @@ class StacSearch(PostJsonSearch):
 
     def discover_queryables(
         self, product_type: Optional[str] = None
-    ) -> Optional[Dict[str, Tuple[Annotated, Any]]]:
+    ) -> Optional[Dict[str, Tuple[Annotated[Any, FieldInfo], Any]]]:
         """Fetch queryables list from provider using `discover_queryables` conf
 
         :param product_type: (optional) product type

--- a/eodag/rest/types/stac_queryables.py
+++ b/eodag/rest/types/stac_queryables.py
@@ -17,12 +17,15 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from pydantic import BaseModel, Field
 
 from eodag.types import python_field_definition_to_json
 from eodag.utils import Annotated
+
+if TYPE_CHECKING:
+    from pydantic.fields import FieldInfo
 
 
 class StacQueryableProperty(BaseModel):
@@ -49,7 +52,7 @@ class StacQueryableProperty(BaseModel):
 
     @classmethod
     def from_python_field_definition(
-        cls, id: str, python_field_definition: Tuple[Annotated, Any]
+        cls, id: str, python_field_definition: Tuple[Annotated[Any, FieldInfo], Any]
     ) -> StacQueryableProperty:
         """Build Model from python_field_definition"""
         def_dict = python_field_definition_to_json(python_field_definition)

--- a/eodag/types/__init__.py
+++ b/eodag/types/__init__.py
@@ -122,7 +122,7 @@ def json_field_definition_to_python(
 
 
 def python_field_definition_to_json(
-    python_field_definition: Tuple[Annotated, Any]
+    python_field_definition: Tuple[Annotated[Any, FieldInfo], Any]
 ) -> Dict[str, Any]:
     """Get json field definition from python `typing.Annotated`
 
@@ -144,7 +144,8 @@ def python_field_definition_to_json(
         or len(python_field_definition) != 2
     ):
         raise ValidationError(
-            "%s must be an instance of Tuple[Annotated, Any]" % python_field_definition
+            "%s must be an instance of Tuple[Annotated[Any, FieldInfo], Any]"
+            % python_field_definition
         )
 
     python_field_annotated = python_field_definition[0]
@@ -196,7 +197,7 @@ def python_field_definition_to_json(
 
 def model_fields_to_annotated_tuple(
     model_fields: Dict[str, FieldInfo]
-) -> Dict[str, Tuple[Annotated, Any]]:
+) -> Dict[str, Tuple[Annotated[Any, FieldInfo], Any]]:
     """Convert BaseModel.model_fields from FieldInfo to Annotated tuple usable as create_model argument
 
     >>> from pydantic import create_model

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -437,6 +437,11 @@ class TestConfigFunctions(unittest.TestCase):
             "EODAG__AWS_EOS__AUTH__CREDENTIALS__AWS_SECRET_ACCESS_KEY"
         ] = "secret-access-key"
         os.environ["EODAG__PEPS__DOWNLOAD__OUTPUTS_PREFIX"] = "/data"
+        # check a parameter that has not been set yet
+        self.assertFalse(hasattr(default_config["peps"].search, "timeout"))
+        self.assertNotIn("start_page", default_config["peps"].search.pagination)
+        os.environ["EODAG__PEPS__SEARCH__TIMEOUT"] = "3.1"
+        os.environ["EODAG__PEPS__SEARCH__PAGINATION__START_PAGE"] = "2"
 
         config.override_config_from_env(default_config)
         usgs_conf = default_config["usgs"]
@@ -457,6 +462,8 @@ class TestConfigFunctions(unittest.TestCase):
 
         peps_conf = default_config["peps"]
         self.assertEqual(peps_conf.download.outputs_prefix, "/data")
+        self.assertEqual(peps_conf.search.timeout, 3.1)
+        self.assertEqual(peps_conf.search.pagination["start_page"], 2)
 
     @mock.patch("requests.get", autospec=True)
     def test_get_ext_product_types_conf(self, mock_get):


### PR DESCRIPTION
Fixes #985 and #973

- Cast loaded environment variables type using `PluginConfig` parameters type-hints.
- also adds some more type hint fixes