### PR TITLE
fix(server): add datetime in collections cache hash

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -1045,8 +1045,8 @@ class EODataAccessGateway:
 
         # datetime filtering
         if missionStartDate or missionEndDate:
-            today = datetime.datetime.now(datetime.timezone.utc)
-            earliest = datetime.datetime(1900, 1, 1, tzinfo=datetime.timezone.utc)
+            min_aware = datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
+            max_aware = datetime.datetime.max.replace(tzinfo=datetime.timezone.utc)
             guesses = [
                 g
                 for g in guesses
@@ -1054,18 +1054,18 @@ class EODataAccessGateway:
                     max(
                         rfc3339_str_to_datetime(missionStartDate)
                         if missionStartDate
-                        else earliest,
+                        else min_aware,
                         rfc3339_str_to_datetime(g["missionStartDate"])
                         if g.get("missionStartDate")
-                        else earliest,
+                        else min_aware,
                     )
                     <= min(
                         rfc3339_str_to_datetime(missionEndDate)
                         if missionEndDate
-                        else today,
+                        else max_aware,
                         rfc3339_str_to_datetime(g["missionEndDate"])
                         if g.get("missionEndDate")
-                        else today,
+                        else max_aware,
                     )
                 )
             ]

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import datetime
 import logging
 import os
 import re
@@ -1044,20 +1045,28 @@ class EODataAccessGateway:
 
         # datetime filtering
         if missionStartDate or missionEndDate:
+            today = datetime.datetime.now(datetime.timezone.utc)
+            earliest = datetime.datetime(1900, 1, 1, tzinfo=datetime.timezone.utc)
             guesses = [
                 g
                 for g in guesses
                 if (
-                    not missionEndDate
-                    or g.get("missionStartDate")
-                    and rfc3339_str_to_datetime(g["missionStartDate"])
-                    <= rfc3339_str_to_datetime(missionEndDate)
-                )
-                and (
-                    not missionStartDate
-                    or g.get("missionEndDate")
-                    and rfc3339_str_to_datetime(g["missionEndDate"])
-                    >= rfc3339_str_to_datetime(missionStartDate)
+                    max(
+                        rfc3339_str_to_datetime(missionStartDate)
+                        if missionStartDate
+                        else earliest,
+                        rfc3339_str_to_datetime(g["missionStartDate"])
+                        if g.get("missionStartDate")
+                        else earliest,
+                    )
+                    <= min(
+                        rfc3339_str_to_datetime(missionEndDate)
+                        if missionEndDate
+                        else today,
+                        rfc3339_str_to_datetime(g["missionEndDate"])
+                        if g.get("missionEndDate")
+                        else today,
+                    )
                 )
             ]
 

--- a/eodag/rest/core.py
+++ b/eodag/rest/core.py
@@ -439,7 +439,9 @@ async def all_collections(
         collections = format_dict_items(collections, **format_args)
         return collections
 
-    hashed_collections = hash(f"{provider}:{q}:{platform}:{instrument}:{constellation}")
+    hashed_collections = hash(
+        f"{provider}:{q}:{platform}:{instrument}:{constellation}:{datetime}"
+    )
     cache_key = f"{CACHE_KEY_COLLECTIONS}:{hashed_collections}"
     return await cached(_fetch, cache_key, request)
 

--- a/tests/resources/ext_product_types_free_text_search.json
+++ b/tests/resources/ext_product_types_free_text_search.json
@@ -18,6 +18,24 @@
         "metadata_mapping": {
           "cloudCover": "$.null"
         }
+      },
+      "interval_start": {
+        "productType": "interval_start",
+        "metadata_mapping": {
+          "cloudCover": "$.null"
+        }
+      },
+      "interval_end": {
+        "productType": "interval_end",
+        "metadata_mapping": {
+          "cloudCover": "$.null"
+        }
+      },
+      "interval_start_end": {
+        "productType": "interval_start_end",
+        "metadata_mapping": {
+          "cloudCover": "$.null"
+        }
       }
     },
     "product_types_config": {
@@ -53,6 +71,19 @@
         "license": "WTFPL",
         "title": "titleFOOBAR - Lorem FOOBAR collection",
         "missionStartDate": "2012-12-12T00:00:00.000Z"
+      },
+      "interval_start": {
+        "title": "TEST DATES [start; end)",
+        "missionStartDate": "2013-02-10T00:00:00.000Z"
+      },
+      "interval_end": {
+        "title": "TEST DATES (start; end]",
+        "missionEndDate": "2013-02-20T00:00:00.000Z"
+      },
+      "interval_start_end": {
+        "title": "TEST DATES [start; end]",
+        "missionStartDate": "2013-02-10T00:00:00.000Z",
+        "missionEndDate": "2013-02-20T00:00:00.000Z"
       }
     }
   }

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -752,6 +752,42 @@ class TestCore(TestCoreBase):
         product_types_ids = self.dag.guess_product_type(filter)
         self.assertListEqual(sorted(product_types_ids), ["foo"])
 
+    def test_guess_product_type_with_mission_dates(self):
+        """Testing the datetime interval"""
+
+        with open(
+            os.path.join(TEST_RESOURCES_PATH, "ext_product_types_free_text_search.json")
+        ) as f:
+            ext_product_types_conf = json.load(f)
+        self.dag.update_product_types_list(ext_product_types_conf)
+
+        product_types_ids = self.dag.guess_product_type(
+            title="TEST DATES",
+            missionStartDate="2013-02-01",
+            missionEndDate="2013-02-05",
+        )
+        self.assertListEqual(product_types_ids, ["interval_end"])
+        product_types_ids = self.dag.guess_product_type(
+            title="TEST DATES",
+            missionStartDate="2013-02-01",
+            missionEndDate="2013-02-15",
+        )
+        self.assertListEqual(
+            product_types_ids, ["interval_end", "interval_start", "interval_start_end"]
+        )
+        product_types_ids = self.dag.guess_product_type(
+            title="TEST DATES", missionStartDate="2013-02-01"
+        )
+        self.assertListEqual(
+            product_types_ids, ["interval_end", "interval_start", "interval_start_end"]
+        )
+        product_types_ids = self.dag.guess_product_type(
+            title="TEST DATES", missionEndDate="2013-02-20"
+        )
+        self.assertListEqual(
+            product_types_ids, ["interval_end", "interval_start", "interval_start_end"]
+        )
+
     def test_update_product_types_list(self):
         """Core api.update_product_types_list must update eodag product types list"""
         with open(os.path.join(TEST_RESOURCES_PATH, "ext_product_types.json")) as f:


### PR DESCRIPTION
all_collections cache hash does not include datetime filter

this PR also fixes the datetime filter to correctly handle open datetime intervals