### PR TITLE
fix: missing tileIdentifier for creodias and cop_dataspace

### DIFF
--- a/docs/_static/params_mapping_extra.csv
+++ b/docs/_static/params_mapping_extra.csv
@@ -12,6 +12,6 @@ polarizationMode,,,,,:green:`queryable metadata`,,metadata only,,,,:green:`query
 quicklook,metadata only,,,metadata only,metadata only,metadata only,metadata only,metadata only,,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only
 storageStatus,metadata only,,,metadata only,metadata only,metadata only,metadata only,metadata only,,metadata only,metadata only,metadata only,metadata only,metadata only,metadata only
 thumbnail,metadata only,,,metadata only,metadata only,metadata only,metadata only,metadata only,,,metadata only,metadata only,metadata only,metadata only,metadata only
-tileIdentifier,,,,metadata only,metadata only,:green:`queryable metadata`,,,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,,:green:`queryable metadata`,
+tileIdentifier,,,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,,,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,,:green:`queryable metadata`,
 uid,,,,metadata only,metadata only,,,,,metadata only,metadata only,,metadata only,metadata only,
 utmZone,,,,,,:green:`queryable metadata`,,,,,,,,,

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -977,7 +977,9 @@
       id:
         - 'productIdentifier=%{id#remove_extension}%'
         - '{$.properties.title#remove_extension}'
-      tileIdentifier: '$.null'
+      tileIdentifier:
+        - tileId
+        - '$.null'
       # The geographic extent of the product
       geometry:
         - 'geometry={geometry#to_rounded_wkt}'
@@ -3498,7 +3500,9 @@
       id:
         - 'productIdentifier={id#remove_extension}'
         - '{$.properties.title#remove_extension}'
-      tileIdentifier: '$.null'
+      tileIdentifier:
+        - tileId
+        - '$.null'
       # The geographic extent of the product
       geometry:
         - 'geometry={geometry#to_rounded_wkt}'
@@ -6835,7 +6839,9 @@
       id:
         - 'productIdentifier=%{id#remove_extension}%'
         - '{$.properties.title#remove_extension}'
-      tileIdentifier: '$.null'
+      tileIdentifier:
+        - tileId
+        - '$.null'
       # The geographic extent of the product
       geometry:
         - 'geometry={geometry#to_rounded_wkt}'


### PR DESCRIPTION
Add missing `tileIdentifier` queryable  for `creodias`, `creodias_s3` and `cop_dataspace`