### PR TITLE
build: install boto3 by default

### DIFF
--- a/docs/getting_started_guide/install.rst
+++ b/docs/getting_started_guide/install.rst
@@ -28,7 +28,6 @@ the following extras:
 
 * ``eodag[all]``, includes everything that would be needed to run EODAG and associated tutorials with all features
 * ``eodag[all-providers]``, includes dependencies required to have all providers available
-* ``eodag[aws]``, includes dependencies for plugins using Amazon S3
 * ``eodag[csw]``, includes dependencies for plugins using CSW
 * ``eodag[ecmwf]``, includes dependencies for :class:`~eodag.plugins.apis.ecmwf.EcmwfApi` (`ecmwf` provider)
 * ``eodag[usgs]``, includes dependencies for :class:`~eodag.plugins.apis.usgs.UsgsApi` (`usgs` provider)

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,8 @@ include_package_data = True
 python_requires = >=3.6
 install_requires =
     annotated-types
+    boto3
+    botocore
     click
     geojson
     jsonpath-ng < 1.6.0
@@ -64,10 +66,7 @@ install_requires =
 all =
     eodag[all-providers,csw,server,tutorials]
 all-providers =
-    eodag[aws,ecmwf,usgs]
-aws =
-    boto3
-    botocore
+    eodag[ecmwf,usgs]
 csw =
     OWSLib >=0.27.1
 ecmwf =
@@ -162,10 +161,10 @@ eodag.plugins.crunch =
     FilterProperty = eodag.plugins.crunch.filter_property:FilterProperty
     FilterDate = eodag.plugins.crunch.filter_date:FilterDate
 eodag.plugins.download =
-    AwsDownload = eodag.plugins.download.aws:AwsDownload [aws]
+    AwsDownload = eodag.plugins.download.aws:AwsDownload
     HTTPDownload = eodag.plugins.download.http:HTTPDownload
     S3RestDownload = eodag.plugins.download.s3rest:S3RestDownload
-    CreodiasS3Download = eodag.plugins.download.creodias_s3:CreodiasS3Download [aws]
+    CreodiasS3Download = eodag.plugins.download.creodias_s3:CreodiasS3Download
 eodag.plugins.search =
     CSWSearch = eodag.plugins.search.csw:CSWSearch [csw]
     QueryStringSearch = eodag.plugins.search.qssearch:QueryStringSearch
@@ -176,8 +175,8 @@ eodag.plugins.search =
     BuildSearchResult = eodag.plugins.search.build_search_result:BuildSearchResult
     BuildPostSearchResult = eodag.plugins.search.build_search_result:BuildPostSearchResult
     DataRequestSearch = eodag.plugins.search.data_request_search:DataRequestSearch
-    CreodiasS3Search = eodag.plugins.search.creodias_s3:CreodiasS3Search [aws]
-    CopMarineSearch = eodag.plugins.search.cop_marine:CopMarineSearch [aws]
+    CreodiasS3Search = eodag.plugins.search.creodias_s3:CreodiasS3Search
+    CopMarineSearch = eodag.plugins.search.cop_marine:CopMarineSearch
 
 [flake8]
 ignore = E203, W503


### PR DESCRIPTION
Following #1108, restore `boto3` requirement to default installation and remove `[aws]` extra requirement