### PR TITLE
feat(core): SearchResult HTML representation

### DIFF
--- a/eodag/api/product/_assets.py
+++ b/eodag/api/product/_assets.py
@@ -22,6 +22,7 @@ from collections import UserDict
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from eodag.utils.exceptions import NotAvailableError
+from eodag.utils.repr import dict_to_html_table
 
 if TYPE_CHECKING:
     from eodag.api.product import EOProduct
@@ -84,6 +85,43 @@ class AssetsDict(UserDict):
         else:
             return [a for a in self.values() if "href" in a]
 
+    def _repr_html_(self, embeded=False):
+        thead = (
+            f"""<thead><tr><td style='text-align: left; color: grey;'>
+                {type(self).__name__}&ensp;({len(self)})
+                </td></tr></thead>
+            """
+            if not embeded
+            else ""
+        )
+        tr_style = "style='background-color: transparent;'" if embeded else ""
+        return (
+            f"<table>{thead}"
+            + "".join(
+                [
+                    f"""<tr {tr_style}><td style='text-align: left;'>
+                <details><summary style='color: grey;'>
+                    <span style='color: black'>'{k}'</span>:&ensp;
+                    {{
+                        {"'roles': '<span style='color: black'>"+str(v['roles'])+"</span>',&ensp;"
+                            if v.get("roles") else ""}
+                        {"'type': '"+str(v['type'])+"',&ensp;"
+                            if v.get("type") else ""}
+                        {"'title': '<span style='color: black'>"+str(v['title'])+"</span>',&ensp;"
+                            if v.get("title") else ""}
+                        ...
+                    }}
+                </summary>
+                    {dict_to_html_table(v, depth=1)}
+                </details>
+                </td></tr>
+                """
+                    for k, v in self.items()
+                ]
+            )
+            + "</table>"
+        )
+
 
 class Asset(UserDict):
     """A UserDict object containg one of the assets of a
@@ -127,3 +165,15 @@ class Asset(UserDict):
         :rtype: str
         """
         return self.product.download(asset=self.key, **kwargs)
+
+    def _repr_html_(self):
+        thead = f"""<thead><tr><td style='text-align: left; color: grey;'>
+            {type(self).__name__}&ensp;-&ensp;{self.key}
+            </td></tr></thead>
+        """
+        return f"""<table>{thead}
+                <tr><td style='text-align: left;'>
+                    {dict_to_html_table(self)}
+                </details>
+                </td></tr>
+            </table>"""

--- a/eodag/api/search_result.py
+++ b/eodag/api/search_result.py
@@ -174,6 +174,33 @@ class SearchResult(UserList):
         """
         return self.as_geojson_object()
 
+    def _repr_html_(self):
+        total_count = f"/{self.number_matched}" if self.number_matched else ""
+        return (
+            f"""<table>
+                <thead><tr><td style='text-align: left; color: grey;'>
+                 {type(self).__name__}&ensp;({len(self)}{total_count})
+                </td></tr></thead>
+            """
+            + "".join(
+                [
+                    f"""<tr><td style='text-align: left;'>
+                <details><summary style='color: grey; font-family: monospace;'>
+                    {i}&ensp;
+                    {type(p).__name__}(id=<span style='color: black;'>{
+                        p.properties['id']
+                    }</span>, provider={p.provider})
+                </summary>
+                {p._repr_html_()}
+                </details>
+                </td></tr>
+                """
+                    for i, p in enumerate(self)
+                ]
+            )
+            + "</table>"
+        )
+
 
 class RawSearchResult(UserList):
     """An object representing a collection of raw/unparsed search results obtained from a provider.

