### PR TITLE
docs: remove current module from summarized items

### DIFF
--- a/docs/plugins_reference/api.rst
+++ b/docs/plugins_reference/api.rst
@@ -14,5 +14,5 @@ This table lists all the api plugins currently available:
 .. autosummary::
    :toctree: generated/
 
-   eodag.plugins.apis.usgs.UsgsApi
-   eodag.plugins.apis.ecmwf.EcmwfApi
+   usgs.UsgsApi
+   ecmwf.EcmwfApi

--- a/docs/plugins_reference/auth.rst
+++ b/docs/plugins_reference/auth.rst
@@ -14,12 +14,12 @@ This table lists all the authentication plugins currently available:
 .. autosummary::
    :toctree: generated/
 
-   eodag.plugins.authentication.generic.GenericAuth
-   eodag.plugins.authentication.token.TokenAuth
-   eodag.plugins.authentication.header.HTTPHeaderAuth
-   eodag.plugins.authentication.aws_auth.AwsAuth
-   eodag.plugins.authentication.oauth.OAuth
-   eodag.plugins.authentication.openid_connect.OIDCAuthorizationCodeFlowAuth
-   eodag.plugins.authentication.keycloak.KeycloakOIDCPasswordAuth
-   eodag.plugins.authentication.qsauth.HttpQueryStringAuth
-   eodag.plugins.authentication.sas_auth.SASAuth
+   generic.GenericAuth
+   token.TokenAuth
+   header.HTTPHeaderAuth
+   aws_auth.AwsAuth
+   oauth.OAuth
+   openid_connect.OIDCAuthorizationCodeFlowAuth
+   keycloak.KeycloakOIDCPasswordAuth
+   qsauth.HttpQueryStringAuth
+   sas_auth.SASAuth

--- a/docs/plugins_reference/crunch.rst
+++ b/docs/plugins_reference/crunch.rst
@@ -14,11 +14,11 @@ This table lists all the crunch plugins currently available:
 .. autosummary::
    :toctree: generated/
 
-   eodag.plugins.crunch.filter_date.FilterDate
-   eodag.plugins.crunch.filter_latest_intersect.FilterLatestIntersect
-   eodag.plugins.crunch.filter_latest_tpl_name.FilterLatestByName
-   eodag.plugins.crunch.filter_overlap.FilterOverlap
-   eodag.plugins.crunch.filter_property.FilterProperty
+   filter_date.FilterDate
+   filter_latest_intersect.FilterLatestIntersect
+   filter_latest_tpl_name.FilterLatestByName
+   filter_overlap.FilterOverlap
+   filter_property.FilterProperty
 
 The signature of each plugin's :meth:`proceed` method is displayed below, it may contain information useful to execute the cruncher:
 

--- a/docs/plugins_reference/download.rst
+++ b/docs/plugins_reference/download.rst
@@ -14,10 +14,10 @@ This table lists all the download plugins currently available:
 .. autosummary::
    :toctree: generated/
 
-   eodag.plugins.download.http.HTTPDownload
-   eodag.plugins.download.aws.AwsDownload
-   eodag.plugins.download.s3rest.S3RestDownload
-   eodag.plugins.download.creodias_s3.CreodiasS3Download
+   http.HTTPDownload
+   aws.AwsDownload
+   s3rest.S3RestDownload
+   creodias_s3.CreodiasS3Download
 
 ---------------------------
 Download methods call graph

--- a/docs/plugins_reference/search.rst
+++ b/docs/plugins_reference/search.rst
@@ -14,13 +14,13 @@ This table lists all the search plugins currently available:
 .. autosummary::
    :toctree: generated/
 
-   eodag.plugins.search.qssearch.QueryStringSearch
-   eodag.plugins.search.qssearch.ODataV4Search
-   eodag.plugins.search.qssearch.PostJsonSearch
-   eodag.plugins.search.qssearch.StacSearch
-   eodag.plugins.search.static_stac_search.StaticStacSearch
-   eodag.plugins.search.creodias_s3.CreodiasS3Search
-   eodag.plugins.search.build_search_result.BuildSearchResult
-   eodag.plugins.search.build_search_result.BuildPostSearchResult
-   eodag.plugins.search.data_request_search.DataRequestSearch
-   eodag.plugins.search.csw.CSWSearch
+   qssearch.QueryStringSearch
+   qssearch.ODataV4Search
+   qssearch.PostJsonSearch
+   qssearch.StacSearch
+   static_stac_search.StaticStacSearch
+   creodias_s3.CreodiasS3Search
+   build_search_result.BuildSearchResult
+   build_search_result.BuildPostSearchResult
+   data_request_search.DataRequestSearch
+   csw.CSWSearch


### PR DESCRIPTION
Following `sphinx 7.4.0` release and https://github.com/sphinx-doc/sphinx/pull/6792, remove current module from summarized items in documentation `autosummary` sections