### PR TITLE
fix(plugins): better error handling for cop_marine

### DIFF
--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -145,7 +145,9 @@ class CopMarineSearch(StaticStacSearch):
                 logger.error("product %s not found", product_type)
                 raise UnsupportedProductType(product_type)
             logger.error("data for product %s could not be fetched", product_type)
-            raise RequestError.from_error(exc, f"data for product {product_type} could not be fetched") from exc
+            raise RequestError.from_error(
+                exc, f"data for product {product_type} could not be fetched"
+            ) from exc
 
         datasets = []
         for link in [li for li in collection_data["links"] if li["rel"] == "item"]:

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -37,7 +37,7 @@ from eodag.config import PluginConfig
 from eodag.plugins.search import PreparedSearch
 from eodag.plugins.search.static_stac_search import StaticStacSearch
 from eodag.utils import get_bucket_name_and_prefix
-from eodag.utils.exceptions import UnsupportedProductType, ValidationError
+from eodag.utils.exceptions import RequestError, UnsupportedProductType, ValidationError
 
 if TYPE_CHECKING:
     from mypy_boto3_s3 import S3Client
@@ -145,7 +145,7 @@ class CopMarineSearch(StaticStacSearch):
                 logger.error("product %s not found", product_type)
                 raise UnsupportedProductType(product_type)
             logger.error("data for product %s could not be fetched", product_type)
-            raise
+            raise RequestError(f"data for product {product_type} could not be fetched")
 
         datasets = []
         for link in [li for li in collection_data["links"] if li["rel"] == "item"]:

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -145,7 +145,7 @@ class CopMarineSearch(StaticStacSearch):
                 logger.error("product %s not found", product_type)
                 raise UnsupportedProductType(product_type)
             logger.error("data for product %s could not be fetched", product_type)
-            raise RequestError(f"data for product {product_type} could not be fetched")
+            raise RequestError.from_error(exc, f"data for product {product_type} could not be fetched") from exc
 
         datasets = []
         for link in [li for li in collection_data["links"] if li["rel"] == "item"]:

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -140,9 +140,12 @@ class CopMarineSearch(StaticStacSearch):
         )
         try:
             collection_data = requests.get(collection_url).json()
-        except requests.RequestException:
+        except requests.RequestException as exc:
+            if exc.errno == 404:
+                logger.error("product %s not found", product_type)
+                raise UnsupportedProductType(product_type)
             logger.error("data for product %s could not be fetched", product_type)
-            raise UnsupportedProductType(product_type)
+            raise
 
         datasets = []
         for link in [li for li in collection_data["links"] if li["rel"] == "item"]:

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2919,7 +2919,7 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
             )
         mock_requests_get.reset()
         mock_requests_get.side_effect = requests.exceptions.ConnectionError()
-        with self.assertRaises(requests.exceptions.ConnectionError):
+        with self.assertRaises(RequestError):
             search_plugin.query(
                 productType="PRODUCT_A",
                 id="item_20200204_20200205_niznjvnqkrf_20210101",

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -39,6 +39,7 @@ from requests import RequestException
 
 from eodag.api.product.metadata_mapping import get_queryable_from_provider
 from eodag.utils import deepcopy
+from eodag.utils.exceptions import UnsupportedProductType
 from tests.context import (
     DEFAULT_MISSION_START_DATE,
     HTTP_REQ_TIMEOUT,
@@ -2903,6 +2904,25 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
             self.assertEqual(
                 "item_20200204_20200205_niznjvnqkrf_20210101",
                 result[0].properties["id"],
+            )
+
+    @mock.patch("eodag.plugins.search.cop_marine.requests.get")
+    def test_plugins_search_cop_marine_with_errors(self, mock_requests_get):
+        exc = requests.RequestException()
+        exc.errno = 404
+        mock_requests_get.side_effect = exc
+        search_plugin = self.get_search_plugin("PRODUCT_A", self.provider)
+        with self.assertRaises(UnsupportedProductType):
+            search_plugin.query(
+                productType="PRODUCT_AX",
+                id="item_20200204_20200205_niznjvnqkrf_20210101",
+            )
+        mock_requests_get.reset()
+        mock_requests_get.side_effect = requests.exceptions.ConnectionError()
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            search_plugin.query(
+                productType="PRODUCT_A",
+                id="item_20200204_20200205_niznjvnqkrf_20210101",
             )
 
 


### PR DESCRIPTION
improves the error handling at the request to fetch the product type information in `CopMarineSearch`:
- only use `UnsupportedProductType` exception in case of `NotFound` error code
- otherwise `RequestError` will be raised
