### PR TITLE
fix(utils): include response text in RequestError

### DIFF
--- a/eodag/utils/exceptions.py
+++ b/eodag/utils/exceptions.py
@@ -94,7 +94,10 @@ class RequestError(EodagError):
         status_code = getattr(error, "code", None)
         text = getattr(error, "msg", None)
 
-        if response := getattr(error, "response", None):
+        response = getattr(error, "response", None)
+        # Explicitly test for None because response objects are considered false if they
+        # have a status code other than 200
+        if response is not None:
             status_code = response.status_code
             text = response.text
 

--- a/tests/units/test_utils_exceptions.py
+++ b/tests/units/test_utils_exceptions.py
@@ -1,0 +1,23 @@
+from requests.models import Response
+
+from eodag.utils.exceptions import RequestError
+
+
+def test_request_error_includes_response_text():
+    """
+    This test triggers a bug in RequestError due to the code doing an if on a response
+    object without realizing that a response object evaluates to False if it doesn't
+    have a status code 200. This resulted in error text from the provider not being
+    included in the error.
+    """
+    original_exception = Exception()
+    response = Response()
+    response.status_code = 400
+    response._content = b"*** my response text ***"
+    original_exception.response = response
+
+    error = RequestError.from_error(original_exception)
+
+    # Verify that the error message from the server is included in the error
+    assert "*** my response text ***" in str(error)
+    assert error.status_code == 400

--- a/tests/units/test_utils_exceptions.py
+++ b/tests/units/test_utils_exceptions.py
@@ -1,23 +1,26 @@
+from unittest import TestCase
+
 from requests.models import Response
 
 from eodag.utils.exceptions import RequestError
 
 
-def test_request_error_includes_response_text():
-    """
-    This test triggers a bug in RequestError due to the code doing an if on a response
-    object without realizing that a response object evaluates to False if it doesn't
-    have a status code 200. This resulted in error text from the provider not being
-    included in the error.
-    """
-    original_exception = Exception()
-    response = Response()
-    response.status_code = 400
-    response._content = b"*** my response text ***"
-    original_exception.response = response
+class TestRequestError(TestCase):
+    def test_request_error_includes_response_text(self):
+        """
+        This test triggers a bug in RequestError due to the code doing an if on a response
+        object without realizing that a response object evaluates to False if it doesn't
+        have a status code 200. This resulted in error text from the provider not being
+        included in the error.
+        """
+        original_exception = Exception()
+        response = Response()
+        response.status_code = 400
+        response._content = b"*** my response text ***"
+        original_exception.response = response
 
-    error = RequestError.from_error(original_exception)
+        error = RequestError.from_error(original_exception)
 
-    # Verify that the error message from the server is included in the error
-    assert "*** my response text ***" in str(error)
-    assert error.status_code == 400
+        # Verify that the error message from the server is included in the error
+        self.assertIn("*** my response text ***", str(error))
+        self.assertEqual(error.status_code, 400)


### PR DESCRIPTION
Fixes issue with missing `Response` handling in `RequestError`.

This PR includes a test triggering the bug it's addressing. The issue was due to doing an `if` on a `Response` object to test the presence of that response object. But this response object evaluates to `False` if it doesn't have a status code 200. So instead we explicitly test that the response object is not `None`.

With this change, the exception triggered by the code example provided in #1339 should include the error message contained in the response from the provider:
```
eodag.utils.exceptions.RequestError: ('Skipping error while searching for dedl StacSearch instance', '{"description":"1 error(s). datetime: Value error, Invalid datetime range, must match format (begin_date, end_date)"}')
```