### PR TITLE
fix(server): replace 400 with 404 when collection or item not found

### DIFF
--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -458,7 +458,7 @@ def stac_collections_item(collection_id: str, item_id: str, request: Request) ->
 
     if not item_collection["features"]:
         raise HTTPException(
-            status_code=400,
+            status_code=404,
             detail=f"Item {item_id} in Collection {collection_id} does not exist.",
         )
 
@@ -665,7 +665,7 @@ def stac_catalogs_item(catalogs: str, item_id: str, request: Request):
 
     if not item_collection["features"]:
         raise HTTPException(
-            status_code=400,
+            status_code=404,
             detail=f"Item {item_id} in Catalog {catalogs} does not exist.",
         )
 


### PR DESCRIPTION
### Description
This PR proposes a fix for improving the responses sent to the user.

Currently, we respond 400 BadRequest for:
- Item searches of a collection that does not exist
- Item that does not exist in an existing collection

The response should explain to the user that their request was correct, but that such items do not exist, hence the `404 Not Found` 

Thanks!
