### PR TITLE
Setting missing stac version 

### DIFF
--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -762,6 +762,7 @@ class StacCollection(StacCommon):
             for collec in collections["collections"]
         ]
 
+        collections["stac_version"] = self.stac_config["stac_version"]
         self.update_data(collections)
         return self.as_dict()
 


### PR DESCRIPTION
Fixes #1055 
Setting unparsed stac_version in api response.
