### PR TITLE
fix(plugins): aws_session_token support in aws_auth

### DIFF
--- a/eodag/plugins/authentication/aws_auth.py
+++ b/eodag/plugins/authentication/aws_auth.py
@@ -45,6 +45,7 @@ class AwsAuth(Authentication):
         super(AwsAuth, self).__init__(provider, config)
         self.aws_access_key_id = None
         self.aws_secret_access_key = None
+        self.aws_session_token = None
         self.profile_name = None
 
     def authenticate(self) -> Dict[str, str]:
@@ -60,7 +61,15 @@ class AwsAuth(Authentication):
         self.aws_secret_access_key = credentials.get(
             "aws_secret_access_key", self.aws_secret_access_key
         )
+        self.aws_session_token = credentials.get(
+            "aws_session_token", self.aws_session_token
+        )
         self.profile_name = credentials.get("aws_profile", self.profile_name)
 
-        auth_keys = ["aws_access_key_id", "aws_secret_access_key", "profile_name"]
+        auth_keys = [
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "aws_session_token",
+            "profile_name",
+        ]
         return {k: getattr(self, k) for k in auth_keys if getattr(self, k)}

--- a/eodag/plugins/authentication/aws_auth.py
+++ b/eodag/plugins/authentication/aws_auth.py
@@ -35,6 +35,7 @@ class AwsAuth(Authentication):
     - auth anonymously using no-sign-request
     - auth using ``aws_profile``
     - auth using ``aws_access_key_id`` and ``aws_secret_access_key``
