### PR TITLE
fix: queryables fixes + small refactor

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -23,18 +23,7 @@ import re
 import shutil
 import tempfile
 from operator import itemgetter
-from typing import (
-    TYPE_CHECKING,
-    AbstractSet,
-    Any,
-    Dict,
-    Iterator,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Set, Tuple, Union
 
 import geojson
 import pkg_resources
@@ -2166,9 +2155,7 @@ class EODataAccessGateway:
         return self._plugins_manager.get_crunch_plugin(name, **plugin_conf)
 
     def list_queryables(
-        self,
-        provider: Optional[str] = None,
-        **kwargs: Any,
+        self, provider: Optional[str] = None, **kwargs: Any
     ) -> Dict[str, Annotated[Any, FieldInfo]]:
         """Fetch the queryable properties for a given product type and/or provider.
 
@@ -2177,11 +2164,14 @@ class EODataAccessGateway:
         :param kwargs: additional filters for queryables (`productType` or other search
                        arguments)
         :type kwargs: Any
+
+        :raises UnsupportedProductType: If the specified product type is not available for the
+                                        provider.
+
         :returns: A dict containing the EODAG queryable properties, associating
                   parameters to their annotated type
         :rtype: Dict[str, Annotated[Any, FieldInfo]]
         """
-        # unknown product type
         available_product_types = [
             pt["ID"] for pt in self.list_product_types(fetch_providers=False)
         ]
@@ -2189,101 +2179,28 @@ class EODataAccessGateway:
         if product_type is not None and product_type not in available_product_types:
             self.fetch_product_types_list()
 
-        # dictionary of the queryable properties of the providers supporting the given product type
-        providers_available_queryables: Dict[
-            str, Dict[str, Annotated[Any, FieldInfo]]
-        ] = dict()
-
-        if provider is None and product_type is None:
-            return model_fields_to_annotated(CommonQueryables.model_fields)
-        elif provider is None:
-            for plugin in self._plugins_manager.get_search_plugins(
-                product_type, provider
-            ):
-                providers_available_queryables[plugin.provider] = self.list_queryables(
-                    provider=plugin.provider, **kwargs
-                )
-
-            # return providers queryables intersection
-            queryables_keys: AbstractSet[str] = set()
-            for queryables in providers_available_queryables.values():
-                queryables_keys = (
-                    queryables_keys & queryables.keys()
-                    if queryables_keys
-                    else queryables.keys()
-                )
-            return {
-                k: v
-                for k, v in providers_available_queryables.popitem()[1].items()
-                if k in queryables_keys
-            }
-
-        all_queryables = copy_deepcopy(
-            model_fields_to_annotated(Queryables.model_fields)
-        )
-
-        try:
-            plugin = next(
-                self._plugins_manager.get_search_plugins(product_type, provider)
-            )
-        except StopIteration:
-            # return default queryables if no plugin is found
+        if not provider and not product_type:
             return model_fields_to_annotated(CommonQueryables.model_fields)
 
-        providers_available_queryables[plugin.provider] = dict()
+        providers_queryables: Dict[str, Dict[str, Annotated[Any, FieldInfo]]] = {}
 
-        # unknown product type: try again after fetch_product_types_list()
-        if (
-            product_type
-            and product_type not in plugin.config.products.keys()
-            and provider is None
-        ):
-            raise UnsupportedProductType(product_type)
-        elif product_type and product_type not in plugin.config.products.keys():
-            raise UnsupportedProductType(
-                f"{product_type} is not available for provider {provider}"
+        for plugin in self._plugins_manager.get_search_plugins(product_type, provider):
+            if product_type and product_type not in plugin.config.products.keys():
+                raise UnsupportedProductType(
+                    f"{product_type} is not available for provider {plugin.provider}"
+                )
+            providers_queryables[plugin.provider] = _list_plugin_queryables(
+                plugin, kwargs, product_type
             )
 
-        metadata_mapping = deepcopy(getattr(plugin.config, "metadata_mapping", {}))
-
-        # product_type-specific metadata-mapping
-        metadata_mapping.update(
-            getattr(plugin.config, "products", {})
-            .get(product_type, {})
-            .get("metadata_mapping", {})
+        queryable_keys: Set[str] = set.intersection(  # type: ignore
+            *[set(q.keys()) for q in providers_queryables.values()]
         )
-
-        # default values
-        default_values = deepcopy(
-            getattr(plugin.config, "products", {}).get(product_type, {})
-        )
-        default_values.pop("metadata_mapping", None)
-        kwargs = dict(default_values, **kwargs)
-
-        # remove not mapped parameters or non-queryables
-        for param in list(metadata_mapping.keys()):
-            if NOT_MAPPED in metadata_mapping[param] or not isinstance(
-                metadata_mapping[param], list
-            ):
-                del metadata_mapping[param]
-
-        for key, value in all_queryables.items():
-            annotated_args = get_args(value)
-            if len(annotated_args) < 1:
-                continue
-            field_info = annotated_args[1]
-            if not isinstance(field_info, FieldInfo):
-                continue
-            if key in kwargs:
-                field_info.default = kwargs[key]
-            if field_info.is_required() or (
-                (field_info.alias or key) in metadata_mapping
-            ):
-                providers_available_queryables[plugin.provider][key] = value
-
-        provider_queryables = plugin.discover_queryables(**kwargs) or dict()
-        # use EODAG configured queryables by default
-        provider_queryables.update(providers_available_queryables[provider])
+        queryables = {
+            k: v
+            for k, v in list(providers_queryables.values())[0].items()
+            if k in queryable_keys
+        }
 
         # always keep at least CommonQueryables
         common_queryables = copy_deepcopy(CommonQueryables.model_fields)
@@ -2291,9 +2208,9 @@ class EODataAccessGateway:
             if key in kwargs:
                 queryable.default = kwargs[key]
 
-        provider_queryables.update(model_fields_to_annotated(common_queryables))
+        queryables.update(model_fields_to_annotated(common_queryables))
 
-        return provider_queryables
+        return queryables
 
     def available_sortables(self) -> Dict[str, Optional[ProviderSortables]]:
         """For each provider, gives its available sortable parameter(s) and its maximum
@@ -2327,3 +2244,61 @@ class EODataAccessGateway:
                 ],
             }
         return sortables
+
+
+def _list_plugin_queryables(
+    plugin: Union[Search, Api],
+    filters: Dict[str, Any],
+    product_type: Optional[str] = None,
+) -> Dict[str, Annotated[Any, FieldInfo]]:
+    """
+    Get queryables for a specific search plugin.
+
+    :param plugin: The search plugin (either Search or Api).
+    :type plugin: Union[Search, Api]
+    :param filters: Additional filters for queryables.
+    :type filters: Dict[str, Any]
+    :param product_type: (optional) The product type.
+    :type product_type: Optional[str]
+
+    :return: A dictionary containing the queryable properties, associating parameters to their
+             annotated type.
+    :rtype: Dict[str, Annotated[Any, FieldInfo]]
+    """
+    default_values: Dict[str, Any] = deepcopy(
+        getattr(plugin.config, "products", {}).get(product_type, {})
+    )
+    default_values.pop("metadata_mapping", None)
+
+    queryables: Dict[str, Annotated[Any, FieldInfo]] = (
+        plugin.discover_queryables(**{**default_values, **filters}) or {}
+    )
+
+    metadata_mapping: Dict[str, Any] = deepcopy(
+        getattr(plugin.config, "metadata_mapping", {})
+    )
+    metadata_mapping.update(
+        getattr(plugin.config, "products", {})
+        .get(product_type, {})
+        .get("metadata_mapping", {})
+    )
+
+    for param in list(metadata_mapping.keys()):
+        if NOT_MAPPED in metadata_mapping[param] or not isinstance(
+            metadata_mapping[param], list
+        ):
+            del metadata_mapping[param]
+
+    eoadag_queryables = copy_deepcopy(
+        model_fields_to_annotated(Queryables.model_fields)
+    )
+    for k, v in eoadag_queryables.items():
+        field_info = get_args(v)[1] if len(get_args(v)) > 1 else None
+        if not isinstance(field_info, FieldInfo):
+            continue
+        if k in filters:
+            field_info.default = filters[k]
+        if field_info.is_required() or ((field_info.alias or k) in metadata_mapping):
+            queryables[k] = v
+
+    return queryables

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -2173,10 +2173,20 @@ class EODataAccessGateway:
         :rtype: Dict[str, Annotated[Any, FieldInfo]]
         """
         available_product_types = [
-            pt["ID"] for pt in self.list_product_types(fetch_providers=False)
+            pt["ID"]
+            for pt in self.list_product_types(provider=provider, fetch_providers=False)
         ]
-        product_type = kwargs.get("productType", None)
-        if product_type is not None and product_type not in available_product_types:
+        product_type = kwargs.get("productType")
+
+        if product_type:
+            try:
+                kwargs["productType"] = product_type = self.get_product_type_from_alias(
+                    product_type
+                )
+            except NoMatchingProductType as e:
+                raise UnsupportedProductType(f"{product_type} is not available") from e
+
+        if product_type and product_type not in available_product_types:
             self.fetch_product_types_list()
 
         if not provider and not product_type:
@@ -2185,10 +2195,6 @@ class EODataAccessGateway:
         providers_queryables: Dict[str, Dict[str, Annotated[Any, FieldInfo]]] = {}
 
         for plugin in self._plugins_manager.get_search_plugins(product_type, provider):
-            if product_type and product_type not in plugin.config.products.keys():
-                raise UnsupportedProductType(
-                    f"{product_type} is not available for provider {plugin.provider}"
-                )
             providers_queryables[plugin.provider] = _list_plugin_queryables(
                 plugin, kwargs, product_type
             )

--- a/eodag/plugins/apis/cds.py
+++ b/eodag/plugins/apis/cds.py
@@ -471,6 +471,11 @@ class CdsApi(Api, HTTPDownload, BuildPostSearchResult):
                 f"Cannot change dataset from {provider_product_type} to {user_provider_product_type}"
             )
 
+        # defaults
+        default_queryables = self._get_defaults_as_queryables(product_type)
+        # remove dataset from queryables
+        default_queryables.pop("dataset", None)
+
         non_empty_kwargs = {k: v for k, v in kwargs.items() if v}
 
         if "{" in constraints_file_url:
@@ -479,12 +484,7 @@ class CdsApi(Api, HTTPDownload, BuildPostSearchResult):
             )
         constraints = fetch_constraints(constraints_file_url, self)
         if not constraints:
-            return {}
-
-        # defaults
-        default_queryables = self.get_defaults_as_queryables(product_type)
-        # remove dataset from queryables
-        default_queryables.pop("dataset", None)
+            return default_queryables
 
         constraint_params: Dict[str, Dict[str, Set[Any]]] = {}
         if len(kwargs) == 0:

--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -513,7 +513,9 @@ def list_collection_queryables(
     additional_params = dict(request.query_params)
     provider = additional_params.pop("provider", None)
 
-    queryables = get_queryables(request, collection_id, provider, **additional_params)
+    queryables = get_queryables(
+        request, collection=collection_id, provider=provider, **additional_params
+    )
 
     return jsonable_encoder(queryables)
 
@@ -733,7 +735,7 @@ def list_queryables(request: Request, provider: Optional[str] = None) -> Any:
     logger.debug(f"URL: {request.url}")
     additional_params = dict(request.query_params.items())
     additional_params.pop("provider", None)
-    queryables = get_queryables(request, None, provider, **additional_params)
+    queryables = get_queryables(request, provider=provider, **additional_params)
 
     return jsonable_encoder(queryables)
 

--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -49,8 +49,8 @@ from eodag.config import load_stac_api_config
 from eodag.rest.core import (
     download_stac_item,
     eodag_api_init,
-    fetch_collection_queryable_properties,
     get_detailled_collections_list,
+    get_queryables,
     get_stac_api_version,
     get_stac_catalogs,
     get_stac_collection_by_id,
@@ -60,7 +60,6 @@ from eodag.rest.core import (
     search_stac_items,
 )
 from eodag.rest.types.eodag_search import EODAGSearch
-from eodag.rest.types.stac_queryables import StacQueryables
 from eodag.rest.types.stac_search import SearchPostRequest, sortby2list
 from eodag.rest.utils import format_pydantic_error, str2json, str2list
 from eodag.utils import parse_header, update_nested_dict
@@ -511,17 +510,10 @@ def list_collection_queryables(
     :rtype: Any
     """
     logger.debug(f"URL: {request.url}")
-    kwargs = dict(request.query_params)
-    provider = kwargs.pop("provider", None)
+    additional_params = dict(request.query_params)
+    provider = additional_params.pop("provider", None)
 
-    queryables = StacQueryables(q_id=request.state.url, additional_properties=False)
-
-    collection_queryables = fetch_collection_queryable_properties(
-        collection_id, provider, **kwargs
-    )
-    for key, collection_queryable in collection_queryables.items():
-        queryables[key] = collection_queryable
-    queryables.properties.pop("collections")
+    queryables = get_queryables(request, collection_id, provider, **additional_params)
 
     return jsonable_encoder(queryables)
 
@@ -739,14 +731,9 @@ def list_queryables(request: Request, provider: Optional[str] = None) -> Any:
     :rtype: Any
     """
     logger.debug(f"URL: {request.url}")
-    query_params = request.query_params.items()
-    additional_params = dict(query_params)
+    additional_params = dict(request.query_params.items())
     additional_params.pop("provider", None)
-    queryables = StacQueryables(q_id=request.state.url)
-    if provider:
-        queryables.properties.update(
-            fetch_collection_queryable_properties(None, provider, **additional_params)
-        )
+    queryables = get_queryables(request, None, provider, **additional_params)
 
     return jsonable_encoder(queryables)
 

--- a/eodag/rest/types/stac_queryables.py
+++ b/eodag/rest/types/stac_queryables.py
@@ -88,11 +88,11 @@ class StacQueryables(BaseModel):
         default="Queryable names for the EODAG STAC API Item Search filter."
     )
     default_properties: ClassVar[Dict[str, StacQueryableProperty]] = {
-        "ids": StacQueryableProperty(
+        "id": StacQueryableProperty(
             description="ID",
             ref="https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/id",
         ),
-        "collections": StacQueryableProperty(
+        "collection": StacQueryableProperty(
             description="Collection",
             ref="https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/collection",
         ),

--- a/eodag/rest/types/stac_queryables.py
+++ b/eodag/rest/types/stac_queryables.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -87,48 +87,28 @@ class StacQueryables(BaseModel):
     description: str = Field(
         default="Queryable names for the EODAG STAC API Item Search filter."
     )
-    properties: Dict[str, StacQueryableProperty] = Field(
-        default={
-            "ids": StacQueryableProperty(
-                description="ID",
-                ref="https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/id",
-            ),
-            "collections": StacQueryableProperty(
-                description="Collection",
-                ref="https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/collection",
-            ),
-            "geometry": StacQueryableProperty(
-                description="Geometry",
-                ref="https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/geometry",
-            ),
-            "datetime": StacQueryableProperty(
-                description="Datetime - use parameters year, month, day, time instead if available",
-                ref="https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/datetime.json#/properties/datetime",
-            ),
-        }
-    )
+    default_properties: ClassVar[Dict[str, StacQueryableProperty]] = {
+        "ids": StacQueryableProperty(
+            description="ID",
+            ref="https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/id",
+        ),
+        "collections": StacQueryableProperty(
+            description="Collection",
+            ref="https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/collection",
+        ),
+        "geometry": StacQueryableProperty(
+            description="Geometry",
+            ref="https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/geometry",
+        ),
+        "datetime": StacQueryableProperty(
+            description="Datetime - use parameters year, month, day, time instead if available",
+            ref="https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/datetime.json#/properties/datetime",
+        ),
+    }
+    properties: Dict[str, StacQueryableProperty] = Field()
     additional_properties: bool = Field(
         default=True, serialization_alias="additionalProperties"
     )
 
-    def get_properties(self) -> Dict[str, StacQueryableProperty]:
-        """Get the queryable properties.
-
-        :returns: A dictionary containing queryable properties.
-        :rtype: typing.Dict[str, StacQueryableProperty]
-        """
-        properties = {}
-        for key, property in self.properties.items():
-            property = StacQueryableProperty(
-                description=property.description, type=property.type
-            )
-            properties[key] = property
-        return properties
-
     def __contains__(self, name: str) -> bool:
         return name in self.properties
-
-    def __setitem__(self, name: str, qprop: StacQueryableProperty) -> None:
-        # only keep "datetime" queryable for dates
-        if name not in ("start_datetime", "end_datetime"):
-            self.properties[name] = qprop

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -27,6 +27,7 @@ import unittest
 import uuid
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import Mock
 
 from pkg_resources import resource_filename
 from shapely import wkt
@@ -1129,8 +1130,8 @@ class TestCore(TestCoreBase):
         "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
     )
     def test_list_queryables(
-        self, mock_discover_queryables, mock_fetch_product_types_list
-    ):
+        self, mock_discover_queryables: Mock, mock_fetch_product_types_list: Mock
+    ) -> None:
         """list_queryables must return queryables list adapted to provider and product-type"""
         with self.assertRaises(UnsupportedProvider):
             self.dag.list_queryables(provider="not_supported_provider")
@@ -1167,7 +1168,7 @@ class TestCore(TestCoreBase):
                 self.assertEqual(str(expected_longer_result[key]), str(queryable))
 
     @mock.patch("eodag.plugins.apis.cds.CdsApi.discover_queryables", autospec=True)
-    def test_list_queryables_with_constraints(self, mock_discover_queryables):
+    def test_list_queryables_with_constraints(self, mock_discover_queryables: Mock):
         plugin = next(
             self.dag._plugins_manager.get_search_plugins(
                 provider="cop_cds", product_type="ERA5_SL"

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -1194,7 +1194,7 @@ class RequestTestCase(unittest.TestCase):
         )
         self.assertListEqual(
             list(res_no_provider["properties"].keys()),
-            ["ids", "geometry", "datetime"],
+            ["id", "geometry", "datetime"],
         )
         self.assertIn("geometry", res_no_provider["properties"])
         self.assertNotIn("s1:processing_level", res_no_provider["properties"])
@@ -1255,9 +1255,9 @@ class RequestTestCase(unittest.TestCase):
         )
         self.assertEqual(10, len(res["properties"]))
         self.assertIn("year", res["properties"])
-        self.assertIn("ids", res["properties"])
+        self.assertIn("id", res["properties"])
         self.assertIn("geometry", res["properties"])
-        self.assertNotIn("collections", res["properties"])
+        self.assertNotIn("collection", res["properties"])
 
     def test_cql_post_search(self):
         self._request_valid(


### PR DESCRIPTION
- refactor: simplify list_queryables in api core
- feat: create a list_queryables in base search plugin
- feat: handle multiple search plugins per provider
- fix[server]: do not modify type of default queryables
- fix[server]: use `collection` and `id` instead of `collections` and `ids`


