### PR TITLE
fix(plugins): skip product types discovery on parsing errors

### DIFF
--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -517,6 +517,12 @@ class QueryStringSearch(Search):
                     e,
                 )
                 return None
+            except requests.RequestException as e:
+                logger.debug(
+                    "Could not parse discovered product types response from "
+                    f"{self.provider}, {type(e).__name__}: {e.args}"
+                )
+                return None
         conf_update_dict["product_types_config"] = dict_items_recursive_apply(
             conf_update_dict["product_types_config"],
             lambda k, v: v if v != NOT_AVAILABLE else None,


### PR DESCRIPTION
Skips parsing error if provider response cannot be read while discovering product types in `QueryStringSearch`