### PR TITLE
build(docs): pin sphinxcontrib dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -98,6 +98,11 @@ docs =
     sphinx
     sphinx-book-theme < 1.0.0
     sphinx-copybutton
+    sphinxcontrib-applehelp < 1.0.8
+    sphinxcontrib-devhelp < 1.0.6
+    sphinxcontrib-htmlhelp < 2.0.5
+    sphinxcontrib-qthelp < 1.0.7
+    sphinxcontrib-serializinghtml < 1.1.10
     sphinxcontrib-jquery
     nbsphinx
     ipython!=8.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -105,8 +105,6 @@ docs =
     sphinxcontrib-serializinghtml < 1.1.10
     sphinxcontrib-jquery
     nbsphinx
-    ipython!=8.7.0
-    # pined ipython until https://github.com/spatialaudio/nbsphinx/issues/687 is fixed
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Pin `sphinxcontrib-*` dependencies that make documentation build crash because they need `sphinx > 5`