### PR TITLE
feat: configurable assets filtering

### DIFF
--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -514,6 +514,27 @@ def format_metadata(search_param: str, *args: Tuple[Any], **kwargs: Any) -> str:
             return dict(input_dict, **new_items_dict)
 
         @staticmethod
+        def convert_dict_filter(
+            input_dict: Dict[Any, Any], jsonpath_filter_str: str
+        ) -> Dict[Any, Any]:
+            """Fitlers dict items using jsonpath"""
+
+            jsonpath_filter = string_to_jsonpath(jsonpath_filter_str, force=True)
+            if isinstance(jsonpath_filter, str) or not isinstance(input_dict, dict):
+                return {}
+
+            keys_list = list(input_dict.keys())
+            matches = jsonpath_filter.find(input_dict)
+            result = {}
+            for match in matches:
+                # extract key index from matched jsonpath
+                matched_jsonpath_str = str(match.full_path)
+                matched_index = int(matched_jsonpath_str.split(".")[-1][1:-1])
+                key = keys_list[matched_index]
+                result[key] = match.value
+            return result
+
+        @staticmethod
         def convert_slice_str(string: str, args: str) -> str:
             cmin, cmax, cstep = [x.strip() for x in args.split(",")]
             return string[int(cmin) : int(cmax) : int(cstep)]

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1770,6 +1770,7 @@
       tileIdentifier:
         - '{{"query":{{"mgrs:utm_zone":{{"eq":"{tileIdentifier#slice_str(0,2,1)}"}},"mgrs:latitude_band":{{"eq":"{tileIdentifier#slice_str(2,3,1)}"}},"mgrs:grid_square":{{"eq":"{tileIdentifier#slice_str(3,5,1)}"}}}}}}'
         - '{utmZone}{latitudeBand}{gridSquare}'
+      assets: '{$.assets#dict_filter($[?(href=~"^s3.*")])}'
   products:
     S1_SAR_GRD:
       productType: sentinel-1-grd
@@ -1862,6 +1863,7 @@
       platformSerialIdentifier: '$.id.`split(_, 0, -1)`'
       polarizationMode: '$.id.`sub(/.{14}([A-Z]{2}).*/, \\1)`'
       title: '{$.properties."s2:product_uri"#remove_extension}'
+      assets: '{$.assets#dict_filter($[?(href=~"^http.*")])}'
   products:
     S2_MSI_L2A_COG:
       productType: sentinel-2-l2a

--- a/tests/units/test_metadata_mapping.py
+++ b/tests/units/test_metadata_mapping.py
@@ -239,6 +239,16 @@ class TestMetadataFormatter(unittest.TestCase):
             "{'a': {'title': 'foo'}, 'b': {'href': 'bar', 'title': 'baz'}}",
         )
 
+    def test_convert_dict_filter(self):
+        to_format = '{fieldname#dict_filter($[?(href=~"^s3.*")])}'
+        self.assertEqual(
+            format_metadata(
+                to_format,
+                fieldname={"a": {"href": "https://foo"}, "b": {"href": "s3://bar"}},
+            ),
+            "{'b': {'href': 's3://bar'}}",
+        )
+
     def test_convert_slice_str(self):
         to_format = "{fieldname#slice_str(1,12,2)}"
         self.assertEqual(


### PR DESCRIPTION
Adds a new metadata-mapping convert method `convert_dict_filter()` to help filtering assets.
Method used to update providers configuration:
- `earth_search` only lists `s3` assets
- `earth_search_cog` only lists `http` assets