### PR TITLE
fix(plugins): default disabled product-types discovery on StaticStacSearch

### DIFF
--- a/eodag/plugins/search/static_stac_search.py
+++ b/eodag/plugins/search/static_stac_search.py
@@ -85,6 +85,12 @@ class StaticStacSearch(StacSearch):
             "total_items_nb_key_path", "$.null"
         )
         self.config.__dict__["pagination"].setdefault("max_items_per_page", -1)
+        # disable product types discovery by default (if endpoints equals to STAC API default)
+        if (
+            getattr(self.config, "discover_product_types", {}).get("fetch_url")
+            == "{api_endpoint}/../collections"
+        ):
+            self.config.discover_product_types = {"fetch_url": None}
 
     def discover_product_types(self, **kwargs: Any) -> Optional[Dict[str, Any]]:
         """Fetch product types list from a static STAC Catalog provider using `discover_product_types` conf

--- a/tests/integration/test_search_stac_static.py
+++ b/tests/integration/test_search_stac_static.py
@@ -152,12 +152,11 @@ class TestSearchStacStatic(unittest.TestCase):
             self.assertEqual(item.provider, self.stac_provider)
             self.assertEqual(item.product_type, self.product_type)
 
-    @mock.patch(
-        "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
-    )
-    def test_search_stac_static(self, mock_fetch_product_types_list):
+    def test_search_stac_static(self):
         """Use StaticStacSearch plugin to search all items"""
-        search_result = self.dag.search(count=True)
+        # mock on fetch_product_types_list not needed with provider specified,
+        #    as product types discovery must be disabled by default for stac static
+        search_result = self.dag.search(provider=self.static_stac_provider, count=True)
         self.assertEqual(len(search_result), self.root_cat_len)
         self.assertEqual(search_result.number_matched, self.root_cat_len)
         for item in search_result:


### PR DESCRIPTION
If not specified in provider configuration, product-types discovery will be disabled by default when using `StaticStacSearch` plugin, in order to avoid using pre-configured and not adapted STAC API endpoint