### PR TITLE
fix(queryables): missing search plugin auth

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -2308,6 +2308,10 @@ class EODataAccessGateway:
         providers_queryables: Dict[str, Dict[str, Annotated[Any, FieldInfo]]] = {}
 
         for plugin in self._plugins_manager.get_search_plugins(product_type, provider):
+            if getattr(plugin.config, "need_auth", False) and (
+                auth := self._plugins_manager.get_auth_plugin(plugin.provider)
+            ):
+                plugin.auth = auth.authenticate()
             providers_queryables[plugin.provider] = plugin.list_queryables(
                 filters=kwargs, product_type=product_type
             )

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1290,6 +1290,10 @@ class TestCore(TestCoreBase):
         self.dag.update_providers_config(new_config)
 
     @mock.patch(
+        "eodag.plugins.manager.PluginManager.get_auth_plugin",
+        autospec=True,
+    )
+    @mock.patch(
         "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
     )
     @mock.patch(
@@ -1304,6 +1308,7 @@ class TestCore(TestCoreBase):
         mock_stacsearch_discover_queryables: Mock,
         mock_qssearch_discover_queryables: Mock,
         mock_fetch_product_types_list: Mock,
+        mock_auth_plugin: Mock,
     ) -> None:
         """list_queryables must return queryables list adapted to provider and product-type"""
         mock_stacsearch_discover_queryables.return_value = {}

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -1392,9 +1392,7 @@ class RequestTestCase(unittest.TestCase):
 
         self.assertEqual(400, response.status_code)
 
-    @mock.patch(
-        "eodag.plugins.authentication.token.requests.Session.post", autospec=True
-    )
+    @mock.patch("eodag.plugins.manager.PluginManager.get_auth_plugin", autospec=True)
     def test_product_type_queryables(self, mock_requests_session_post):
         """Request to /collections/{collection_id}/queryables should return a valid response."""
 


### PR DESCRIPTION
Add authentication object to search plugin when listing queryables with need_search enabled