### PR TITLE
fix(plugins): add ssl_verify where necessary and remove where unnecessary

### DIFF
--- a/eodag/plugins/authentication/keycloak.py
+++ b/eodag/plugins/authentication/keycloak.py
@@ -117,6 +117,7 @@ class KeycloakOIDCPasswordAuth(OIDCRefreshTokenBase):
             "grant_type": self.GRANT_TYPE,
         }
         credentials = {k: v for k, v in self.config.credentials.items()}
+        ssl_verify = getattr(self.config, "ssl_verify", True)
         try:
             response = self.session.post(
                 self.TOKEN_URL_TEMPLATE.format(
@@ -126,6 +127,7 @@ class KeycloakOIDCPasswordAuth(OIDCRefreshTokenBase):
                 data=dict(req_data, **credentials),
                 headers=USER_AGENT,
                 timeout=HTTP_REQ_TIMEOUT,
+                verify=ssl_verify,
             )
             response.raise_for_status()
         except requests.exceptions.Timeout as exc:
@@ -142,6 +144,7 @@ class KeycloakOIDCPasswordAuth(OIDCRefreshTokenBase):
             "grant_type": "refresh_token",
             "refresh_token": self.token_info["refresh_token"],
         }
+        ssl_verify = getattr(self.config, "ssl_verify", True)
         try:
             response = self.session.post(
                 self.TOKEN_URL_TEMPLATE.format(
@@ -151,6 +154,7 @@ class KeycloakOIDCPasswordAuth(OIDCRefreshTokenBase):
                 data=req_data,
                 headers=USER_AGENT,
                 timeout=HTTP_REQ_TIMEOUT,
+                verify=ssl_verify,
             )
             response.raise_for_status()
         except requests.RequestException as e:

--- a/eodag/plugins/authentication/openid_connect.py
+++ b/eodag/plugins/authentication/openid_connect.py
@@ -336,10 +336,12 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
         post_request_kwargs: Any = {
             self.config.token_exchange_post_data_method: token_data
         }
+        ssl_verify = getattr(self.config, "ssl_verify", True)
         try:
             token_response = self.session.post(
                 self.config.token_uri,
                 timeout=HTTP_REQ_TIMEOUT,
+                verify=ssl_verify,
                 **post_request_kwargs,
             )
             token_response.raise_for_status()
@@ -363,11 +365,13 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
             "state": state,
             "redirect_uri": self.config.redirect_uri,
         }
+        ssl_verify = getattr(self.config, "ssl_verify", True)
         authorization_response = self.session.get(
             self.config.authorization_uri,
             params=params,
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
+            verify=ssl_verify,
         )
 
         login_document = etree.HTML(authorization_response.text)
@@ -401,7 +405,11 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
             if not auth_uri:
                 raise MisconfiguredError("authentication_uri is missing")
         return self.session.post(
-            auth_uri, data=login_data, headers=USER_AGENT, timeout=HTTP_REQ_TIMEOUT
+            auth_uri,
+            data=login_data,
+            headers=USER_AGENT,
+            timeout=HTTP_REQ_TIMEOUT,
+            verify=ssl_verify,
         )
 
     def grant_user_consent(self, authentication_response: Response) -> Response:
@@ -415,11 +423,13 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
             key: self._constant_or_xpath_extracted(value, user_consent_form)
             for key, value in self.config.user_consent_form_data.items()
         }
+        ssl_verify = getattr(self.config, "ssl_verify", True)
         return self.session.post(
             self.config.authorization_uri,
             data=user_consent_data,
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
+            verify=ssl_verify,
         )
 
     def _prepare_token_post_data(self, token_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -467,10 +477,12 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
         post_request_kwargs: Any = {
             self.config.token_exchange_post_data_method: token_exchange_data
         }
+        ssl_verify = getattr(self.config, "ssl_verify", True)
         r = self.session.post(
             self.config.token_uri,
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
+            verify=ssl_verify,
             **post_request_kwargs,
         )
         return r

--- a/eodag/plugins/authentication/token.py
+++ b/eodag/plugins/authentication/token.py
@@ -126,6 +126,7 @@ class TokenAuth(Authentication):
         req_kwargs: Dict[str, Any] = {
             "headers": dict(self.config.headers, **USER_AGENT)
         }
+        ssl_verify = getattr(self.config, "ssl_verify", True)
 
         if self.refresh_token:
             logger.debug("fetching access token with refresh token")
@@ -135,6 +136,7 @@ class TokenAuth(Authentication):
                     self.config.refresh_uri,
                     data={"refresh_token": self.refresh_token},
                     timeout=HTTP_REQ_TIMEOUT,
+                    verify=ssl_verify,
                     **req_kwargs,
                 )
                 response.raise_for_status()
@@ -170,6 +172,7 @@ class TokenAuth(Authentication):
             method=method,
             url=self.config.auth_uri,
             timeout=HTTP_REQ_TIMEOUT,
+            verify=ssl_verify,
             **req_kwargs,
         )
 

--- a/eodag/plugins/authentication/token_exchange.py
+++ b/eodag/plugins/authentication/token_exchange.py
@@ -100,12 +100,14 @@ class OIDCTokenExchangeAuth(Authentication):
             "audience": self.config.audience,
         }
         logger.debug("Getting target auth token")
+        ssl_verify = getattr(self.config, "ssl_verify", True)
         try:
             auth_response = self.subject.session.post(
                 self.config.token_uri,
                 data=auth_data,
                 headers=USER_AGENT,
                 timeout=HTTP_REQ_TIMEOUT,
+                verify=ssl_verify,
             )
             auth_response.raise_for_status()
         except requests.exceptions.Timeout as exc:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -25,6 +25,7 @@
   url: https://earthexplorer.usgs.gov/
   api: !plugin
     type: UsgsApi
