### PR TITLE
refactor: PreparedSearch and RawSearchResult usage

### DIFF
--- a/eodag/api/search_result.py
+++ b/eodag/api/search_result.py
@@ -168,3 +168,18 @@ class SearchResult(UserList):
         See https://gist.github.com/sgillies/2217756
         """
         return self.as_geojson_object()
+
+
+class RawSearchResult(UserList):
+    """An object representing a collection of raw/unparsed search results obtained from a provider.
+
+    :param results: A list of raw/unparsed search results
+    :type results: List[Any]
+    """
+
+    data: List[Any]
+    query_params: Dict[str, Any]
+    product_type_def_params: Dict[str, Any]
+
+    def __init__(self, results: List[Any]) -> None:
+        super(RawSearchResult, self).__init__(results)

--- a/eodag/plugins/apis/ecmwf.py
+++ b/eodag/plugins/apis/ecmwf.py
@@ -27,14 +27,13 @@ from ecmwfapi import ECMWFDataServer, ECMWFService
 from ecmwfapi.api import APIException, Connection, get_apikey_values
 
 from eodag.plugins.apis.base import Api
+from eodag.plugins.search import PreparedSearch
 from eodag.plugins.search.base import Search
 from eodag.plugins.search.build_search_result import BuildPostSearchResult
 from eodag.utils import (
     DEFAULT_DOWNLOAD_TIMEOUT,
     DEFAULT_DOWNLOAD_WAIT,
-    DEFAULT_ITEMS_PER_PAGE,
     DEFAULT_MISSION_START_DATE,
-    DEFAULT_PAGE,
     get_geometry_from_various,
     path_to_uri,
     sanitize,
@@ -90,10 +89,7 @@ class EcmwfApi(Api, BuildPostSearchResult):
 
     def query(
         self,
-        product_type: Optional[str] = None,
-        items_per_page: int = DEFAULT_ITEMS_PER_PAGE,
-        page: int = DEFAULT_PAGE,
-        count: bool = True,
+        prep: PreparedSearch = PreparedSearch(),
         **kwargs: Any,
     ) -> Tuple[List[EOProduct], Optional[int]]:
         """Build ready-to-download SearchResult"""
@@ -126,9 +122,7 @@ class EcmwfApi(Api, BuildPostSearchResult):
         if "geometry" in kwargs:
             kwargs["geometry"] = get_geometry_from_various(geometry=kwargs["geometry"])
 
-        return BuildPostSearchResult.query(
-            self, items_per_page=items_per_page, page=page, count=count, **kwargs
-        )
+        return BuildPostSearchResult.query(self, prep, **kwargs)
 
     def authenticate(self) -> Dict[str, Optional[str]]:
         """Check credentials and returns information needed for auth

--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -36,6 +36,7 @@ from eodag.api.product.metadata_mapping import (
     properties_from_json,
 )
 from eodag.plugins.apis.base import Api
