### PR TITLE
feat: provider groups

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -537,9 +537,19 @@ class EODataAccessGateway:
             self.fetch_product_types_list(provider=provider)
 
         product_types: List[Dict[str, Any]] = []
-        if provider is not None:
-            if provider in self.providers_config:
-                provider_supported_products = self.providers_config[provider].products
+
+        if provider:
+            providers = [
+                p
+                for p in self.providers_config.values()
+                if provider in [p.name, getattr(p, "group", None)]
+            ]
+            if len(providers) == 0:
+                raise UnsupportedProvider(
+                    f"The requested provider is not (yet) supported: {provider}"
+                )
+            for p in providers:
+                provider_supported_products = p.products
                 for product_type_id in provider_supported_products:
                     if product_type_id == GENERIC_PRODUCT_TYPE:
                         continue
@@ -551,10 +561,8 @@ class EODataAccessGateway:
                     product_type = dict(ID=product_type_id, **config)
                     if product_type_id not in product_types:
                         product_types.append(product_type)
-                return sorted(product_types, key=itemgetter("ID"))
-            raise UnsupportedProvider(
-                f"invalid requested provider: {provider} is not (yet) supported"
-            )
+            return sorted(product_types, key=itemgetter("ID"))
+
         # Only get the product types supported by the available providers
         for provider in self.available_providers():
             current_product_type_ids = [pt["ID"] for pt in product_types]
@@ -856,23 +864,48 @@ class EODataAccessGateway:
         # rebuild index after product types list update
         self.build_index()
 
-    def available_providers(self, product_type: Optional[str] = None) -> List[str]:
-        """Gives the sorted list of the available providers
+    def available_providers(
+        self, product_type: Optional[str] = None, by_group: bool = False
+    ) -> List[str]:
+        """Gives the sorted list of the available providers or groups
+
+        The providers or groups are sorted first by their priority level in descending order,
+        and then alphabetically in ascending order for providers or groups with the same
+        priority level.
 
         :param product_type: (optional) Only list providers configured for this product_type
-        :type product_type: str
-        :returns: the sorted list of the available providers
-        :rtype: list
+        :type product_type: Optional[str]
+        :param by_group: (optional) If set to True, list groups instead of providers
+        :type by_group: bool
+        :returns: the sorted list of the available providers or groups
+        :rtype: List[str]
         """
 
         if product_type:
-            return sorted(
-                k
+            providers = [
+                (v.group if by_group and hasattr(v, "group") else k, v.priority)
                 for k, v in self.providers_config.items()
                 if product_type in getattr(v, "products", {}).keys()
-            )
+            ]
         else:
-            return sorted(tuple(self.providers_config.keys()))
+            providers = [
+                (v.group if by_group and hasattr(v, "group") else k, v.priority)
+                for k, v in self.providers_config.items()
+            ]
+
+        # If by_group is True, keep only the highest priority for each group
+        if by_group:
+            group_priority: Dict[str, int] = {}
+            for name, priority in providers:
+                if name not in group_priority or priority > group_priority[name]:
+                    group_priority[name] = priority
+            providers = list(group_priority.items())
+
+        # Sort by priority (descending) and then by name (ascending)
+        providers.sort(key=lambda x: (-x[1], x[0]))
+
+        # Return only the names of the providers or groups
+        return [name for name, _ in providers]
 
     def get_product_type_from_alias(self, alias_or_id: str) -> str:
         """Return the ID of a product type by either its ID or alias

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -538,43 +538,33 @@ class EODataAccessGateway:
 
         product_types: List[Dict[str, Any]] = []
 
