### PR TITLE
fix: handle creodias and cop_dataspace empty geometries

### DIFF
--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -37,7 +37,11 @@ except ImportError:
     from eodag.api.product._assets import AssetsDict  # type: ignore # noqa
 
 from eodag.api.product.drivers import DRIVERS, NoDriver
-from eodag.api.product.metadata_mapping import NOT_AVAILABLE, NOT_MAPPED
+from eodag.api.product.metadata_mapping import (
+    DEFAULT_GEOMETRY,
+    NOT_AVAILABLE,
+    NOT_MAPPED,
+)
 from eodag.utils import (
     DEFAULT_DOWNLOAD_TIMEOUT,
     DEFAULT_DOWNLOAD_WAIT,
@@ -142,7 +146,7 @@ class EOProduct:
                 f"No geometry available to build EOProduct(id={properties.get('id', None)}, provider={provider})"
             )
         elif not properties["geometry"] or properties["geometry"] == NOT_AVAILABLE:
-            product_geometry = properties.pop("defaultGeometry")
+            product_geometry = properties.pop("defaultGeometry", DEFAULT_GEOMETRY)
         else:
             product_geometry = properties["geometry"]
         # Let's try 'latmin lonmin latmax lonmax'

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -82,6 +82,7 @@ OFFLINE_STATUS = "OFFLINE"
 COORDS_ROUNDING_PRECISION = 4
 WKT_MAX_LEN = 1600
 COMPLEX_QS_REGEX = re.compile(r"^(.+=)?([^=]*)({.+})+([^=&]*)$")
+DEFAULT_GEOMETRY = "POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))"
 
 
 def get_metadata_path(
@@ -387,7 +388,9 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
         def convert_from_ewkt(ewkt_string: str) -> Union[BaseGeometry, str]:
             """Convert EWKT (Extended Well-Known text) to shapely geometry"""
 
-            ewkt_regex = re.compile(r"^(?P<proj>[A-Za-z]+=[0-9]+);(?P<wkt>.*)$")
+            ewkt_regex = re.compile(
+                r"^.*(?P<proj>SRID=[0-9]+);(?P<wkt>[A-Z0-9 \(\),\.-]+).*$"
+            )
             ewkt_match = ewkt_regex.match(ewkt_string)
             if ewkt_match:
                 g = ewkt_match.groupdict()

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1020,7 +1020,7 @@
       # The geographic extent of the product
       geometry:
         - null
-        - '{$.Footprint.`sub(/.*(SRID=[0-9]+;[A-Z0-9 \(\),\.-]+).*/, \\1)`#from_ewkt}'
+        - '{$.Footprint#from_ewkt}'
       # The url to download the product "as is" (literal or as a template to be completed either after the search result
       # is obtained from the provider or during the eodag download phase)
       downloadLink: 'https://zipper.creodias.eu/odata/v1/Products({uid})/$value'
@@ -3967,7 +3967,7 @@
       # The geographic extent of the product
       geometry:
         - null
-        - '{$.Footprint.`sub(/.*(SRID=[0-9]+;[A-Z0-9 \(\),\.-]+).*/, \\1)`#from_ewkt}'
+        - '{$.Footprint#from_ewkt}'
       # The url to download the product "as is" (literal or as a template to be completed either after the search result
       # is obtained from the provider or during the eodag download phase)
       downloadLink: 'https://catalogue.dataspace.copernicus.eu/odata/v1/Products({uid})/$value'
@@ -6205,7 +6205,7 @@
       # The geographic extent of the product
       geometry:
         - null
-        - '{$.Footprint.`sub(/.*(SRID=[0-9]+;[A-Z0-9 \(\),\.-]+).*/, \\1)`#from_ewkt}'
+        - '{$.Footprint#from_ewkt}'
       # The url to download the product "as is" (literal or as a template to be completed either after the search result
       # is obtained from the provider or during the eodag download phase)
       downloadLink: 'https://zipper.creodias.eu/odata/v1/Products({uid})/$value'

--- a/tests/units/test_metadata_mapping.py
+++ b/tests/units/test_metadata_mapping.py
@@ -135,6 +135,12 @@ class TestMetadataFormatter(unittest.TestCase):
         geom = wkt.loads(wkt_str)
         self.assertEqual(round(geom.x, 1), 2.9)
         self.assertEqual(round(geom.y, 1), 43.5)
+        self.assertEqual(
+            wkt_str,
+            format_metadata(
+                to_format, fieldname="geography'SRID=3857;POINT (321976 5390999)'"
+            ),
+        )
 
     def test_convert_to_ewkt(self):
         to_format = "{fieldname#to_ewkt}"


### PR DESCRIPTION
- Handles empty geometries on `creodias` and `cop_dataspace`
- Use `POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))` as default `EOProduct` geometry