### PR TITLE
build: refactor and new optional dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,9 @@ And with ``conda`` from the `conda-forge channel <https://anaconda.org/conda-for
 
    conda install -c conda-forge eodag
 
+Please note that EODAG comes with a minimal set of dependencies. If you want more features, please install using one of
+the `available extras <https://eodag.readthedocs.io/en/latest/getting_started_guide/install.html#optional-dependencies>`_.
+
 Usage
 =====
 

--- a/docs/getting_started_guide/install.rst
+++ b/docs/getting_started_guide/install.rst
@@ -20,6 +20,20 @@ Or with ``conda`` from the *conda-forge* channel:
 
    conda install -c conda-forge eodag
 
+Optional dependencies
+^^^^^^^^^^^^^^^^^^^^^
+
+Since ``v3.0``, EODAG comes with a minimal set of dependencies. If you want more features, please install using one of
+the following extras:
+
+* ``eodag[all]``, includes everything that would be needed to run EODAG and associated tutorials with all features
+* ``eodag[all-providers]``, includes dependencies required to have all providers available
+* ``eodag[aws]``, includes dependencies for plugins using Amazon S3
+* ``eodag[csw]``, includes dependencies for plugins using CSW
+* ``eodag[ecmwf]``, includes dependencies for :class:`~eodag.plugins.apis.ecmwf.EcmwfApi` (`ecmwf` provider)
+* ``eodag[usgs]``, includes dependencies for :class:`~eodag.plugins.apis.usgs.UsgsApi` (`usgs` provider)
+* ``eodag[server]``, includes dependencies for server-mode
+
 .. _install_notebooks:
 
 Run the notebooks locally
@@ -30,7 +44,7 @@ that can be run locally:
 
 1. Install the extras dependencies it requires by executing this command (preferably in a virtual environment)::
 
-      python -m pip install eodag[tutorials]
+      python -m pip install "eodag[tutorials]"
 
 2. Clone ``eodag`` 's repository with git::
 

--- a/docs/plugins_reference/auth.rst
+++ b/docs/plugins_reference/auth.rst
@@ -22,3 +22,4 @@ This table lists all the authentication plugins currently available:
    eodag.plugins.authentication.openid_connect.OIDCAuthorizationCodeFlowAuth
    eodag.plugins.authentication.keycloak.KeycloakOIDCPasswordAuth
    eodag.plugins.authentication.qsauth.HttpQueryStringAuth
+   eodag.plugins.authentication.sas_auth.SASAuth

--- a/docs/plugins_reference/download.rst
+++ b/docs/plugins_reference/download.rst
@@ -17,6 +17,7 @@ This table lists all the download plugins currently available:
    eodag.plugins.download.http.HTTPDownload
    eodag.plugins.download.aws.AwsDownload
    eodag.plugins.download.s3rest.S3RestDownload
+   eodag.plugins.download.creodias_s3.CreodiasS3Download
 
 ---------------------------
 Download methods call graph

--- a/docs/plugins_reference/search.rst
+++ b/docs/plugins_reference/search.rst
@@ -15,11 +15,12 @@ This table lists all the search plugins currently available:
    :toctree: generated/
 
    eodag.plugins.search.qssearch.QueryStringSearch
-   eodag.plugins.search.qssearch.AwsSearch
    eodag.plugins.search.qssearch.ODataV4Search
    eodag.plugins.search.qssearch.PostJsonSearch
    eodag.plugins.search.qssearch.StacSearch
    eodag.plugins.search.static_stac_search.StaticStacSearch
+   eodag.plugins.search.creodias_s3.CreodiasS3Search
    eodag.plugins.search.build_search_result.BuildSearchResult
    eodag.plugins.search.build_search_result.BuildPostSearchResult
+   eodag.plugins.search.data_request_search.DataRequestSearch
    eodag.plugins.search.csw.CSWSearch

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -75,7 +75,10 @@ class PluginManager:
 
     product_type_to_provider_config_map: Dict[str, List[ProviderConfig]]
 
+    skipped_plugins: List[str]
+
     def __init__(self, providers_config: Dict[str, ProviderConfig]) -> None:
+        self.skipped_plugins = []
         self.providers_config = providers_config
         # Load all the plugins. This will make all plugin classes of a particular
         # type to be available in the base plugin class's 'plugins' attribute.
