### PR TITLE
fix: sorted keys in gh action fetch product types diff

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -59,7 +59,7 @@ jobs:
         echo "commit [${COMMIT_SHA}](${COMMIT_URL})" >> $GITHUB_STEP_SUMMARY
         echo '```diff' >> $GITHUB_STEP_SUMMARY
         git show --name-only --format=tformat: >> $GITHUB_STEP_SUMMARY
-        (diff <(curl ${JSON_REF_FILE} | jq ) <(cat ${JSON_OUTPUT_FILE} | jq) || true) >> $GITHUB_STEP_SUMMARY
+        (diff <(curl ${JSON_REF_FILE} | jq --sort-keys) <(cat ${JSON_OUTPUT_FILE} | jq --sort-keys) || true) >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
         # truncated PR body (too long causes error)
         full_update_summary=$(cat $GITHUB_STEP_SUMMARY)


### PR DESCRIPTION
Sorted keys in github action *fetch product types* diff summary 