### PR TITLE
refactor: queryables type to Annotated

### DIFF
--- a/eodag/plugins/apis/base.py
+++ b/eodag/plugins/apis/base.py
@@ -97,7 +97,7 @@ class Api(PluginTopic):
 
     def discover_queryables(
         self, product_type: Optional[str] = None
-    ) -> Optional[Dict[str, Tuple[Annotated[Any, FieldInfo], Any]]]:
+    ) -> Optional[Dict[str, Annotated[Any, FieldInfo]]]:
         """Fetch queryables list from provider using `discover_queryables` conf"""
         return None
 

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -92,7 +92,7 @@ class Search(PluginTopic):
 
     def discover_queryables(
         self, product_type: Optional[str] = None
-    ) -> Optional[Dict[str, Tuple[Annotated[Any, FieldInfo], Any]]]:
+    ) -> Optional[Dict[str, Annotated[Any, FieldInfo]]]:
         """Fetch queryables list from provider using `discover_queryables` conf"""
         return None
 

--- a/eodag/rest/types/stac_queryables.py
+++ b/eodag/rest/types/stac_queryables.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -52,7 +52,7 @@ class StacQueryableProperty(BaseModel):
 
     @classmethod
     def from_python_field_definition(
-        cls, id: str, python_field_definition: Tuple[Annotated[Any, FieldInfo], Any]
+        cls, id: str, python_field_definition: Annotated[Any, FieldInfo]
     ) -> StacQueryableProperty:
         """Build Model from python_field_definition"""
         def_dict = python_field_definition_to_json(python_field_definition)

--- a/tests/context.py
+++ b/tests/context.py
@@ -65,7 +65,7 @@ from eodag.plugins.download.http import HTTPDownload
 from eodag.plugins.manager import PluginManager
 from eodag.plugins.search.base import Search
 from eodag.rest.stac import DEFAULT_MISSION_START_DATE
-from eodag.types import model_fields_to_annotated_tuple
+from eodag.types import model_fields_to_annotated
 from eodag.types.queryables import CommonQueryables, Queryables
 from eodag.utils import (
     DEFAULT_STREAM_REQUESTS_TIMEOUT,

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -50,7 +50,7 @@ from tests.context import (
     get_geometry_from_various,
     load_default_config,
     makedirs,
-    model_fields_to_annotated_tuple,
+    model_fields_to_annotated,
 )
 from tests.utils import mock, write_eodag_conf_with_fake_credentials
 
@@ -1090,16 +1090,14 @@ class TestCore(TestCoreBase):
             self.dag.list_queryables(product_type="not_existing_product_type")
 
         queryables_none_none = self.dag.list_queryables()
-        expected_result = model_fields_to_annotated_tuple(CommonQueryables.model_fields)
+        expected_result = model_fields_to_annotated(CommonQueryables.model_fields)
         self.assertEqual(len(queryables_none_none), len(expected_result))
         for key, queryable in queryables_none_none.items():
             # compare obj.__repr__
             self.assertEqual(str(expected_result[key]), str(queryable))
 
         queryables_peps_none = self.dag.list_queryables(provider="peps")
-        expected_longer_result = model_fields_to_annotated_tuple(
-            Queryables.model_fields
-        )
+        expected_longer_result = model_fields_to_annotated(Queryables.model_fields)
         self.assertGreater(len(queryables_peps_none), len(queryables_none_none))
         self.assertLess(len(queryables_peps_none), len(expected_longer_result))
         for key, queryable in queryables_peps_none.items():


### PR DESCRIPTION
Following https://github.com/CS-SI/eodag/pull/974 (no release between these 2 Pull Requests), 

changes `list_queryables()` output from 
`Dict[str, Tuple[Annotated[Any, FieldInfo], Any]]`
to
`Dict[str, Annotated[Any, FieldInfo]]`.

Previous format returned *field default value* in the the 2nd argument of the tuple.
This is not needed any more as this value can be included in `FieldInfo`.

Also, `pydantic.create_model` can be still be used with `list_queryables()` output:
- before:
```py
>>> from pydantic import create_model
>>> from eodag import EODataAccessGateway
>>> dag = EODataAccessGateway()
>>> queryables = dag.list_queryables(product_type="S2_MSI_L1C", provider="peps")
>>> queryables
{'productType': (typing.Annotated[str, FieldInfo(annotation=NoneType, required=True)], None), ...}
>>> create_model("my_model", **queryables)
<class 'pydantic.main.my_model'>
```
- now:
```py
>>> from pydantic import create_model
>>> from typing_extensions import get_args
>>> from eodag import EODataAccessGateway
>>> dag = EODataAccessGateway()
>>> queryables = dag.list_queryables(product_type="S2_MSI_L1C", provider="peps")
>>> queryables
{'productType': typing.Annotated[str, FieldInfo(annotation=NoneType, required=True)], ...}
>>> create_model("my_model", **{k: get_args(v) for k, v in queryables.items()})
<class 'pydantic.main.my_model'>
```