### PR TITLE
fix: download of single asset with aws download and ignore assets not…

### DIFF
--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -430,7 +430,7 @@ class AwsDownload(Download):
             filter_regex = re.compile(asset_filter)
             unique_product_chunks = set(
                 filter(
-                    lambda c: filter_regex.fullmatch(os.path.basename(c.key)),
+                    lambda c: filter_regex.search(os.path.basename(c.key)),
                     unique_product_chunks,
                 )
             )


### PR DESCRIPTION
regex search used instead of fullmatch in case of ignore_assets=true to ensure that filters that don't match whole path are also working
