### PR TITLE
fix(core): download authentication without downloadLink

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -1924,7 +1924,10 @@ class EODataAccessGateway:
                     matching_url = (
                         next(iter(eo_product.assets.values()))["href"]
                         if len(eo_product.assets) > 0
-                        else eo_product.properties.get("downloadLink")
+                        else (
+                            eo_product.properties.get("downloadLink")
+                            or eo_product.properties.get("orderLink")
+                        )
                     )
                     try:
                         auth_plugin = next(

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -280,7 +280,9 @@ class PluginManager:
         if product is not None and len(product.assets) > 0:
             matching_url = next(iter(product.assets.values()))["href"]
         elif product is not None:
-            matching_url = product.properties.get("downloadLink")
+            matching_url = product.properties.get(
+                "downloadLink"
+            ) or product.properties.get("orderLink")
         else:
             # search auth
             matching_url = getattr(associated_plugin.config, "api_endpoint", None)

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -2227,7 +2227,7 @@
       - '{$.completionTimeFromAscendingNode#to_iso_date}'
   auth: !plugin
     type: HTTPHeaderAuth
-    matching_url: https://ads.atmosphere.copernicus.eu
+    matching_url: https://ads-beta.atmosphere.copernicus.eu
     ssl_verify: true
     headers:
       PRIVATE-TOKEN: "{apikey}"
@@ -2586,7 +2586,7 @@
     - '{$.completionTimeFromAscendingNode#to_iso_date}'
   auth: !plugin
     type: HTTPHeaderAuth
-    matching_url: https://cds.climate.copernicus.eu
+    matching_url: https://cds-beta.climate.copernicus.eu
     ssl_verify: true
     headers:
       PRIVATE-TOKEN: "{apikey}"

--- a/tests/integration/test_core_search.py
+++ b/tests/integration/test_core_search.py
@@ -542,6 +542,33 @@ class TestCoreSearch(unittest.TestCase):
         )
         mock_query.reset_mock()
 
+        # order link matching
+        self.dag.add_provider(
+            "provider_matching_order_link",
+            "https://foo.bar/baz/search",
+        )
+        mock_query.side_effect = [
+            (
+                [
+                    EOProduct(
+                        "provider_matching_download_link",
+                        dict(
+                            geometry="POINT (0 0)",
+                            id="a",
+                            orderLink="https://somewhere/to/download",
+                        ),
+                    )
+                ],
+                1,
+            ),
+        ]
+        results = self.dag.search(provider="provider_matching_download_link")
+        self.assertEqual(
+            results[0].downloader_auth.config.credentials["username"],
+            "yet-another-username",
+        )
+        mock_query.reset_mock()
+
         # first asset matching
         self.dag.add_provider(
             "provider_matching_asset",

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -1036,7 +1036,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         self.product.product_type = "CAMS_EAC4"
         self.product.properties[
             "downloadLink"
-        ] = "https://ads.atmosphere.copernicus.eu/dummy"
+        ] = "https://ads-beta.atmosphere.copernicus.eu/dummy"
         product_dataset = "cams-global-reanalysis-eac4"
 
         plugin = self.get_download_plugin(self.product)


### PR DESCRIPTION
Following #1292

Fixes missing download authenticator when `downloadLink` is missing after a search (`cop_ads` and `cop_cds` providers which products are OFFLINE and orderable)