### PR TITLE
build: remove owslib version upper limit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,8 +45,7 @@ install_requires =
     tqdm
     shapely
     pyshp
-    OWSLib < 0.26;python_version>='3.10'
-    OWSLib;python_version<'3.10'
+    OWSLib >=0.27.1
     orjson
     geojson
     pyproj >= 2.1.0


### PR DESCRIPTION
Following #469 and now that `pyproj` was removed from `OWSLib` dependencies, remove `OWSLib` version upper limit