### PR TITLE
feat: add refresh token to `OIDCAuthorizationCodeFlowAuth` plugin

### DIFF
--- a/eodag/plugins/authentication/keycloak.py
+++ b/eodag/plugins/authentication/keycloak.py
@@ -18,15 +18,16 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, TypedDict
+from typing import TYPE_CHECKING, Any, Dict
 
 import requests
 
-from eodag.plugins.authentication import Authentication
-from eodag.plugins.authentication.openid_connect import CodeAuthorizedAuth
+from eodag.plugins.authentication.openid_connect import (
+    CodeAuthorizedAuth,
+    OIDCRefreshTokenBase,
+)
 from eodag.utils import HTTP_REQ_TIMEOUT, USER_AGENT
-from eodag.utils.exceptions import AuthenticationError, MisconfiguredError
+from eodag.utils.exceptions import MisconfiguredError, TimeOutError
 
 if TYPE_CHECKING:
     from requests.auth import AuthBase
@@ -37,7 +38,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("eodag.auth.keycloak")
 
 
-class KeycloakOIDCPasswordAuth(Authentication):
+class KeycloakOIDCPasswordAuth(OIDCRefreshTokenBase):
     """Authentication plugin using Keycloak and OpenId Connect.
 
     This plugin request a token and use it through a query-string or a header.
@@ -80,23 +81,9 @@ class KeycloakOIDCPasswordAuth(Authentication):
     GRANT_TYPE = "password"
     TOKEN_URL_TEMPLATE = "{auth_base_uri}/realms/{realm}/protocol/openid-connect/token"
     REQUIRED_PARAMS = ["auth_base_uri", "client_id", "client_secret", "token_provision"]
-    # already retrieved token store, to be used if authenticate() fails (OTP use-case)
-    retrieved_token: str = ""
-
-    class TokenInfo(TypedDict, total=False):
-        """Token infos"""
-
-        refresh_token: str
-        refresh_time: datetime
-        token_time: datetime
-        access_token_expiration: float
-        refresh_token_expiration: float
-
-    token_info: TokenInfo = {}
 
     def __init__(self, provider: str, config: PluginConfig) -> None:
         super(KeycloakOIDCPasswordAuth, self).__init__(provider, config)
-        self.session = requests.Session()
 
     def validate_config_credentials(self) -> None:
         """Validate configured credentials"""
@@ -115,49 +102,12 @@ class KeycloakOIDCPasswordAuth(Authentication):
         """
         self.validate_config_credentials()
         access_token = self._get_access_token()
-        self.retrieved_token = access_token
+        self.token_info["access_token"] = access_token
         return CodeAuthorizedAuth(
-            self.retrieved_token,
+            self.token_info["access_token"],
             self.config.token_provision,
             key=getattr(self.config, "token_qs_key", None),
         )
-
-    def _get_access_token(self) -> str:
-        current_time = datetime.now()
-        if (
-            not self.token_info
-            or (
-                "refresh_token" in self.token_info
-                and (current_time - self.token_info["token_time"]).seconds
-                >= self.token_info["refresh_token_expiration"]
-            )
-            or (
-                "refresh_token" not in self.token_info
-                and (current_time - self.token_info["token_time"]).seconds
-                >= self.token_info["access_token_expiration"]
-            )
-        ):
-            # Request new TOKEN on first attempt or if token expired
-            res = self._request_new_token()
-            self.token_info["token_time"] = current_time
-            self.token_info["access_token_expiration"] = res["expires_in"]
-            if "refresh_token" in res:
-                self.token_info["refresh_time"] = current_time
-                self.token_info["refresh_token_expiration"] = res["refresh_expires_in"]
-                self.token_info["refresh_token"] = res["refresh_token"]
-            return res["access_token"]
-        elif (
-            "refresh_token" in self.token_info
-            and (current_time - self.token_info["refresh_time"]).seconds
-            >= self.token_info["access_token_expiration"]
-        ):
-            # Use refresh token
-            res = self._get_token_with_refresh_token()
-            self.token_info["refresh_token"] = res["refresh_token"]
-            self.token_info["refresh_time"] = current_time
-            return res["access_token"]
-        logger.debug("using already retrieved access token")
-        return self.retrieved_token
 
     def _request_new_token(self) -> Dict[str, Any]:
         logger.debug("fetching new access token")
