### PR TITLE
fix(server): single asset download with ignore_assets plugin setting

### DIFF
--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -779,7 +779,7 @@ class HTTPDownload(Download):
         # download assets if exist instead of remote_location
         if len(product.assets) > 0 and (
             not getattr(self.config, "ignore_assets", False)
-            or kwargs.get("asset", None) is not None
+            or kwargs.get("asset") is not None
         ):
             try:
                 assets_values = product.assets.get_values(kwargs.get("asset", None))

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -777,7 +777,10 @@ class HTTPDownload(Download):
             raise MisconfiguredError(f"Incompatible auth plugin: {type(auth)}")
 
         # download assets if exist instead of remote_location
-        if len(product.assets) > 0 and not getattr(self.config, "ignore_assets", False):
+        if len(product.assets) > 0 and (
+            not getattr(self.config, "ignore_assets", False)
+            or kwargs.get("asset", None) is not None
+        ):
             try:
                 assets_values = product.assets.get_values(kwargs.get("asset", None))
                 chunks_tuples = self._stream_download_assets(


### PR DESCRIPTION
Check if the user set `asset` in download `kwargs` so the `download_link` is not automatically used if the provider has `ignore_assets` attribute set to True in its configuration.