### PR TITLE
feat: allow no auth for download requests

### DIFF
--- a/eodag/config.py
+++ b/eodag/config.py
@@ -348,8 +348,15 @@ class PluginConfig(yaml.YAMLObject):
     order_enabled: bool  # HTTPDownload
     order_method: str  # HTTPDownload
     order_headers: Dict[str, str]  # HTTPDownload
+
     order_on_response: PluginConfig.OrderOnResponse
     order_status: PluginConfig.OrderStatus
+    no_auth_download: Annotated[
+        bool,
+        Doc(
+            "Do not authenticate the download request but only the order and order status ones."
+        ),
+    ]
     bucket_path_level: int  # S3RestDownload
     requester_pays: bool  # AwsDownload
     flatten_top_dirs: bool

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -964,6 +964,9 @@ class HTTPDownload(Download):
         if req_url.startswith(NOT_AVAILABLE):
             raise NotAvailableError("Download link is not available")
 
+        if getattr(self.config, "no_auth_download", False):
+            auth = None
+
         s = requests.Session()
         with s.request(
             req_method,

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -6570,6 +6570,7 @@
         result_type: json
         metadata_mapping:
           downloadLink: $.headers.Location
+    no_auth_download: True
     products:
       DT_EXTREMES:
         outputs_extension: .grib


### PR DESCRIPTION
needed for providers like dedt_lumi where auth should only be applied upon order