### PR TITLE
fix: re-login in UsgsApi plugin on api file error

### DIFF
--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import tarfile
 import zipfile
@@ -101,7 +102,12 @@ class UsgsApi(Api):
             except USGSAuthExpiredError:
                 api.logout()
                 continue
-            except USGSError:
+            except USGSError as e:
+                if str(e).startswith("AUTH_REVOKED"):
+                    # If error code is "AUTH_REVOKED" then api.logout() fails to logout
+                    # Manually removing file with API key
+                    os.remove(api.TMPFILE)
+                    continue
                 raise AuthenticationError(
                     "Please check your USGS credentials."
                 ) from None

--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -103,14 +103,12 @@ class UsgsApi(Api):
                 api.logout()
                 continue
             except USGSError as e:
-                if str(e).startswith("AUTH_REVOKED"):
-                    # If error code is "AUTH_REVOKED" then api.logout() fails to logout
-                    # Manually removing file with API key
+                if i == 0:
+                    # `.usgs` API file key might be obsolete
+                    # Remove it and try again
                     os.remove(api.TMPFILE)
                     continue
-                raise AuthenticationError(
-                    "Please check your USGS credentials."
-                ) from None
+                raise AuthenticationError("Please check your USGS credentials.") from e
 
     def query(
         self,

--- a/tests/context.py
+++ b/tests/context.py
@@ -108,3 +108,4 @@ from eodag.utils.exceptions import (
 from eodag.utils.stac_reader import fetch_stac_items, _TextOpener
 from tests import TEST_RESOURCES_PATH
 from usgs.api import USGSAuthExpiredError, USGSError
+from usgs.api import TMPFILE as USGS_TMPFILE


### PR DESCRIPTION
If the file `~/.usgs` exists when EODAG is launched and it contains a revoked API key, then `usgs.api.login()` raises the exception `USGSError` (with message `AUTH_REVOKED: API key has been revoked, please logout and re-login.`). The file `~/.usgs` must be manually removed because calling `usgs.api.logout()` raises the same exception without removing it.