### PR TITLE
fix(server): type missing on some queryables

### DIFF
--- a/eodag/rest/types/stac_queryables.py
+++ b/eodag/rest/types/stac_queryables.py
@@ -44,6 +44,8 @@ class StacQueryableProperty(BaseModel):
     type: Optional[Union[str, List[str]]] = None
     enum: Optional[List[Any]] = None
     value: Optional[Any] = None
+    min: Optional[Union[int, List[Union[int, None]]]] = None
+    max: Optional[Union[int, List[Union[int, None]]]] = None
 
     @classmethod
     def from_python_field_definition(

--- a/eodag/types/__init__.py
+++ b/eodag/types/__init__.py
@@ -18,9 +18,9 @@
 """EODAG types"""
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, TypedDict, Union
 
-from annotated_types import Gt
+from annotated_types import Gt, Lt
 from pydantic import Field
 from pydantic.fields import FieldInfo
 
@@ -57,7 +57,45 @@ def json_type_to_python(json_type: Union[str, List[str]]) -> type:
         return type(None)
 
 
-def python_type_to_json(python_type: type) -> Optional[Union[str, List[str]]]:
+def _get_min_or_max(type_info: Union[Lt, Gt, Any]) -> Tuple[str, Any]:
+    """
+    checks if the value from an Annotated object is a minimum or maximum
+    :param type_info: info from Annotated
+    :return: "min" or "max"
+    """
+    if isinstance(type_info, Gt):
+        return "min", type_info.gt
+    if isinstance(type_info, Lt):
+        return "max", type_info.lt
+    return "", None
+
+
+def _get_type_info_from_annotated(
+    annotated_type: Annotated[type, Any]
+) -> Dict[str, Any]:
+    """
+    retrieves type information from an annotated object
+    :param annotated_type: annotated object
+    :return: dict containing type and min/max if available
+    """
+    type_args = get_args(annotated_type)
+    type_data = {
+        "type": list(JSON_TYPES_MAPPING.keys())[
+            list(JSON_TYPES_MAPPING.values()).index(type_args[0])
+        ]
+    }
+    if len(type_args) >= 2:
+        min_or_max, value = _get_min_or_max(type_args[1])
+        type_data[min_or_max] = value
+    if len(type_args) > 2:
+        min_or_max, value = _get_min_or_max(type_args[2])
+        type_data[min_or_max] = value
+    return type_data
+
+
+def python_type_to_json(
+    python_type: type,
+) -> Optional[Union[str, List[Dict[str, Any]]]]:
     """Get json type from python https://spec.openapis.org/oas/v3.1.0#data-types
 
     >>> python_type_to_json(int)
@@ -71,18 +109,25 @@ def python_type_to_json(python_type: type) -> Optional[Union[str, List[str]]]:
     if get_origin(python_type) is Union:
         json_type = list()
         for single_python_type in get_args(python_type):
+            type_data = {}
             if single_python_type in JSON_TYPES_MAPPING.values():
                 # JSON_TYPES_MAPPING key from given value
                 single_json_type = list(JSON_TYPES_MAPPING.keys())[
                     list(JSON_TYPES_MAPPING.values()).index(single_python_type)
                 ]
-                json_type.append(single_json_type)
+                type_data["type"] = single_json_type
+                json_type.append(type_data)
+            elif get_origin(single_python_type) == Annotated:
+                type_data = _get_type_info_from_annotated(single_python_type)
+                json_type.append(type_data)
         return json_type
     elif python_type in JSON_TYPES_MAPPING.values():
         # JSON_TYPES_MAPPING key from given value
         return list(JSON_TYPES_MAPPING.keys())[
             list(JSON_TYPES_MAPPING.values()).index(python_type)
         ]
+    elif get_origin(python_type) == Annotated:
+        return [_get_type_info_from_annotated(python_type)]
     else:
         return None
 
@@ -160,13 +205,39 @@ def python_field_definition_to_json(
     # enum & type
     if get_origin(python_field_args[0]) is Literal:
         enum_args = get_args(python_field_args[0])
-        json_field_definition["type"] = python_type_to_json(type(enum_args[0]))
+        type_data = python_type_to_json(type(enum_args[0]))
+        if isinstance(type_data, str):
+            json_field_definition["type"] = type_data
+        else:
+            json_field_definition["type"] = [row["type"] for row in type_data]
+            json_field_definition["min"] = [
+                row["min"] if "min" in row else None for row in type_data
+            ]
+            json_field_definition["max"] = [
+                row["max"] if "max" in row else None for row in type_data
+            ]
         json_field_definition["enum"] = list(enum_args)
     # type
     else:
         field_type = python_type_to_json(python_field_args[0])
-        if field_type is not None:
-            json_field_definition["type"] = python_type_to_json(python_field_args[0])
+        if isinstance(field_type, str):
+            json_field_definition["type"] = field_type
+        else:
+            json_field_definition["type"] = [row["type"] for row in field_type]
+            json_field_definition["min"] = [
+                row["min"] if "min" in row else None for row in field_type
+            ]
+            json_field_definition["max"] = [
+                row["max"] if "max" in row else None for row in field_type
+            ]
+    if "min" in json_field_definition and json_field_definition["min"].count(
+        None
+    ) == len(json_field_definition["min"]):
+        json_field_definition.pop("min")
+    if "max" in json_field_definition and json_field_definition["max"].count(
+        None
+    ) == len(json_field_definition["max"]):
+        json_field_definition.pop("max")
 
     if len(python_field_args) < 2:
         return json_field_definition

--- a/eodag/types/__init__.py
+++ b/eodag/types/__init__.py
@@ -101,7 +101,7 @@ def python_type_to_json(
     >>> python_type_to_json(int)
     'integer'
     >>> python_type_to_json(Union[float, str])
-    ['number', 'string']
+    [{'type': 'number'}, {'type': 'string'}]
 
     :param python_type: the python type
     :returns: the json type

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -1235,6 +1235,24 @@ class RequestTestCase(unittest.TestCase):
         self.assertIn("platform", res["properties"])
         self.assertEqual("string", res["properties"]["platform"]["type"][0])
 
+    def test_stac_queryables_type(self):
+        res = self._request_valid(
+            "collections/S2_MSI_L2A/queryables?provider=creodias",
+            check_links=False,
+        )
+        self.assertIn("eo:cloud_cover", res["properties"])
+        cloud_cover = res["properties"]["eo:cloud_cover"]
+        self.assertIn("type", cloud_cover)
+        self.assertListEqual(["integer", "null"], cloud_cover["type"])
+        self.assertIn("min", cloud_cover)
+        self.assertListEqual([0, None], cloud_cover["min"])
+        self.assertIn("max", cloud_cover)
+        self.assertListEqual([100, None], cloud_cover["max"])
+        self.assertIn("processing:level", res["properties"])
+        processing_level = res["properties"]["processing:level"]
+        self.assertListEqual(["string", "null"], processing_level["type"])
+        self.assertIsNone(processing_level["min"])
+
     @mock.patch("eodag.utils.constraints.requests.get", autospec=True)
     def test_product_type_queryables_from_constraints(
         self, mock_requests_constraints: Mock


### PR DESCRIPTION
- type for queryables where Annotated is used in type is now also set in server mode
- new parameters for additional information from Annotated (min, max) created
