### PR TITLE
fix: orderLink in build_search plugins

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -24,7 +24,7 @@ from urllib.parse import quote_plus, unquote_plus
 
 import geojson
 import orjson
-from jsonpath_ng import Fields
+from jsonpath_ng import Child, Fields, Root
 
 from eodag.api.product import EOProduct
 from eodag.api.product.metadata_mapping import properties_from_json
@@ -171,8 +171,10 @@ class BuildPostSearchResult(PostJsonSearch):
         parsed_properties["_dc_qs"] = quote_plus(qs)
 
         # parse metadata needing downloadLink
+        dl_path = Fields("downloadLink")
+        dl_path_from_root = Child(Root(), dl_path)
         for param, mapping in self.config.metadata_mapping.items():
-            if Fields("downloadLink") in mapping:
+            if dl_path in mapping or dl_path_from_root in mapping:
                 parsed_properties.update(
                     properties_from_json(parsed_properties, {param: mapping})
                 )

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3510,7 +3510,7 @@
       timeIntervalsAlignment:
         - '{{"timeIntervalsAlignment": {timeIntervalsAlignment#to_geojson} }}'
         - '$.timeIntervalsAlignment'
-      orderLink: '{downloadLink#replace_str(r"^(.*)(\")(queries\")(.)",r"\1\2runOnJobQueue\2\4 true, \2\3\4")}'
+      orderLink: '{$.downloadLink#replace_str(r"^(.*)(\")(queries\")(.)",r"\1\2runOnJobQueue\2\4 true, \2\3\4")}'
   products:
     NEMSGLOBAL_TCDC:
       queries: [{'domain':'NEMSGLOBAL','gapFillDomain':null,'timeResolution':'daily','codes':[{'code':71,'level':'sfc','aggregation':'mean'}]}]


### PR DESCRIPTION
Fixes parsing issue for `orderLink` in `build_search` plugins