### PR TITLE
fix(server): merge providers from external STAC collection

### DIFF
--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -697,7 +697,7 @@ class StacCollection(StacCommon):
         # override EODAG's collection with the external collection
         ext_stac_collection = self.ext_stac_collections.get(product_type["ID"], {})
 
-        # update links
+        # update links (keep eodag links as defaults)
         ext_stac_collection.setdefault("links", {})
         for link in product_type_collection["links"]:
             ext_stac_collection["links"] = [
@@ -707,12 +707,21 @@ class StacCollection(StacCommon):
 
         # merge "keywords" lists
         if "keywords" in ext_stac_collection:
-            ext_stac_collection["keywords"] = list(
-                set(
-                    ext_stac_collection["keywords"]
-                    + product_type_collection["keywords"]
+            try:
+                ext_stac_collection["keywords"] = list(
+                    set(
+                        ext_stac_collection["keywords"]
+                        + product_type_collection["keywords"]
+                    )
                 )
-            )
+            except TypeError as e:
+                logger.warning(
+                    f"Could not merge keywords from external collection for {product_type}: {str(e)}"
+                )
+
+        # merge providers
+        if "providers" in ext_stac_collection:
+            ext_stac_collection["providers"] += product_type_collection["providers"]
 
         product_type_collection.update(ext_stac_collection)
 

--- a/tests/units/test_stac_utils.py
+++ b/tests/units/test_stac_utils.py
@@ -260,6 +260,7 @@ class TestStacUtils(unittest.TestCase):
             "new_field":"New Value",
             "title":"A different title for Sentinel 2 MSI Level 1C",
             "keywords":["New Keyword"],
+            "providers":[{"name":"foo_provider","roles":["producer"]}],
             "links":[
                 {"rel":"self","href":"http://another.self"},
                 {"rel":"license","href":"http://foo.bar"}
@@ -291,6 +292,12 @@ class TestStacUtils(unittest.TestCase):
             self.assertNotEqual(links_self[0]["href"], "http://another.self")
             links_license = [x for x in stac_coll["links"] if x["rel"] == "license"]
             self.assertEqual(links_license[0]["href"], "http://foo.bar")
+
+            # Merged providers
+            self.assertIn(
+                {"name": "foo_provider", "roles": ["producer"]}, stac_coll["providers"]
+            )
+            self.assertGreater(len(stac_coll["providers"]), 1)
 
             # Merged keywords
             self.assertListEqual(


### PR DESCRIPTION
In server mode, merge `providers` entry from external STAC collection.

Also ignores keywords formatting issues with a warning