### PR TITLE
fix(plugins): build_search_result end_date preprocessing

### DIFF
--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -1920,6 +1920,61 @@ class TestSearchPluginBuildSearchResult(unittest.TestCase):
             )
         )
 
+    def test_plugins_search_buildsearchresult_exclude_end_date(self):
+        """BuildSearchResult.query must adapt end date in certain cases"""
+        # start & stop as dates -> keep end date as it is
+        results, _ = self.search_plugin.query(
+            productType=self.product_type,
+            startTimeFromAscendingNode="2020-01-01",
+            completionTimeFromAscendingNode="2020-01-02",
+        )
+        eoproduct = results[0]
+        self.assertEqual(
+            "2020-01-01", eoproduct.properties["startTimeFromAscendingNode"]
+        )
+        self.assertEqual(
+            "2020-01-02", eoproduct.properties["completionTimeFromAscendingNode"]
+        )
+        # start & stop as datetimes, not midnight -> keep and dates as it is
+        results, _ = self.search_plugin.query(
+            productType=self.product_type,
+            startTimeFromAscendingNode="2020-01-01T02:00:00Z",
+            completionTimeFromAscendingNode="2020-01-02T03:00:00Z",
+        )
+        eoproduct = results[0]
+        self.assertEqual(
+            "2020-01-01", eoproduct.properties["startTimeFromAscendingNode"]
+        )
+        self.assertEqual(
+            "2020-01-02", eoproduct.properties["completionTimeFromAscendingNode"]
+        )
+        # start & stop as datetimes, midnight -> exclude end date
+        results, _ = self.search_plugin.query(
+            productType=self.product_type,
+            startTimeFromAscendingNode="2020-01-01T00:00:00Z",
+            completionTimeFromAscendingNode="2020-01-02T00:00:00Z",
+        )
+        eoproduct = results[0]
+        self.assertEqual(
+            "2020-01-01", eoproduct.properties["startTimeFromAscendingNode"]
+        )
+        self.assertEqual(
+            "2020-01-01", eoproduct.properties["completionTimeFromAscendingNode"]
+        )
+        # start & stop same date -> keep end date
+        results, _ = self.search_plugin.query(
+            productType=self.product_type,
+            startTimeFromAscendingNode="2020-01-01T00:00:00Z",
+            completionTimeFromAscendingNode="2020-01-01T00:00:00Z",
+        )
+        eoproduct = results[0]
+        self.assertEqual(
+            "2020-01-01", eoproduct.properties["startTimeFromAscendingNode"]
+        )
+        self.assertEqual(
+            "2020-01-01", eoproduct.properties["completionTimeFromAscendingNode"]
+        )
+
     def test_plugins_search_buildsearchresult_dates_missing(self):
         """BuildSearchResult.query must use default dates if missing"""
         # given start & stop
@@ -1933,7 +1988,7 @@ class TestSearchPluginBuildSearchResult(unittest.TestCase):
             eoproduct.properties["startTimeFromAscendingNode"], "2020-01-01"
         )
         self.assertEqual(
-            eoproduct.properties["completionTimeFromAscendingNode"], "2020-01-01"
+            eoproduct.properties["completionTimeFromAscendingNode"], "2020-01-02"
         )
 
         # missing start & stop
@@ -1947,7 +2002,7 @@ class TestSearchPluginBuildSearchResult(unittest.TestCase):
         )
         self.assertIn(
             eoproduct.properties["completionTimeFromAscendingNode"],
-            "2015-01-01",
+            "2015-01-02",
         )
 
         # missing start & stop and plugin.product_type_config set (set in core._prepare_search)
@@ -1964,7 +2019,7 @@ class TestSearchPluginBuildSearchResult(unittest.TestCase):
             eoproduct.properties["startTimeFromAscendingNode"], "1985-10-26"
         )
         self.assertEqual(
-            eoproduct.properties["completionTimeFromAscendingNode"], "1985-10-26"
+            eoproduct.properties["completionTimeFromAscendingNode"], "1985-10-27"
         )
 
     def test_plugins_search_buildsearchresult_without_producttype(self):
@@ -1981,7 +2036,7 @@ class TestSearchPluginBuildSearchResult(unittest.TestCase):
         eoproduct = results[0]
         assert eoproduct.geometry.bounds == (-180.0, -90.0, 180.0, 90.0)
         assert eoproduct.properties["startTimeFromAscendingNode"] == "2020-01-01"
-        assert eoproduct.properties["completionTimeFromAscendingNode"] == "2020-01-01"
+        assert eoproduct.properties["completionTimeFromAscendingNode"] == "2020-01-02"
         assert eoproduct.properties["title"] == eoproduct.properties["id"]
         assert eoproduct.properties["title"].startswith(
             f"{self.product_dataset.upper()}"


### PR DESCRIPTION
When `end_date_excluded` was set to `false`, which is the case for `cop_cds` and `cop_ads`, invalid requests (`end_date < start_date`) were sent to the provider when the user entered the same start and end date. 
Also, when the user entered only a date and not a datetime, unexpected results were returned because the end date was reduced by one. 
With this fix, the end date is only reduced by one when the user enters a datetime with `00:00:00`. If only dates are given by the user, they are kept as they are.
