### PR TITLE
feat: configurable requests ssl_verify

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -2024,6 +2024,7 @@ class EODataAccessGateway:
         provider: Optional[str] = None,
         productType: Optional[str] = None,
         timeout: int = HTTP_REQ_TIMEOUT,
+        ssl_verify: bool = True,
         **kwargs: Any,
     ) -> SearchResult:
         """Loads STAC items from a geojson file / STAC catalog or collection, and convert to SearchResult.
@@ -2057,6 +2058,7 @@ class EODataAccessGateway:
             recursive=recursive,
             max_connections=max_connections,
             timeout=timeout,
+            ssl_verify=ssl_verify,
         )
         feature_collection = geojson.FeatureCollection(features)
 

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -281,6 +281,7 @@ class PluginConfig(yaml.YAMLObject):
     max_connections: int  # StaticStacSearch
     timeout: float  # StaticStacSearch
     s3_bucket: str  # CreodiasS3Search
+    ssl_verify: bool
 
     # download -------------------------------------------------------------------------
     base_uri: str

--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -314,6 +314,7 @@ class UsgsApi(Download, Api):
         req_url = req_urls[0]
         progress_callback.reset()
         logger.debug(f"Downloading {req_url}")
+        ssl_verify = getattr(self.config, "ssl_verify", True)
 
         @self._download_retry(product, wait, timeout)
         def download_request(
@@ -328,6 +329,7 @@ class UsgsApi(Download, Api):
                     stream=True,
                     headers=USER_AGENT,
                     timeout=wait * 60,
+                    verify=ssl_verify,
                 ) as stream:
                     try:
                         stream.raise_for_status()

--- a/eodag/plugins/authentication/qsauth.py
+++ b/eodag/plugins/authentication/qsauth.py
@@ -67,6 +67,8 @@ class HttpQueryStringAuth(Authentication):
         auth = QueryStringAuth(**self.config.credentials)
 
         auth_uri = getattr(self.config, "auth_uri", None)
+        ssl_verify = getattr(self.config, "ssl_verify", True)
+
         if auth_uri:
             try:
                 response = requests.get(
@@ -74,6 +76,7 @@ class HttpQueryStringAuth(Authentication):
                     timeout=HTTP_REQ_TIMEOUT,
                     headers=USER_AGENT,
                     auth=auth,
+                    verify=ssl_verify,
                 )
                 response.raise_for_status()
             except requests.exceptions.Timeout as exc:

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -439,6 +439,8 @@ class AwsDownload(Download):
         product_conf = getattr(self.config, "products", {}).get(
             product.product_type, {}
         )
+        ssl_verify = getattr(self.config, "ssl_verify", True)
+
         if build_safe and "fetch_metadata" in product_conf.keys():
             fetch_format = product_conf["fetch_metadata"]["fetch_format"]
             update_metadata = product_conf["fetch_metadata"]["update_metadata"]
@@ -448,7 +450,10 @@ class AwsDownload(Download):
             logger.info("Fetching extra metadata from %s" % fetch_url)
             try:
                 resp = requests.get(
-                    fetch_url, headers=USER_AGENT, timeout=HTTP_REQ_TIMEOUT
+                    fetch_url,
+                    headers=USER_AGENT,
+                    timeout=HTTP_REQ_TIMEOUT,
+                    verify=ssl_verify,
                 )
             except requests.exceptions.Timeout as exc:
                 raise TimeOutError(exc, timeout=HTTP_REQ_TIMEOUT) from exc

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -158,6 +158,7 @@ class HTTPDownload(Download):
         :type kwargs: Union[str, bool, dict]
         """
         order_method = getattr(self.config, "order_method", "GET").lower()
+        ssl_verify = getattr(self.config, "ssl_verify", True)
         OrderKwargs = TypedDict(
             "OrderKwargs", {"json": Dict[str, Union[Any, List[str]]]}, total=False
         )
@@ -174,13 +175,13 @@ class HTTPDownload(Download):
         else:
             order_url = product.properties["orderLink"]
             order_kwargs = {}
-
         with requests.request(
             method=order_method,
             url=order_url,
             auth=auth,
             timeout=HTTP_REQ_TIMEOUT,
             headers=dict(getattr(self.config, "order_headers", {}), **USER_AGENT),
+            verify=ssl_verify,
             **order_kwargs,
         ) as response:
             try:
@@ -253,6 +254,9 @@ class HTTPDownload(Download):
             "StatusKwargs", {"json": Dict[str, Union[Any, List[str]]]}, total=False
         )
         status_kwargs: StatusKwargs = {}
+
+        ssl_verify = getattr(self.config, "ssl_verify", True)
+
         if status_method == "post":
             # separate url & parameters
             parts = urlparse(str(product.properties["orderStatusLink"]))
