### PR TITLE
feat: remove mandatory and fixed parameters from queryables

### DIFF
--- a/eodag/config.py
+++ b/eodag/config.py
@@ -334,7 +334,7 @@ class PluginConfig(yaml.YAMLObject):
     timeout: float  # StaticStacSearch
     s3_bucket: str  # CreodiasS3Search
     end_date_excluded: bool  # BuildSearchResult
-    remove_from_query: List[str]  # BuildSearchResult
+    remove_from_query: Dict[str, List[Any]]  # BuildSearchResult
     ssl_verify: bool
 
     # download -------------------------------------------------------------------------

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -321,7 +321,7 @@ class PluginConfig(yaml.YAMLObject):
     metadata_mapping: Dict[str, Union[str, List[str]]]
     free_params: Dict[Any, Any]
     constraints_file_url: str
-    remove_from_queryables: List[str]
+    remove_from_queryables: Dict[str, List[Any]]
     free_text_search_operations: Dict[str, Any]  # ODataV4Search
     metadata_pre_mapping: Dict[str, Any]  # ODataV4Search
     data_request_url: str  # DataRequestSearch
@@ -334,7 +334,7 @@ class PluginConfig(yaml.YAMLObject):
     timeout: float  # StaticStacSearch
     s3_bucket: str  # CreodiasS3Search
     end_date_excluded: bool  # BuildSearchResult
-    remove_from_query: Dict[str, List[Any]]  # BuildSearchResult
+    remove_from_query: List[Any]  # BuildSearchResult
     ssl_verify: bool
 
     # download -------------------------------------------------------------------------

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -645,7 +645,20 @@ class QueryStringSearch(Search):
             field_definitions[param] = get_args(annotated_def)
 
         python_queryables = create_model("m", **field_definitions).model_fields
-        return dict(default_queryables, **model_fields_to_annotated(python_queryables))
+        queryables = {
+            **default_queryables,
+            **model_fields_to_annotated(python_queryables),
+        }
+        # remove fixed params from queryables
+        for param in getattr(self.config, "remove_from_queryables", {}).get(
+            "shared_queryables", []
+        ):
+            queryables.pop(param)
+        for param in getattr(self.config, "remove_from_queryables", {}).get(
+            product_type, []
+        ):
+            queryables.pop(param)
+        return queryables
 
     def query(
         self,

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -1699,8 +1699,18 @@ class StacSearch(PostJsonSearch):
                     )
                     or json_param
                 )
-
-                default = kwargs.get(param, None)
+                # prevent fixed params from being in queryables python model
+                if param in getattr(self.config, "remove_from_queryables", {}).get(
+                    "shared_queryables", []
+                ):
+                    continue
+                if param in getattr(self.config, "remove_from_queryables", {}).get(
+                    product_type, []
+                ):
+                    continue
+                default = kwargs.get(param, None) or self.config.products.get(
+                    product_type, {}
+                ).get(param, None)
                 annotated_def = json_field_definition_to_python(
                     json_mtd, default_value=default
                 )

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -2283,6 +2283,9 @@
       fetch_url: null
       product_type_fetch_url: null
     constraints_file_url: "https://datastore.copernicus-climate.eu/cams/published-forms/camsprod/{dataset}/constraints.json"
+    remove_from_queryables:
+      shared_queryables:
+        - dataset
     metadata_mapping:
       productType: '$.productType'
       title: '$.id'
@@ -2857,6 +2860,9 @@
       fetch_url: null
       product_type_fetch_url: null
     constraints_file_url: http://datastore.copernicus-climate.eu/c3s/published-forms/c3sprod/{dataset}/constraints.json
+    remove_from_queryables:
+      shared_queryables:
+        - dataset
     metadata_mapping:
       productType: $.productType
       title: $.id
@@ -6527,6 +6533,20 @@
       fetch_url: null
       product_type_fetch_url: null
     constraints_file_url: eodag/resources/constraints/{dataset}.json
+    remove_from_queryables:
+      shared_queryables:
+        - dataset
+        - class
+        - expver
+        - type
+      DT_EXTREMES:
+        - time
+      DT_CLIMATE_ADAPTATION:
+        - generation
+        - realization
+        - stream
+        - activity
+        - experiment
     metadata_mapping:
       productType: destination-earth
       storageStatus: OFFLINE

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -612,6 +612,7 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
             timeout=5,
         )
 