+      (optionally ``aws_session_token``)
     - auth using current environment (AWS environment variables and/or ``~/aws/*``),
       will be skipped if AWS credentials are filled in eodag conf
     """

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -34,6 +34,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    TypedDict,
     Union,
     cast,
 )
@@ -229,7 +230,7 @@ class AwsDownload(Download):
     def __init__(self, provider: str, config: PluginConfig) -> None:
         super(AwsDownload, self).__init__(provider, config)
         self.requester_pays = getattr(self.config, "requester_pays", False)
-        self.s3_session = None
+        self.s3_session: Optional[boto3.session.Session] = None
 
     def download(
         self,
@@ -941,15 +942,15 @@ class AwsDownload(Download):
     ) -> Optional[ResourceCollection]:
         """Auth strategy using no-sign-request"""
 
-        s3_resource = boto3.resource(  # type: ignore
+        s3_resource = boto3.resource(
             service_name="s3", endpoint_url=getattr(self.config, "base_uri", None)
         )
-        s3_resource.meta.client.meta.events.register(  # type: ignore
+        s3_resource.meta.client.meta.events.register(
             "choose-signer.s3.*", disable_signing
         )
-        objects = s3_resource.Bucket(bucket_name).objects  # type: ignore
-        list(objects.filter(Prefix=prefix).limit(1))  # type: ignore
-        return objects  # type: ignore
+        objects = s3_resource.Bucket(bucket_name).objects
+        list(objects.filter(Prefix=prefix).limit(1))
+        return objects
 
     def _get_authenticated_objects_from_auth_profile(
         self, bucket_name: str, prefix: str, auth_dict: Dict[str, str]
@@ -957,20 +958,20 @@ class AwsDownload(Download):
         """Auth strategy using RequestPayer=requester and ``aws_profile`` from provided credentials"""
 
         if "profile_name" in auth_dict.keys():
-            s3_session = boto3.session.Session(profile_name=auth_dict["profile_name"])  # type: ignore
-            s3_resource = s3_session.resource(  # type: ignore
+            s3_session = boto3.session.Session(profile_name=auth_dict["profile_name"])
+            s3_resource = s3_session.resource(
                 service_name="s3",
                 endpoint_url=getattr(self.config, "base_uri", None),
             )
             if self.requester_pays:
-                objects = s3_resource.Bucket(bucket_name).objects.filter(  # type: ignore
+                objects = s3_resource.Bucket(bucket_name).objects.filter(
                     RequestPayer="requester"
                 )
             else:
-                objects = s3_resource.Bucket(bucket_name).objects  # type: ignore
-            list(objects.filter(Prefix=prefix).limit(1))  # type: ignore
-            self.s3_session = s3_session  # type: ignore
-            return objects  # type: ignore
+                objects = s3_resource.Bucket(bucket_name).objects
+            list(objects.filter(Prefix=prefix).limit(1))
+            self.s3_session = s3_session
+            return objects
         else:
             return None
 
@@ -981,26 +982,35 @@ class AwsDownload(Download):
         from provided credentials"""
 
         if all(k in auth_dict for k in ("aws_access_key_id", "aws_secret_access_key")):
-            s3_session_kwargs = {
+            S3SessionKwargs = TypedDict(
+                "S3SessionKwargs",
+                {
+                    "aws_access_key_id": str,
+                    "aws_secret_access_key": str,
+                    "aws_session_token": str,
+                },
+                total=False,
+            )
+            s3_session_kwargs: S3SessionKwargs = {
                 "aws_access_key_id": auth_dict["aws_access_key_id"],
                 "aws_secret_access_key": auth_dict["aws_secret_access_key"],
             }
             if auth_dict.get("aws_session_token"):
                 s3_session_kwargs["aws_session_token"] = auth_dict["aws_session_token"]
-            s3_session = boto3.session.Session(**s3_session_kwargs)  # type: ignore
-            s3_resource = s3_session.resource(  # type: ignore
+            s3_session = boto3.session.Session(**s3_session_kwargs)
+            s3_resource = s3_session.resource(
                 service_name="s3",
                 endpoint_url=getattr(self.config, "base_uri", None),
             )
             if self.requester_pays:
-                objects = s3_resource.Bucket(bucket_name).objects.filter(  # type: ignore
+                objects = s3_resource.Bucket(bucket_name).objects.filter(
                     RequestPayer="requester"
                 )
             else:
-                objects = s3_resource.Bucket(bucket_name).objects  # type: ignore
-            list(objects.filter(Prefix=prefix).limit(1))  # type: ignore
-            self.s3_session = s3_session  # type: ignore
-            return objects  # type: ignore
+                objects = s3_resource.Bucket(bucket_name).objects
+            list(objects.filter(Prefix=prefix).limit(1))
+            self.s3_session = s3_session
+            return objects
         else:
             return None
 
@@ -1009,19 +1019,19 @@ class AwsDownload(Download):
     ) -> Optional[ResourceCollection]:
         """Auth strategy using RequestPayer=requester and current environment"""
 
-        s3_session = boto3.session.Session()  # type: ignore
-        s3_resource = s3_session.resource(  # type: ignore
+        s3_session = boto3.session.Session()
+        s3_resource = s3_session.resource(
             service_name="s3", endpoint_url=getattr(self.config, "base_uri", None)
         )
         if self.requester_pays:
-            objects = s3_resource.Bucket(bucket_name).objects.filter(  # type: ignore
+            objects = s3_resource.Bucket(bucket_name).objects.filter(
                 RequestPayer="requester"
             )
         else:
-            objects = s3_resource.Bucket(bucket_name).objects  # type: ignore
-        list(objects.filter(Prefix=prefix).limit(1))  # type: ignore
-        self.s3_session = s3_session  # type: ignore
-        return objects  # type: ignore
+            objects = s3_resource.Bucket(bucket_name).objects
+        list(objects.filter(Prefix=prefix).limit(1))
+        self.s3_session = s3_session
+        return objects
 
     def get_product_bucket_name_and_prefix(
         self, product: EOProduct, url: Optional[str] = None

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -981,10 +981,13 @@ class AwsDownload(Download):
         from provided credentials"""
 
         if all(k in auth_dict for k in ("aws_access_key_id", "aws_secret_access_key")):
-            s3_session = boto3.session.Session(  # type: ignore
-                aws_access_key_id=auth_dict["aws_access_key_id"],
-                aws_secret_access_key=auth_dict["aws_secret_access_key"],
-            )
+            s3_session_kwargs = {
+                "aws_access_key_id": auth_dict["aws_access_key_id"],
+                "aws_secret_access_key": auth_dict["aws_secret_access_key"],
+            }
+            if auth_dict.get("aws_session_token"):
+                s3_session_kwargs["aws_session_token"] = auth_dict["aws_session_token"]
+            s3_session = boto3.session.Session(**s3_session_kwargs)  # type: ignore
             s3_resource = s3_session.resource(  # type: ignore
                 service_name="s3",
                 endpoint_url=getattr(self.config, "base_uri", None),

--- a/tests/units/test_auth_plugins.py
+++ b/tests/units/test_auth_plugins.py
@@ -327,6 +327,76 @@ class TestAuthPluginTokenAuth(BaseAuthPluginTest):
                 auth_plugin.authenticate()
 
 
+class TestAuthPluginAwsAuth(BaseAuthPluginTest):
+    @classmethod
+    def setUpClass(cls):
+        super(TestAuthPluginAwsAuth, cls).setUpClass()
+        cls.aws_access_key_id = "my_access_key"
+        cls.aws_secret_access_key = "my_secret_key"
+        cls.aws_session_token = "my_session_token"
+        cls.profile_name = "my_profile"
+        override_config_from_mapping(
+            cls.providers_config,
+            {
+                "provider_with_auth_keys": {
+                    "products": {"foo_product": {}},
+                    "auth": {
+                        "type": "AwsAuth",
+                        "credentials": {
+                            "aws_access_key_id": cls.aws_access_key_id,
+                            "aws_secret_access_key": cls.aws_secret_access_key,
+                        },
+                    },
+                },
+                "provider_with_auth_keys_session": {
+                    "products": {"foo_product": {}},
+                    "auth": {
+                        "type": "AwsAuth",
+                        "credentials": {
+                            "aws_access_key_id": cls.aws_access_key_id,
+                            "aws_secret_access_key": cls.aws_secret_access_key,
+                            "aws_session_token": cls.aws_session_token,
+                        },
+                    },
+                },
+                "provider_with_auth_profile": {
+                    "products": {"foo_product": {}},
+                    "auth": {
+                        "type": "AwsAuth",
+                        "credentials": {
+                            "aws_profile": cls.profile_name,
+                        },
+                    },
+                },
+            },
+        )
+        cls.plugins_manager = PluginManager(cls.providers_config)
+
+    def test_plugins_auth_aws_authenticate(self):
+        """AwsAuth.authenticate must return credentials in a dict"""
+        self.assertDictEqual(
+            self.get_auth_plugin("provider_with_auth_keys").authenticate(),
+            {
+                "aws_access_key_id": self.aws_access_key_id,
+                "aws_secret_access_key": self.aws_secret_access_key,
+            },
+        )
+        self.assertDictEqual(
+            self.get_auth_plugin("provider_with_auth_keys_session").authenticate(),
+            {
+                "aws_access_key_id": self.aws_access_key_id,
+                "aws_secret_access_key": self.aws_secret_access_key,
+                "aws_session_token": self.aws_session_token,
+            },
+        )
+        self.assertDictEqual(
+            self.get_auth_plugin("provider_with_auth_profile").authenticate(),
+            {
+                "profile_name": self.profile_name,
+            },
+        )
+
+
 class TestAuthPluginHTTPHeaderAuth(BaseAuthPluginTest):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Fixes `AwsAuth` plugin to support `aws_session_token` credentials.

Updates types hints for this plugin