### PR TITLE
build: uvicorn extras fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,7 @@ server =
     fastapi >= 0.93.0
     pygeofilter
     starlette
-    uvicorn
+    uvicorn[standard]
 
 notebook = tqdm[notebook]
 tutorials =


### PR DESCRIPTION
Fixes https://github.com/conda-forge/eodag-feedstock/issues/25

Install `uvicorn[standard]` in server mode. Fixes missing `watchfiles` dependency