### PR TITLE
refactor: search all and crunch for _search_by_id 

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -1480,6 +1480,10 @@ class EODataAccessGateway:
                     for result in results:
                         if result.properties["id"] == uid.split(".")[0]:
                             return SearchResult([results[0]]), 1
+                # try using crunch to get unique result
+                if len(filtered := results.filter_property(id=uid)) == 1:
+                    return filtered, 1
+
                 logger.info(
                     "Several products found for this id (%s). You may try searching using more selective criteria.",
                     results,

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1998,6 +1998,19 @@ class TestCoreSearch(TestCoreBase):
             self.assertEqual(found, (SearchResult([]), 0))
             self.assertIn("Several products found for this id", str(cm.output))
 
+        mock__do_search.reset_mock()
+        # return 1 result if more than 1 product is found but only 1 has the matching id
+        m = mock.MagicMock()
+        p2 = EOProduct(
+            "peps", {"id": "foo", "geometry": {"type": "Point", "coordinates": [1, 1]}}
+        )
+        m.__len__.return_value = 2
+        m.__iter__.return_value = [p, p2]
+        mock__do_search.return_value = (m, 2)
+        found = self.dag._search_by_id(uid="foo", productType="bar", provider="baz")
+        self.assertEqual(found[1], 1)
+        self.assertEqual(len(found[0]), 1)
+
     @mock.patch("eodag.plugins.search.qssearch.QueryStringSearch", autospec=True)
     def test__do_search_support_itemsperpage_higher_than_maximum(self, search_plugin):
         """_do_search must create a count query by default"""


### PR DESCRIPTION
Iterate over all pages in [search_by_id](https://eodag.readthedocs.io/en/stable/notebooks/api_user_guide/4_search.html#id-and-provider) and if it returns more than one result, try filtering results using [crunch](https://eodag.readthedocs.io/en/stable/notebooks/api_user_guide/6_crunch.html#Filter-by-property) before failing