### PR TITLE
feat: handle integers as shapefile attributes

### DIFF
--- a/docs/notebooks/api_user_guide/4_search.ipynb
+++ b/docs/notebooks/api_user_guide/4_search.ipynb
@@ -1286,7 +1286,7 @@
     ")\n",
     "```\n",
     "\n",
-    "The location query (`continent=\"Europe\"`) is passed as a dictionary to the `locations` parameter. It accepts [regular expressions](https://en.wikipedia.org/wiki/Regular_expression) which can come in handy when the query field has an underlying structure (e.g. see [this tutorial](../tutos/tuto_search_location_tile.ipynb) dedicated to search for products by tile(s)).\n",
+    "The location query (`continent=\"Europe\"`) is passed as a dictionary to the `locations` parameter. It accepts [regular expressions](https://en.wikipedia.org/wiki/Regular_expression) which can come in handy when the query field has an underlying structure (e.g. see [this tutorial](../tutos/tuto_search_location_tile.ipynb) dedicated to search for products by tile(s)). As the `locations` parameter must be a string or a regex, please consider using a string even for names which are numbers like in the following example (`location_entity=\"1234\"`).\n",
     "\n",
     "The locations configuration is stored in the `locations_config` attribute of the `EODataAcessGateway` once instantiated. `eodag` provides a default location which is a [Natural Earth Countries](https://www.naturalearthdata.com/downloads/110m-cultural-vectors/110m-admin-0-countries/) shapefile whose *ADM0_A3_US* field can be used to query specific countries by a short code such as *FRA* for *France* or *JPN* for *Japan*."
    ]

--- a/docs/notebooks/api_user_guide/4_search.ipynb
+++ b/docs/notebooks/api_user_guide/4_search.ipynb
@@ -1286,7 +1286,7 @@
     ")\n",
     "```\n",
     "\n",
-    "The location query (`continent=\"Europe\"`) is passed as a dictionary to the `locations` parameter. It accepts [regular expressions](https://en.wikipedia.org/wiki/Regular_expression) which can come in handy when the query field has an underlying structure (e.g. see [this tutorial](../tutos/tuto_search_location_tile.ipynb) dedicated to search for products by tile(s)). As the `locations` parameter must be a string or a regex, please consider using a string even for names which are numbers like in the following example (`location_entity=\"1234\"`).\n",
+    "The location query (`continent=\"Europe\"`) is passed as a dictionary to the `locations` parameter. It accepts [regular expressions](https://en.wikipedia.org/wiki/Regular_expression) which can come in handy when the query field has an underlying structure (e.g. see [this tutorial](../tutos/tuto_search_location_tile.ipynb) dedicated to search for products by tile(s)).\n",
     "\n",
     "The locations configuration is stored in the `locations_config` attribute of the `EODataAcessGateway` once instantiated. `eodag` provides a default location which is a [Natural Earth Countries](https://www.naturalearthdata.com/downloads/110m-cultural-vectors/110m-admin-0-countries/) shapefile whose *ADM0_A3_US* field can be used to query specific countries by a short code such as *FRA* for *France* or *JPN* for *Japan*."
    ]

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -1100,7 +1100,7 @@ def get_geometry_from_various(
             attr = locations_dict[arg]["attr"]
             with shapefile.Reader(locations_dict[arg]["path"]) as shp:
                 for shaperec in shp.shapeRecords():
-                    if re.search(pattern, shaperec.record[attr]):
+                    if re.search(pattern, str(shaperec.record[attr])):
                         found = True
                         new_geom = shape(shaperec.shape)
                         # get geoms union

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -1096,7 +1096,7 @@ def get_geometry_from_various(
     for arg in query_locations.keys():
         if arg in locations_dict.keys():
             found = False
-            pattern = query_locations[arg]
+            pattern = rf"{query_locations[arg]}"
             attr = locations_dict[arg]["attr"]
             with shapefile.Reader(locations_dict[arg]["path"]) as shp:
                 for shaperec in shp.shapeRecords():


### PR DESCRIPTION
Locations shapefile attributes are automatically converted to strings so integers like ids can be handled in search arguments:
```
locations=dict(entity_type=1234)
```