### PR TITLE
fix(providers): handle cop_marine in situ historical data

### DIFF
--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -196,6 +196,8 @@ class CopMarineSearch(StaticStacSearch):
         }
         if use_dataset_dates:
             dates = _get_dates_from_dataset_data(dataset_item)
+            if not dates:
+                return None
             properties["startTimeFromAscendingNode"] = dates["start"]
             properties["completionTimeFromAscendingNode"] = dates["end"]
         else:
@@ -392,21 +394,21 @@ class CopMarineSearch(StaticStacSearch):
                         use_dataset_dates = True
                         dates = _get_dates_from_dataset_data(dataset_item)
                         if dates:
-                            item_start = dates["start"].replace("Z", "+0000")
-                            item_end = dates["end"].replace("Z", "+0000")
+                            item_start_str = dates["start"].replace("Z", "+0000")
+                            item_end_str = dates["end"].replace("Z", "+0000")
                             try:
                                 item_start = datetime.strptime(
-                                    item_start, "%Y-%m-%dT%H:%M:%S.%f%z"
+                                    item_start_str, "%Y-%m-%dT%H:%M:%S.%f%z"
                                 )
                                 item_end = datetime.strptime(
-                                    item_end, "%Y-%m-%dT%H:%M:%S.%f%z"
+                                    item_end_str, "%Y-%m-%dT%H:%M:%S.%f%z"
                                 )
                             except ValueError:
                                 item_start = datetime.strptime(
-                                    item_start, "%Y-%m-%dT%H:%M:%S%z"
+                                    item_start_str, "%Y-%m-%dT%H:%M:%S%z"
                                 )
                                 item_end = datetime.strptime(
-                                    item_end, "%Y-%m-%dT%H:%M:%S%z"
+                                    item_end_str, "%Y-%m-%dT%H:%M:%S%z"
                                 )
                     if not item_start:
                         # no valid datetime in id and dataset data

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -67,6 +67,21 @@ def _get_date_from_yyyymmdd(date_str: str, item_key: str) -> Optional[datetime]:
         return date
 
 
+def _get_dates_from_dataset_data(
+    dataset_item: Dict[str, Any]
+) -> Optional[Dict[str, str]]:
+    dates = {}
+    if "start_datetime" in dataset_item["properties"]:
+        dates["start"] = dataset_item["properties"]["start_datetime"]
+        dates["end"] = dataset_item["properties"]["end_datetime"]
+    elif "datetime" in dataset_item["properties"]:
+        dates["start"] = dataset_item["properties"]["datetime"]
+        dates["end"] = dataset_item["properties"]["datetime"]
+    else:
+        return None
+    return dates
+
+
 def _get_s3_client(endpoint_url: str) -> S3Client:
     s3_session = boto3.Session()
     return s3_session.client(
@@ -180,20 +195,14 @@ class CopMarineSearch(StaticStacSearch):
             "dataset": dataset_item["id"],
         }
         if use_dataset_dates:
-            if "start_datetime" in dataset_item:
-                properties["startTimeFromAscendingNode"] = dataset_item[
-                    "start_datetime"
-                ]
-                properties["completionTimeFromAscendingNode"] = dataset_item[
-                    "end_datetime"
-                ]
-            elif "datetime" in dataset_item:
-                properties["startTimeFromAscendingNode"] = dataset_item["datetime"]
-                properties["completionTimeFromAscendingNode"] = dataset_item["datetime"]
+            dates = _get_dates_from_dataset_data(dataset_item)
+            properties["startTimeFromAscendingNode"] = dates["start"]
+            properties["completionTimeFromAscendingNode"] = dates["end"]
         else:
-            item_dates = re.findall(r"\d{8}", item_key)
+            item_dates = re.findall(r"(\d{4})(0[1-9]|1[0-2])([0-3]\d)", item_id)
             if not item_dates:
-                item_dates = re.findall(r"\d{6}", item_key)
+                item_dates = re.findall(r"_(\d{4})(0[1-9]|1[0-2])", item_id)
+            item_dates = ["".join(row) for row in item_dates]
             item_start = _get_date_from_yyyymmdd(item_dates[0], item_key)
             if not item_start:  # identified pattern was not a valid datetime
                 return None
@@ -209,11 +218,26 @@ class CopMarineSearch(StaticStacSearch):
             ).strftime("%Y-%m-%dT%H:%M:%SZ")
 
         for key, value in collection_dict["properties"].items():
-            if key not in ["id", "title", "start_datetime", "end_datetime"]:
+            if key not in ["id", "title", "start_datetime", "end_datetime", "datetime"]:
                 properties[key] = value
         for key, value in dataset_item["properties"].items():
