### PR TITLE
fix(providers): usgs search by id

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -31,7 +31,9 @@
       max_items_per_page: 5000
       total_items_nb_key_path: '$.totalHits'
     metadata_mapping:
-      id: '$.displayId'
+      id:
+        - '_ID'
+        - '$.displayId'
       geometry: '$.spatialBounds'
       productType: '$.productType'
       title: '$.displayId'

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -392,6 +392,65 @@ class TestApisPluginEcmwfApi(BaseApisPluginTest):
 
 
 class TestApisPluginUsgsApi(BaseApisPluginTest):
+    SCENE_SEARCH_RETURN = {
+        "data": {
+            "results": [
+                {
+                    "browse": [
+                        {
+                            "browsePath": "https://path/to/quicklook.jpg",
+                            "thumbnailPath": "https://path/to/thumbnail.jpg",
+                        },
+                        {},
+                        {},
+                    ],
+                    "cloudCover": "77.46",
+                    "entityId": "LC81780382020041LGN00",
+                    "displayId": "LC08_L1GT_178038_20200210_20200224_01_T2",
+                    "spatialBounds": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [28.03905, 30.68073],
+                                [28.03905, 32.79057],
+                                [30.46294, 32.79057],
+                                [30.46294, 30.68073],
+                                [28.03905, 30.68073],
+                            ]
+                        ],
+                    },
+                    "temporalCoverage": {
+                        "endDate": "2020-02-10 00:00:00",
+                        "startDate": "2020-02-10 00:00:00",
+                    },
+                    "publishDate": "2020-02-10 08:24:46",
+                },
+            ],
+            "recordsReturned": 5,
+            "totalHits": 139,
+            "startingNumber": 6,
+            "nextRecord": 11,
+        }
+    }
+
+    DOWNLOAD_OPTION_RETURN = {
+        "data": [
+            {
+                "id": "5e83d0b8e7f6734c",
+                "entityId": "LC81780382020041LGN00",
+                "available": True,
+                "filesize": 9186067,
+                "productName": "LandsatLook Natural Color Image",
+                "downloadSystem": "dds",
+            },
+            {
+                "entityId": "LC81780382020041LGN00",
+                "available": False,
+                "downloadSystem": "wms",
+            },
+        ]
+    }
+
     def setUp(self):
         self.provider = "usgs"
         self.api_plugin = self.get_search_plugin(provider=self.provider)
@@ -450,67 +509,12 @@ class TestApisPluginUsgsApi(BaseApisPluginTest):
     @mock.patch(
         "usgs.api.scene_search",
         autospec=True,
-        return_value={
-            "data": {
-                "results": [
-                    {
-                        "browse": [
-                            {
-                                "browsePath": "https://path/to/quicklook.jpg",
-                                "thumbnailPath": "https://path/to/thumbnail.jpg",
-                            },
-                            {},
-                            {},
-                        ],
-                        "cloudCover": "77.46",
-                        "entityId": "LC81780382020041LGN00",
-                        "displayId": "LC08_L1GT_178038_20200210_20200224_01_T2",
-                        "spatialBounds": {
-                            "type": "Polygon",
-                            "coordinates": [
-                                [
-                                    [28.03905, 30.68073],
-                                    [28.03905, 32.79057],
-                                    [30.46294, 32.79057],
-                                    [30.46294, 30.68073],
-                                    [28.03905, 30.68073],
-                                ]
-                            ],
-                        },
-                        "temporalCoverage": {
-                            "endDate": "2020-02-10 00:00:00",
-                            "startDate": "2020-02-10 00:00:00",
-                        },
-                        "publishDate": "2020-02-10 08:24:46",
-                    },
-                ],
-                "recordsReturned": 5,
-                "totalHits": 139,
-                "startingNumber": 6,
-                "nextRecord": 11,
-            }
-        },
+        return_value=SCENE_SEARCH_RETURN,
     )
     @mock.patch(
         "usgs.api.download_options",
         autospec=True,
-        return_value={
-            "data": [
-                {
-                    "id": "5e83d0b8e7f6734c",
-                    "entityId": "LC81780382020041LGN00",
-                    "available": True,
-                    "filesize": 9186067,
-                    "productName": "LandsatLook Natural Color Image",
-                    "downloadSystem": "dds",
-                },
-                {
-                    "entityId": "LC81780382020041LGN00",
-                    "available": False,
-                    "downloadSystem": "wms",
-                },
-            ]
-        },
+        return_value=DOWNLOAD_OPTION_RETURN,
     )
     def test_plugins_apis_usgs_query(
         self,
@@ -565,6 +569,61 @@ class TestApisPluginUsgsApi(BaseApisPluginTest):
         self.assertEqual(
             total_count, mock_api_scene_search.return_value["data"]["totalHits"]
         )
+
+    @mock.patch("usgs.api.login", autospec=True)
+    @mock.patch("usgs.api.logout", autospec=True)
+    @mock.patch(
+        "usgs.api.scene_search",
+        autospec=True,
+        return_value=SCENE_SEARCH_RETURN,
+    )
+    @mock.patch(
+        "usgs.api.download_options",
+        autospec=True,
+        return_value=DOWNLOAD_OPTION_RETURN,
+    )
+    @mock.patch(
+        "usgs.api.dataset_filters",
+        autospec=True,
+        return_value={
+            "data": [
+                {"id": "foo_id", "searchSql": "DONT_USE_THIS !"},
+                {"id": "bar_id", "searchSql": "USE_THIS_ID !"},
+            ]
+        },
+    )
+    def test_plugins_apis_usgs_query_by_id(
+        self,
+        mock_dataset_filters,
+        mock_api_download_options,
+        mock_api_scene_search,
+        mock_api_logout,
+        mock_api_login,
+    ):
+        """UsgsApi.query by id must search using usgs api"""
+
+        search_kwargs = {
+            "productType": "LANDSAT_C2L1",
+            "id": "SOME_PRODUCT_ID",
+            "prep": PreparedSearch(
+                items_per_page=500,
+                page=1,
+            ),
+        }
+        search_results, total_count = self.api_plugin.query(**search_kwargs)
+        mock_api_scene_search.assert_called_once_with(
+            "landsat_ot_c2_l1",
+            where={"filter_id": "bar_id", "value": "SOME_PRODUCT_ID"},
+            start_date=None,
+            end_date=None,
+            ll=None,
+            ur=None,
+            max_results=500,
+            starting_number=1,
+        )
+        self.assertEqual(search_results[0].provider, "usgs")
+        self.assertEqual(search_results[0].product_type, "LANDSAT_C2L1")
+        self.assertEqual(len(search_results), 1)
 
     @mock.patch("usgs.api.login", autospec=True)
     @mock.patch("usgs.api.logout", autospec=True)


### PR DESCRIPTION
Fixes #1252

Implements lacking search-by-id mechanism on `UsgsApi` plugin for `usgs` provider