### PR TITLE
refactor: constraints fetch using fetch_json method

### DIFF
--- a/tests/context.py
+++ b/tests/context.py
@@ -91,6 +91,7 @@ from eodag.utils import (
     parse_header,
     get_ssl_context,
 )
+from eodag.utils.requests import fetch_json
 from eodag.utils.exceptions import (
     AddressNotFound,
     AuthenticationError,

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -1426,7 +1426,7 @@ class RequestTestCase(unittest.TestCase):
         self.assertListEqual(["string", "null"], processing_level["type"])
         self.assertIsNone(processing_level["min"])
 
-    @mock.patch("eodag.utils.constraints.requests.Session.get", autospec=True)
+    @mock.patch("eodag.utils.requests.requests.Session.get", autospec=True)
     def test_product_type_queryables_from_constraints(
         self, mock_requests_session_constraints: Mock
     ):
@@ -1446,6 +1446,7 @@ class RequestTestCase(unittest.TestCase):
             "http://datastore.copernicus-climate.eu/c3s/published-forms/c3sprod/"
             "reanalysis-era5-single-levels/constraints.json",
             headers=USER_AGENT,
+            auth=None,
             timeout=5,
         )
         self.assertEqual(10, len(res["properties"]))

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -1935,7 +1935,7 @@ class TestSearchPluginBuildSearchResult(unittest.TestCase):
             except Exception:
                 assert eoproduct.properties[param] == self.custom_query_params[param]
 
-    @mock.patch("eodag.utils.constraints.requests.Session.get", autospec=True)
+    @mock.patch("eodag.utils.requests.requests.Session.get", autospec=True)
     def test_plugins_search_buildsearchresult_discover_queryables(
         self, mock_requests_session_constraints
     ):


### PR DESCRIPTION
Refactors #1105 to make use of separated generic function `eodag.requests.fetch_json`