### PR TITLE
fix(providers): area metadata mapping for CAMS_EU_AIR_QUALITY_FORECAST

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -2569,7 +2569,7 @@
       leadtime_hour: '0'
       metadata_mapping:
         geometry:
-          - 'area={geometry#to_nwse_bounds}'
+          - '{{"area": {geometry#to_nwse_bounds} }}'
           - '$.geometry'
     CAMS_EU_AIR_QUALITY_RE:
       dataset: cams-europe-air-quality-reanalyses


### PR DESCRIPTION
Fixes `area` metadata mapping for `CAMS_EU_AIR_QUALITY_FORECAST` on `cop_ads`