### PR TITLE
fix(server): raise error if search fallback fails

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -1005,6 +1005,7 @@ class EODataAccessGateway:
             search_kwargs.update(
                 page=1,
                 items_per_page=2,
+                raise_errors=raise_errors,
             )
             return self._search_by_id(
                 search_kwargs.pop("id"), provider=provider, **search_kwargs

--- a/eodag/rest/utils.py
+++ b/eodag/rest/utils.py
@@ -67,6 +67,7 @@ from eodag.utils.exceptions import (
     MisconfiguredError,
     NoMatchingProductType,
     NotAvailableError,
+    RequestError,
     UnsupportedProductType,
     ValidationError,
 )
@@ -502,6 +503,14 @@ def search_products(
         criterias = dict((k, v) for k, v in criterias.items() if v is not None)
 
         products, total = eodag_api.search(**criterias)
+
+        if not products and eodag_api.search_errors:
+            search_error = RequestError(
+                "No result could be obtained from any available provider and following "
+                "error(s) appeared while searching:"
+            )
+            search_error.history = eodag_api.search_errors
+            raise search_error
 
         products = filter_products(products, arguments, **criterias)
 

--- a/eodag/utils/exceptions.py
+++ b/eodag/utils/exceptions.py
@@ -15,6 +15,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Set, Tuple
 
 
 class ValidationError(Exception):
@@ -70,8 +76,16 @@ class NotAvailableError(Exception):
 
 
 class RequestError(Exception):
-    """An error indicating that a HTTP request has failed. Usually eodag functions
+    """An error indicating that a request has failed. Usually eodag functions
     and methods should catch and skip this"""
+
+    history: Set[Tuple[Exception, str]] = set()
+
+    def __str__(self):
+        repr = super().__str__()
+        for err_tuple in self.history:
+            repr += f"\n- {str(err_tuple)}"
+        return repr
 
 
 class NoMatchingProductType(Exception):


### PR DESCRIPTION
- raises an error in server mode if search fallback fails
- `raise_errors` enabled when search by id