### PR TITLE
fix: eumetsat_ds METOP search by id

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -6979,7 +6979,7 @@
       # Custom parameters (not defined in the base document referenced above)
       id:
         - id
-        - '{$.properties.identifier#remove_extension}'
+        - $.properties.identifier
       utmZone:
         - zone
         - '$.null'
@@ -7112,10 +7112,6 @@
       parentIdentifier: EO:EUM:DAT:METOP:AMSUL1
     METOP_OSI_104:
       parentIdentifier: EO:EUM:DAT:METOP:OSI-104
-      metadata_mapping:
-        id:
-          - id
-          - $.properties.identifier
     METOP_OSI_150A:
       parentIdentifier: EO:EUM:DAT:METOP:OSI-150-A
     METOP_OSI_150B:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -7124,6 +7124,8 @@
       parentIdentifier: EO:EUM:CM:METOP:ASCSZOR02
     METOP_ASCSZRR02:
       parentIdentifier: EO:EUM:CM:METOP:ASCSZRR02
+    METOP_AVHRRL1:
+      parentIdentifier: EO:EUM:DAT:METOP:AVHRRL1
     METOP_SOMO12:
       parentIdentifier: EO:EUM:DAT:METOP:SOMO12
     METOP_SOMO25:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -7108,6 +7108,10 @@
       parentIdentifier: EO:EUM:DAT:METOP:AMSUL1
     METOP_OSI_104:
       parentIdentifier: EO:EUM:DAT:METOP:OSI-104
+      metadata_mapping:
+        id:
+          - id
+          - $.properties.identifier
     METOP_OSI_150A:
       parentIdentifier: EO:EUM:DAT:METOP:OSI-150-A
     METOP_OSI_150B:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -6890,6 +6890,7 @@
     type: QueryStringSearch
     api_endpoint: 'https://api.eumetsat.int/data/search-products/1.0.0/os'
     need_auth: false
+    ssl_verify: true
     dont_quote:
       - '='
       - '&'
@@ -7164,6 +7165,7 @@
     extract: true
     flatten_top_dirs: True
     ignore_assets: True
+    ssl_verify: true
   auth: !plugin
     type: TokenAuth
     auth_uri: 'https://api.eumetsat.int/token'
@@ -7172,3 +7174,4 @@
       grant_type: client_credentials
     token_type: json
     token_key: access_token
+    ssl_verify: true

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -6890,6 +6890,9 @@
     type: QueryStringSearch
     api_endpoint: 'https://api.eumetsat.int/data/search-products/1.0.0/os'
     need_auth: false
+    dont_quote:
+      - '='
+      - '&'
     pagination:
       next_page_url_tpl: '{url}?{search}&c={items_per_page}&pw={page}'
       start_page: 0

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -189,6 +189,7 @@ class TestCore(TestCoreBase):
         "METOP_ASCSZOR02": ["eumetsat_ds"],
         "METOP_ASCSZR1B": ["eumetsat_ds"],
         "METOP_ASCSZRR02": ["eumetsat_ds"],
+        "METOP_AVHRRL1": ["eumetsat_ds"],
         "METOP_AVHRRGACR02": ["eumetsat_ds"],
         "METOP_GLB_SST_NC": ["eumetsat_ds"],
         "METOP_GOMEL1": ["eumetsat_ds"],


### PR DESCRIPTION
Some `METOP` products could not have been search by id:

- `METOP_AVHRRL1` was missing in `eumetsat_ds` provider configuration
- `METOP_OSI_104` has an extension in its `id` that must have been kept
- `METOP_AVHRRGACR02` and `METOP_IASTHR011` have `+` characters in their `id` that must have been encoded