### PR TITLE
fix(server): add provider in self link of item

### DIFF
--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -310,7 +310,7 @@ class StacItem(StacCommon):
             product_item = self.__filter_item_properties_values(product_item)
 
             # update item link with datacube query-string
-            if _dc_qs:
+            if _dc_qs or self.provider:
                 url_parts = urlparse(str(product_item["links"][0]["href"]))
                 without_arg_url = (
                     f"{url_parts.scheme}://{url_parts.netloc}{url_parts.path}"

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -738,6 +738,32 @@ class RequestTestCase(unittest.TestCase):
         )
         self.assertEqual(len(result["features"]), 0)
 
+    def test_date_search_from_catalog_items_with_provider(self):
+        """Search through eodag server catalog/items endpoint using dates filtering should return a valid response
+        and the provider should be added to the item link
+        """
+        results = self._request_valid(
+            f"catalogs/{self.tested_product_type}/year/2018/month/01/items?bbox=0,43,1,44&provider=creodias",
+            expected_search_kwargs=dict(
+                productType=self.tested_product_type,
+                page=1,
+                items_per_page=DEFAULT_ITEMS_PER_PAGE,
+                start="2018-01-01T00:00:00Z",
+                end="2018-02-01T00:00:00Z",
+                provider="creodias",
+                geom=box(0, 43, 1, 44, ccw=False),
+                raise_errors=True,
+            ),
+        )
+        self.assertEqual(len(results.features), 2)
+        links = results.features[0]["links"]
+        self_link = None
+        for link in links:
+            if link["rel"] == "self":
+                self_link = link
+        self.assertIsNotNone(self_link)
+        self.assertIn("?provider=creodias", self_link["href"])
+
     def test_search_item_id_from_catalog(self):
         """Search by id through eodag server /catalog endpoint should return a valid response"""
         self._request_valid(


### PR DESCRIPTION
provider is now added to "self" link in features of /items and /catalogs/.../items endpoints