+        self.assertEqual(10, len(queryables))
         # queryables from provider constraints file are added (here the ones of ERA5_SL_MONTHLY for wekeo)
         for provider_queryable in provider_queryables_from_constraints_file:
             provider_queryable = (
@@ -2053,6 +2054,7 @@ class TestSearchPluginBuildSearchResult(unittest.TestCase):
             timeout=5,
         )
 
+        self.assertEqual(11, len(queryables))
         # queryables from provider constraints file are added (here the ones of CAMS_EU_AIR_QUALITY_RE for cop_ads)
         for provider_queryable in provider_queryables_from_constraints_file:
             provider_queryable = (
@@ -2092,6 +2094,16 @@ class TestSearchPluginBuildSearchResult(unittest.TestCase):
             self.assertSetEqual(
                 set(variable_constraints), set(queryable.__origin__.__args__)
             )
+
+        # check that fixed params have been removed from queryables if necessary
+        for param in getattr(
+            self.search_plugin.config, "remove_from_queryables", {}
+        ).get("shared_queryables", []):
+            self.assertNotIn(param, queryables)
+        for param in getattr(
+            self.search_plugin.config, "remove_from_queryables", {}
+        ).get("CAMS_EU_AIR_QUALITY_RE", []):
+            self.assertNotIn(param, queryables)
 
         # reset mock
         mock_requests_session_constraints.reset_mock()
@@ -2119,6 +2131,16 @@ class TestSearchPluginBuildSearchResult(unittest.TestCase):
             self.assertEqual("a", queryable.__metadata__[0].get_default())
             self.assertFalse(queryable.__metadata__[0].is_required())
 
+        # check that fixed params have been removed from queryables if necessary
+        for param in getattr(
+            self.search_plugin.config, "remove_from_queryables", {}
+        ).get("shared_queryables", []):
+            self.assertNotIn(param, queryables)
+        for param in getattr(
+            self.search_plugin.config, "remove_from_queryables", {}
+        ).get("CAMS_EU_AIR_QUALITY_RE", []):
+            self.assertNotIn(param, queryables)
+
     def test_plugins_search_buildsearchresult_discover_queryables_with_local_constraints_file(
         self,
     ):
@@ -2144,6 +2166,7 @@ class TestSearchPluginBuildSearchResult(unittest.TestCase):
         )
         self.assertIsNotNone(queryables)
 
+        self.assertEqual(9, len(queryables))
         # queryables from provider constraints file are added (here the ones of CAMS_EU_AIR_QUALITY_RE for cop_ads)
         for provider_queryable in provider_queryables_from_constraints_file:
             provider_queryable = (
@@ -2197,6 +2220,16 @@ class TestSearchPluginBuildSearchResult(unittest.TestCase):
         if queryable is not None:
             self.assertEqual("a", queryable.__metadata__[0].get_default())
             self.assertFalse(queryable.__metadata__[0].is_required())
+
+        # check that fixed params have been removed from queryables if necessary
+        for param in getattr(
+            self.search_plugin.config, "remove_from_queryables", {}
+        ).get("shared_queryables", []):
+            self.assertNotIn(param, queryables)
+        for param in getattr(
+            self.search_plugin.config, "remove_from_queryables", {}
+        ).get("CAMS_EU_AIR_QUALITY_RE", []):
+            self.assertNotIn(param, queryables)
 
         # restore configuration
         self.search_plugin.config.constraints_file_url = tmp_search_constraints_file_url

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2054,7 +2054,7 @@ class TestSearchPluginBuildSearchResult(unittest.TestCase):
             timeout=5,
         )
 
-        self.assertEqual(11, len(queryables))
+        self.assertEqual(9, len(queryables))
         # queryables from provider constraints file are added (here the ones of CAMS_EU_AIR_QUALITY_RE for cop_ads)
         for provider_queryable in provider_queryables_from_constraints_file:
             provider_queryable = (


### PR DESCRIPTION
Among default parameters of a product type in a provider configuration, some may be mandatory and fixed. Then they are not queryable anymore and we remove them from the returned queryables in `discover_queryables()` method at search plugin level.

It works by using the keyword `remove_from_queryables` in providers search configuration.
We list unwanted queryables for all product types of the provider in a list called `shared_queryables` and product type-specific unwanted queryables are in the list called by the name of the product type.