--- a/eodag/utils/repr.py
+++ b/eodag/utils/repr.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+# Copyright 2024, CS GROUP - France, https://www.csgroup.eu/
+#
+# This file is part of EODAG project
+#     https://www.github.com/CS-SI/EODAG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import collections.abc
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+
+def str_as_href(link: str) -> str:
+    """URL to html link"""
+    if urlparse(link).scheme in ("file", "http", "https", "s3"):
+        return f"<a href='{link}' target='_blank'>{link}</a>"
+    else:
+        return link
+
+
+def html_table(input: Any, depth: Optional[int] = None) -> str:
+    """Transform input to HTML table"""
+    if isinstance(input, collections.abc.Mapping):
+        return dict_to_html_table(input, depth=depth)
+    elif isinstance(input, collections.abc.Sequence) and not isinstance(input, str):
+        return list_to_html_table(input, depth=depth)
+    elif isinstance(input, str):
+        return f"'{str_as_href(input)}'"
+    else:
+        return str_as_href(str(input))
+
+
+def dict_to_html_table(
+    input_dict: collections.abc.Mapping,
+    depth: Optional[int] = None,
+    brackets: bool = True,
+) -> str:
+    """Transform input dict to HTML table"""
+    opening_bracket = "<span style='color: grey;'>{</span>" if brackets else ""
+    closing_bracket = "<span style='color: grey;'>}</span>" if brackets else ""
+    indent = "10px" if brackets else "0"
+
+    if depth is not None:
+        depth -= 1
+
+    if depth is None or depth >= 0:
+        return (
+            f"{opening_bracket}<table style='margin: 0;'>"
+            + "".join(
+                [
+                    f"""<tr style='background-color: transparent;'>
+                    <td style='padding: 5px 0 0 {indent}; text-align: left; color: grey; vertical-align:top;'>{k}:</td>
+                    <td style='padding: 5px 0 0 10px; text-align: left;'>{
+                        html_table(v, depth=depth)
+                    },</td>
+                </tr>
+                """
+                    for k, v in input_dict.items()
+                ]
+            )
+            + f"</table>{closing_bracket}"
+        )
+    else:
+        return (
+            f"{opening_bracket}"
+            + ", ".join(
+                [
+                    f"""<span style='text-align: left;'>
+                    '{k}': {html_table(v, depth=depth)}
+                </span>"""
+                    for k, v in input_dict.items()
+                ]
+            )
+            + f"{closing_bracket}"
+        )
+
+
+def list_to_html_table(
+    input_list: collections.abc.Sequence, depth: Optional[int] = None
+) -> str:
+    """Transform input list to HTML table"""
+    if depth is not None:
+        depth -= 1
+    separator = (
+        ",<br />"
+        if any(isinstance(v, collections.abc.Mapping) for v in input_list)
+        else ", "
+    )
+    return (
+        "<span style='color: grey;'>[</span>"
+        + separator.join(
+            [
+                f"""<span style='text-align: left;'>{
+                html_table(v, depth=depth)
+            }</span>
+            """
+                for v in input_list
+            ]
+        )
+        + "<span style='color: grey;'>]</span>"
+    )

--- a/tests/units/test_eoproduct.py
+++ b/tests/units/test_eoproduct.py
@@ -26,6 +26,7 @@ import zipfile
 
 import geojson
 import requests
+from lxml import html
 from shapely import geometry
 
 from tests import EODagTestCase
@@ -539,3 +540,18 @@ class TestEOProduct(EODagTestCase):
             ]
             for needed_log in needed_logs:
                 self.assertIn(needed_log, str(mock_debug.call_args_list))
+
+    def test_eoproduct_repr_html(self):
+        """eoproduct html repr must be correctly formatted"""
+        product = self._dummy_product()
+        product_repr = html.fromstring(product._repr_html_())
+        self.assertIn("EOProduct", product_repr.xpath("//thead/tr/td")[0].text)
+
+        # assets dict
+        product.assets.update({"foo": {"href": "foo.href"}})
+        assets_dict_repr = html.fromstring(product.assets._repr_html_())
+        self.assertIn("AssetsDict", assets_dict_repr.xpath("//thead/tr/td")[0].text)
+
+        # asset
+        asset_repr = html.fromstring(product.assets._repr_html_())
+        self.assertIn("Asset", asset_repr.xpath("//thead/tr/td")[0].text)

--- a/tests/units/test_search_result.py
+++ b/tests/units/test_search_result.py
@@ -20,6 +20,7 @@ import unittest
 from collections import UserList
 
 import geojson
+from lxml import html
 from shapely.geometry.collection import GeometryCollection
 
 from tests.context import EOProduct, SearchResult
@@ -82,3 +83,8 @@ class TestSearchResult(unittest.TestCase):
             geojson.loads(geojson.dumps(self.search_result))
         )
         self.assertEqual(len(same_search_result), len(self.search_result))
+
+    def test_search_result_repr_html(self):
+        """SearchResult html repr must be correctly formatted"""
+        sr_repr = html.fromstring(self.search_result._repr_html_())
+        self.assertIn("SearchResult", sr_repr.xpath("//thead/tr/td")[0].text)


### PR DESCRIPTION
Implements HTML representation for `SearchResult`, `EOProduct`, `AssetsDict` and `Asset`, in order to enhance rendering in notebooks.

![image](https://github.com/CS-SI/eodag/assets/61419125/34f3dc0c-4be0-43f2-a6b6-f1e3bb6a48ca)
