### PR TITLE
fix(core): missing _search_by_id warning

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -1570,9 +1570,10 @@ class EODataAccessGateway:
                     **kwargs,
                 ):
                     results.data.extend(page_results.data)
-            except Exception:
+            except Exception as e:
                 if kwargs.get("raise_errors"):
                     raise
+                logger.warning(e)
                 continue
 
             # try using crunch to get unique result


### PR DESCRIPTION
Adds missing `warning` level logs when an error occurs while [searching by id](https://eodag.readthedocs.io/en/latest/notebooks/api_user_guide/4_search.html#id-and-provider) with `raise_errors=False`.

Related to #1291
