### PR TITLE
refactor: remove not needed anymore requests-ftp

### DIFF
--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -41,7 +41,6 @@ from urllib.parse import parse_qs, urlparse
 
 import geojson
 import requests
-import requests_ftp
 from lxml import etree
 from requests import RequestException
 from requests.auth import AuthBase
@@ -768,8 +767,6 @@ class HTTPDownload(Download):
             req_url = url
             req_kwargs = {}
 
-        # url where data is downloaded from can be ftp -> add ftp adapter
-        requests_ftp.monkeypatch_session()
         s = requests.Session()
         with s.request(
             req_method,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ module = [
     "geojson",
     "IPython.display",
     "owslib.*",
-    "requests_ftp",
     "shapefile",
     "shapely",
     "shapely.*",

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,6 @@ install_requires =
     ecmwf-api-client
     cdsapi
     stream-zip
-    requests-ftp
     pydantic >= 2.1.0
     pydantic_core
     typing_extensions


### PR DESCRIPTION
requests-ftp was only necessary for some wekeo product types and is not needed anymore with the new version of the wekeo API -> dependency removed
