### PR TITLE
build: orjson pinned for windows py312

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,8 @@ install_requires =
     shapely
     pyshp
     OWSLib >=0.27.1
-    orjson
+    orjson < 3.10.0;python_version>='3.12' and platform_system=='Windows'
+    orjson;python_version<'3.12' and platform_system!='Windows'
     geojson
     pyproj >= 2.1.0
     usgs >= 0.3.1


### PR DESCRIPTION
Fixes CI failures with `orjson` on python 3.12 for Windows:
```
[gw2] [ 10%] FAILED tests/units/test_metadata_mapping.py::TestMetadataFormatter::test_convert_interval_to_datetime_dict 
[...]
>       formated_dict = orjson.loads(formated.replace("'", '"'))
E       AttributeError: module 'orjson' has no attribute 'loads'
```
Pins `orjson` version following its [v3.10.0 release](https://github.com/ijl/orjson/releases/tag/3.10.0)