### PR TITLE
942 query parameters validation

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -2187,8 +2187,6 @@ class EODataAccessGateway:
         ]
         user_kwargs = deepcopy(kwargs)
         product_type = kwargs.get("productType", None)
-        if product_type is not None and product_type not in available_product_types:
-            self.fetch_product_types_list()
 
         if product_type:
             try:

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -1619,10 +1619,10 @@ class EODataAccessGateway:
             try:
                 self.list_queryables(p, **kwargs)
             except ValidationError:
+                to_remove.append(p)
                 if i == len(providers) - 1 and len(to_remove) == len(providers):
                     raise
-                else:
-                    to_remove.append(p)
+
         providers = [p for p in providers if p not in to_remove]
         if provider not in providers:
             logger.warning(
@@ -2231,6 +2231,7 @@ class EODataAccessGateway:
                 "completionTimeFromAscendingNode",
                 "productType",
                 "geometry",
+                "sortBy",
             ]:
                 continue
             elif key not in queryables.keys():

--- a/eodag/plugins/apis/cds.py
+++ b/eodag/plugins/apis/cds.py
@@ -513,6 +513,7 @@ class CdsApi(Api, HTTPDownload, BuildPostSearchResult):
                         non_empty_kwargs.pop(constraint_param)
                     else:
                         not_queryables.add(constraint_param)
