### PR TITLE
fix(providers): usage of `hydrological_year` in provider `wekeo_ecmwf`

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -53,6 +53,7 @@ from eodag.config import (
 from eodag.plugins.manager import PluginManager
 from eodag.plugins.search import PreparedSearch
 from eodag.plugins.search.build_search_result import BuildPostSearchResult
+from eodag.plugins.search.qssearch import PostJsonSearch
 from eodag.types import model_fields_to_annotated
 from eodag.types.queryables import CommonQueryables
 from eodag.types.whoosh import EODAGQueryParser
@@ -1561,7 +1562,7 @@ class EODataAccessGateway:
                 "max_items_per_page", DEFAULT_MAX_ITEMS_PER_PAGE
             )
             kwargs.update(items_per_page=items_per_page)
-            if isinstance(plugin, BuildPostSearchResult):
+            if isinstance(plugin, PostJsonSearch):
                 kwargs.update(
                     items_per_page=items_per_page,
                     _dc_qs=_dc_qs,

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -41,6 +41,7 @@ import geojson
 import orjson
 import pyproj
 from dateutil.parser import isoparse
+from dateutil.relativedelta import relativedelta
 from dateutil.tz import UTC, tzutc
 from jsonpath_ng.jsonpath import Child, JSONPath
 from lxml import etree
@@ -831,7 +832,7 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
         def convert_get_hydrological_year(date: str):
             utc_date = MetadataFormatter.convert_to_iso_utc_datetime(date)
             date_object = datetime.strptime(utc_date, "%Y-%m-%dT%H:%M:%S.%fZ")
-            date_object_second_year = date_object + timedelta(days=365)
+            date_object_second_year = date_object + relativedelta(years=1)
             return [
                 f'{date_object.strftime("%Y")}_{date_object_second_year.strftime("%y")}'
             ]

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -4886,6 +4886,9 @@
       statistic:
         - '{{"statistic": {statistic}}}'
         - '$.null'
+      hydrological_year:
+        - hydrological_year
+        - $.hydrological_year
   products:
     SATELLITE_CARBON_DIOXIDE:
       productType: EO:ECMWF:DAT:SATELLITE_CARBON_DIOXIDE

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -4887,8 +4887,8 @@
         - '{{"statistic": {statistic}}}'
         - '$.null'
       hydrological_year:
-        - hydrological_year
-        - $.hydrological_year
+        - '{{"hydrological_year": {hydrological_year}}}'
+        - '$.null'
   products:
     SATELLITE_CARBON_DIOXIDE:
       productType: EO:ECMWF:DAT:SATELLITE_CARBON_DIOXIDE


### PR DESCRIPTION
- Add mapping for parameter `hydrological_year` to provider `wekeo_ecmwf` and fix a typo in the `orderLink`
- Pass down the `_dc_qs` for the `PostJsonSearch` when downloading the product
- Manage leap years when calculating `hydrological_year`

Follow examples of queries and the generated `_dc_qs`. These tests can also be found in `tests.units.test_search_plugins.TestSearchPluginPostJsonSearch.test_plugins_search_postjsonsearch_query_params_wekeo`.

## Using the `datetime`

```bash
curl --location 'http://localhost:5000/search?provider=wekeo_ecmwf' --header 'Content-Type: application/json' --data '{
    "collections": [
        "GRIDDED_GLACIERS_MASS_CHANGE"
    ],
    "limit": 10,
    "page": 1,
    "datetime": "1980-01-01T00:00:00Z/1981-12-31T23:59:59Z",
    "query": {
        "variable": {
            "eq": "glacier_mass_change"
        },
        "format": {
            "eq": "zip"
        },
        "version": {
            "eq": "wgms_fog_2022_09"
        }
    }
}'
```

Generated `_dc_qs`:

```json
{
    "dataset_id": "EO:ECMWF:DAT:DERIVED_GRIDDED_GLACIER_MASS_CHANGE",
    "variable": "glacier_mass_change",
    "format": "zip",
    "product_version": "wgms_fog_2022_09",
    "hydrological_year": [
        "1980_81"
    ]
}
```

## Using parameter `hydrological_year` (single value)

```bash
curl --location 'http://localhost:5000/search?provider=wekeo_ecmwf' \
--header 'Content-Type: application/json' \
--data '{
    "collections": [
        "GRIDDED_GLACIERS_MASS_CHANGE"
    ],
    "limit": 10,
    "page": 1,
    "query": {
        "variable": {
            "eq": "glacier_mass_change"
        },
        "format": {
            "eq": "zip"
        },
        "version": {
            "eq": "wgms_fog_2022_09"
        },
        "hydrological_year": {
            "eq": [
                "2020_21"
            ]
        }
    }
}'
```

Generated `_dc_qs`:

```json
{
    "dataset_id": "EO:ECMWF:DAT:DERIVED_GRIDDED_GLACIER_MASS_CHANGE",
    "variable": "glacier_mass_change",
    "format": "zip",
    "product_version": "wgms_fog_2022_09",
    "hydrological_year": [
        "2020_21"
    ]
}
```
## Using parameter `hydrological_year` (multiple values)

```bash
curl --location 'http://localhost:5000/search?provider=wekeo_ecmwf' \
--header 'Content-Type: application/json' \
--data '{
    "collections": [
        "GRIDDED_GLACIERS_MASS_CHANGE"
    ],
    "limit": 10,
    "page": 1,
    "query": {
        "variable": {
            "eq": "glacier_mass_change"
        },
        "format": {
            "eq": "zip"
        },
        "version": {
            "eq": "wgms_fog_2022_09"
        },
        "hydrological_year": {
            "eq": [
                "1990_91", "2020_21"
            ]
        }
    }
}'
```

Generated `_dc_qs`:

```json
{
    "dataset_id": "EO:ECMWF:DAT:DERIVED_GRIDDED_GLACIER_MASS_CHANGE",
    "variable": "glacier_mass_change",
    "format": "zip",
    "product_version": "wgms_fog_2022_09",
    "hydrological_year": [
        "1990_91",
        "2020_21"
    ]
}
```