@@ -178,42 +128,10 @@ class KeycloakOIDCPasswordAuth(Authentication):
                 timeout=HTTP_REQ_TIMEOUT,
             )
             response.raise_for_status()
+        except requests.exceptions.Timeout as exc:
+            raise TimeOutError(exc, timeout=HTTP_REQ_TIMEOUT) from exc
         except requests.RequestException as e:
-            if self.retrieved_token:
-                # try using already retrieved token if authenticate() fails (OTP use-case)
-                if "access_token_expiration" in self.token_info:
-                    return {
-                        "access_token": self.retrieved_token,
-                        "expires_in": self.token_info["access_token_expiration"],
-                    }
-                else:
-                    return {"access_token": self.retrieved_token, "expires_in": 0}
-            response_text = getattr(e.response, "text", "").strip()
-            # check if error is identified as auth_error in provider conf
-            auth_errors = getattr(self.config, "auth_error_code", [None])
-            if not isinstance(auth_errors, list):
-                auth_errors = [auth_errors]
-            if (
-                e.response
-                and hasattr(e.response, "status_code")
-                and e.response.status_code in auth_errors
-            ):
-                raise AuthenticationError(
-                    "HTTP Error %s returned, %s\nPlease check your credentials for %s"
-                    % (e.response.status_code, response_text, self.provider)
-                )
-            # other error
-            else:
-                import traceback as tb
-
-                logger.error(
-                    f"Provider {self.provider} returned {getattr(e.response, 'status_code', '')}: {response_text}"
-                )
-                raise AuthenticationError(
-                    "Something went wrong while trying to get access token:\n{}".format(
-                        tb.format_exc()
-                    )
-                )
+            return self._request_new_token_error(e)
         return response.json()
 
     def _get_token_with_refresh_token(self) -> Dict[str, str]:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -6580,6 +6580,7 @@
     user_consent_needed: false
     token_exchange_post_data_method: data
     token_key: access_token
+    refresh_token_key: refresh_token
     token_provision: header
     login_form_xpath: //form[@id='kc-form-login']
     authentication_uri_source: login-form

--- a/tests/units/test_auth_plugins.py
+++ b/tests/units/test_auth_plugins.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 import unittest
+from datetime import datetime, timedelta
 from unittest import mock
 
 import responses
@@ -26,6 +27,7 @@ from requests.exceptions import RequestException
 
 from eodag.config import override_config_from_mapping
 from eodag.plugins.authentication.openid_connect import CodeAuthorizedAuth
