### PR TITLE
build: specify shapely min version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     PyYAML
     requests
     setuptools
-    shapely
+    shapely >= 2.0.0
     stream-zip
     tqdm
     typing_extensions >= 4.8.0


### PR DESCRIPTION
Fixes #1154 

Use `shapely >= 2.0.0` , as needed to be able to import `shapely.errors.GEOSException`