### PR TITLE
fix(build): update shapely to fix issues with numpy 2.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     PyYAML
     requests
     setuptools
-    shapely >= 2.0.0
+    shapely >= 2.0.6
     stream-zip
     tqdm
     typing_extensions >= 4.8.0


### PR DESCRIPTION
Enforce the use of shapely>=2.0.6 to fix issues with numpy 2.1 occurring with python 3.12.

Fixes #1302