+from eodag.utils import MockResponse
 from eodag.utils.exceptions import RequestError
 from tests.context import (
     HTTP_REQ_TIMEOUT,
@@ -909,22 +911,27 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         """OIDCAuthorizationCodeFlowAuth.validate_credentials must raise an error if credentials are not valid"""
         # `token_provision` not valid
         auth_plugin = self.get_auth_plugin("provider_token_provision_invalid")
-        self.assertRaises(
-            MisconfiguredError,
-            auth_plugin.validate_config_credentials,
+        auth_plugin.config.credentials = {"foo": "bar"}
+        with self.assertRaises(MisconfiguredError) as context:
+            auth_plugin.validate_config_credentials()
+        self.assertTrue(
+            '"token_provision" must be one of "qs" or "header"'
+            in str(context.exception)
         )
         # `token_provision=="qs"` but `token_qs_key` is missing
         auth_plugin = self.get_auth_plugin("provider_token_qs_key_missing")
-        self.assertRaises(
-            MisconfiguredError,
-            auth_plugin.validate_config_credentials,
+        auth_plugin.config.credentials = {"foo": "bar"}
+        with self.assertRaises(MisconfiguredError) as context:
+            auth_plugin.validate_config_credentials()
+        self.assertTrue(
+            '"qs" must have "token_qs_key" config parameter as well'
+            in str(context.exception)
         )
         # Missing credentials
         auth_plugin = self.get_auth_plugin("provider_ok")
-        self.assertRaises(
-            MisconfiguredError,
-            auth_plugin.validate_config_credentials,
-        )
+        with self.assertRaises(MisconfiguredError) as context:
+            auth_plugin.validate_config_credentials()
+        self.assertTrue("Missing credentials" in str(context.exception))
 
     def test_plugins_auth_codeflowauth_validate_credentials_ok(self):
         """OIDCAuthorizationCodeFlowAuth.validate_credentials must be ok on non-empty credentials"""
@@ -938,16 +945,16 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         autospec=True,
         return_value=mock.Mock(url="http://foo.bar"),
     )
-    def test_plugins_auth_codeflowauth_authenticate_no_redirect(
+    def test_plugins_auth_codeflowauth_request_new_token_no_redirect(
         self,
         mock_authenticate_user,
     ):
-        """OIDCAuthorizationCodeFlowAuth.authenticate must raise and error if the provider doesn't redirect
-        to the given URI"""
+        """OIDCAuthorizationCodeFlowAuth.request_new_token must raise and error if the provider doesn't redirect
+        to `redirect_uri`"""
         auth_plugin = self.get_auth_plugin("provider_ok")
         self.assertRaises(
             AuthenticationError,
-            auth_plugin.authenticate,
+            auth_plugin.request_new_token,
         )
 
     @mock.patch(
@@ -962,31 +969,152 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         "eodag.plugins.authentication.openid_connect.OIDCAuthorizationCodeFlowAuth.authenticate_user",
         autospec=True,
     )
-    def test_plugins_auth_codeflowauth_authenticate_ok(
+    def test_plugins_auth_codeflowauth_request_new_token_ok(
         self,
         mock_authenticate_user,
         mock_exchange_code_for_token,
         mock_compute_state,
     ):
-        """OIDCAuthorizationCodeFlowAuth.authenticate must return a CodeAuthorizedAuth object"""
+        """OIDCAuthorizationCodeFlowAuth.request_new_token must return the JSON response from the auth server"""
         auth_plugin = self.get_auth_plugin("provider_ok")
         state = "1234567890123456789012"
         exchange_url = auth_plugin.config.redirect_uri
-        token = "token123"
+        json_response = {
+            "access_token": "obtained-access-token",
+            "expires_in": "3600",
+            "refresh_expires_in": "0",
+            "refresh_token": "obtained-refresh-token",
+        }
         mock_authenticate_user.return_value = mock.Mock(url=exchange_url)
         mock_compute_state.return_value = state
-        mock_exchange_code_for_token.return_value = token
+        mock_exchange_code_for_token.return_value.json.return_value = json_response
 
-        auth = auth_plugin.authenticate()
+        resp = auth_plugin.request_new_token()
 
         mock_authenticate_user.assert_called_once_with(auth_plugin, state)
         mock_exchange_code_for_token.assert_called_once_with(
             auth_plugin, exchange_url, state
         )
-        self.assertIsInstance(auth, CodeAuthorizedAuth)
-        self.assertEqual(auth.token, token)
-        self.assertEqual(auth.where, "header")
-        self.assertIsNone(auth.key)
+        # Check returned value is the server's JSON response
+        self.assertEqual(resp, json_response)
+
+    @mock.patch(
+        "eodag.plugins.authentication.openid_connect.OIDCAuthorizationCodeFlowAuth.get_token_with_refresh_token",
+        autospec=True,
+    )
+    @mock.patch(
+        "eodag.plugins.authentication.openid_connect.OIDCAuthorizationCodeFlowAuth.request_new_token",
+        autospec=True,
+    )
+    def test_plugins_auth_codeflowauth_authenticate_ok(
+        self,
+        mock_request_new_token,
+        mock_get_token_with_refresh_token,
+    ):
+        """OIDCAuthorizationCodeFlowAuth.authenticate must check if the token is expired, call the correct
+        function to get a new one and update the access token"""
+        auth_plugin = self.get_auth_plugin("provider_ok")
+        current_time = datetime.now()
+        json_response = {
+            "access_token": "obtained-access-token",
+            "expires_in": "3600",
+            "refresh_expires_in": "7200",
+            "refresh_token": "obtained-refresh-token",
+        }
+        mock_request_new_token.return_value = json_response
+        mock_get_token_with_refresh_token.return_value = json_response
+
+        def _authenticate(
+            called_once: mock.Mock, not_called: mock.Mock, access_token: str
+        ) -> None:
+            auth = auth_plugin.authenticate()
+            called_once.assert_called_once()
+            not_called.assert_not_called()
+            self.assertEqual(auth.token, access_token)
+            called_once.reset_mock()
+            not_called.reset_mock()
+
+        # No info: first time -> new auth
+        _authenticate(
+            mock_request_new_token,
+            mock_get_token_with_refresh_token,
+            json_response["access_token"],
+        )
+        # Check internal `token_info`` stores the new data
+        self.assertEqual(
+            auth_plugin.token_info["refresh_token"],
+            json_response["refresh_token"],
+        )
+        self.assertIsNotNone(auth_plugin.token_info["refresh_time"])
+        self.assertEqual(
+            auth_plugin.token_info["access_token"],
+            json_response["access_token"],
+        )
+        self.assertIsNotNone(auth_plugin.token_info["token_time"])
+        self.assertEqual(
+            auth_plugin.token_info["access_token_expiration"],
+            json_response["expires_in"],
+        )
+        self.assertEqual(
+            auth_plugin.token_info["refresh_token_expiration"],
+            json_response["refresh_expires_in"],
+        )
+
+        # Refresh token available but expired -> new auth
+        auth_plugin.token_info = {
+            "refresh_token": "old-refresh-token",
+            "refresh_time": current_time - timedelta(hours=3),
+            "access_token": "old-access-token",
+            "token_time": current_time - timedelta(hours=3),
+            "access_token_expiration": 3600,
+            "refresh_token_expiration": 7200,
+        }
+        _authenticate(
+            mock_request_new_token,
+            mock_get_token_with_refresh_token,
+            json_response["access_token"],
+        )
+
+        # Refresh token *not* available and access token expired - new auth
+        auth_plugin.token_info = {
+            "access_token": "old-access-token",
+            "token_time": current_time - timedelta(hours=3),
+            "access_token_expiration": 3600,
+        }
+        _authenticate(
+            mock_request_new_token,
+            mock_get_token_with_refresh_token,
+            json_response["access_token"],
+        )
+
+        # Refresh token available and access token expired -> refresh
+        auth_plugin.token_info = {
+            "refresh_token": "old-refresh-token",
+            "refresh_time": current_time - timedelta(seconds=4000),
+            "access_token": "old-access-token",
+            "token_time": current_time - timedelta(seconds=4000),
+            "access_token_expiration": 3600,
+            "refresh_token_expiration": 7200,
+        }
+        _authenticate(
+            mock_get_token_with_refresh_token,
+            mock_request_new_token,
+            json_response["access_token"],
+        )
+
+        # Access token not expired -> use already retrieved token
+        auth_plugin.token_info = {
+            "refresh_token": "old-refresh-token",
+            "refresh_time": current_time - timedelta(seconds=1800),
+            "access_token": "old-access-token",
+            "token_time": current_time - timedelta(seconds=1800),
+            "access_token_expiration": 3600,
+            "refresh_token_expiration": 7200,
+        }
+        auth = auth_plugin.authenticate()
+        mock_request_new_token.assert_not_called()
+        mock_get_token_with_refresh_token.assert_not_called()
+        self.assertEqual(auth.token, auth_plugin.token_info["access_token"])
 
     @mock.patch(
         "eodag.plugins.authentication.openid_connect.OIDCAuthorizationCodeFlowAuth.grant_user_consent",
@@ -1004,26 +1132,32 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         "eodag.plugins.authentication.openid_connect.OIDCAuthorizationCodeFlowAuth.authenticate_user",
         autospec=True,
     )
-    def test_plugins_auth_codeflowauth_authenticate_user_consent_needed_ok(
+    def test_plugins_auth_codeflowauth_request_new_token_user_consent_needed_ok(
         self,
         mock_authenticate_user,
         mock_exchange_code_for_token,
         mock_compute_state,
         mock_grant_user_consent,
     ):
-        """OIDCAuthorizationCodeFlowAuth.authenticate must call `grant_user_consent` if `user_consent_needed==True`"""
+        """OIDCAuthorizationCodeFlowAuth.request_new_token must call `grant_user_consent`
+        if `user_consent_needed==True`"""
         auth_plugin = self.get_auth_plugin("provider_user_consent")
         state = "1234567890123456789012"
         exchange_url = auth_plugin.config.redirect_uri
-        token = "token123"
+        json_response = {
+            "access_token": "obtained-access-token",
+            "expires_in": "3600",
+            "refresh_expires_in": "0",
+            "refresh_token": "obtained-refresh-token",
+        }
         mock_authenticate_user.return_value = mock.Mock(
             url=auth_plugin.config.redirect_uri + "/user_consent"
         )
         mock_compute_state.return_value = state
-        mock_exchange_code_for_token.return_value = token
+        mock_exchange_code_for_token.return_value = MockResponse(json_response, 200)
         mock_grant_user_consent.return_value = mock.Mock(url=exchange_url)
 
-        auth = auth_plugin.authenticate()
+        resp = auth_plugin.request_new_token()
 
         mock_authenticate_user.assert_called_once_with(auth_plugin, state)
         mock_grant_user_consent.assert_called_once_with(
@@ -1033,10 +1167,73 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         mock_exchange_code_for_token.assert_called_once_with(
             auth_plugin, exchange_url, state
         )
-        self.assertIsInstance(auth, CodeAuthorizedAuth)
-        self.assertEqual(auth.token, token)
-        self.assertEqual(auth.where, "header")
-        self.assertIsNone(auth.key)
+        self.assertEqual(resp, json_response)
+
+    @mock.patch(
+        "eodag.plugins.authentication.openid_connect.OIDCAuthorizationCodeFlowAuth.request_new_token",
+        autospec=True,
+    )
+    @mock.patch(
+        "eodag.plugins.authentication.openid_connect.requests.Session.post",
+        autospec=True,
+    )
+    def test_plugins_auth_codeflowauth_get_token_with_refresh_token_ok(
+        self,
+        mock_requests_post,
+        mock_request_new_token,
+    ):
+        """OIDCAuthorizationCodeFlowAuth.get_token_with_refresh_token must call the token URI with a token refresh
+        request and return the JSON response"""
+        auth_plugin = self.get_auth_plugin("provider_ok")
+        auth_plugin.token_info = {"refresh_token": "old-refresh-token"}
+        token_data = auth_plugin._prepare_token_post_data(
+            {
+                "refresh_token": auth_plugin.token_info["refresh_token"],
+                "grant_type": "refresh_token",
+            }
+        )
+        json_response = {
+            "access_token": "obtained-access-token",
+            "expires_in": "3600",
+            "refresh_expires_in": "0",
+            "refresh_token": "obtained-refresh-token",
+        }
+        mock_requests_post.return_value = MockResponse(json_response, 200)
+
+        resp = auth_plugin.get_token_with_refresh_token()
+        post_request_kwargs = {
+            auth_plugin.config.token_exchange_post_data_method: token_data
+        }
+        mock_requests_post.assert_called_once_with(
+            mock.ANY,
+            auth_plugin.config.token_uri,
+            timeout=HTTP_REQ_TIMEOUT,
+            **post_request_kwargs,
+        )
+        mock_request_new_token.assert_not_called()
+        self.assertEqual(resp, json_response)
+
+    @mock.patch(
+        "eodag.plugins.authentication.openid_connect.OIDCAuthorizationCodeFlowAuth.request_new_token",
+        autospec=True,
+    )
+    @mock.patch(
+        "eodag.plugins.authentication.openid_connect.requests.Session.post",
+        autospec=True,
+    )
+    def test_plugins_auth_codeflowauth_get_token_with_refresh_token_http_exception(
+        self,
+        mock_requests_post,
+        mock_request_new_token,
+    ):
+        """OIDCAuthorizationCodeFlowAuth.get_token_with_refresh_token must call `request_new_token()` if the POST
+        request raise and exception other than time out"""
+        auth_plugin = self.get_auth_plugin("provider_ok")
+        auth_plugin.token_info = {"refresh_token": "old-refresh-token"}
+        mock_requests_post.return_value = MockResponse({"err": "message"}, 500)
+
+        auth_plugin.get_token_with_refresh_token()
+        mock_request_new_token.assert_called_once()
 
     @mock.patch(
         "eodag.plugins.authentication.openid_connect.OIDCAuthorizationCodeFlowAuth.compute_state",
@@ -1061,10 +1258,15 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         auth_plugin = self.get_auth_plugin("provider_token_qs_key")
         state = "1234567890123456789012"
         exchange_url = auth_plugin.config.redirect_uri
-        token = "token123"
+        json_response = {
+            "access_token": "obtained-access-token",
+            "expires_in": "3600",
+            "refresh_expires_in": "0",
+            "refresh_token": "obtained-refresh-token",
+        }
         mock_authenticate_user.return_value = mock.Mock(url=exchange_url)
         mock_compute_state.return_value = state
-        mock_exchange_code_for_token.return_value = token
+        mock_exchange_code_for_token.return_value = MockResponse(json_response, 200)
 
         auth = auth_plugin.authenticate()
 
@@ -1073,7 +1275,7 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
             auth_plugin, exchange_url, state
         )
         self.assertIsInstance(auth, CodeAuthorizedAuth)
-        self.assertEqual(auth.token, token)
+        self.assertEqual(auth.token, json_response["access_token"])
         self.assertEqual(auth.where, "qs")
         self.assertEqual(auth.key, auth_plugin.config.token_qs_key)
 
@@ -1107,31 +1309,6 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
         )
-
-    @mock.patch(
-        "eodag.plugins.authentication.openid_connect.requests.Session.get",
-        autospec=True,
-    )
-    def test_plugins_auth_codeflowauth_authenticate_user_no_login_forms(
-        self,
-        mock_requests_post,
-    ):
-        """OIDCAuthorizationCodeFlowAuth.authenticate_user must assume user is already logged in if there is
-        no form in the reply"""
-        auth_plugin = self.get_auth_plugin("provider_ok")
-        auth_plugin.config.credentials = {"foo": "bar"}
-
-        # mock token post request response
-        mock_requests_post.return_value = mock.Mock()
-        mock_requests_post.return_value.text = """
-            <html>
-                <head><title>No forms</title></head>
-                <body><p>Hello</p></body>
-            </html>
-        """
-        state = "1234567890123456789012"
-        auth = auth_plugin.authenticate_user(state)
-        self.assertEqual(auth, mock_requests_post.return_value)
 
     @mock.patch(
         "eodag.plugins.authentication.openid_connect.requests.Session.get",
@@ -1327,10 +1504,13 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         and the state"""
         auth_plugin = self.get_auth_plugin("provider_ok")
         mock_requests_post.return_value = mock.Mock()
-        access_token = "token_12345"
-        mock_requests_post.return_value.json.return_value = {
-            "access_token": access_token
+        json_response = {
+            "access_token": "obtained-access-token",
+            "expires_in": "3600",
+            "refresh_expires_in": "0",
+            "refresh_token": "obtained-refresh-token",
         }
+        mock_requests_post.return_value = MockResponse(json_response, 200)
         state = "1234567890123456789012"
         auth_code = "code_abcde"
         authorized_url = (
@@ -1338,10 +1518,8 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         )
         auth_plugin.config.credentials = {"foo": "bar"}
 
-        returned_access_token = auth_plugin.exchange_code_for_token(
-            authorized_url, state
-        )
-        self.assertEqual(returned_access_token, access_token)
+        response = auth_plugin.exchange_code_for_token(authorized_url, state)
+        self.assertEqual(response.json()["access_token"], json_response["access_token"])
         mock_requests_post.assert_called_once_with(
             mock.ANY,
             auth_plugin.config.token_uri,
@@ -1367,10 +1545,13 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         `client_secret` is known"""
         auth_plugin = self.get_auth_plugin("provider_client_sercret")
         mock_requests_post.return_value = mock.Mock()
-        access_token = "token_12345"
-        mock_requests_post.return_value.json.return_value = {
-            "access_token": access_token
+        json_response = {
+            "access_token": "obtained-access-token",
+            "expires_in": "3600",
+            "refresh_expires_in": "0",
+            "refresh_token": "obtained-refresh-token",
         }
+        mock_requests_post.return_value = MockResponse(json_response, 200)
         state = "1234567890123456789012"
         auth_code = "code_abcde"
         authorized_url = (
@@ -1378,10 +1559,8 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         )
         auth_plugin.config.credentials = {"foo": "bar"}
 
-        returned_access_token = auth_plugin.exchange_code_for_token(
-            authorized_url, state
-        )
-        self.assertEqual(returned_access_token, access_token)
+        response = auth_plugin.exchange_code_for_token(authorized_url, state)
+        self.assertEqual(response.json()["access_token"], json_response["access_token"])
         mock_requests_post.assert_called_once_with(
             mock.ANY,
             auth_plugin.config.token_uri,
@@ -1412,10 +1591,13 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         auth_plugin = self.get_auth_plugin("provider_token_exchange_params")
 
         mock_requests_post.return_value = mock.Mock()
-        access_token = "token_12345"
-        mock_requests_post.return_value.json.return_value = {
-            "access_token": access_token
+        json_response = {
+            "access_token": "obtained-access-token",
+            "expires_in": "3600",
+            "refresh_expires_in": "0",
+            "refresh_token": "obtained-refresh-token",
         }
+        mock_requests_post.return_value = MockResponse(json_response, 200)
         state = "1234567890123456789012"
         auth_code = "code_abcde"
         authorized_url = (
@@ -1423,10 +1605,8 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         )
         auth_plugin.config.credentials = {"foo": "bar"}
 
-        returned_access_token = auth_plugin.exchange_code_for_token(
-            authorized_url, state
-        )
-        self.assertEqual(returned_access_token, access_token)
+        response = auth_plugin.exchange_code_for_token(authorized_url, state)
+        self.assertEqual(response.json()["access_token"], json_response["access_token"])
         mock_requests_post.assert_called_once_with(
             mock.ANY,
             auth_plugin.config.token_uri,


### PR DESCRIPTION
- Add support for the refresh token
- Use the expiration time of the access token and refresh token to determine if requesting a new token or using the already retrieved one