@@ -92,6 +95,13 @@ class PluginManager:
             ):
                 try:
                     entry_point.load()
+                except pkg_resources.DistributionNotFound:
+                    logger.debug(
+                        "%s plugin skipped, eodag[%s] or eodag[all] needed",
+                        entry_point.name,
+                        ",".join(entry_point.extras),
+                    )
+                    self.skipped_plugins.append(entry_point.name)
                 except ImportError:
                     import traceback as tb
 

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -1002,34 +1002,6 @@ class QueryStringSearch(Search):
         return response
 
 
-class AwsSearch(QueryStringSearch):
-    """A specialisation of RestoSearch that modifies the way the EOProducts are built
-    from the search results"""
-
-    def normalize_results(
-        self, results: List[Dict[str, Any]], **kwargs: Any
-    ) -> List[EOProduct]:
-        """Transform metadata from provider representation to eodag representation"""
-        normalized: List[EOProduct] = []
-        logger.debug("Adapting plugin results to eodag product representation")
-        for result in results:
-            ref = result["properties"]["title"].split("_")[5]
-            year = result["properties"]["completionDate"][0:4]
-            month = str(int(result["properties"]["completionDate"][5:7]))
-            day = str(int(result["properties"]["completionDate"][8:10]))
-
-            properties = QueryStringSearch.extract_properties[self.config.result_type](
-                result, self.get_metadata_mapping(kwargs.get("productType"))
-            )
-
-            properties["downloadLink"] = (
-                "s3://tiles/{ref[1]}{ref[2]}/{ref[3]}/{ref[4]}{ref[5]}/{year}/"
-                "{month}/{day}/0/"
-            ).format(**locals())
-            normalized.append(EOProduct(self.provider, properties, **kwargs))
-        return normalized
-
-
 class ODataV4Search(QueryStringSearch):
     """A specialisation of a QueryStringSearch that does a two step search to retrieve
     all products metadata"""

