### PR TITLE
fix: move DEFAULT_MISSION_START_DATE to utils

### DIFF
--- a/eodag/plugins/apis/ecmwf.py
+++ b/eodag/plugins/apis/ecmwf.py
@@ -29,11 +29,11 @@ from ecmwfapi.api import APIException, Connection, get_apikey_values
 from eodag.plugins.apis.base import Api
 from eodag.plugins.search.base import Search
 from eodag.plugins.search.build_search_result import BuildPostSearchResult
-from eodag.rest.stac import DEFAULT_MISSION_START_DATE
 from eodag.utils import (
     DEFAULT_DOWNLOAD_TIMEOUT,
     DEFAULT_DOWNLOAD_WAIT,
     DEFAULT_ITEMS_PER_PAGE,
+    DEFAULT_MISSION_START_DATE,
     DEFAULT_PAGE,
     get_geometry_from_various,
     path_to_uri,

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -41,11 +41,11 @@ from eodag.api.product.metadata_mapping import (
 )
 from eodag.plugins.search.base import Search
 from eodag.plugins.search.qssearch import PostJsonSearch
-from eodag.rest.stac import DEFAULT_MISSION_START_DATE
 from eodag.types import json_field_definition_to_python, model_fields_to_annotated
 from eodag.types.queryables import CommonQueryables
 from eodag.utils import (
     DEFAULT_ITEMS_PER_PAGE,
+    DEFAULT_MISSION_START_DATE,
     DEFAULT_PAGE,
     Annotated,
     deepcopy,

--- a/eodag/plugins/search/data_request_search.py
+++ b/eodag/plugins/search/data_request_search.py
@@ -31,9 +31,9 @@ from eodag.api.product.metadata_mapping import (
     properties_from_json,
 )
 from eodag.plugins.search.base import Search
-from eodag.rest.stac import DEFAULT_MISSION_START_DATE
 from eodag.utils import (
     DEFAULT_ITEMS_PER_PAGE,
+    DEFAULT_MISSION_START_DATE,
     DEFAULT_PAGE,
     GENERIC_PRODUCT_TYPE,
     HTTP_REQ_TIMEOUT,

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -40,6 +40,7 @@ from eodag.api.product.metadata_mapping import (
     get_metadata_path,
 )
 from eodag.utils import (
+    DEFAULT_MISSION_START_DATE,
     deepcopy,
     dict_items_recursive_apply,
     format_dict_items,
@@ -63,7 +64,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("eodag.rest.stac")
 
-DEFAULT_MISSION_START_DATE = "2015-01-01T00:00:00Z"
 STAC_CATALOGS_PREFIX = "catalogs"
 
 

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -138,6 +138,9 @@ DEFAULT_ITEMS_PER_PAGE = 20
 # (DEFAULT_ITEMS_PER_PAGE) to increase it to the known and current minimum value (mundi)
 DEFAULT_MAX_ITEMS_PER_PAGE = 50
 
+# default product-types start date
+DEFAULT_MISSION_START_DATE = "2015-01-01T00:00:00Z"
+
 
 def _deprecated(reason: str = "", version: Optional[str] = None) -> Callable[..., Any]:
     """Simple decorator to mark functions/methods/classes as deprecated.

--- a/tests/context.py
+++ b/tests/context.py
@@ -65,10 +65,10 @@ from eodag.plugins.download.base import (
 from eodag.plugins.download.http import HTTPDownload
 from eodag.plugins.manager import PluginManager
 from eodag.plugins.search.base import Search
-from eodag.rest.stac import DEFAULT_MISSION_START_DATE
 from eodag.types import model_fields_to_annotated
 from eodag.types.queryables import CommonQueryables, Queryables
 from eodag.utils import (
+    DEFAULT_MISSION_START_DATE,
     DEFAULT_STREAM_REQUESTS_TIMEOUT,
     HTTP_REQ_TIMEOUT,
     USER_AGENT,


### PR DESCRIPTION
Moves `DEFAULT_MISSION_START_DATE` constant to `eodag.utils` (prevents `eodag.rest` import from client-mode)