### PR TITLE
fix[server]: only lte for eo:cloud_cover in query extension

### DIFF
--- a/eodag/rest/types/eodag_search.py
+++ b/eodag/rest/types/eodag_search.py
@@ -219,8 +219,13 @@ class EODAGSearch(BaseModel):
             operator, value = next(iter(cast(Dict[str, Any], conditions).items()))
 
             # Validate the operator
-            if operator not in ("eq", "lte", "in") or (
-                operator == "lte" and prop != "eo:cloud_cover"
+            # only eq, in and lte are allowed
+            # lte is only supported with eo:cloud_cover
+            # eo:cloud_cover only accept lte operator
+            if (
+                operator not in ("eq", "lte", "in")
+                or (operator == "lte" and prop != "eo:cloud_cover")
+                or (prop == "eo:cloud_cover" and operator != "lte")
             ):
                 add_error(
                     f'operator "{operator}" is not supported for property "{prop}"',


### PR DESCRIPTION
In server mode with the query extension, allow `eo:cloud_cover` filtering only with the `lte` operator.