### PR TITLE
fix(plugins): missing products conf in api plugin download

### DIFF
--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -242,6 +242,7 @@ class PluginManager:
                 self._build_plugin(product.provider, download, Download),
             )
         elif api := getattr(plugin_conf, "api", None):
+            plugin_conf.api.products = plugin_conf.products
             plugin_conf.api.priority = plugin_conf.priority
             plugin = cast(Api, self._build_plugin(product.provider, api, Api))
         else:


### PR DESCRIPTION
Fixes #1233 

Adds missing `products` configuration in `Api` plugin download, when the `Api` plugin was not already retrieved through search (CLI mode)