### PR TITLE
fix: handle empty response from provider

### DIFF
--- a/docker/stac-server.dockerfile
+++ b/docker/stac-server.dockerfile
@@ -52,7 +52,7 @@ COPY README.rst README.rst
 COPY ./eodag /eodag/eodag
 
 # install eodag
-RUN python -m pip install .
+RUN python -m pip install .[all-providers,server]
 
 # add python path
 ENV PYTHONPATH="${PYTHONPATH}:/eodag/eodag/resources"


### PR DESCRIPTION
raise an error when the download request to the provider returns an empty response