+from eodag.plugins.search import PreparedSearch
 from eodag.utils import (
     DEFAULT_DOWNLOAD_TIMEOUT,
     DEFAULT_DOWNLOAD_WAIT,
@@ -112,13 +113,16 @@ class UsgsApi(Api):
 
     def query(
         self,
-        product_type: Optional[str] = None,
-        items_per_page: int = DEFAULT_ITEMS_PER_PAGE,
-        page: int = DEFAULT_PAGE,
-        count: bool = True,
+        prep: PreparedSearch = PreparedSearch(),
         **kwargs: Any,
     ) -> Tuple[List[EOProduct], Optional[int]]:
         """Search for data on USGS catalogues"""
+        page = prep.page if prep.page is not None else DEFAULT_PAGE
+        items_per_page = (
+            prep.items_per_page
+            if prep.items_per_page is not None
+            else DEFAULT_ITEMS_PER_PAGE
+        )
         product_type = kwargs.get("productType")
         if product_type is None:
             raise NoMatchingProductType(

--- a/eodag/plugins/search/__init__.py
+++ b/eodag/plugins/search/__init__.py
@@ -16,3 +16,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """EODAG search package"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from eodag.utils import DEFAULT_ITEMS_PER_PAGE, DEFAULT_PAGE
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, List, Optional, Union
+
+    from requests.auth import AuthBase
+
+    from eodag.plugins.authentication.base import Authentication
+
+
+@dataclass
+class PreparedSearch:
+    """An object collecting needed information for search."""
+
+    product_type: Optional[str] = None
+    page: Optional[int] = DEFAULT_PAGE
+    items_per_page: Optional[int] = DEFAULT_ITEMS_PER_PAGE
+    auth: Optional[Union[AuthBase, Dict[str, str]]] = None
+    auth_plugin: Optional[Authentication] = None
+    count: bool = True
+    url: Optional[str] = None
+    info_message: Optional[str] = None
+    exception_message: Optional[str] = None
+
+    need_count: bool = field(init=False)
+    query_params: Dict[str, Any] = field(init=False)
+    query_string: str = field(init=False)
+    search_urls: List[str] = field(init=False)
+    product_type_def_params: Dict[str, Any] = field(init=False)
+    total_items_nb: int = field(init=False)
+    sort_by_qs: str = field(init=False)

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -29,12 +29,11 @@ from eodag.api.product.metadata_mapping import (
     mtd_cfg_as_conversion_and_querypath,
 )
 from eodag.plugins.base import PluginTopic
+from eodag.plugins.search import PreparedSearch
 from eodag.types import model_fields_to_annotated
 from eodag.types.queryables import Queryables
 from eodag.types.search_args import SortByList
 from eodag.utils import (
-    DEFAULT_ITEMS_PER_PAGE,
-    DEFAULT_PAGE,
     GENERIC_PRODUCT_TYPE,
     Annotated,
     copy_deepcopy,
@@ -93,17 +92,14 @@ class Search(PluginTopic):
 
     def query(
         self,
-        product_type: Optional[str] = None,
-        items_per_page: int = DEFAULT_ITEMS_PER_PAGE,
-        page: int = DEFAULT_PAGE,
-        count: bool = True,
+        prep: PreparedSearch = PreparedSearch(),
         **kwargs: Any,
     ) -> Tuple[List[EOProduct], Optional[int]]:
         """Implementation of how the products must be searched goes here.
 
         This method must return a tuple with (1) a list of EOProduct instances (see eodag.api.product module)
         which will be processed by a Download plugin (2) and the total number of products matching
-        the search criteria. If ``count`` is False, the second element returned must be ``None``.
+        the search criteria. If ``prep.count`` is False, the second element returned must be ``None``.
         """
         raise NotImplementedError("A Search plugin must implement a method named query")
 

--- a/eodag/plugins/search/creodias_s3.py
+++ b/eodag/plugins/search/creodias_s3.py
@@ -17,13 +17,14 @@
 # limitations under the License.
 import logging
 from types import MethodType
-from typing import Any, Dict, List
+from typing import Any, List
 
 import boto3
 import botocore
 from botocore.exceptions import BotoCoreError
 
 from eodag.api.product import AssetsDict, EOProduct  # type: ignore
+from eodag.api.search_result import RawSearchResult
 from eodag.config import PluginConfig
 from eodag.plugins.authentication.aws_auth import AwsAuth
 from eodag.plugins.search.qssearch import ODataV4Search
@@ -119,7 +120,7 @@ class CreodiasS3Search(ODataV4Search):
         super(CreodiasS3Search, self).__init__(provider, config)
 
     def normalize_results(
-        self, results: List[Dict[str, Any]], **kwargs: Any
+        self, results: RawSearchResult, **kwargs: Any
     ) -> List[EOProduct]:
         """Build EOProducts from provider results"""
 

--- a/eodag/plugins/search/csw.py
+++ b/eodag/plugins/search/csw.py
@@ -35,8 +35,9 @@ from shapely import geometry, wkt
 
 from eodag.api.product import EOProduct
 from eodag.api.product.metadata_mapping import properties_from_xml
+from eodag.plugins.search import PreparedSearch
 from eodag.plugins.search.base import Search
-from eodag.utils import DEFAULT_ITEMS_PER_PAGE, DEFAULT_PAGE, DEFAULT_PROJ
+from eodag.utils import DEFAULT_PROJ
 from eodag.utils.import_system import patch_owslib_requests
 
 if TYPE_CHECKING:
@@ -64,10 +65,7 @@ class CSWSearch(Search):
 
     def query(
         self,
-        product_type: Optional[str] = None,
-        items_per_page: int = DEFAULT_ITEMS_PER_PAGE,
-        page: int = DEFAULT_PAGE,
-        count: bool = True,
+        prep: PreparedSearch = PreparedSearch(),
         **kwargs: Any,
     ) -> Tuple[List[EOProduct], Optional[int]]:
         """Perform a search on a OGC/CSW-like interface"""
@@ -118,7 +116,7 @@ class CSWSearch(Search):
                 )
                 results.extend(partial_results)
         logger.info("Found %s overall results", len(results))
-        total_results = len(results) if count else None
+        total_results = len(results) if prep.count else None
         return results, total_results
 
     def __init_catalog(

--- a/eodag/plugins/search/data_request_search.py
+++ b/eodag/plugins/search/data_request_search.py
@@ -30,6 +30,7 @@ from eodag.api.product.metadata_mapping import (
     mtd_cfg_as_conversion_and_querypath,
     properties_from_json,
 )
+from eodag.plugins.search import PreparedSearch
 from eodag.plugins.search.base import Search
 from eodag.utils import (
     DEFAULT_ITEMS_PER_PAGE,
@@ -126,10 +127,7 @@ class DataRequestSearch(Search):
 
     def query(
         self,
-        product_type: Optional[str] = None,
-        items_per_page: int = DEFAULT_ITEMS_PER_PAGE,
-        page: int = DEFAULT_PAGE,
-        count: bool = True,
+        prep: PreparedSearch = PreparedSearch(),
         **kwargs: Any,
     ) -> Tuple[List[EOProduct], Optional[int]]:
         """

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -64,6 +64,7 @@ from eodag.api.product.metadata_mapping import (
     properties_from_json,
     properties_from_xml,
 )
+from eodag.api.search_result import RawSearchResult
 from eodag.plugins.search import PreparedSearch
 from eodag.plugins.search.base import Search
 from eodag.types import json_field_definition_to_python, model_fields_to_annotated
@@ -725,7 +726,12 @@ class QueryStringSearch(Search):
         provider_results = self.do_search(prep, **kwargs)
         if count and total_items is None and hasattr(prep, "total_items_nb"):
             total_items = prep.total_items_nb
-        eo_products = self.normalize_results(provider_results, **kwargs)
+
+        raw_search_result = RawSearchResult(provider_results)
+        raw_search_result.query_params = prep.query_params
+        raw_search_result.product_type_def_params = prep.product_type_def_params
+
+        eo_products = self.normalize_results(raw_search_result, **kwargs)
         total_items = len(eo_products) if total_items == 0 else total_items
         return eo_products, total_items
 
@@ -971,7 +977,7 @@ class QueryStringSearch(Search):
         return results
 
     def normalize_results(
-        self, results: List[Dict[str, Any]], **kwargs: Any
+        self, results: RawSearchResult, **kwargs: Any
     ) -> List[EOProduct]:
         """Build EOProducts from provider results"""
         normalize_remaining_count = len(results)
@@ -1198,7 +1204,7 @@ class ODataV4Search(QueryStringSearch):
         )
 
     def normalize_results(
-        self, results: List[Dict[str, Any]], **kwargs: Any
+        self, results: RawSearchResult, **kwargs: Any
     ) -> List[EOProduct]:
         """Build EOProducts from provider results
 
@@ -1351,12 +1357,17 @@ class PostJsonSearch(QueryStringSearch):
         provider_results = self.do_search(prep, **kwargs)
         if count and total_items is None and hasattr(prep, "total_items_nb"):
             total_items = prep.total_items_nb
-        eo_products = self.normalize_results(provider_results, **kwargs)
+
+        raw_search_result = RawSearchResult(provider_results)
+        raw_search_result.query_params = prep.query_params
+        raw_search_result.product_type_def_params = prep.product_type_def_params
+
+        eo_products = self.normalize_results(raw_search_result, **kwargs)
         total_items = len(eo_products) if total_items == 0 else total_items
         return eo_products, total_items
 
     def normalize_results(
-        self, results: List[Dict[str, Any]], **kwargs: Any
+        self, results: RawSearchResult, **kwargs: Any
     ) -> List[EOProduct]:
         """Build EOProducts from provider results"""
         normalized = super().normalize_results(results, **kwargs)

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Iterable
-from copy import deepcopy as copy_deepcopy
+from copy import copy as copy_copy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -845,7 +845,7 @@ class QueryStringSearch(Search):
 
         results: List[Any] = []
         for search_url in prep.search_urls:
-            single_search_prep = copy_deepcopy(prep)
+            single_search_prep = copy_copy(prep)
             single_search_prep.url = search_url
             single_search_prep.info_message = "Sending search request: {}".format(
                 search_url

--- a/eodag/plugins/search/static_stac_search.py
+++ b/eodag/plugins/search/static_stac_search.py
@@ -26,13 +26,9 @@ from eodag.api.search_result import SearchResult
 from eodag.plugins.crunch.filter_date import FilterDate
 from eodag.plugins.crunch.filter_overlap import FilterOverlap
 from eodag.plugins.crunch.filter_property import FilterProperty
+from eodag.plugins.search import PreparedSearch
 from eodag.plugins.search.qssearch import StacSearch
-from eodag.utils import (
-    DEFAULT_ITEMS_PER_PAGE,
-    DEFAULT_PAGE,
-    HTTP_REQ_TIMEOUT,
-    MockResponse,
-)
+from eodag.utils import HTTP_REQ_TIMEOUT, MockResponse
 from eodag.utils.stac_reader import fetch_stac_items
 
 if TYPE_CHECKING:
@@ -83,10 +79,7 @@ class StaticStacSearch(StacSearch):
 
     def query(
         self,
-        product_type: Optional[str] = None,
-        items_per_page: int = DEFAULT_ITEMS_PER_PAGE,
-        page: int = DEFAULT_PAGE,
-        count: bool = True,
+        prep: PreparedSearch = PreparedSearch(),
         **kwargs: Any,
     ) -> Tuple[List[EOProduct], Optional[int]]:
         """Perform a search on a static STAC Catalog"""
@@ -111,7 +104,7 @@ class StaticStacSearch(StacSearch):
 
         # query on mocked StacSearch
         eo_products, _ = super(StaticStacSearch, self).query(
-            items_per_page=nb_features, page=1, count=True, **kwargs
+            PreparedSearch(items_per_page=nb_features, page=1, count=True), **kwargs
         )
         # filter using query params
         search_result = SearchResult(eo_products)

--- a/tests/context.py
+++ b/tests/context.py
@@ -64,6 +64,7 @@ from eodag.plugins.download.base import (
 )
 from eodag.plugins.download.http import HTTPDownload
 from eodag.plugins.manager import PluginManager
+from eodag.plugins.search import PreparedSearch
 from eodag.plugins.search.base import Search
 from eodag.types import model_fields_to_annotated
 from eodag.types.queryables import CommonQueryables, Queryables

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -38,6 +38,7 @@ from tests.context import (
     EOProduct,
     NotAvailableError,
     PluginManager,
+    PreparedSearch,
     SearchResult,
     USGSAuthExpiredError,
     USGSError,
@@ -525,8 +526,10 @@ class TestApisPluginUsgsApi(BaseApisPluginTest):
             "startTimeFromAscendingNode": "2020-02-01",
             "completionTimeFromAscendingNode": "2020-02-10",
             "geometry": get_geometry_from_various(geometry=[10, 20, 30, 40]),
-            "items_per_page": 5,
-            "page": 2,
+            "prep": PreparedSearch(
+                items_per_page=5,
+                page=2,
+            ),
         }
         search_results, total_count = self.api_plugin.query(**search_kwargs)
         mock_api_scene_search.assert_called_once_with(

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -2679,7 +2679,7 @@ class TestCoreSearch(TestCoreBase):
         # a provider-specific string has been created to sort by
         self.assertIn(
             "sortParam=providerSortParam&sortOrder=desc",
-            mock_qssearch__request.call_args[0][1],
+            mock_qssearch__request.call_args[0][1].url,
         )
 
         # with a POST mode search
@@ -2713,11 +2713,11 @@ class TestCoreSearch(TestCoreBase):
 
         # a provider-specific dictionnary has been created to sort by
         self.assertIn(
-            "sortby", mock_postjsonsearch__request.call_args[0][0].query_params.keys()
+            "sortby", mock_postjsonsearch__request.call_args[0][1].query_params.keys()
         )
         self.assertEqual(
             [{"field": "providerSortParam", "direction": "desc"}],
-            mock_postjsonsearch__request.call_args[0][0].query_params["sortby"],
+            mock_postjsonsearch__request.call_args[0][1].query_params["sortby"],
         )
 
         # TODO: sort by default sorting parameter and sorting order


### PR DESCRIPTION
Implements:
- `PreparedSearch`, an object collecting needed information for search
- `RawSearchResult`, an object representing a collection of raw/unparsed search results obtained from a provider.

This avoids storing search temporary data as plugin attributes