@@ -273,6 +277,7 @@ class HTTPDownload(Download):
             headers=dict(
                 getattr(self.config, "order_status_headers", {}), **USER_AGENT
             ),
+            verify=ssl_verify,
             **status_kwargs,
         ) as response:
             try:
@@ -326,6 +331,7 @@ class HTTPDownload(Download):
                         product.properties["searchLink"],
                         timeout=HTTP_REQ_TIMEOUT,
                         headers=USER_AGENT,
+                        verify=ssl_verify,
                     )
                     response.raise_for_status()
                     if (
@@ -833,6 +839,7 @@ class HTTPDownload(Download):
         flatten_top_dirs = product_conf.get(
             "flatten_top_dirs", getattr(self.config, "flatten_top_dirs", False)
         )
+        ssl_verify = getattr(self.config, "ssl_verify", True)
 
         # loop for assets download
         for asset in assets_values:
@@ -849,6 +856,7 @@ class HTTPDownload(Download):
                 params=params,
                 headers=USER_AGENT,
                 timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
+                verify=ssl_verify,
             ) as stream:
                 try:
                     stream.raise_for_status()
@@ -1041,6 +1049,7 @@ class HTTPDownload(Download):
     ) -> int:
         total_size = 0
 
+        ssl_verify = getattr(self.config, "ssl_verify", True)
         # loop for assets size & filename
         for asset in assets_values:
             if not asset["href"].startswith("file:"):
@@ -1082,6 +1091,7 @@ class HTTPDownload(Download):
                         params=params,
                         headers=USER_AGENT,
                         timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
+                        verify=ssl_verify,
                     ) as stream:
                         # size from GET header / Content-length
                         asset.size = int(stream.headers.get("Content-length", 0))

--- a/eodag/plugins/download/s3rest.py
+++ b/eodag/plugins/download/s3rest.py
@@ -178,8 +178,15 @@ class S3RestDownload(Download):
 
             # get nodes/files list contained in the bucket
             logger.debug("Retrieving product content from %s", nodes_list_url)
+
+            ssl_verify = getattr(self.config, "ssl_verify", True)
+
             bucket_contents = requests.get(
-                nodes_list_url, auth=auth, headers=USER_AGENT, timeout=HTTP_REQ_TIMEOUT
+                nodes_list_url,
+                auth=auth,
+                headers=USER_AGENT,
+                timeout=HTTP_REQ_TIMEOUT,
+                verify=ssl_verify,
             )
             try:
                 bucket_contents.raise_for_status()
@@ -310,6 +317,7 @@ class S3RestDownload(Download):
                     auth=auth,
                     headers=USER_AGENT,
                     timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
+                    verify=ssl_verify,
                 ) as stream:
                     try:
                         stream.raise_for_status()

--- a/eodag/plugins/search/data_request_search.py
+++ b/eodag/plugins/search/data_request_search.py
@@ -260,6 +260,7 @@ class DataRequestSearch(Search):
         self, product_type: str, eodag_product_type: str, **kwargs: Any
     ) -> str:
         headers = getattr(self.auth, "headers", USER_AGENT)
+        ssl_verify = getattr(self.config.ssl_verify, "ssl_verify", True)
         try:
             url = self.config.data_request_url
             request_body = format_query_params(
@@ -269,7 +270,11 @@ class DataRequestSearch(Search):
                 f"Sending search job request to {url} with {str(request_body)}"
             )
             request_job = requests.post(
-                url, json=request_body, headers=headers, timeout=HTTP_REQ_TIMEOUT
+                url,
+                json=request_body,
+                headers=headers,
+                timeout=HTTP_REQ_TIMEOUT,
+                verify=ssl_verify,
             )
             request_job.raise_for_status()
         except requests.exceptions.Timeout as exc:
@@ -300,9 +305,14 @@ class DataRequestSearch(Search):
         logger.debug("checking status of request job %s", data_request_id)
         status_url = self.config.status_url + data_request_id
         headers = getattr(self.auth, "headers", USER_AGENT)
+        ssl_verify = getattr(self.config, "ssl_verify", True)
+
         try:
             status_resp = requests.get(
-                status_url, headers=headers, timeout=HTTP_REQ_TIMEOUT
+                status_url,
+                headers=headers,
+                timeout=HTTP_REQ_TIMEOUT,
+                verify=ssl_verify,
             )
             status_resp.raise_for_status()
         except requests.exceptions.Timeout as exc:
@@ -331,9 +341,12 @@ class DataRequestSearch(Search):
         url = self.config.result_url.format(
             jobId=data_request_id, items_per_page=items_per_page, page=page
         )
