### PR TITLE
fix: improve stac collection links generation

### DIFF
--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -668,7 +668,7 @@ class StacCollection(StacCommon):
         return [
             plugin.provider
             for plugin in self.eodag_api._plugins_manager.get_search_plugins(
-                product_type=(product_type.get("_id", None) or product_type["ID"])
+                product_type=product_type.get("_id", product_type["ID"])
             )
         ]
 
@@ -697,11 +697,15 @@ class StacCollection(StacCommon):
         # override EODAG's collection with the external collection
         ext_stac_collection = self.ext_stac_collections.get(product_type["ID"], {})
 
-        if "links" in ext_stac_collection:
-            for link in product_type_collection["links"]:
-                if link not in ext_stac_collection["links"]:
-                    ext_stac_collection["links"].append(link)
+        # update links
+        ext_stac_collection.setdefault("links", {})
+        for link in product_type_collection["links"]:
+            ext_stac_collection["links"] = [
+                x for x in ext_stac_collection["links"] if x["rel"] != link["rel"]
+            ]
+            ext_stac_collection["links"].append(link)
 
+        # merge "keywords" lists
         if "keywords" in ext_stac_collection:
             ext_stac_collection["keywords"] = list(
                 set(

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -35,7 +35,6 @@ from shapely.ops import unary_union
 
 from eodag.api.product.metadata_mapping import (
     DEFAULT_METADATA_MAPPING,
-    NOT_AVAILABLE,
     format_metadata,
     get_metadata_path,
 )

--- a/tests/units/test_stac_utils.py
+++ b/tests/units/test_stac_utils.py
@@ -278,7 +278,7 @@ class TestStacUtils(unittest.TestCase):
             # New field
             self.assertIn("new_field", stac_coll)
             # Merge keywords
-            self.assertListEqual(
+            self.assertCountEqual(
                 ["MSI", "SENTINEL2", "S2A,S2B", "L1", "OPTICAL", "New Keyword"],
                 stac_coll["keywords"],
             )


### PR DESCRIPTION
### Description

This PR provides an additional fix for the generation of a stac collection.

The links created by the stac config were erased when updating the dictionary contents, resulting in a 500 InternalServerError when trying to retrieve the list of collections if one of the collection was generated using an external stac collection.
