### PR TITLE
fix: remove metadata_mapping from CdsApi queryables

### DIFF
--- a/eodag/plugins/apis/base.py
+++ b/eodag/plugins/apis/base.py
@@ -35,6 +35,7 @@ from eodag.utils import (
     DEFAULT_ITEMS_PER_PAGE,
     DEFAULT_PAGE,
     Annotated,
+    deepcopy,
 )
 
 logger = logging.getLogger("eodag.apis.base")
@@ -120,7 +121,9 @@ class Api(PluginTopic):
         :returns: queryable parameters dict
         :rtype: Dict[str, Annotated[Any, FieldInfo]]
         """
-        defaults = self.config.products.get(product_type, {})
+        defaults = deepcopy(self.config.products.get(product_type, {}))
+        defaults.pop("metadata_mapping", None)
+
         queryables = {}
         for parameter, value in defaults.items():
             queryables[parameter] = Annotated[type(value), Field(default=value)]

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -941,14 +941,15 @@ class TestApisPluginCdsApi(BaseApisPluginTest):
         queryables = self.api_plugin.discover_queryables(
             productType="CAMS_EU_AIR_QUALITY_RE"
         )
-        self.assertEqual(12, len(queryables))
+        self.assertEqual(11, len(queryables))
         self.assertIn("variable", queryables)
+        self.assertNotIn("metadata_mapping", queryables)
         # with additional param
         queryables = self.api_plugin.discover_queryables(
             productType="CAMS_EU_AIR_QUALITY_RE",
             variable="a",
         )
-        self.assertEqual(12, len(queryables))
+        self.assertEqual(11, len(queryables))
         queryable = queryables.get("variable")
         self.assertEqual("a", queryable.__metadata__[0].get_default())
         queryable = queryables.get("month")


### PR DESCRIPTION
Fixes #1047

Remove `metadata_mapping` from `CdsApi` queryables