+
                 if not_queryables:
                     raise ValidationError(
                         f"parameter(s) {str(not_queryables)} not queryable"

--- a/tests/integration/test_core_config.py
+++ b/tests/integration/test_core_config.py
@@ -47,11 +47,14 @@ class TestCoreProvidersConfig(TestCase):
         self.tmp_home_dir.cleanup()
 
     @mock.patch(
+        "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
+    )
+    @mock.patch(
         "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
     )
     @mock.patch("eodag.plugins.search.qssearch.PostJsonSearch._request", autospec=True)
     def test_core_providers_config_update(
-        self, mock__request, mock_fetch_product_types_list
+        self, mock__request, mock_fetch_product_types_list, mock_qssearch_request
     ):
         """Providers config must be updatable"""
         mock__request.return_value = mock.Mock()

--- a/tests/integration/test_search_stac_static.py
+++ b/tests/integration/test_search_stac_static.py
@@ -144,9 +144,15 @@ class TestSearchStacStatic(unittest.TestCase):
             self.assertEqual(item.product_type, self.product_type)
 
     @mock.patch(
+        "eodag.plugins.search.qssearch.QueryStringSearch._request",
+        autospec=True,
+    )
+    @mock.patch(
         "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
     )
-    def test_search_stac_static(self, mock_fetch_product_types_list):
+    def test_search_stac_static(
+        self, mock_fetch_product_types_list, mock_qssearch_request
+    ):
         """Use StaticStacSearch plugin to search all items"""
         items, nb = self.dag.search()
         self.assertEqual(len(items), self.root_cat_len)
@@ -258,9 +264,15 @@ class TestSearchStacStatic(unittest.TestCase):
             self.assertIn("2018", item.properties["startTimeFromAscendingNode"])
 
     @mock.patch(
+        "eodag.plugins.search.qssearch.QueryStringSearch._request",
+        autospec=True,
+    )
+    @mock.patch(
         "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
     )
-    def test_search_stac_static_by_date(self, mock_fetch_product_types_list):
+    def test_search_stac_static_by_date(
+        self, mock_fetch_product_types_list, mock_qssearch_request
+    ):
         """Use StaticStacSearch plugin to search by date"""
         filtered_items, nb = self.dag.search(start="2018-01-01", end="2019-01-01")
         self.assertEqual(len(filtered_items), self.child_cat_len)
@@ -329,9 +341,15 @@ class TestSearchStacStatic(unittest.TestCase):
         self.assertEqual(len(filtered_items), 1)
 
     @mock.patch(
+        "eodag.plugins.search.qssearch.QueryStringSearch._request",
+        autospec=True,
+    )
+    @mock.patch(
         "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
     )
-    def test_search_stac_static_by_geom(self, mock_fetch_product_types_list):
+    def test_search_stac_static_by_geom(
+        self, mock_fetch_product_types_list, mock_qssearch_request
+    ):
         """Use StaticStacSearch plugin to search by geometry"""
         items, nb = self.dag.search(
             geom=self.extent_big,
@@ -339,7 +357,11 @@ class TestSearchStacStatic(unittest.TestCase):
         self.assertEqual(len(items), 3)
         self.assertEqual(nb, 3)
 
-    def test_search_stac_static_crunch_filter_property(self):
+    @mock.patch(
+        "eodag.plugins.search.qssearch.QueryStringSearch._request",
+        autospec=True,
+    )
+    def test_search_stac_static_crunch_filter_property(self, mock_qssearch_request):
         """load_stac_items from root and filter by property"""
         with pytest.warns(
             DeprecationWarning,
@@ -367,18 +389,30 @@ class TestSearchStacStatic(unittest.TestCase):
         self.assertEqual(len(filtered_items), 1)
 
     @mock.patch(
+        "eodag.plugins.search.qssearch.QueryStringSearch._request",
+        autospec=True,
+    )
+    @mock.patch(
         "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
     )
-    def test_search_stac_static_by_property(self, mock_fetch_product_types_list):
+    def test_search_stac_static_by_property(
+        self, mock_fetch_product_types_list, mock_qssearch_request
+    ):
         """Use StaticStacSearch plugin to search by property"""
         items, nb = self.dag.search(orbitNumber=110)
         self.assertEqual(len(items), 3)
         self.assertEqual(nb, 3)
 
     @mock.patch(
+        "eodag.plugins.search.qssearch.QueryStringSearch._request",
+        autospec=True,
+    )
+    @mock.patch(
         "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
     )
-    def test_search_stac_static_by_cloudcover(self, mock_fetch_product_types_list):
+    def test_search_stac_static_by_cloudcover(
+        self, mock_fetch_product_types_list, mock_qssearch_request
+    ):
         """Use StaticStacSearch plugin to search by cloud cover"""
         items, nb = self.dag.search(cloudCover=10)
         self.assertEqual(len(items), 1)

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -258,6 +258,9 @@ class TestApisPluginEcmwfApi(BaseApisPluginTest):
         del self.api_plugin.config.credentials
 
     @mock.patch(
+        "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
+    )
+    @mock.patch(
         "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
     )
     @mock.patch("ecmwfapi.api.ECMWFService.execute", autospec=True)
@@ -269,6 +272,7 @@ class TestApisPluginEcmwfApi(BaseApisPluginTest):
         mock_ecmwfdataserver_retrieve,
         mock_ecmwfservice_execute,
         mock_fetch_product_types_list,
+        mock_qssearch_request,
     ):
         """EcmwfApi.download must call the appriate ecmwf api service"""
 
@@ -355,6 +359,9 @@ class TestApisPluginEcmwfApi(BaseApisPluginTest):
         mock_ecmwfdataserver_retrieve.assert_not_called()
 
     @mock.patch(
+        "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
+    )
+    @mock.patch(
         "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
     )
     @mock.patch("ecmwfapi.api.ECMWFDataServer.retrieve", autospec=True)
@@ -364,6 +371,7 @@ class TestApisPluginEcmwfApi(BaseApisPluginTest):
         mock_connection_call,
         mock_ecmwfdataserver_retrieve,
         mock_fetch_product_types_list,
+        mock_qssearch_request,
     ):
         """EcmwfApi.download_all must call the appropriate ecmwf api service"""
 

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -835,7 +835,7 @@ class TestApisPluginCdsApi(BaseApisPluginTest):
         assert auth_dict["url"] == self.api_plugin.config.api_endpoint
         del self.api_plugin.config.credentials
 
-    @mock.patch("eodag.utils.constraints.requests.get")
+    @mock.patch("eodag.plugins.apis.cds.fetch_constraints")
     @mock.patch("eodag.plugins.download.http.requests.head", autospec=True)
     @mock.patch("eodag.plugins.download.http.requests.get", autospec=True)
     @mock.patch(
@@ -865,7 +865,7 @@ class TestApisPluginCdsApi(BaseApisPluginTest):
             "content-disposition": ""
         }
         mock_head.return_value.headers = {"content-disposition": ""}
-        mock_constraints.return_value.json.return_value = [
+        mock_constraints.return_value = [
             {
                 "dataset": ["cams-global-ghg-reanalysis-egg4"],
                 "step": [0, 1],

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -894,6 +894,9 @@ class TestApisPluginCdsApi(BaseApisPluginTest):
         assert path_to_uri(expected_path) == eoproduct.location
 
     @mock.patch(
+        "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
+    )
+    @mock.patch(
         "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
     )
     @mock.patch("eodag.plugins.apis.cds.CdsApi.authenticate", autospec=True)
@@ -905,6 +908,7 @@ class TestApisPluginCdsApi(BaseApisPluginTest):
         mock_cds_download,
         mock_cds_authenticate,
         mock_fetch_product_types_list,
+        mock_qssearch_request,
     ):
         """CdsApi.download_all must call download on each product"""
         mock_cds_authenticate.return_value = {

--- a/tests/units/test_constraints.py
+++ b/tests/units/test_constraints.py
@@ -82,3 +82,32 @@ class TestConstraints(unittest.TestCase):
         self.assertSetEqual({"C", "B"}, queryable["enum"])
         queryable = queryables.get("year")
         self.assertSetEqual({"2000", "2001"}, queryable["enum"])
+
+    def test_get_constraint_queryables_with_additional_params_dates(self):
+        constraints = [{"date": ["2003-01-01/2020-12-31"], "variable": ["a", "b"]}]
+        plugins = self.plugins_manager.get_search_plugins(
+            "CAMS_GREENHOUSE_EGG4", "cop_ads"
+        )
+        plugin = next(plugins)
+
+        # filter on one parameter
+        queryables = get_constraint_queryables_with_additional_params(
+            constraints,
+            {
+                "variable": "a",
+                "completionTimeFromAscendingNode": "2019-07-03T17:42:24Z",
+            },
+            plugin,
+            "CAMS_GREENHOUSE_EGG4",
+        )
+        self.assertEqual(2, len(queryables))
+        with self.assertRaises(ValidationError):
+            get_constraint_queryables_with_additional_params(
+                constraints,
+                {
+                    "variable": "a",
+                    "completionTimeFromAscendingNode": "2021-07-03T17:42:24Z",
+                },
+                plugin,
+                "CAMS_GREENHOUSE_EGG4",
+            )


### PR DESCRIPTION
- the queryables are fetched during the search preparation and compared to the query parameters entered by the user
- a discover_queryables method for the ecmwf plugin was added
- a bug in the constraint queryables concerning constraints with dates was fixed
