### PR TITLE
fix(plugins): raise error if no data available on AwsDownload

### DIFF
--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -70,6 +70,7 @@ from eodag.utils.exceptions import (
     AuthenticationError,
     DownloadError,
     MisconfiguredError,
+    NoMatchingProductType,
     NotAvailableError,
     TimeOutError,
 )
@@ -611,6 +612,10 @@ class AwsDownload(Download):
                 raise NotAvailableError(
                     rf"No file basename matching re.fullmatch(r'{asset_filter}') was found in {product.remote_location}"
                 )
+
+        if not unique_product_chunks:
+            raise NoMatchingProductType("No product found to download.")
+
         return unique_product_chunks
 
     def _raise_if_auth_error(self, exception: ClientError) -> None:
@@ -751,7 +756,6 @@ class AwsDownload(Download):
             product_chunk: Any, progress_callback: ProgressCallback
         ) -> Any:
             try:
-
                 chunk_start = 0
                 chunk_end = chunk_start + chunk_size - 1
 

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -96,7 +96,7 @@ class BaseDownloadPluginTest(unittest.TestCase):
         super(BaseDownloadPluginTest, self).tearDown()
         self.tmp_dir.cleanup()
 
-    def get_download_plugin(self, product):
+    def get_download_plugin(self, product: EOProduct):
         return self.plugins_manager.get_download_plugin(product)
 
     def get_auth_plugin(self, provider):
@@ -1482,6 +1482,9 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
         )
         self.assertEqual((bucket, prefix), ("default_bucket", "somewhere/else"))
 
+    @mock.patch(
+        "eodag.plugins.download.aws.AwsDownload._get_unique_products", autospec=True
+    )
     @mock.patch("eodag.plugins.download.aws.flatten_top_directories", autospec=True)
     @mock.patch(
         "eodag.plugins.download.aws.AwsDownload.check_manifest_file_list", autospec=True
@@ -1499,12 +1502,13 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
     @mock.patch("eodag.plugins.download.aws.requests.get", autospec=True)
     def test_plugins_download_aws_no_safe_build_no_flatten_top_dirs(
         self,
-        mock_requests_get,
-        mock_get_authenticated_objects,
-        mock_get_chunk_dest_path,
-        mock_finalize_s2_safe_product,
-        mock_check_manifest_file_list,
-        mock_flatten_top_directories,
+        mock_requests_get: mock.Mock,
+        mock_get_authenticated_objects: mock.Mock,
+        mock_get_chunk_dest_path: mock.Mock,
+        mock_finalize_s2_safe_product: mock.Mock,
+        mock_check_manifest_file_list: mock.Mock,
+        mock_flatten_top_directories: mock.Mock,
+        mock__get_unique_products: mock.Mock,
     ):
         """AwsDownload.download() must not call safe build methods if not needed"""
 
@@ -1525,6 +1529,9 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
         self.assertEqual(mock_check_manifest_file_list.call_count, 0)
         self.assertEqual(mock_flatten_top_directories.call_count, 0)
 
+    @mock.patch(
+        "eodag.plugins.download.aws.AwsDownload._get_unique_products", autospec=True
+    )
     @mock.patch("eodag.plugins.download.aws.flatten_top_directories", autospec=True)
     @mock.patch(
         "eodag.plugins.download.aws.AwsDownload.check_manifest_file_list", autospec=True
@@ -1542,12 +1549,13 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
     @mock.patch("eodag.plugins.download.aws.requests.get", autospec=True)
     def test_plugins_download_aws_no_safe_build_flatten_top_dirs(
         self,
-        mock_requests_get,
-        mock_get_authenticated_objects,
-        mock_get_chunk_dest_path,
-        mock_finalize_s2_safe_product,
-        mock_check_manifest_file_list,
-        mock_flatten_top_directories,
+        mock_requests_get: mock.Mock,
+        mock_get_authenticated_objects: mock.Mock,
+        mock_get_chunk_dest_path: mock.Mock,
+        mock_finalize_s2_safe_product: mock.Mock,
+        mock_check_manifest_file_list: mock.Mock,
+        mock_flatten_top_directories: mock.Mock,
+        mock__get_unique_products: mock.Mock,
     ):
         """AwsDownload.download() must not call safe build methods if not needed"""
 


### PR DESCRIPTION
Handle correctly situations with aws plugin when no data to download is found on s3.