### PR TITLE
fix: completed progress_callback with unknown total

### DIFF
--- a/docs/notebooks/tutos/tuto_wekeo.ipynb
+++ b/docs/notebooks/tutos/tuto_wekeo.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "tags": []
    },
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "tags": []
    },
@@ -86,7 +86,7 @@
        "81"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "tags": []
    },
@@ -189,7 +189,7 @@
        " 'UERRA_EUROPE_SL']"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -236,7 +236,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Download found product to `/tmp`:"
+    "Download found product to `/tmp`, changing wait time to 12s (0.2') between product order and download retries:"
    ]
   },
   {
@@ -247,7 +247,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "73f7efd0ef104cb8932124d531430b0f",
+       "model_id": "9925bcf0ed804fd0bbec2f5efe4ea519",
        "version_major": 2,
        "version_minor": 0
       },
@@ -261,7 +261,7 @@
     {
      "data": {
       "text/html": [
-       "[Retry #3] Waiting 118.618292s until next download try for ordered product (retry every 2' for 20')"
+       "[Retry #1] Waiting 11.999954s until next download try for ordered product (retry every 0.2' for 20')"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -269,13 +269,6 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Downloaded product is not a Zip File. Please check its file type before using it\n"
-     ]
     },
     {
      "data": {
@@ -289,7 +282,7 @@
     }
    ],
    "source": [
-    "path = products[0].download(outputs_prefix=\"/tmp\")\n",
+    "path = products[0].download(outputs_prefix=\"/tmp\", wait=0.2)\n",
     "path"
    ]
   },
@@ -319,7 +312,118 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.12"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "21473516ad1d4c068c3a5e545c8dfcf1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "36968842fea54ba98d0cfd6c58e526b4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "6aff6dba5b9d48bc8c1fc085987d5b44": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "display": "inline-flex",
+       "flex_flow": "row wrap",
+       "width": "100%"
+      }
+     },
+     "7ddb60a045a6443ba92e17175e30656a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "flex": "2"
+      }
+     },
+     "8769c5368c334dd69b0c04bdbcc06812": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "91cd62f3d8e941b9ac8b7750d43b9fcf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e0b39382c4764717b02317df3dfa7c87",
+       "style": "IPY_MODEL_8769c5368c334dd69b0c04bdbcc06812",
+       "value": "4bd37b17b45d146f378e349ab3f90464: "
+      }
+     },
+     "9925bcf0ed804fd0bbec2f5efe4ea519": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_91cd62f3d8e941b9ac8b7750d43b9fcf",
+        "IPY_MODEL_f6d232de7f064cc7885528a9b41acb3a",
+        "IPY_MODEL_f38e4e2ab3c149a680153e368eb198ab"
+       ],
+       "layout": "IPY_MODEL_6aff6dba5b9d48bc8c1fc085987d5b44"
+      }
+     },
+     "c2ae4ebd11714f98b099dcd87ee08af6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e0b39382c4764717b02317df3dfa7c87": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f38e4e2ab3c149a680153e368eb198ab": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c2ae4ebd11714f98b099dcd87ee08af6",
+       "style": "IPY_MODEL_36968842fea54ba98d0cfd6c58e526b4",
+       "value": " 1.08k/? [00:00&lt;00:00, 809kB/s]"
+      }
+     },
+     "f6d232de7f064cc7885528a9b41acb3a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_7ddb60a045a6443ba92e17175e30656a",
+       "max": 1,
+       "style": "IPY_MODEL_21473516ad1d4c068c3a5e545c8dfcf1",
+       "value": 1
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,

--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -341,7 +341,9 @@ class UsgsApi(Api):
                             error_message = str(e)
                         raise NotAvailableError(error_message)
                     else:
-                        stream_size = int(stream.headers.get("content-length", 0))
+                        stream_size = (
+                            int(stream.headers.get("content-length", 0)) or None
+                        )
                         progress_callback.reset(total=stream_size)
                         with open(fs_path, "wb") as fhandle:
                             for chunk in stream.iter_content(chunk_size=64 * 1024):

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -337,7 +337,7 @@ class AwsDownload(Download):
             product,
         )
 
-        total_size = sum([p.size for p in unique_product_chunks])
+        total_size = sum([p.size for p in unique_product_chunks]) or None
 
         # download
         progress_callback.reset(total=total_size)

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -799,7 +799,7 @@ class HTTPDownload(Download):
                     if self.stream.status_code == status_running:
                         product.properties["storageStatus"] = "ORDERED"
                         self._process_exception(None, product, ordered_message)
-                stream_size = self._check_stream_size(product)
+                stream_size = self._check_stream_size(product) or None
                 product.headers = self.stream.headers
                 progress_callback.reset(total=stream_size)
                 for chunk in self.stream.iter_content(chunk_size=64 * 1024):
@@ -831,7 +831,7 @@ class HTTPDownload(Download):
             self.config, "dl_url_params", {}
         )
 
-        total_size = self._get_asset_sizes(assets_values, auth, params)
+        total_size = self._get_asset_sizes(assets_values, auth, params) or None
 
         progress_callback.reset(total=total_size)
 

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -922,6 +922,23 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             plugin.download(self.product, outputs_prefix=temp_dir)
         mock_progress_callback_reset.assert_called_once_with(mock.ANY, total=4 + 4)
 
+        # unknown size
+        mock_requests_get.return_value.__enter__.return_value.headers.pop(
+            "content-disposition"
+        )
+        mock_progress_callback_reset.reset_mock()
+        self.product.location = "http://somewhere"
+        self.product.assets.clear()
+        self.product.assets.update(
+            {
+                "foo": {"href": "http://somewhere/a"},
+                "bar": {"href": "http://somewhere/b"},
+            }
+        )
+        with TemporaryDirectory() as temp_dir:
+            plugin.download(self.product, outputs_prefix=temp_dir)
+        mock_progress_callback_reset.assert_called_once_with(mock.ANY, total=None)
+
     def test_plugins_download_http_one_local_asset(
         self,
     ):


### PR DESCRIPTION
Mark progress bar as completed (green in notebooks) even if total size is unknown:
- use `total=None` instead of `total=0` in `download` `progress_callback` parameters