-            if key not in ["id", "title", "start_datetime", "end_datetime"]:
+            if key not in ["id", "title", "start_datetime", "end_datetime", "datetime"]:
                 properties[key] = value
+
+        code_mapping = self.config.products.get(product_type, {}).get(
+            "code_mapping", None
+        )
+        if code_mapping:
+            id_parts = item_id.split("_")
+            if len(id_parts) > code_mapping["index"]:
+                code = id_parts[code_mapping["index"]]
+                if "pattern" not in code_mapping:
+                    properties[code_mapping["param"]] = code
+                elif re.findall(code_mapping["pattern"], code):
+                    properties[code_mapping["param"]] = re.findall(
+                        code_mapping["pattern"], code
+                    )[0]
+
         _check_int_values_properties(properties)
 
         properties["thumbnail"] = collection_dict["assets"]["thumbnail"]["href"]
@@ -348,16 +372,54 @@ class CopMarineSearch(StaticStacSearch):
 
                 for obj in s3_objects["Contents"]:
                     item_key = obj["Key"]
+                    item_id = item_key.split("/")[-1].split(".")[0]
                     # filter according to date(s) in item id
-                    item_dates = re.findall(r"\d{8}", item_key)
+                    item_dates = re.findall(r"(\d{4})(0[1-9]|1[0-2])([0-3]\d)", item_id)
                     if not item_dates:
-                        item_dates = re.findall(r"\d{6}", item_key)
-                    item_start = _get_date_from_yyyymmdd(item_dates[0], item_key)
-                    if not item_start:  # identified pattern was not a valid datetime
+                        item_dates = re.findall(r"_(\d{4})(0[1-9]|1[0-2])", item_id)
+                    item_dates = [
+                        "".join(row) for row in item_dates
+                    ]  # join tuples returned by findall
+                    item_start = None
+                    item_end = None
+                    use_dataset_dates = False
+                    if item_dates:
+                        item_start = _get_date_from_yyyymmdd(item_dates[0], item_key)
+                        if len(item_dates) > 2:  # start, end and created_at timestamps
+                            item_end = _get_date_from_yyyymmdd(item_dates[1], item_key)
+                    if not item_start:
+                        # no valid datetime given in id
+                        use_dataset_dates = True
+                        dates = _get_dates_from_dataset_data(dataset_item)
+                        if dates:
+                            item_start = dates["start"].replace("Z", "+0000")
+                            item_end = dates["end"].replace("Z", "+0000")
+                            try:
+                                item_start = datetime.strptime(
+                                    item_start, "%Y-%m-%dT%H:%M:%S.%f%z"
+                                )
+                                item_end = datetime.strptime(
+                                    item_end, "%Y-%m-%dT%H:%M:%S.%f%z"
+                                )
+                            except ValueError:
+                                item_start = datetime.strptime(
+                                    item_start, "%Y-%m-%dT%H:%M:%S%z"
+                                )
+                                item_end = datetime.strptime(
+                                    item_end, "%Y-%m-%dT%H:%M:%S%z"
+                                )
+                    if not item_start:
+                        # no valid datetime in id and dataset data
                         continue
                     if item_start > end_date:
                         stop_search = True
-                    if not item_dates or (start_date <= item_start <= end_date):
+                    if (
+                        (start_date <= item_start <= end_date)
+                        or (item_end and start_date <= item_end <= end_date)
+                        or (
+                            item_end and item_start < start_date and item_end > end_date
+                        )
+                    ):
                         num_total += 1
                         if num_total < start_index:
                             continue
@@ -368,6 +430,7 @@ class CopMarineSearch(StaticStacSearch):
                                 endpoint_url + "/" + bucket,
                                 dataset_item,
                                 collection_dict,
+                                use_dataset_dates,
                             )
                             if product:
                                 products.append(product)

--- a/eodag/resources/product_types.yml
+++ b/eodag/resources/product_types.yml
@@ -5518,7 +5518,7 @@ MO_OCEANCOLOUR_GLO_BGC_L3_MY_009_107:
   platformSerialIdentifier:
   processingLevel: Level 3
   keywords: CMEMS,Mercator,ocean,global,L3,bio-geo-chemical,BGC,chlorophyll,phytoplankton,reflectance
-  sensorType:
+  sensorType: multi
   license: proprietary
   title: Global Ocean Colour Plankton and Reflectances MY L3 daily observations
   missionStartDate: "1997-09-04T00:00:00Z"
@@ -5622,7 +5622,7 @@ MO_OCEANCOLOUR_GLO_BGC_L4_MY_009_108:
   platformSerialIdentifier:
   processingLevel: L4
   keywords: CMEMS,Mercator,ocean,global,colour,L4,bio-geo-chemical,BGC,chlorophyll,MY,multi-years,monthly