+    need_auth: true
     pagination:
       max_items_per_page: 5000
       total_items_nb_key_path: '$.totalHits'

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -25,8 +25,6 @@
   url: https://earthexplorer.usgs.gov/
   api: !plugin
     type: UsgsApi
-    need_auth: true
-    google_base_url: 'http://storage.googleapis.com/earthengine-public/landsat/'
     pagination:
       max_items_per_page: 5000
       total_items_nb_key_path: '$.totalHits'
@@ -1982,7 +1980,6 @@
   api: !plugin
     type: EcmwfApi
     api_endpoint: https://api.ecmwf.int/v1
-    extract: false
     metadata_mapping:
       productType: '$.productType'
       title: '$.id'

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1983,7 +1983,6 @@
     type: EcmwfApi
     api_endpoint: https://api.ecmwf.int/v1
     extract: false
-    ssl_verify: true
     metadata_mapping:
       productType: '$.productType'
       title: '$.id'

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -539,7 +539,6 @@
           - productPath
   auth: !plugin
     type: AwsAuth
-    ssl_verify: true
 
 ---
 !provider # MARK: theia
@@ -875,8 +874,6 @@
       issuerId: peps
   auth: !plugin
     type: GenericAuth
-    auth_uri: 'https://peps.cnes.fr/resto/api/users/connect'
-    ssl_verify: true
 ---
 !provider # MARK: creodias
   name: creodias
@@ -1562,7 +1559,6 @@
       Content-Type: application/json
   auth: !plugin
     type: GenericAuth
-    ssl_verify: true
 
 ---
 !provider # MARK: astraea_eod
@@ -1691,7 +1687,6 @@
           - tilePath
   auth: !plugin
     type: AwsAuth
-    ssl_verify: true
 
 ---
 !provider # MARK: usgs_satapi_aws
@@ -1752,7 +1747,6 @@
     ssl_verify: true
   auth: !plugin
     type: AwsAuth
-    ssl_verify: true
 
 ---
 !provider # MARK: earth_search
@@ -1855,7 +1849,6 @@
           - tilePath
   auth: !plugin
     type: AwsAuth
-    ssl_verify: true
 
 ---
 !provider # MARK: earth_search_cog
@@ -1978,7 +1971,6 @@
         default_bucket: 'gcp-public-data-sentinel-2'
   auth: !plugin
     type: AwsAuth
-    ssl_verify: true
 ---
 !provider # MARK: ecmwf
   name: ecmwf
@@ -2215,7 +2207,6 @@
   auth: !plugin
     type: GenericAuth
     method: basic
-    ssl_verify: true
   download: !plugin
     type: HTTPDownload
     timeout: 30
@@ -2745,7 +2736,6 @@
   auth: !plugin
     type: GenericAuth
     method: basic
-    ssl_verify: true
   download: !plugin
     type: HTTPDownload
     timeout: 30
@@ -3758,7 +3748,6 @@
   auth: !plugin
     type: GenericAuth
     method: basic
-    ssl_verify: true
 ---
 !provider # MARK: meteoblue
   name: meteoblue
@@ -4332,7 +4321,6 @@
     ssl_verify: true
   auth: !plugin
     type: HTTPHeaderAuth
-    ssl_verify: true
     headers:
       X-API-Key: "{apikey}"
 
@@ -6307,7 +6295,6 @@
   auth: !plugin
     type: AwsAuth
     auth_error_code: 403
-    ssl_verify: true
   products:
       # S1
     S1_SAR_RAW:

--- a/tests/units/test_auth_plugins.py
+++ b/tests/units/test_auth_plugins.py
@@ -1419,6 +1419,7 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
             mock.ANY,
             auth_plugin.config.token_uri,
             timeout=HTTP_REQ_TIMEOUT,
+            verify=True,
             **post_request_kwargs,
         )
         mock_request_new_token.assert_not_called()
@@ -1475,6 +1476,7 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
             data={"const_key": "const_value", "xpath_key": "additional value"},
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
+            verify=True,
         )
 
     @mock.patch(
@@ -1526,6 +1528,7 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
             },
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
+            verify=True,
         )
 
     @mock.patch(
@@ -1576,6 +1579,7 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
             },
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
+            verify=True,
         )
 
     @mock.patch(
@@ -1627,6 +1631,7 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
             },
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
+            verify=True,
         )
         # Second request: post to the authentication URI
         mock_requests_post.assert_called_once_with(
@@ -1639,6 +1644,7 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
             },
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
+            verify=True,
         )
         # authenticate_user returns the authentication response
         self.assertEqual(mock_requests_post.return_value, auth_response)
@@ -1699,6 +1705,7 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
                 "state": state,
                 "grant_type": "authorization_code",
             },
+            verify=True,
         )
 
     @mock.patch(
@@ -1745,6 +1752,7 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
                 "state": state,
                 "grant_type": "authorization_code",
             },
+            verify=True,
         )
 
     @mock.patch(
@@ -1790,4 +1798,5 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
                 "state": state,
                 "grant_type": "authorization_code",
             },
+            verify=True,
         )


### PR DESCRIPTION
- add `ssl_verify` parameter to requests in `TokenAuth`, `OpenidConnect` and `KeycloakAuth`
- remove unnecessary `ssl_verify` config param from `GenericAuth`, `AwsAuth` and `HeaderAuth`
- also removes a few other unnecessary parameters
