### PR TITLE
docs: mock search plugin section

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "nbsphinx",
     "sphinx_copybutton",
+    "sphinx_tabs.tabs",
 ]
 
 # Notebook integration parameters

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -111,19 +111,28 @@ named ``your_package.your_module``:
 Then, in the `setup.py <https://setuptools.readthedocs.io/en/latest/userguide/quickstart.html#id2>`_ of your Python project,
 add this:
 
-.. code-block:: python
 
-   setup(
-      ...
-      entry_points={
+.. tabs::
+   .. tab:: pyproject.toml
+   .. code-block:: toml
+
+      [project.entry-points."eodag.plugins.api"]
+      SampleApiPlugin = "your_package.your_module:SampleApiPlugin"
+
+   .. tab:: setup.py
+   .. code-block:: python
+
+      setup(
          ...
-         'eodag.plugins.api': [
-            'SampleApiPlugin = your_package.your_module:SampleApiPlugin'
-         ],
+         entry_points={
+            ...
+            'eodag.plugins.api': [
+               'SampleApiPlugin = your_package.your_module:SampleApiPlugin'
+            ],
+            ...
+         },
          ...
-      },
-      ...
-   )
+      )
 
 See `what the PyPa explains <https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata>`_ to better
 understand this concept. In EODAG, the name you give to your plugin in the

--- a/setup.cfg
+++ b/setup.cfg
@@ -122,6 +122,7 @@ docs =
     sphinx
     sphinx-book-theme
     sphinx-copybutton
+    sphinx-tabs
     nbsphinx
 
 [options.packages.find]


### PR DESCRIPTION
- add a mock search plugin section to the documentation to describe further how to build a custom search plugin. 