--- a/eodag/rest/__init__.py
+++ b/eodag/rest/__init__.py
@@ -16,3 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """EODAG REST API"""
+try:
+    from fastapi import __version__  # noqa: F401
+except ImportError:
+    raise ImportError(
+        f"{__name__} not available, please install eodag[server] or eodag[all]"
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,40 +37,64 @@ packages = find:
 include_package_data = True
 python_requires = >=3.6
 install_requires =
+    annotated-types
     click
-    requests
-    urllib3
-    python-dateutil
-    PyYAML
-    tqdm
-    shapely
-    pyshp
-    OWSLib >=0.27.1
-    orjson < 3.10.0;python_version>='3.12' and platform_system=='Windows'
-    orjson;python_version<'3.12' and platform_system!='Windows'
     geojson
-    pyproj >= 2.1.0
-    usgs >= 0.3.1
-    boto3
-    botocore
-    fastapi >= 0.93.0
-    starlette
-    uvicorn
     jsonpath-ng < 1.6.0
     lxml
-    Whoosh
-    pystac >= 1.0.0b1
-    ecmwf-api-client
-    stream-zip
+    orjson < 3.10.0;python_version>='3.12' and platform_system=='Windows'
+    orjson;python_version<'3.12' and platform_system!='Windows'
     pydantic >= 2.1.0
     pydantic_core
-    typing_extensions
-    annotated-types
+    pyproj >= 2.1.0
+    pyshp
+    pystac >= 1.0.0b1
+    python-dateutil
+    PyYAML
+    requests
     setuptools
-    pygeofilter
+    shapely
+    stream-zip
+    tqdm
+    typing_extensions
+    urllib3
+    Whoosh
 
 [options.extras_require]
+all =
+    eodag[all-providers,csw,server,tutorials]
+all-providers =
+    eodag[aws,ecmwf,usgs]
+aws =
+    boto3
+    botocore
+csw =
+    OWSLib >=0.27.1
+ecmwf =
+    ecmwf-api-client
+usgs =
+    usgs >= 0.3.1
+server =
+    fastapi >= 0.93.0
+    pygeofilter
+    starlette
+    uvicorn
+
+notebook = tqdm[notebook]
+tutorials =
+    eodag[notebook]
+    eodag-cube >= 0.2.0
+    jupyter
+    ipyleaflet >= 0.10.0
+    ipywidgets
+    matplotlib
+    folium
+    imageio
+    rasterio
+    netcdf4
+
 dev =
+    eodag[all-providers,csw,server]
     pytest
     pytest-cov
     # pytest-html max version set and py requirement added
@@ -92,19 +116,8 @@ dev =
     stdlib-list
     boto3-stubs[essential]
     types-lxml
-
-notebook = tqdm[notebook]
-tutorials =
-    eodag-cube >= 0.2.0
-    jupyter
-    ipyleaflet >= 0.10.0
-    ipywidgets
-    matplotlib
-    folium
-    imageio
-    rasterio
-    netcdf4
 docs =
+    eodag[all]
     sphinx
     sphinx-book-theme
     sphinx-copybutton
@@ -127,8 +140,8 @@ exclude =
 console_scripts =
     eodag = eodag.cli:eodag
 eodag.plugins.api =
-    UsgsApi = eodag.plugins.apis.usgs:UsgsApi
-    EcmwfApi = eodag.plugins.apis.ecmwf:EcmwfApi
+    UsgsApi = eodag.plugins.apis.usgs:UsgsApi [usgs]
+    EcmwfApi = eodag.plugins.apis.ecmwf:EcmwfApi [ecmwf]
 eodag.plugins.auth =
     GenericAuth = eodag.plugins.authentication.generic:GenericAuth
     HTTPHeaderAuth = eodag.plugins.authentication.header:HTTPHeaderAuth
@@ -146,12 +159,12 @@ eodag.plugins.crunch =
     FilterProperty = eodag.plugins.crunch.filter_property:FilterProperty
     FilterDate = eodag.plugins.crunch.filter_date:FilterDate
 eodag.plugins.download =
-    AwsDownload = eodag.plugins.download.aws:AwsDownload
+    AwsDownload = eodag.plugins.download.aws:AwsDownload [aws]
     HTTPDownload = eodag.plugins.download.http:HTTPDownload
     S3RestDownload = eodag.plugins.download.s3rest:S3RestDownload
-    CreodiasS3Download = eodag.plugins.download.creodias_s3:CreodiasS3Download
+    CreodiasS3Download = eodag.plugins.download.creodias_s3:CreodiasS3Download [aws]
 eodag.plugins.search =
-    CSWSearch = eodag.plugins.search.csw:CSWSearch
+    CSWSearch = eodag.plugins.search.csw:CSWSearch [csw]
     QueryStringSearch = eodag.plugins.search.qssearch:QueryStringSearch
     ODataV4Search = eodag.plugins.search.qssearch:ODataV4Search
     PostJsonSearch = eodag.plugins.search.qssearch:PostJsonSearch
@@ -160,7 +173,7 @@ eodag.plugins.search =
     BuildSearchResult = eodag.plugins.search.build_search_result:BuildSearchResult
     BuildPostSearchResult = eodag.plugins.search.build_search_result:BuildPostSearchResult
     DataRequestSearch = eodag.plugins.search.data_request_search:DataRequestSearch
-    CreodiasS3Search = eodag.plugins.search.creodias_s3:CreodiasS3Search
+    CreodiasS3Search = eodag.plugins.search.creodias_s3:CreodiasS3Search [aws]
 
 [flake8]
 ignore = E203, W503

--- a/setup.cfg
+++ b/setup.cfg
@@ -153,7 +153,6 @@ eodag.plugins.download =
 eodag.plugins.search =
     CSWSearch = eodag.plugins.search.csw:CSWSearch
     QueryStringSearch = eodag.plugins.search.qssearch:QueryStringSearch
-    AwsSearch = eodag.plugins.search.qssearch:AwsSearch
     ODataV4Search = eodag.plugins.search.qssearch:ODataV4Search
     PostJsonSearch = eodag.plugins.search.qssearch:PostJsonSearch
     StacSearch = eodag.plugins.search.qssearch:StacSearch


### PR DESCRIPTION
Fixes #461 

Add new extras and move some required dependencies to optional dependencies.
This will make basic installation way lighter.

New available extras:
- `eodag[all]`, including everything that would be needed to run eodag and associated tutorials with all features
- `eodag[all-providers]`, including dependencies required to have all providers available
- `eodag[aws]`, including dependencies for plugins using Amazon S3
- `eodag[csw]`, including dependencies for plugins using CSW
- `eodag[ecmwf]`, including dependencies for `EcmwfApi`
- `eodag[usgs]`, including dependencies for `UsgsApi`
- `eodag[server]`, including dependencies for server-mode