-        if provider:
-            providers = [
+        providers = (
+            list(self.providers_config.values())
+            if not provider
+            else [
                 p
                 for p in self.providers_config.values()
                 if provider in [p.name, getattr(p, "group", None)]
             ]
-            if len(providers) == 0:
-                raise UnsupportedProvider(
-                    f"The requested provider is not (yet) supported: {provider}"
-                )
-            for p in providers:
-                provider_supported_products = p.products
-                for product_type_id in provider_supported_products:
-                    if product_type_id == GENERIC_PRODUCT_TYPE:
-                        continue
+        )
 
-                    config = self.product_types_config[product_type_id]
-                    config["_id"] = product_type_id
-                    if "alias" in config:
-                        product_type_id = config["alias"]
-                    product_type = dict(ID=product_type_id, **config)
-                    if product_type_id not in product_types:
-                        product_types.append(product_type)
-            return sorted(product_types, key=itemgetter("ID"))
-
-        # Only get the product types supported by the available providers
-        for provider in self.available_providers():
-            current_product_type_ids = [pt["ID"] for pt in product_types]
-            product_types.extend(
-                [
-                    pt
-                    for pt in self.list_product_types(
-                        provider=provider, fetch_providers=False
-                    )
-                    if pt["ID"] not in current_product_type_ids
-                ]
+        if provider and not providers:
+            raise UnsupportedProvider(
+                f"The requested provider is not (yet) supported: {provider}"
             )
+
+        for p in providers:
+            for product_type_id in p.products:  # type: ignore
+                if product_type_id == GENERIC_PRODUCT_TYPE:
+                    continue
+                config = self.product_types_config[product_type_id]
+                config["_id"] = product_type_id 
+                if "alias" in config:
+                    product_type_id = config["alias"]
+                product_type = {"ID": product_type_id, **config}
+                if product_type not in product_types:
+                    product_types.append(product_type)
+
         # Return the product_types sorted in lexicographic order of their ID
         return sorted(product_types, key=itemgetter("ID"))
 

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -558,7 +558,7 @@ class EODataAccessGateway:
                 if product_type_id == GENERIC_PRODUCT_TYPE:
                     continue
                 config = self.product_types_config[product_type_id]
-                config["_id"] = product_type_id 
+                config["_id"] = product_type_id
                 if "alias" in config:
                     product_type_id = config["alias"]
                 product_type = {"ID": product_type_id, **config}

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -538,7 +538,7 @@ class EODataAccessGateway:
 
         product_types: List[Dict[str, Any]] = []
 
-        providers = (
+        providers_configs = (
             list(self.providers_config.values())
             if not provider
             else [
@@ -548,12 +548,12 @@ class EODataAccessGateway:
             ]
         )
 
-        if provider and not providers:
+        if provider and not providers_configs:
             raise UnsupportedProvider(
                 f"The requested provider is not (yet) supported: {provider}"
             )
 
-        for p in providers:
+        for p in providers_configs:
             for product_type_id in p.products:  # type: ignore
                 if product_type_id == GENERIC_PRODUCT_TYPE:
                     continue
@@ -865,7 +865,8 @@ class EODataAccessGateway:
 
         :param product_type: (optional) Only list providers configured for this product_type
         :type product_type: Optional[str]
-        :param by_group: (optional) If set to True, list groups instead of providers
+        :param by_group: (optional) If set to True, list groups when available instead
+                         of providers, mixed with other providers
         :type by_group: bool
         :returns: the sorted list of the available providers or groups
         :rtype: List[str]

--- a/eodag/cli.py
+++ b/eodag/cli.py
@@ -445,8 +445,6 @@ def list_pt(ctx: Context, **kwargs: Any) -> None:
                     provider=provider, fetch_providers=fetch_providers
                 )
                 if pt["ID"] in guessed_product_types
-                or "alias" in pt
-                and pt["alias"] in guessed_product_types
             ]
         else:
             product_types = dag.list_product_types(

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -129,7 +129,11 @@ class ProviderConfig(yaml.YAMLObject):
     """
 
     name: str
+    group: str
     priority: int = 0  # Set default priority to 0
+    roles: List[str]
+    description: str
+    url: str
     api: PluginConfig
     search: PluginConfig
     products: Dict[str, Any]
@@ -142,7 +146,7 @@ class ProviderConfig(yaml.YAMLObject):
     yaml_tag = "!provider"
 
     @classmethod
-    def from_yaml(cls, loader: yaml.Loader, node: Any) -> ProviderConfig:
+    def from_yaml(cls, loader: yaml.Loader, node: Any) -> Iterator[ProviderConfig]:
         """Build a :class:`~eodag.config.ProviderConfig` from Yaml"""
         cls.validate(tuple(node_key.value for node_key, _ in node.value))
         for node_key, node_value in node.value:
@@ -437,7 +441,7 @@ def load_config(config_path: str) -> Dict[str, ProviderConfig]:
     :returns: The default provider's configuration
     :rtype: dict
     """
-    logger.debug(f"Loading configuration from {config_path}")
+    logger.debug("Loading configuration from %s", config_path)
     config: Dict[str, ProviderConfig] = {}
     try:
         # Providers configs are stored in this file as separated yaml documents

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -173,11 +173,13 @@ class PluginManager:
         :param product_type: (optional) The product type that the constructed plugins
                              must support
         :type product_type: str
-        :param provider: (optional) The provider on which to get the search plugin
+        :param provider: (optional) The provider or the provider group on which to get
+            the search plugins
         :type provider: str
         :returns: All the plugins supporting the product type, one by one (a generator
                   object)
-        :rtype: types.GeneratorType(:class:`~eodag.plugins.search.Search` or :class:`~eodag.plugins.download.Api`)
+        :rtype: types.GeneratorType(:class:`~eodag.plugins.search.Search`
+            or :class:`~eodag.plugins.download.Api`)
         :raises: :class:`~eodag.utils.exceptions.UnsupportedProvider`
         """
 
@@ -209,7 +211,9 @@ class PluginManager:
             configs = list(self.providers_config.values())
 
         if provider:
-            configs = [c for c in configs if provider == c.name]
+            configs = [
+                c for c in configs if provider in [getattr(c, "group", None), c.name]
+            ]
 
         if not configs:
             raise UnsupportedProvider(f"{provider} is not (yet) supported")
@@ -233,7 +237,6 @@ class PluginManager:
                 Download,
                 self._build_plugin(product.provider, download, Download),
             )
-            return plugin
         elif api := getattr(plugin_conf, "api", None):
             plugin_conf.api.priority = plugin_conf.priority
             plugin = cast(Api, self._build_plugin(product.provider, api, Api))

--- a/eodag/resources/stac.yml
+++ b/eodag/resources/stac.yml
@@ -136,14 +136,6 @@ collection:
       - '$.product_type.instrument'
     processing:level: '$.product_type.processingLevel'
 
-provider:
-  name: '$.provider.name'
-  description: '$.provider.description'
-  # one or more of "producer" "licensor" "processor" "host"
-  roles: '$.provider.roles'
-  url: '$.provider.url'
-  priority: '$.provider.priority'
-
 # Data ------------------------------------------------------------------------
 
 # https://stacspec.org/STAC-api.html#operation/getFeatures

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -178,10 +178,10 @@ class StacCommon:
         ][0]
         return {
             "name": getattr(provider_config, "group", provider_config.name),
-            "description": provider_config.description,
-            "roles": provider_config.roles,
-            "url": provider_config.url,
-            "priority": provider_config.priority,
+            "description": getattr(provider_config, "description", None),
+            "roles": getattr(provider_config, "roles", None),
+            "url": getattr(provider_config, "url", None),
+            "priority": getattr(provider_config, "priority", None),
         }
 
 

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -729,16 +729,13 @@ class StacCollection(StacCommon):
                     )
                 ]
             )
-            providers_models: List[Dict[str, Any]] = []
-            for provider in providers:
-                providers_models.append(self.get_provider_dict(provider["name"]))
 
             # parse jsonpath
             product_type_collection = jsonpath_parse_dict_items(
                 collection_model,
                 {
                     "product_type": product_type,
-                    "providers": providers_models,
+                    "providers": [self.get_provider_dict(p) for p in providers],
                 },
             )
             # override EODAG's collection with the external collection
@@ -756,10 +753,10 @@ class StacCollection(StacCommon):
                 product_type_collection["keywords"] = merged_keywords
             # parse f-strings
             format_args = deepcopy(self.stac_config)
-            format_args["collection"] = dict(
-                product_type_collection,
+            format_args["collection"] = {
+                **product_type_collection,
                 **{"url": f"{self.url}/{product_type['ID']}", "root": self.root},
-            )
+            }
             product_type_collection = format_dict_items(
                 product_type_collection, **format_args
             )

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -21,7 +21,6 @@ import logging
 import os
 from collections import defaultdict
 from datetime import datetime, timezone
-from operator import itemgetter
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, cast
 from urllib.parse import parse_qs, urlencode, urlparse
 
@@ -170,6 +169,21 @@ class StacCommon:
 
     __geo_interface__ = property(as_dict)
 
+    def get_provider_dict(self, provider: str) -> Dict[str, Any]:
+        """Generate STAC provider dict"""
+        provider_config = [
+            p
+            for p in self.eodag_api.providers_config.values()
+            if provider in [p.name, getattr(p, "group", None)]
+        ][0]
+        return {
+            "name": getattr(provider_config, "group", provider_config.name),
+            "description": provider_config.description,
+            "roles": provider_config.roles,
+            "url": provider_config.url,
+            "priority": provider_config.priority,
+        }
+
 
 class StacItem(StacCommon):
     """Stac item object
@@ -220,7 +234,6 @@ class StacItem(StacCommon):
         item_model = self.__filter_item_model_properties(
             self.stac_config["item"], str(search_results[0].product_type)
         )
-        provider_model = deepcopy(self.stac_config["provider"])
 
         # check if some items need to be converted
         need_conversion: Dict[str, Any] = {}
@@ -238,23 +251,13 @@ class StacItem(StacCommon):
 
         item_list: List[Dict[str, Any]] = []
         for product in search_results:
-            # parse jsonpath
-            provider_dict = jsonpath_parse_dict_items(
-                provider_model,
-                {
-                    "provider": self.eodag_api.providers_config[
-                        product.provider
-                    ].__dict__
-                },
-            )
-
             product_dict = deepcopy(product.__dict__)
 
             product_item = jsonpath_parse_dict_items(
                 item_model,
                 {
                     "product": product_dict,
-                    "providers": [provider_dict],
+                    "providers": [self.get_provider_dict(product.provider)],
                 },
             )
             # parse download link
@@ -556,12 +559,6 @@ class StacItem(StacCommon):
         item_model = self.__filter_item_model_properties(
             self.stac_config["item"], product_type
         )
-        provider_model = deepcopy(self.stac_config["provider"])
-
-        provider_dict = jsonpath_parse_dict_items(
-            provider_model,
-            {"provider": self.eodag_api.providers_config[product.provider].__dict__},
-        )
 
         catalog = StacCatalog(
             url=self.url.split("/items")[0],
@@ -580,7 +577,7 @@ class StacItem(StacCommon):
             item_model,
             {
                 "product": product_dict,
-                "providers": provider_dict,
+                "providers": self.get_provider_dict(product.provider),
             },
         )
         # parse f-strings
@@ -714,32 +711,27 @@ class StacCollection(StacCommon):
         :rtype: list
         """
         collection_model = deepcopy(self.stac_config["collection"])
-        provider_model = deepcopy(self.stac_config["provider"])
 
         product_types = self.__get_product_types(filters)
 
         collection_list: List[Dict[str, Any]] = []
         for product_type in product_types:
-            if self.provider:
-                providers = [self.provider]
-            else:
-                providers = sorted(
-                    [
-                        self.eodag_api.providers_config[p].__dict__
-                        for p in self.eodag_api.available_providers(
-                            product_type=product_type["_id"]
+            # get available providers for each product_type
+            providers = (
+                [self.provider]
+                if self.provider
+                else [
+                    plugin.provider
+                    for plugin in self.eodag_api._plugins_manager.get_search_plugins(
+                        product_type=(
+                            product_type.get("_id", None) or product_type["ID"]
                         )
-                    ],
-                    key=itemgetter("priority"),
-                    reverse=True,
-                )
+                    )
+                ]
+            )
             providers_models: List[Dict[str, Any]] = []
             for provider in providers:
-                provider_m = jsonpath_parse_dict_items(
-                    provider_model,
-                    {"provider": provider},
-                )
-                providers_models.append(provider_m)
+                providers_models.append(self.get_provider_dict(provider["name"]))
 
             # parse jsonpath
             product_type_collection = jsonpath_parse_dict_items(

--- a/tests/integration/test_core_search.py
+++ b/tests/integration/test_core_search.py
@@ -236,7 +236,7 @@ class TestCoreSearch(unittest.TestCase):
         available_providers = self.dag.available_providers(product_type)
         self.assertListEqual(
             available_providers,
-            ["cop_dataspace", "creodias", "onda", "peps", "sara", "wekeo"],
+            ["peps", "cop_dataspace", "creodias", "onda", "sara", "wekeo"],
         )
 
         products, count = self.dag.search(productType="S1_SAR_SLC")
@@ -264,7 +264,7 @@ class TestCoreSearch(unittest.TestCase):
         available_providers = self.dag.available_providers(product_type)
         self.assertListEqual(
             available_providers,
-            ["cop_dataspace", "creodias", "onda", "peps", "sara", "wekeo"],
+            ["peps", "cop_dataspace", "creodias", "onda", "sara", "wekeo"],
         )
 
         self.assertRaises(
@@ -291,7 +291,7 @@ class TestCoreSearch(unittest.TestCase):
         available_providers = self.dag.available_providers(product_type)
         self.assertListEqual(
             available_providers,
-            ["cop_dataspace", "creodias", "onda", "peps", "sara", "wekeo"],
+            ["peps", "cop_dataspace", "creodias", "onda", "sara", "wekeo"],
         )
 
         # peps comes 1st by priority
@@ -338,7 +338,7 @@ class TestCoreSearch(unittest.TestCase):
         available_providers = self.dag.available_providers(product_type)
         self.assertListEqual(
             available_providers,
-            ["cop_dataspace", "creodias", "onda", "peps", "sara", "wekeo"],
+            ["peps", "cop_dataspace", "creodias", "onda", "sara", "wekeo"],
         )
 
         # onda comes 3rd by priority
@@ -373,7 +373,7 @@ class TestCoreSearch(unittest.TestCase):
         available_providers = self.dag.available_providers(product_type)
         self.assertListEqual(
             available_providers,
-            ["cop_dataspace", "creodias", "onda", "peps", "sara", "wekeo"],
+            ["peps", "cop_dataspace", "creodias", "onda", "sara", "wekeo"],
         )
 
         mock_query.side_effect = [
@@ -400,7 +400,7 @@ class TestCoreSearch(unittest.TestCase):
         available_providers = self.dag.available_providers(product_type)
         self.assertListEqual(
             available_providers,
-            ["cop_dataspace", "creodias", "onda", "peps", "sara", "wekeo"],
+            ["peps", "cop_dataspace", "creodias", "onda", "sara", "wekeo"],
         )
 
         mock_query.return_value = ([], 0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -615,9 +615,7 @@ class TestEodagCli(unittest.TestCase):
         self.assertEqual(result.exit_code, 1)
         self.assertIn("Unsupported provider. You may have a typo", result.output)
         self.assertIn(
-            "Available providers: {}".format(
-                ", ".join(sorted(test_core.TestCore.SUPPORTED_PROVIDERS))
-            ),
+            f"Available providers: {', '.join(test_core.TestCore.SUPPORTED_PROVIDERS)}",
             result.output,
         )
 

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -2988,16 +2988,16 @@ class TestCoreProviderGroup(TestCoreBase):
     def setUpClass(cls) -> None:
         super().setUpClass()
         cls.dag = EODataAccessGateway()
-        providers = cls.dag.providers_config
+        providers_configs = cls.dag.providers_config
 
-        setattr(providers[cls.group[0]], "group", cls.group_name)
-        setattr(providers[cls.group[1]], "group", cls.group_name)
+        setattr(providers_configs[cls.group[0]], "group", cls.group_name)
+        setattr(providers_configs[cls.group[1]], "group", cls.group_name)
 
     def test_available_providers_by_group(self) -> None:
         """
         The method available_providers returns only one entry for both grouped providers
         """
-        # drop the provider names grouped as they are grouped under "testgroup" name
+        # drop the grouped names from expected providers, as they are grouped under "testgroup" name
         providers = self.dag.available_providers()
         providers.remove(self.group[0])
         providers.remove(self.group[1])

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -521,30 +521,30 @@ class TestCore(TestCoreBase):
     }
     SUPPORTED_PROVIDERS = [
         "peps",
-        "usgs",
-        "theia",
-        "creodias",
-        "onda",
-        "aws_eos",
         "astraea_eod",
-        "usgs_satapi_aws",
+        "aws_eos",
+        "cop_ads",
+        "cop_cds",
+        "cop_dataspace",
+        "creodias",
+        "creodias_s3",
+        "dedl",
+        "dedt_lumi",
         "earth_search",
         "earth_search_cog",
         "earth_search_gcs",
         "ecmwf",
-        "cop_ads",
-        "cop_cds",
-        "sara",
-        "meteoblue",
-        "cop_dataspace",
-        "planetary_computer",
+        "eumetsat_ds",
         "hydroweb_next",
+        "meteoblue",
+        "onda",
+        "planetary_computer",
+        "sara",
+        "theia",
+        "usgs",
+        "usgs_satapi_aws",
         "wekeo",
         "wekeo_cmems",
-        "creodias_s3",
-        "dedt_lumi",
-        "dedl",
-        "eumetsat_ds",
     ]
 
     def setUp(self):
@@ -1636,7 +1636,8 @@ class TestCoreInvolvingConfDir(unittest.TestCase):
     def execution_involving_conf_dir(self, inspect=None, conf_dir=None):
         """Check that the path(s) inspected (str, list) are created after the instantation
         of EODataAccessGateway. If they were already there, rename them (.old), instantiate,
-        check, delete the new files, and restore the existing files to there previous name."""
+        check, delete the new files, and restore the existing files to there previous name.
+        """
         if inspect is not None:
             if conf_dir is None:
                 conf_dir = os.path.join(os.path.expanduser("~"), ".config", "eodag")
@@ -2350,6 +2351,7 @@ class TestCoreSearch(TestCoreBase):
 
     def test__do_search_does_not_raise_by_default(self):
         """_do_search must not raise any error by default"""
+
         # provider attribute required internally by __do_search for logging purposes.
         class DummyConfig:
             pagination = {}

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -2682,7 +2682,8 @@ class TestCoreSearch(TestCoreBase):
 
     def test_search_sort_by_raise_errors(self):
         """search used with "sortBy" argument must raise errors if the argument is incorrect or if the provider does
-        not support a maximum number of sorting parameter, one sorting parameter or the sorting feature"""
+        not support a maximum number of sorting parameter, one sorting parameter or the sorting feature
+        """
         dag = EODataAccessGateway()
         dummy_provider_config = """
         dummy_provider:
@@ -2977,3 +2978,73 @@ class TestCoreProductAlias(TestCoreBase):
         # not existing product type
         with self.assertRaises(NoMatchingProductType):
             self.dag.get_product_type_from_alias("JUST_A_TYPE")
+
+
+class TestCoreProviderGroup(TestCoreBase):
+    group = ("peps", "creodias")
+    group_name = "testgroup"
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.dag = EODataAccessGateway()
+        providers = cls.dag.providers_config
+
+        setattr(providers[cls.group[0]], "group", cls.group_name)
+        setattr(providers[cls.group[1]], "group", cls.group_name)
+
+    def test_available_providers_by_group(self) -> None:
+        """
+        The method available_providers returns only one entry for both grouped providers
+        """
+        # drop the provider names grouped as they are grouped under "testgroup" name
+        providers = self.dag.available_providers()
+        providers.remove(self.group[0])
+        providers.remove(self.group[1])
+        providers.append(self.group_name)
+
+        self.assertCountEqual(self.dag.available_providers(by_group=True), providers)
+
+    def test_list_product_types(self) -> None:
+        """
+        List the product types for the provider group.
+        EODAG return the merged list of product types from both providers of the group.
+        """
+
+        earth_search_products = self.dag.list_product_types(
+            self.group[0], fetch_providers=False
+        )
+        earth_search_cog_products = self.dag.list_product_types(
+            self.group[1], fetch_providers=False
+        )
+
+        merged_list = list(
+            {
+                d["ID"]: d for d in earth_search_products + earth_search_cog_products
+            }.values()
+        )
+
+        self.assertCountEqual(
+            self.dag.list_product_types(self.group_name, fetch_providers=False),
+            merged_list,
+        )
+
+    def test_get_search_plugins(
+        self,
+    ) -> None:
+        """
+        The method _plugins_manager.get_search_plugins is called with provider group
+        It returns a list containing the 2 grouped plugins
+        """
+        plugin1 = list(
+            self.dag._plugins_manager.get_search_plugins(provider=self.group[0])
+        )
+        plugin2 = list(
+            self.dag._plugins_manager.get_search_plugins(provider=self.group[1])
+        )
+
+        group_plugins = list(
+            self.dag._plugins_manager.get_search_plugins(provider=self.group_name)
+        )
+
+        self.assertCountEqual(group_plugins, [*plugin1, *plugin2])


### PR DESCRIPTION
in EODAG library:
- add a `by_group` option on `core.available_providers`. If set, we return the unique list of groups instead of the list of provider names.
- update `list_product_types` to accept group name as provider names. Calling `list_product_types` with a group name set in the provider name will return the union of product types from all the providers of this group.
- update `get_search_plugin` to accept group names as provider names. Calling `get_search_plugin` with a group name as provider name will yield all the plugins belonging to the group.

in EODAG server:
- use group when set instead of provider name

> `group` is an optional field

Example:

I have 2 provider configuration in EODAG:

- earth_search
- earth_search_cog

I configure both with `group` **earth_search**. 

- [x] When I `list  the product types` for provider **earth_search**, EODAG return the merged list of product types from earth_search and earth_search_cog. 
- [x] In server mode, the returned product types display **earth_search** as provider name.

- [x] When I `search` for products with provider **earth_search**, EDOAG search on both provider using the existing fallback mechanism.

- [x] When I ask for `queryables `with provider **earth_search** the response is the intersect of queryables from earth_search and earth_search_cog. 
- [x] `available_providers` returns only one entry for both: **earth_search**.