### PR TITLE
fix(plugins): raise error when http download order fails

### DIFF
--- a/eodag/rest/errors.py
+++ b/eodag/rest/errors.py
@@ -126,7 +126,10 @@ async def eodag_errors_handler(request: Request, exc: Exception) -> ORJSONRespon
     if not isinstance(exc, EodagError):
         return starlette_exception_handler(request, exc)
 
-    code = EODAG_DEFAULT_STATUS_CODES.get(type(exc), getattr(exc, "status_code", 500))
+    exception_status_code = getattr(exc, "status_code", None)
+    default_status_code = exception_status_code or 500
+    code = EODAG_DEFAULT_STATUS_CODES.get(type(exc), default_status_code)
+
     detail = f"{type(exc).__name__}: {str(exc)}"
 
     if type(exc) in (MisconfiguredError, AuthenticationError, TimeOutError):

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -1177,7 +1177,7 @@ class RequestTestCase(unittest.TestCase):
             f"collections/{self.tested_product_type}/items/foo/download?provider=peps",
             expected_status_code=500,
         )
-        assert "RequestError" in response.text
+        self.assertIn("RequestError", response.text)
 
     def test_root(self):
         """Request to / should return a valid response"""

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -323,6 +323,7 @@ class RequestTestCase(unittest.TestCase):
         post_data: Optional[Any] = None,
         search_call_count: Optional[int] = None,
         search_result: SearchResult = None,
+        expected_status_code: int = 200,
     ) -> httpx.Response:
         if search_result:
             mock_search.return_value = search_result
@@ -354,7 +355,7 @@ class RequestTestCase(unittest.TestCase):
         elif expected_search_kwargs is not None:
             mock_search.assert_called_once_with(**expected_search_kwargs)
 
-        self.assertEqual(200, response.status_code, response.text)
+        self.assertEqual(expected_status_code, response.status_code, response.text)
 
         return response
 
@@ -1149,6 +1150,34 @@ class RequestTestCase(unittest.TestCase):
         assert not os.path.exists(
             expected_file
         ), f"File {expected_file} should have been deleted"
+
+    @mock.patch(
+        "eodag.plugins.authentication.base.Authentication.authenticate",
+        autospec=True,
+    )
+    @mock.patch(
+        "eodag.plugins.download.base.Download._stream_download_dict",
+        autospec=True,
+    )
+    def test_error_handler_supports_request_exception_with_status_code_none(
+        self, mock_stream_download: Mock, mock_auth: Mock
+    ):
+        """
+        A RequestError with a status code set to None (the default value) should not
+        crash the server. This test ensures that it doesn't crash the server and that a
+        500 status code is returned to the user.
+        """
+        # Make _stream_download_dict reaise an exception object with a status_code
+        # attribute set to None
+        exception = RequestError()
+        exception.status_code = None
+        mock_stream_download.side_effect = exception
+
+        response = self._request_valid_raw(
+            f"collections/{self.tested_product_type}/items/foo/download?provider=peps",
+            expected_status_code=500,
+        )
+        assert "RequestError" in response.text
 
     def test_root(self):
         """Request to / should return a valid response"""


### PR DESCRIPTION
Fix #1337 

When a `HttpDownload.order_download()` fails, the error is logged but this can easily go unnoticed by the user if logs aren't enabled. The purpose of this pull request is to raise an exception instead. 

However, this exception has a `status_code` attribute set to None, which makes the rest server crash when this status code is compared with integer values:
```
  File "/home/al/venvs/dedl_lab/lib/python3.12/site-packages/starlette/responses.py", line 66, in init_headers
    and not (self.status_code < 200 or self.status_code in (204, 304))
             ^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

This pull request provides a fix for that by ensuring that the status code defaults to 500.