### PR TITLE
feat(server): add blacklist config for assets alt URLs

### DIFF
--- a/eodag/rest/config.py
+++ b/eodag/rest/config.py
@@ -18,11 +18,21 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from typing import Annotated, List, Union
 
 from pydantic import Field
+from pydantic.functional_validators import BeforeValidator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing_extensions import Doc
 
 from eodag.rest.constants import DEFAULT_MAXSIZE, DEFAULT_TTL
+
+
+def str2liststr(raw: Union[str, List[str]]) -> List[str]:
+    """Convert str to list[str]"""
+    if isinstance(raw, list):
+        return raw
+    return raw.split(",")
 
 
 class Settings(BaseSettings):
@@ -33,6 +43,14 @@ class Settings(BaseSettings):
     cache_maxsize: int = Field(default=DEFAULT_MAXSIZE)
 
     debug: bool = False
+
+    alt_url_blacklist: Annotated[
+        Union[str, List[str]],
+        BeforeValidator(str2liststr),
+        Doc(
+            "Hide from clients items assets' alternative URLs starting with URLs from the list"
+        ),
+    ] = Field(default=[])
 
     model_config = SettingsConfigDict(
         env_prefix="EODAG_", extra="ignore", env_nested_delimiter="__"

--- a/eodag/rest/config.py
+++ b/eodag/rest/config.py
@@ -44,7 +44,7 @@ class Settings(BaseSettings):
 
     debug: bool = False
 
-    alt_url_blacklist: Annotated[
+    origin_url_blacklist: Annotated[
         Union[str, List[str]],
         BeforeValidator(str2liststr),
         Doc(

--- a/eodag/rest/config.py
+++ b/eodag/rest/config.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import Annotated, List, Union
+from typing import List, Union
 
 from pydantic import Field
 from pydantic.functional_validators import BeforeValidator
@@ -26,6 +26,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Doc
 
 from eodag.rest.constants import DEFAULT_MAXSIZE, DEFAULT_TTL
+from eodag.utils import Annotated
 
 
 def str2liststr(raw: Union[str, List[str]]) -> List[str]:

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -400,7 +400,7 @@ class StacItem(StacCommon):
             "type": "application/zip",
         }
 
-        if not origin_href.startswith(tuple(settings.alt_url_blacklist)):
+        if not origin_href.startswith(tuple(settings.origin_url_blacklist)):
             assets["downloadLink"]["alternate"] = {
                 "origin": {
                     "title": "Origin asset link",
@@ -420,7 +420,7 @@ class StacItem(StacCommon):
                 assets[asset_key] = asset_value
                 # origin assets as alternate link
                 if not asset_value["href"].startswith(
-                    tuple(settings.alt_url_blacklist)
+                    tuple(settings.origin_url_blacklist)
                 ):
                     assets[asset_key]["alternate"] = {
                         "origin": {

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -438,8 +438,8 @@ class StacItem(StacCommon):
                     assets[asset_key]["href"] += f"/{asset_key}"
                 if asset_type := asset_value.get("type", None):
                     assets[asset_key]["type"] = asset_type
-                    if alternate := assets[asset_key].get("alternate"):
-                        alternate["type"] = asset_type
+                    if origin := assets[asset_key].get("alternate", {}).get("origin"):
+                        origin["type"] = asset_type
 
         if thumbnail_url := product.properties.get(
             "quicklook", product.properties.get("thumbnail", None)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import io
 import os
 import random
@@ -355,3 +356,19 @@ class EODagTestCase(unittest.TestCase):
                 pass
 
         return Response()
+
+
+@contextlib.contextmanager
+def temporary_environment(**env_vars):
+    # Save the original environment variables
+    original_env = os.environ.copy()
+
+    # Set the new temporary environment variables
+    os.environ.update(env_vars)
+
+    try:
+        yield
+    finally:
+        # Restore the original environment variables
+        os.environ.clear()
+        os.environ.update(original_env)


### PR DESCRIPTION
Add a config to be able to hide from clients assets alternate origin URLs. Useful to hide backend URLs from EODAG server.