### PR TITLE
fix(providers): remove two_passes_id_search config param

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -4141,7 +4141,6 @@
     need_auth: true
     auth_error_code: 401
     results_entry: 'features'
-    two_passes_id_search: true
     pagination:
       total_items_nb_key_path: '$.properties.totalResults'
       next_page_query_obj: '{{"itemsPerPage":{items_per_page},"startIndex":{skip}}}'
@@ -4669,7 +4668,6 @@
     need_auth: true
     auth_error_code: 401
     results_entry: 'features'
-    dates_required: true
     pagination:
       total_items_nb_key_path: '$.properties.totalResults'
       next_page_query_obj: '{{"itemsPerPage":{items_per_page},"startIndex":{skip}}}'
@@ -5939,7 +5937,6 @@
     timeout: 60
     auth_error_code: 401
     results_entry: 'features'
-    two_passes_id_search: true
     pagination:
       total_items_nb_key_path: '$.properties.totalResults'
       next_page_query_obj: '{{"itemsPerPage":{items_per_page},"startIndex":{skip}}}'

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -4668,6 +4668,7 @@
     need_auth: true
     auth_error_code: 401
     results_entry: 'features'
+    dates_required: true
     pagination:
       total_items_nb_key_path: '$.properties.totalResults'
       next_page_query_obj: '{{"itemsPerPage":{items_per_page},"startIndex":{skip}}}'

--- a/tests/resources/wekeo_old_config.yml
+++ b/tests/resources/wekeo_old_config.yml
@@ -10,7 +10,6 @@ wekeo_old:
     need_auth: true
     auth_error_code: 401
     results_entry: content
-    two_passes_id_search: true
     dates_required: true
     ssl_verify: true
     pagination:


### PR DESCRIPTION
Removes `two_passes_id_search` (old `wekeo` configuration parameter) from the `providers.yml` file because it is not used anymore
