### PR TITLE
feat: resume interrupted assets download using HTTPDownload

### DIFF
--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -886,7 +886,7 @@ class HTTPDownload(Download):
             if os.path.isfile(asset_abs_path_temp):
                 os.remove(asset_abs_path_temp)
             if not os.path.isfile(asset_abs_path):
-                logger.info("Downloading to temporary file '%s'", asset_abs_path_temp)
+                logger.debug("Downloading to temporary file '%s'", asset_abs_path_temp)
                 with open(asset_abs_path_temp, "wb") as fhandle:
                     for chunk in asset_chunks:
                         if chunk:

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -877,17 +877,27 @@ class HTTPDownload(Download):
             asset_path = chunk_tuple[0]
             asset_chunks = chunk_tuple[4]
             asset_abs_path = os.path.join(fs_dir_path, asset_path)
+            asset_abs_path_temp = asset_abs_path + "~"
             # create asset subdir if not exist
             asset_abs_path_dir = os.path.dirname(asset_abs_path)
             if not os.path.isdir(asset_abs_path_dir):
                 os.makedirs(asset_abs_path_dir)
+            # remove temporary file
+            if os.path.isfile(asset_abs_path_temp):
+                os.remove(asset_abs_path_temp)
             if not os.path.isfile(asset_abs_path):
-                with open(asset_abs_path, "wb") as fhandle:
+                logger.info("Downloading to temporary file '%s'", asset_abs_path_temp)
+                with open(asset_abs_path_temp, "wb") as fhandle:
                     for chunk in asset_chunks:
                         if chunk:
                             fhandle.write(chunk)
                             progress_callback(len(chunk))
-
+                logger.debug(
+                    "Download completed. Renaming temporary file '%s' to '%s'",
+                    os.path.basename(asset_abs_path_temp),
+                    os.path.basename(asset_abs_path),
+                )
+                os.rename(asset_abs_path_temp, asset_abs_path)
         # only one local asset
         if local_assets_count == len(assets_urls) and local_assets_count == 1:
             # remove empty {fs_dir_path}

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -311,6 +311,99 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             )
         )
 
+        @mock.patch(
+            "eodag.plugins.download.http.ProgressCallback.__call__",
+            autospec=True,
+        )
+        @mock.patch("eodag.plugins.download.http.requests.head", autospec=True)
+        @mock.patch("eodag.plugins.download.http.requests.get", autospec=True)
+        def test_plugins_download_http_assets_interrupt(
+            self, mock_requests_get, mock_requests_head, mock_progress_callback
+        ):
+            """HTTPDownload.download() must download assets to a temporary file"""
+
+            plugin = self.get_download_plugin(self.product)
+            self.product.location = self.product.remote_location = "http://somewhere"
+            self.product.properties["id"] = "someproduct"
+            self.product.assets.clear()
+            self.product.assets.update({"foo": {"href": "http://somewhere/something"}})
+            mock_requests_get.return_value.__enter__.return_value.iter_content.return_value = io.BytesIO(
+                b"some content"
+            )
+            mock_requests_get.return_value.__enter__.return_value.headers = {
+                "content-disposition": '; filename = "somethingelse"'
+            }
+            mock_requests_head.return_value.headers = {"content-disposition": ""}
+            # ProgressCallback is called twice in HTTPDownload._download_assets. The
+            # temporary asset file is created after the first call.
+            progress_callback_exception = Exception("Interrupt assets download")
+            mock_progress_callback.side_effect = [
+                mock.DEFAULT,
+                progress_callback_exception,
+            ]
+            with self.assertRaises(Exception) as cm:
+                plugin.download(self.product, outputs_prefix=self.output_dir)
+            # Interrupted download
+            self.assertEqual(progress_callback_exception, cm.exception)
+            # Product location not changed
+            self.assertEqual(self.product.location, "http://somewhere")
+            self.assertEqual(self.product.remote_location, "http://somewhere")
+            # Temp file created
+            self.assertTrue(
+                os.path.exists(
+                    os.path.join(self.output_dir, "dummy_product", "somethingelse~")
+                )
+            )
+            # Asset file not created
+            self.assertFalse(
+                os.path.exists(
+                    os.path.join(self.output_dir, "dummy_product", "somethingelse")
+                )
+            )
+
+    @mock.patch("eodag.plugins.download.http.requests.head", autospec=True)
+    @mock.patch("eodag.plugins.download.http.requests.get", autospec=True)
+    def test_plugins_download_http_assets_resume(
+        self, mock_requests_get, mock_requests_head
+    ):
+        """HTTPDownload.download() must resume the interrupted download of assets"""
+
+        plugin = self.get_download_plugin(self.product)
+        self.product.location = self.product.remote_location = "http://somewhere"
+        self.product.properties["id"] = "someproduct"
+        self.product.assets.clear()
+        self.product.assets.update({"foo": {"href": "http://somewhere/something"}})
+        mock_requests_get.return_value.__enter__.return_value.iter_content.return_value = io.BytesIO(
+            b"some content"
+        )
+        mock_requests_get.return_value.__enter__.return_value.headers = {
+            "content-disposition": '; filename = "somethingelse"'
+        }
+        mock_requests_head.return_value.headers = {"content-disposition": ""}
+        # Create directory structure and temp file
+        os.makedirs(os.path.join(self.output_dir, "dummy_product"))
+        with open(
+            os.path.join(self.output_dir, "dummy_product", "somethingelse~"),
+            "w",
+        ):
+            pass
+        path = plugin.download(self.product, outputs_prefix=self.output_dir)
+        # Product directory created
+        self.assertEqual(path, os.path.join(self.output_dir, "dummy_product"))
+        self.assertTrue(os.path.isdir(path))
+        # Asset file created
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(self.output_dir, "dummy_product", "somethingelse")
+            )
+        )
+        # Temp file removed
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(self.output_dir, "dummy_product", "somethingelse~")
+            )
+        )
+
     @mock.patch("eodag.plugins.download.http.requests.head", autospec=True)
     @mock.patch("eodag.plugins.download.http.requests.get", autospec=True)
     def test_plugins_download_http_asset_filter(


### PR DESCRIPTION
In `HTTPDownload` the assets are downloaded to a temporary file with suffix `~`. When the download is completed the file is renamed to remove the suffix. If the file was already correctly downloaded, the asset will not be downloaded again.