### PR TITLE
fix[server]: auth for download through Api plugins

### DIFF
--- a/eodag/rest/core.py
+++ b/eodag/rest/core.py
@@ -262,7 +262,7 @@ def download_stac_item(
             f"Could not find {item_id} item in {product_type} collection"
             + (f" for provider {provider}" if provider else "")
         )
-    auth = product.downloader_auth.authenticate()
+    auth = product.downloader_auth.authenticate() if product.downloader_auth else None
 
     try:
         _order_and_update(product, auth, kwargs)


### PR DESCRIPTION
In server mode, fixes authentication issue when downloading a product through an `Api` plugin