### PR TITLE
fix(plugins): qssearch without productType

### DIFF
--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -701,9 +701,6 @@ class QueryStringSearch(Search):
                 }
             )
 
-        if product_type is None:
-            raise ValidationError("Required productType is missing")
-
         qp, qs = self.build_query_string(product_type, **keywords)
 
         prep.query_params = qp
@@ -823,7 +820,7 @@ class QueryStringSearch(Search):
             else:
                 next_url = "{}?{}".format(search_endpoint, qs_with_sort)
             urls.append(next_url)
-        return urls, total_results
+        return list(set(urls)), total_results
 
     def do_search(
         self, prep: PreparedSearch = PreparedSearch(items_per_page=None), **kwargs: Any
@@ -1501,7 +1498,7 @@ class PostJsonSearch(QueryStringSearch):
                     )
 
             urls.append(search_endpoint)
-        return urls, total_results
+        return list(set(urls)), total_results
 
     def _request(
         self,

--- a/tests/integration/test_core_search.py
+++ b/tests/integration/test_core_search.py
@@ -29,7 +29,6 @@ from tests.context import (
     NoMatchingProductType,
     RequestError,
     USGSError,
-    ValidationError,
 )
 from tests.utils import mock
 
@@ -78,7 +77,6 @@ class TestCoreSearch(unittest.TestCase):
     ):
         # QueryStringSearch / peps
         self.dag.set_preferred_provider("peps")
-        self.assertRaises(ValidationError, self.dag.search, raise_errors=True)
         self.assertRaises(
             RequestError, self.dag.search, productType="foo", raise_errors=True
         )
@@ -153,7 +151,6 @@ class TestCoreSearch(unittest.TestCase):
     ):
         # ODataV4Search / onda
         self.dag.set_preferred_provider("onda")
-        self.assertRaises(ValidationError, self.dag.search, raise_errors=True)
         self.assertRaises(
             RequestError, self.dag.search, productType="foo", raise_errors=True
         )


### PR DESCRIPTION
Fixes #1291 

Allows searching with [QueryStringSearch](https://eodag.readthedocs.io/en/latest/plugins_reference/generated/eodag.plugins.search.qssearch.QueryStringSearch.html) plugin with no `productType` specified