### PR TITLE
refactor(config/productTypes): ignore unindexed fields

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@
 ..
 
     Checkout **EODAG Jupyterlab extension**: `eodag-labextension <https://github.com/CS-SI/eodag-labextension>`_!
-    This will bring a fiendly UI to your notebook and help you search and browse for EO products using ``eodag``.
+    This will bring a friendly UI to your notebook and help you search and browse for EO products using ``eodag``.
 
 EODAG (Earth Observation Data Access Gateway) is a command line tool and a plugin-oriented Python framework for searching,
 aggregating results and downloading remote sensed images while offering a unified API for data access regardless of the
@@ -265,4 +265,4 @@ Credits
 
 EODAG is built on top of amazingly useful open source projects. See NOTICE file for details about those projects and
 their licenses.
-Thank you to all the authors of these projects !
+Thank you to all the authors of these projects!

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -266,7 +266,6 @@ class EODataAccessGateway:
                 missionEndDate=fields.ID,
                 keywords=fields.KEYWORD(analyzer=kw_analyzer),
             )
-            non_indexable_fields: List[str] = []
             self._product_types_index = create_in(index_dir, product_types_schema)
             ix_writer = self._product_types_index.writer()
             for product_type in self.list_product_types(fetch_providers=False):
@@ -278,7 +277,7 @@ class EODataAccessGateway:
                     **{
                         k: v
                         for k, v in versioned_product_type.items()
-                        if k not in non_indexable_fields
+                        if k in product_types_schema.names()
                     }
                 )
             ix_writer.commit()


### PR DESCRIPTION
### Description
This PR simply adds an unindexed field to the product types Schema, not used inside of EODAG but relevant for sharing configuration.