-  sensorType:
+  sensorType: multi
   license: proprietary
   title: Global Ocean Colour Plankton MY L4 monthly observations
   missionStartDate: "1997-09-01T00:00:00Z"

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -7249,10 +7249,19 @@
       productType: GLOBAL_MULTIYEAR_PHY_ENS_001_031
     MO_INSITU_GLO_PHY_UV_DISCRETE_NRT_013_048:
       productType: INSITU_GLO_PHY_UV_DISCRETE_NRT_013_048
+      code_mapping:
+        param: platformSerialIdentifier
+        index: 3
     MO_INSITU_GLO_PHY_TS_OA_NRT_013_002:
       productType: INSITU_GLO_PHY_TS_OA_NRT_013_002
+      code_mapping:
+        param: analysis_name
+        index: 1
     MO_INSITU_GLO_PHY_TS_OA_MY_013_052:
       productType: INSITU_GLO_PHY_TS_OA_MY_013_052
+      code_mapping:
+        param: analysis_name
+        index: 1
     MO_MULTIOBS_GLO_BIO_BGC_3D_REP_015_010:
       productType: MULTIOBS_GLO_BIO_BGC_3D_REP_015_010
     MO_MULTIOBS_GLO_BIO_CARBON_SURFACE_REP_015_008:
@@ -7279,6 +7288,10 @@
       productType: SEALEVEL_GLO_PHY_MDT_008_063
     MO_SST_GLO_SST_L3S_NRT_OBSERVATIONS_010_010:
       productType: SST_GLO_SST_L3S_NRT_OBSERVATIONS_010_010
+      code_mapping:
+        param: sensorType
+        index: 3
+        pattern: '[A-Z]{3}'
     MO_SST_GLO_SST_L4_NRT_OBSERVATIONS_010_001:
       productType: SST_GLO_SST_L4_NRT_OBSERVATIONS_010_001
     MO_SST_GLO_SST_L4_REP_OBSERVATIONS_010_011:
@@ -7287,8 +7300,15 @@
       productType: SST_GLO_SST_L4_REP_OBSERVATIONS_010_024
     MO_WAVE_GLO_WAV_L3_SPC_NRT_OBSERVATIONS_014_002:
       productType: WAVE_GLO_WAV_L3_SPC_NRT_OBSERVATIONS_014_002
+      code_mapping:
+        param: platformSerialIdentifier
+        index: 0
+        pattern: 's1a|s1b|cfo'
     MO_WAVE_GLO_PHY_SWH_L3_NRT_014_001:
       productType: WAVE_GLO_PHY_SWH_L3_NRT_014_001
+      code_mapping:
+        param: platformSerialIdentifier
+        index: 4
     MO_WAVE_GLO_PHY_SWH_L4_NRT_014_003:
       productType: WAVE_GLO_PHY_SWH_L4_NRT_014_003
     MO_WIND_GLO_PHY_CLIMATE_L4_MY_012_003:
@@ -7305,12 +7325,28 @@
       productType: OCEANCOLOUR_GLO_BGC_L3_MY_009_107
     MO_OCEANCOLOUR_GLO_BGC_L3_NRT_009_101:
       productType: OCEANCOLOUR_GLO_BGC_L3_NRT_009_101
+      code_mapping:
+        param: sensorType
+        index: 6
+        pattern: 'olci|gapfree-multi|multi-climatology|multi'
     MO_OCEANCOLOUR_GLO_BGC_L3_MY_009_103:
       productType: OCEANCOLOUR_GLO_BGC_L3_MY_009_103
+      code_mapping:
+        param: sensorType
+        index: 6
+        pattern: 'olci|gapfree-multi|multi-climatology|multi'
     MO_OCEANCOLOUR_GLO_BGC_L4_NRT_009_102:
       productType: OCEANCOLOUR_GLO_BGC_L4_NRT_009_102
+      code_mapping:
+        param: sensorType
+        index: 6
+        pattern: 'olci|gapfree-multi|multi-climatology|multi'
     MO_OCEANCOLOUR_GLO_BGC_L4_MY_009_104:
       productType: OCEANCOLOUR_GLO_BGC_L4_MY_009_104
+      code_mapping:
+        param: sensorType
+        index: 6
+        pattern: 'olci|gapfree-multi|multi-climatology|multi'
     MO_OCEANCOLOUR_GLO_BGC_L4_MY_009_108:
       productType: OCEANCOLOUR_GLO_BGC_L4_MY_009_108
     GENERIC_PRODUCT_TYPE:


### PR DESCRIPTION
`cop_marine` provider fixes:
- if no date is given in the id of the product, the date given for the dataset the product belongs to is now used
- a mapping has been added to retrieve other information from the id (such as platform, analysis type) and to add it to the properties of the product