+        ssl_verify = getattr(self.config, "ssl_verify", True)
         headers = getattr(self.auth, "headers", USER_AGENT)
         try:
-            return requests.get(url, headers=headers, timeout=HTTP_REQ_TIMEOUT).json()
+            return requests.get(
+                url, headers=headers, timeout=HTTP_REQ_TIMEOUT, verify=ssl_verify
+            ).json()
         except requests.exceptions.Timeout as exc:
             raise TimeOutError(exc, timeout=HTTP_REQ_TIMEOUT) from exc
         except requests.RequestException:

--- a/eodag/plugins/search/static_stac_search.py
+++ b/eodag/plugins/search/static_stac_search.py
@@ -71,6 +71,7 @@ class StaticStacSearch(StacSearch):
         super(StaticStacSearch, self).__init__(provider, config)
         self.config.__dict__.setdefault("max_connections", 100)
         self.config.__dict__.setdefault("timeout", HTTP_REQ_TIMEOUT)
+        self.config.__dict__.setdefault("ssl_verify", True)
 
     def discover_product_types(self) -> Dict[str, Any]:
         """Fetch product types is disabled for `StaticStacSearch`
@@ -95,6 +96,7 @@ class StaticStacSearch(StacSearch):
             recursive=True,
             max_connections=self.config.max_connections,
             timeout=self.config.timeout,
+            ssl_verify=self.config.ssl_verify,
         )
         nb_features = len(features)
         feature_collection = geojson.FeatureCollection(features)

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -96,6 +96,7 @@
     need_auth: true
     auth_error_code: 403
     results_entry: 'results'
+    ssl_verify: true
     pagination:
       next_page_query_obj: '{{"limit":{items_per_page},"page":{page}}}'
       total_items_nb_key_path: '$.meta.found'
@@ -499,6 +500,7 @@
   download: !plugin
     type: AwsDownload
     requester_pays: True
+    ssl_verify: true
     products:
       CBERS4_MUX_L2:
         default_bucket: 'cbers-pds'
@@ -535,6 +537,7 @@
           - productPath
   auth: !plugin
     type: AwsAuth
+    ssl_verify: true
 
 ---
 !provider
@@ -548,6 +551,7 @@
     type: QueryStringSearch
     api_endpoint: 'https://theia.cnes.fr/atdistrib/resto2/api/collections/{collection}/search.json'
     need_auth: false
+    ssl_verify: true
     pagination:
       next_page_url_tpl: '{url}?{search}&maxRecords={items_per_page}&page={page}'
       total_items_nb_key_path: '$.properties.totalResults'
@@ -707,11 +711,13 @@
     archive_depth: 2
     order_enabled: true
     auth_error_code: 403
+    ssl_verify: true
     dl_url_params:
       issuerId: theia
   auth: !plugin
     type: TokenAuth
     auth_uri: 'https://theia.cnes.fr/atdistrib/services/authenticate/'
+    ssl_verify: true
 
 ---
 !provider
@@ -727,6 +733,7 @@
     type: QueryStringSearch
     api_endpoint: 'https://peps.cnes.fr/resto/api/collections/{collection}/search.json'
     need_auth: false
+    ssl_verify: true
     pagination:
       next_page_url_tpl: '{url}?{search}&maxRecords={items_per_page}&page={page}'
       total_items_nb_key_path: '$.properties.totalResults'
@@ -861,11 +868,13 @@
     archive_depth: 2
     order_enabled: true
     auth_error_code: 401
+    ssl_verify: true
     dl_url_params:
       issuerId: peps
   auth: !plugin
     type: GenericAuth
     auth_uri: 'https://peps.cnes.fr/resto/api/users/connect'
+    ssl_verify: true
 ---
 !provider
   name: creodias
@@ -879,6 +888,7 @@
     api_endpoint: 'http://datahub.creodias.eu/resto/api/collections/{collection}/search.json'
     need_auth: false
     timeout: 60
+    ssl_verify: true
     pagination:
       next_page_url_tpl: '{url}?{search}&maxRecords={items_per_page}&page={page}&exactCount=1'
       total_items_nb_key_path: '$.properties.totalResults'
@@ -1014,6 +1024,7 @@
     extract: true
     order_enabled: false
     archive_depth: 2
+    ssl_verify: true
   auth: !plugin
     type: KeycloakOIDCPasswordAuth
     auth_base_uri: 'https://identity.cloudferro.com/auth'
@@ -1023,6 +1034,7 @@
     token_provision: qs
     token_qs_key: 'token'
     auth_error_code: 401
+    ssl_verify: true
   products:
       # S1
     S1_SAR_RAW:
@@ -1240,6 +1252,7 @@
     api_endpoint: 'https://catalogue.onda-dias.eu/dias-catalogue/Products'
     timeout: 60
     need_auth: false
+    ssl_verify: true
     dont_quote:
       - '['
       - ']'
@@ -1528,10 +1541,12 @@
     auth_error_code: 401
     order_enabled: true
     order_method: 'POST'
+    ssl_verify: true
     order_headers:
       Content-Type: application/json
   auth: !plugin
     type: GenericAuth
+    ssl_verify: true
 
 ---
 !provider
@@ -1545,6 +1560,7 @@
     type: StacSearch
     api_endpoint: https://eod-catalog-svc-prod.astraea.earth/search
     need_auth: false
+    ssl_verify: true
     discover_queryables:
       fetch_url: null
       product_type_fetch_url: null
@@ -1627,6 +1643,7 @@
     type: AwsDownload
     requester_pays: True
     flatten_top_dirs: True
+    ssl_verify: true
     products:
       S1_SAR_GRD:
         default_bucket: 'sentinel-s1-l1c'
@@ -1659,6 +1676,7 @@
           - tilePath
   auth: !plugin
     type: AwsAuth
+    ssl_verify: true
 
 ---
 !provider
@@ -1672,6 +1690,7 @@
     type: StacSearch
     api_endpoint: https://landsatlook.usgs.gov/stac-server/search
     need_auth: false
+    ssl_verify: true
     discover_queryables:
       fetch_url: null
       product_type_fetch_url: null
@@ -1716,8 +1735,10 @@
     type: AwsDownload
     requester_pays: True
     flatten_top_dirs: True
+    ssl_verify: true
   auth: !plugin
     type: AwsAuth
+    ssl_verify: true
 
 ---
 !provider
@@ -1731,6 +1752,7 @@
     type: StacSearch
     api_endpoint: https://earth-search.aws.element84.com/v1/search
     need_auth: false
+    ssl_verify: true
     discover_product_types:
       results_entry: '$.collections[?id!="sentinel-s2-l2a-cogs"]'
     discover_queryables:
@@ -1810,6 +1832,7 @@
     type: AwsDownload
     requester_pays: True
     flatten_top_dirs: True
+    ssl_verify: true
     products:
       S2_MSI_L1C:
         default_bucket: 'sentinel-s2-l1c'
@@ -1819,6 +1842,7 @@
           - tilePath
   auth: !plugin
     type: AwsAuth
+    ssl_verify: true
 
 ---
 !provider
@@ -1832,6 +1856,7 @@
     type: StacSearch
     api_endpoint: https://earth-search.aws.element84.com/v1/search
     need_auth: false
+    ssl_verify: true
     discover_product_types:
       fetch_url: null
     discover_queryables:
@@ -1872,6 +1897,7 @@
   download: !plugin
     type: HTTPDownload
     base_uri: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com'
+    ssl_verify: true
 ---
 !provider
   name: earth_search_gcs
@@ -1884,6 +1910,7 @@
     type: StacSearch
     api_endpoint: https://earth-search.aws.element84.com/v0/search
     need_auth: false
+    ssl_verify: true
     discover_product_types:
       fetch_url: null
     discover_queryables:
@@ -1933,11 +1960,13 @@
     type: AwsDownload
     base_uri: https://storage.googleapis.com
     ignore_assets: True
+    ssl_verify: true
     products:
       S2_MSI_L1C:
         default_bucket: 'gcp-public-data-sentinel-2'
   auth: !plugin
     type: AwsAuth
+    ssl_verify: true
 ---
 !provider
   name: ecmwf
@@ -1950,6 +1979,7 @@
     type: EcmwfApi
     api_endpoint: https://api.ecmwf.int/v1
     extract: false
+    ssl_verify: true
     metadata_mapping:
       productType: '$.productType'
       title: '$.id'
@@ -2175,6 +2205,7 @@
     extract: false
     flatten_top_dirs: True
     constraints_file_url: "https://datastore.copernicus-climate.eu/cams/published-forms/camsprod/{dataset}/constraints.json"
+    ssl_verify: true
     metadata_mapping:
       productType: '$.productType'
       title: '$.id'
@@ -2579,6 +2610,7 @@
     type: CdsApi
     api_endpoint: https://cds.climate.copernicus.eu/api/v2
     extract: false
+    ssl_verify: true
     discover_queryables:
       fetch_url: null
       product_type_fetch_url: null
@@ -3160,6 +3192,7 @@
     # but can be very slow if not enough metdata is provided.
     api_endpoint: 'https://copernicus.nci.org.au/sara.server/1.0/api/collections/{collection}/search.json'
     need_auth: false
+    ssl_verify: true
     pagination:
       next_page_url_tpl: '{url}?{search}&maxRecords={items_per_page}&page={page}'
       total_items_nb_key_path: '$.properties.totalResults'
@@ -3423,9 +3456,11 @@
     archive_depth: 2
     order_enabled: true
     auth_error_code: 403
+    ssl_verify: true
   auth: !plugin
     type: GenericAuth
     method: basic
+    ssl_verify: true
 ---
 !provider
   name: meteoblue
@@ -3438,6 +3473,7 @@
     type: BuildPostSearchResult
     api_endpoint: 'https://my.meteoblue.com/dataset/query'
     need_auth: true
+    ssl_verify: true
     pagination:
       next_page_query_obj: '{{"checkOnly":true}}'
     discover_metadata:
@@ -3497,6 +3533,7 @@
     extract: False
     order_enabled: true
     order_method: 'POST'
+    ssl_verify: true
     order_on_response:
       metadata_mapping:
         order_id: '$.id'
@@ -3511,6 +3548,7 @@
   auth: !plugin
     type: HttpQueryStringAuth
     auth_uri: 'http://my.meteoblue.com/dataset/meta?dataset=NEMSAUTO'
+    ssl_verify: true
 ---
 !provider
   name: cop_dataspace
@@ -3524,6 +3562,7 @@
     api_endpoint: 'http://catalogue.dataspace.copernicus.eu/resto/api/collections/{collection}/search.json'
     need_auth: false
     timeout: 60
+    ssl_verify: true
     pagination:
       next_page_url_tpl: '{url}?{search}&maxRecords={items_per_page}&page={page}&exactCount=1'
       total_items_nb_key_path: '$.properties.totalResults'
@@ -3623,6 +3662,7 @@
     extract: true
     order_enabled: false
     archive_depth: 2
+    ssl_verify: true
   auth: !plugin
     type: KeycloakOIDCPasswordAuth
     auth_base_uri: 'https://identity.dataspace.copernicus.eu/auth'
@@ -3632,6 +3672,7 @@
     token_provision: qs
     token_qs_key: 'token'
     auth_error_code: 401
+    ssl_verify: true
   products:
     # S2
     S2_MSI_L1C:
@@ -3827,6 +3868,7 @@
     type: StacSearch
     api_endpoint: https://planetarycomputer.microsoft.com/api/stac/v1/search
     need_auth: false
+    ssl_verify: true
     pagination:
       max_items_per_page: 1000
     sort:
@@ -3862,10 +3904,12 @@
     base_uri: 'https://planetarycomputer.microsoft.com/api/stac/download'
     flatten_top_dirs: True
     auth_error_code: 403
+    ssl_verify: true
   auth: !plugin
     type: SASAuth
     auth_uri: 'https://planetarycomputer.microsoft.com/api/sas/v1/sign?href={url}'
     signed_url_key: href
+    ssl_verify: true
     headers:
       Ocp-Apim-Subscription-Key: "{apikey}"
 ---
@@ -3881,6 +3925,7 @@
     api_endpoint: https://hydroweb.next.theia-land.fr/api/v1/rs-catalog/stac/search
     need_auth: true
     auth_error_code: 401
+    ssl_verify: true
     discover_queryables:
       fetch_url: null
       product_type_fetch_url: null
@@ -3910,8 +3955,10 @@
     base_uri: https://hydroweb.next.theia-land.fr
     flatten_top_dirs: true
     auth_error_code: 401
+    ssl_verify: true
   auth: !plugin
     type: HTTPHeaderAuth
+    ssl_verify: true
     headers:
       X-API-Key: "{apikey}"
 ---
@@ -3935,6 +3982,7 @@
     results_entry: content
     two_passes_id_search: true
     dates_required: true
+    ssl_verify: true
     pagination:
       start_page: 0
       max_items_per_page: 20
@@ -3967,6 +4015,7 @@
     token_type: json
     token_key: access_token
     request_method: GET
+    ssl_verify: true
     headers:
       Authorization: Bearer $token
   products:
@@ -6838,6 +6887,7 @@
     auth_error_code: 401
     order_enabled: true
     order_method: 'POST'
+    ssl_verify: true
     order_on_response:
       metadata_mapping:
         order_id: '$.orderId'
@@ -6867,6 +6917,7 @@
     s3_endpoint: 'https://eodata.cloudferro.com'
     need_auth: true
     timeout: 60
+    ssl_verify: true
     pagination:
       next_page_url_tpl: '{url}?{search}&maxRecords={items_per_page}&page={page}&exactCount=1'
       total_items_nb_key_path: '$.properties.totalResults'
@@ -7001,9 +7052,11 @@
     flatten_top_dirs: True
     base_uri: 'https://eodata.cloudferro.com'
     s3_bucket: 'eodata'
+    ssl_verify: true
   auth: !plugin
     type: AwsAuth
     auth_error_code: 403
+    ssl_verify: true
   products:
     # S1
     S1_SAR_RAW:

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -33,6 +33,7 @@ import mimetypes
 import os
 import re
 import shutil
+import ssl
 import string
 import sys
 import types
@@ -1437,3 +1438,22 @@ def guess_file_type(file: str) -> Optional[str]:
     mimetypes.add_type("text/xml", ".xsd")
     mime_type, _ = mimetypes.guess_type(file, False)
     return mime_type
+
+
+def get_ssl_context(ssl_verify: bool) -> ssl.SSLContext:
+
+    """
+    Returns an SSL context based on ssl_verify argument.
+    :param ssl_verify: ssl_verify parameter
+    :type ssl_verify: bool
+    :returns: An SSL context object.
+    :rtype: ssl.SSLContext
+    """
+    ctx = ssl.create_default_context()
+    if not ssl_verify:
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+    else:
+        ctx.check_hostname = True
+        ctx.verify_mode = ssl.CERT_REQUIRED
+    return ctx

--- a/tests/context.py
+++ b/tests/context.py
@@ -88,6 +88,7 @@ from eodag.utils import (
     cached_parse,
     sanitize,
     parse_header,
+    get_ssl_context,
 )
 from eodag.utils.exceptions import (
     AddressNotFound,

--- a/tests/integration/test_core_config.py
+++ b/tests/integration/test_core_config.py
@@ -255,6 +255,7 @@ class TestCoreProductTypesConfig(TestCase):
             auth=mock.ANY,
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
+            verify=True,
         )
 
         mock_urlopen.return_value.json.return_value = {}

--- a/tests/units/test_auth_plugins.py
+++ b/tests/units/test_auth_plugins.py
@@ -251,6 +251,7 @@ class TestAuthPluginHttpQueryStringAuth(BaseAuthPluginTest):
             timeout=HTTP_REQ_TIMEOUT,
             headers=USER_AGENT,
             auth=auth,
+            verify=True,
         )
 
         # check auth query string

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -585,6 +585,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
             verify=False,
         )
+        del plugin.config.ssl_verify
 
     @mock.patch("eodag.plugins.download.http.requests.head", autospec=True)
     @mock.patch("eodag.plugins.download.http.requests.get", autospec=True)
@@ -1007,7 +1008,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             auth=auth,
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
-            verify=False,
+            verify=True,
         )
 
     @mock.patch("eodag.plugins.download.http.requests.request", autospec=True)
@@ -1030,7 +1031,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             auth=auth,
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
-            verify=False,
+            verify=True,
         )
         # orderLink with query query args
         mock_request.reset_mock()
@@ -1043,7 +1044,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
             json={"foo": ["bar"]},
-            verify=False,
+            verify=True,
         )
 
     def test_plugins_download_http_order_status(self):

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -521,6 +521,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             params=plugin.config.dl_url_params,
             headers=USER_AGENT,
             timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
+            verify=True,
         )
         mock_requests_session.assert_not_called()
         # re-enable product download
@@ -550,8 +551,40 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             params=plugin.config.dl_url_params,
             headers=USER_AGENT,
             timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
+            verify=True,
         )
         mock_requests_session.assert_not_called()
+
+    @mock.patch("eodag.plugins.download.http.requests.head", autospec=True)
+    @mock.patch("eodag.plugins.download.http.requests.get", autospec=True)
+    def test_plugins_download_http_ignore_assets_without_ssl(
+        self, mock_requests_get, mock_requests_head
+    ):
+        """HTTPDownload.download() must ignore assets if configured to"""
+
+        plugin = self.get_download_plugin(self.product)
+        self.product.location = (
+            self.product.remote_location
+        ) = "http://somewhere/download_from_location"
+        self.product.properties["id"] = "someproduct"
+        self.product.assets.clear()
+        self.product.assets.update({"foo": {"href": "http://somewhere/download_asset"}})
+        mock_requests_get.return_value.__enter__.return_value.iter_content.side_effect = lambda *x, **y: io.BytesIO(
+            b"some content"
+        )
+        # download asset if ssl_verify = False
+        plugin.config.ssl_verify = False
+
+        plugin.download(self.product, outputs_prefix=self.output_dir)
+        mock_requests_get.assert_called_once_with(
+            self.product.assets["foo"]["href"],
+            stream=True,
+            auth=None,
+            params=plugin.config.dl_url_params,
+            headers=USER_AGENT,
+            timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
+            verify=False,
+        )
 
     @mock.patch("eodag.plugins.download.http.requests.head", autospec=True)
     @mock.patch("eodag.plugins.download.http.requests.get", autospec=True)
@@ -596,6 +629,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             params=plugin.config.dl_url_params,
             headers=USER_AGENT,
             timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
+            verify=True,
         )
         # Check if the HEAD request has been called once for size & filename request
         mock_requests_head.assert_called_once_with(
@@ -973,6 +1007,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             auth=auth,
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
+            verify=False,
         )
 
     @mock.patch("eodag.plugins.download.http.requests.request", autospec=True)
@@ -995,6 +1030,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             auth=auth,
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
+            verify=False,
         )
         # orderLink with query query args
         mock_request.reset_mock()
@@ -1007,6 +1043,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
             json={"foo": ["bar"]},
+            verify=False,
         )
 
     def test_plugins_download_http_order_status(self):
@@ -1431,6 +1468,7 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
             self.product.properties["tileInfo"],
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
+            verify=True,
         )
         self.assertEqual(mock_get_authenticated_objects.call_count, 2)
         mock_get_authenticated_objects.assert_any_call(
@@ -1511,6 +1549,7 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
             self.product.properties["tileInfo"],
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
+            verify=True,
         )
         mock_get_authenticated_objects.assert_called_once_with(
             plugin, "example", "", {}

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -1136,6 +1136,7 @@ class RequestTestCase(unittest.TestCase):
             url="https://planetarycomputer.microsoft.com/api/stac/v1/search/../queryables",
             timeout=HTTP_REQ_TIMEOUT,
             headers=USER_AGENT,
+            verify=True,
         )
         # TODO: with an unsupported provider
 
@@ -1178,6 +1179,7 @@ class RequestTestCase(unittest.TestCase):
             "sentinel-1-grd/queryables",
             timeout=HTTP_REQ_TIMEOUT,
             headers=USER_AGENT,
+            verify=True,
         )
         # returned queryables
         self.assertListEqual(
@@ -1211,6 +1213,7 @@ class RequestTestCase(unittest.TestCase):
             "sentinel-1-grd/queryables",
             timeout=HTTP_REQ_TIMEOUT,
             headers=USER_AGENT,
+            verify=True,
         )
 
         self.assertListEqual(

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -947,6 +947,8 @@ class TestSearchPluginODataV4Search(BaseSearchPluginTest):
             mock_request.return_value, timeout=60, context=ssl_ctx
         )
 
+        del self.onda_search_plugin.config.ssl_verify
+
     @mock.patch("eodag.plugins.search.qssearch.requests.get", autospec=True)
     @mock.patch(
         "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
@@ -1471,6 +1473,8 @@ class TestSearchPluginDataRequestSearch(BaseSearchPluginTest):
             timeout=HTTP_REQ_TIMEOUT,
             verify=False,
         )
+
+        del self.search_plugin.config.ssl_verify
 
     def test_plugins_search_datareq_distinct_product_type_mtd_mapping(self):
         """The metadata mapping for data_request_search should not mix specific product-types metadata-mapping"""

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 import json
 import re
+import ssl
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -907,6 +908,45 @@ class TestSearchPluginODataV4Search(BaseSearchPluginTest):
         # products count non extracted from search results as count endpoint is specified
         self.assertFalse(hasattr(self.onda_search_plugin, "total_items_nb"))
 
+    @mock.patch("eodag.plugins.search.qssearch.get_ssl_context", autospec=True)
+    @mock.patch("eodag.plugins.search.qssearch.Request", autospec=True)
+    @mock.patch("eodag.plugins.search.qssearch.urlopen", autospec=True)
+    @mock.patch("eodag.plugins.search.qssearch.cast", autospec=True)
+    def test_plugins_search_odatav4search_with_ssl_context(
+        self, mock_cast, mock_urlopen, mock_request, mock_get_ssl_context
+    ):
+        """A query with a ODataV4Search (here onda) must return tuple with a list of EOProduct and a number of available products"""  # noqa
+        self.onda_search_plugin.config.ssl_verify = False
+        mock_cast.return_value.json.return_value = 2
+
+        ssl_ctx = ssl.create_default_context()
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode = ssl.CERT_NONE
+
+        mock_request.return_value = mock.Mock()
+
+        # Mocking return value of get_ssl_context
+        mock_get_ssl_context.return_value = ssl_ctx
+
+        self.onda_search_plugin.query(
+            page=1,
+            items_per_page=2,
+            auth=self.onda_auth_plugin,
+            # custom query argument that must be mapped using discovery_metata.search_param
+            foo="bar",
+            **self.search_criteria_s2_msi_l1c,
+        )
+
+        mock_get_ssl_context.assert_called_with(False)
+
+        # # Asserting that get_ssl_context has been called
+        self.assertEqual(mock_get_ssl_context.call_count, 2)
+
+        # Asserting that urlopen has been called with the correct arguments
+        mock_urlopen.assert_called_with(
+            mock_request.return_value, timeout=60, context=ssl_ctx
+        )
+
     @mock.patch("eodag.plugins.search.qssearch.requests.get", autospec=True)
     @mock.patch(
         "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
@@ -959,7 +999,7 @@ class TestSearchPluginODataV4Search(BaseSearchPluginTest):
             products[1].properties["uid"],
         )
         mock_requests_get.assert_called_with(
-            metadata_url, headers=USER_AGENT, timeout=HTTP_REQ_TIMEOUT
+            metadata_url, headers=USER_AGENT, timeout=HTTP_REQ_TIMEOUT, verify=True
         )
         # we check that two requests have been called, one per product
         self.assertEqual(mock_requests_get.call_count, 2)
@@ -1319,6 +1359,7 @@ class TestSearchPluginBuildPostSearchResult(BaseSearchPluginTest):
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
             auth=self.search_plugin.auth,
+            verify=True,
         )
         self.assertEqual(estimate, 1)
         self.assertIsInstance(products[0], EOProduct)
@@ -1363,6 +1404,7 @@ class TestSearchPluginDataRequestSearch(BaseSearchPluginTest):
             json={"datasetId": "EO:DEM:DAT:COP-DEM_GLO-30-DGED__2022_1"},
             headers=getattr(self.search_plugin.auth, "headers", ""),
             timeout=HTTP_REQ_TIMEOUT,
+            verify=True,
         )
         keywords = {
             "format": "GeoTiff100mt",
@@ -1385,6 +1427,7 @@ class TestSearchPluginDataRequestSearch(BaseSearchPluginTest):
             },
             headers=getattr(self.search_plugin.auth, "headers", ""),
             timeout=HTTP_REQ_TIMEOUT,
+            verify=True,
         )
 
     @mock.patch("eodag.plugins.search.data_request_search.requests.get", autospec=True)
@@ -1395,6 +1438,7 @@ class TestSearchPluginDataRequestSearch(BaseSearchPluginTest):
             self.search_plugin.config.status_url + "123",
             headers=getattr(self.search_plugin.auth, "headers", ""),
             timeout=HTTP_REQ_TIMEOUT,
+            verify=True,
         )
         assert successful
         mock_requests_get.return_value = MockResponse(
@@ -1412,6 +1456,20 @@ class TestSearchPluginDataRequestSearch(BaseSearchPluginTest):
             ),
             headers=getattr(self.search_plugin.auth, "headers", ""),
             timeout=HTTP_REQ_TIMEOUT,
+            verify=True,
+        )
+
+    @mock.patch("eodag.plugins.search.data_request_search.requests.get", autospec=True)
+    def test_plugins_get_result_data_ssl_verify_false(self, mock_requests_get):
+        self.search_plugin.config.ssl_verify = False
+        self.search_plugin._get_result_data("123", items_per_page=5, page=1)
+        mock_requests_get.assert_called_with(
+            self.search_plugin.config.result_url.format(
+                jobId="123", items_per_page=5, page=0
+            ),
+            headers=getattr(self.search_plugin.auth, "headers", ""),
+            timeout=HTTP_REQ_TIMEOUT,
+            verify=False,
         )
 
     def test_plugins_search_datareq_distinct_product_type_mtd_mapping(self):

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -19,6 +19,7 @@
 import copy
 import logging
 import os
+import ssl
 import sys
 import unittest
 from contextlib import closing
@@ -33,6 +34,7 @@ from tests.context import (
     deepcopy,
     flatten_top_directories,
     get_bucket_name_and_prefix,
+    get_ssl_context,
     get_timestamp,
     merge_mappings,
     path_to_uri,
@@ -91,6 +93,16 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(actual_path, expected_path)
         with self.assertRaises(ValueError):
             uri_to_path("not_a_uri")
+
+    def test_ssl_context(self):
+
+        ssl_ctx = get_ssl_context(False)
+        self.assertEqual(ssl_ctx.verify_mode, ssl.CERT_NONE)
+        self.assertEqual(ssl_ctx.check_hostname, False)
+
+        ssl_ctx = get_ssl_context(True)
+        self.assertEqual(ssl_ctx.verify_mode, ssl.CERT_REQUIRED)
+        self.assertEqual(ssl_ctx.check_hostname, True)
 
     def test_path_to_uri(self):
         if sys.platform == "win32":


### PR DESCRIPTION
SSL Verification changes to plugins configuration and to the download and auth plugin code to pass the argument to whether allow verification while making request call or not. Also fixed the relevant unit test cases.