### PR TITLE
build: add python3.13 and drop python3.8 support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           # Get history and tags for SCM versioning to work
           fetch-depth: 0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Check that the current version isn't already on PyPi
         run: |

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -17,10 +17,10 @@ jobs:
       with:
         # Get history and tags for SCM versioning to work
         fetch-depth: 0
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Update pip
       run: python -m pip install --upgrade pip
     - name: Get pip cache dir

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
       with:
         # Get history and tags for SCM versioning to work
         fetch-depth: 0
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Update pip
       run: python -m pip install --upgrade pip
     - name: Get pip cache dir
@@ -48,7 +48,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, "3.12"]
+        python-version: [3.9, "3.13"]
         os: [ubuntu-latest, windows-latest]
     steps:
     - name: Checkout the repo
@@ -110,7 +110,7 @@ jobs:
       uses: insightsengineering/coverage-action@v2
       with:
         # Path to the Cobertura XML report.
-        path: artifacts/unit-test-results-python3.12-ubuntu-latest/coverage.xml
+        path: artifacts/unit-test-results-python3.13-ubuntu-latest/coverage.xml
         # Minimum total coverage, if you want to the
         # workflow to enforce it as a standard.
         # This has no effect if the `fail` arg is set to `false`.
@@ -140,7 +140,7 @@ jobs:
       uses: insightsengineering/coverage-action@v2
       with:
         # Path to the Cobertura XML report.
-        path: artifacts/unit-test-results-python3.12-windows-latest/coverage.xml
+        path: artifacts/unit-test-results-python3.13-windows-latest/coverage.xml
         # Minimum total coverage, if you want to the
         # workflow to enforce it as a standard.
         # This has no effect if the `fail` arg is set to `false`.
@@ -175,10 +175,10 @@ jobs:
       with:
         # Get history and tags for SCM versioning to work
         fetch-depth: 0
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Update pip
       run: python -m pip install --upgrade pip
     - name: Get pip cache dir
@@ -213,10 +213,10 @@ jobs:
       with:
         # Get history and tags for SCM versioning to work
         fetch-depth: 0
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Update pip
       run: python -m pip install --upgrade pip
     - name: Get pip cache dir

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -75,7 +75,7 @@ To run the entire tests (units, integration and end-to-end):
       you, please `install <https://pandoc.org/installing.html>`_ pandoc and try
       again.
 
-    * eodag is tested against python versions 3.8, 3.9, 3.10, 3.11 and 3.12. Ensure you have
+    * eodag is tested against python versions 3.9, 3.10, 3.11, 3.12 and 3.13. Ensure you have
       these versions installed before you run tox. You can use
       `pyenv <https://github.com/pyenv/pyenv>`_ to manage many different versions
       of python

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -24,7 +24,18 @@ import re
 import shutil
 import tempfile
 from operator import itemgetter
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import geojson
 import pkg_resources
@@ -102,7 +113,7 @@ if TYPE_CHECKING:
     from eodag.plugins.search.base import Search
     from eodag.types import ProviderSortables
     from eodag.types.download_args import DownloadConf
-    from eodag.utils import Annotated, DownloadedCallback, ProgressCallback, Unpack
+    from eodag.utils import DownloadedCallback, ProgressCallback, Unpack
 
 logger = logging.getLogger("eodag.core")
 

--- a/eodag/api/search_result.py
+++ b/eodag/api/search_result.py
@@ -18,7 +18,17 @@
 from __future__ import annotations
 
 from collections import UserList
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from shapely.geometry import GeometryCollection, shape
 from typing_extensions import Doc
@@ -29,7 +39,6 @@ from eodag.plugins.crunch.filter_latest_intersect import FilterLatestIntersect
 from eodag.plugins.crunch.filter_latest_tpl_name import FilterLatestByName
 from eodag.plugins.crunch.filter_overlap import FilterOverlap
 from eodag.plugins.crunch.filter_property import FilterProperty
-from eodag.utils import Annotated
 
 if TYPE_CHECKING:
     from shapely.geometry.base import BaseGeometry

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -22,6 +22,7 @@ import os
 import tempfile
 from inspect import isclass
 from typing import (
+    Annotated,
     Any,
     Dict,
     ItemsView,
@@ -49,7 +50,6 @@ from eodag.api.product.metadata_mapping import mtd_cfg_as_conversion_and_querypa
 from eodag.utils import (
     HTTP_REQ_TIMEOUT,
     USER_AGENT,
-    Annotated,
     cached_yaml_load,
     cached_yaml_load_all,
     cast_scalar_value,

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated, get_args
 
 import orjson
 from pydantic.fields import Field, FieldInfo
@@ -35,11 +35,9 @@ from eodag.types.queryables import Queryables
 from eodag.types.search_args import SortByList
 from eodag.utils import (
     GENERIC_PRODUCT_TYPE,
-    Annotated,
     copy_deepcopy,
     deepcopy,
     format_dict_items,
-    get_args,
     update_nested_dict,
 )
 from eodag.utils.exceptions import ValidationError

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -20,7 +20,18 @@ from __future__ import annotations
 import hashlib
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, cast
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    cast,
+    get_args,
+)
 from urllib.parse import quote_plus, unquote_plus
 
 import geojson
@@ -30,7 +41,6 @@ from dateutil.tz import tzutc
 from jsonpath_ng import Child, Fields, Root
 from pydantic import create_model
 from pydantic.fields import FieldInfo
-from typing_extensions import get_args
 
 from eodag.api.product import EOProduct
 from eodag.api.product.metadata_mapping import (
@@ -48,7 +58,6 @@ from eodag.types import json_field_definition_to_python, model_fields_to_annotat
 from eodag.types.queryables import CommonQueryables
 from eodag.utils import (
     DEFAULT_MISSION_START_DATE,
-    Annotated,
     deepcopy,
     dict_items_recursive_sort,
     get_geometry_from_various,

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -23,6 +23,7 @@ from copy import copy as copy_copy
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     Callable,
     Dict,
@@ -33,6 +34,7 @@ from typing import (
     Tuple,
     TypedDict,
     cast,
+    get_args,
 )
 from urllib.error import URLError
 from urllib.parse import (
@@ -77,12 +79,10 @@ from eodag.utils import (
     GENERIC_PRODUCT_TYPE,
     HTTP_REQ_TIMEOUT,
     USER_AGENT,
-    Annotated,
     _deprecated,
     deepcopy,
     dict_items_recursive_apply,
     format_dict_items,
-    get_args,
     get_ssl_context,
     quote,
     string_to_jsonpath,

--- a/eodag/rest/config.py
+++ b/eodag/rest/config.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import List, Union
+from typing import Annotated, List, Union
 
 from pydantic import Field
 from pydantic.functional_validators import BeforeValidator
@@ -26,7 +26,6 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Doc
 
 from eodag.rest.constants import DEFAULT_MAXSIZE, DEFAULT_TTL
-from eodag.utils import Annotated
 
 
 def str2liststr(raw: Union[str, List[str]]) -> List[str]:

--- a/eodag/rest/types/queryables.py
+++ b/eodag/rest/types/queryables.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Dict, List, Optional, Union
 
 from pydantic import (
     BaseModel,
@@ -32,7 +32,6 @@ from pydantic import (
 from eodag.rest.types.eodag_search import EODAGSearch
 from eodag.rest.utils.rfc3339 import str_to_interval
 from eodag.types import python_field_definition_to_json
-from eodag.utils import Annotated
 
 if TYPE_CHECKING:
     from pydantic.fields import FieldInfo

--- a/eodag/rest/types/stac_search.py
+++ b/eodag/rest/types/stac_search.py
@@ -19,7 +19,17 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import geojson
 from pydantic import (
@@ -43,7 +53,6 @@ from shapely.geometry import (
     shape,
 )
 from shapely.geometry.base import GEOMETRY_TYPES, BaseGeometry
-from typing_extensions import Annotated
 
 from eodag.rest.utils.rfc3339 import rfc3339_str_to_datetime, str_to_interval
 from eodag.utils.exceptions import ValidationError

--- a/eodag/types/__init__.py
+++ b/eodag/types/__init__.py
@@ -18,13 +18,25 @@
 """EODAG types"""
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, Optional, Tuple, TypedDict, Union
+from typing import (
+    Annotated,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    TypedDict,
+    Union,
+    get_args,
+    get_origin,
+)
 
 from annotated_types import Gt, Lt
 from pydantic import Field
 from pydantic.fields import FieldInfo
 
-from eodag.utils import Annotated, copy_deepcopy, get_args, get_origin
+from eodag.utils import copy_deepcopy
 from eodag.utils.exceptions import ValidationError
 
 # Types mapping from JSON Schema and OpenAPI 3.1.0 specifications to Python
@@ -183,7 +195,7 @@ def python_field_definition_to_json(
     """Get json field definition from python `typing.Annotated`
 
     >>> from pydantic import Field
-    >>> from eodag.utils import Annotated
+    >>> from typing import Annotated
     >>> python_field_definition_to_json(
     ...     Annotated[
     ...         Optional[str],

--- a/eodag/types/queryables.py
+++ b/eodag/types/queryables.py
@@ -15,12 +15,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
+from typing import Annotated, Optional
 
 from annotated_types import Lt
 from pydantic import BaseModel, Field
 from pydantic.types import PositiveInt
-from typing_extensions import Annotated
 
 Percentage = Annotated[PositiveInt, Lt(100)]
 

--- a/eodag/types/search_args.py
+++ b/eodag/types/search_args.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 import re
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Annotated, Any, Dict, List, Optional, Tuple, Union, cast
 
 from annotated_types import MinLen
 from pydantic import BaseModel, ConfigDict, Field, conint, field_validator
@@ -27,7 +27,7 @@ from shapely.geometry import Polygon, shape
 from shapely.geometry.base import GEOMETRY_TYPES, BaseGeometry
 
 from eodag.types.bbox import BBox
-from eodag.utils import DEFAULT_ITEMS_PER_PAGE, DEFAULT_PAGE, Annotated
+from eodag.utils import DEFAULT_ITEMS_PER_PAGE, DEFAULT_PAGE
 from eodag.utils.exceptions import ValidationError
 
 NumType = Union[float, int]

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -79,11 +79,6 @@ from urllib.parse import (  # noqa; noqa
 )
 from urllib.request import url2pathname
 
-if sys.version_info >= (3, 9):
-    from typing import Annotated, get_args, get_origin  # noqa
-else:
-    from typing_extensions import Annotated, get_args, get_origin  # type: ignore # noqa
-
 if sys.version_info >= (3, 12):
     from typing import Unpack  # type: ignore # noqa
 else:

--- a/eodag/utils/exceptions.py
+++ b/eodag/utils/exceptions.py
@@ -17,12 +17,12 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 if TYPE_CHECKING:
     from typing import Optional, Set
 
-    from typing_extensions import Annotated, Doc
+    from typing_extensions import Doc
 
 
 class EodagError(Exception):

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,11 +22,11 @@ classifiers =
     Operating System :: POSIX :: Linux
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Internet :: WWW/HTTP :: Indexing/Search
     Topic :: Scientific/Engineering :: GIS

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -20,6 +20,7 @@ import ast
 import configparser
 import os
 import re
+import sys
 import unittest
 from typing import Any, Dict, Iterator, Set
 
@@ -136,7 +137,12 @@ class TestRequirements(unittest.TestCase):
         setup_requires = get_setup_requires(setup_cfg_path)
         setup_requires.update(get_optional_dependencies(setup_cfg_path, "all"))
         import_required_dict = importlib_metadata.packages_distributions()
-        default_libs = stdlib_list()
+        try:
+            default_libs = stdlib_list()
+        except FileNotFoundError:
+            # python version might not be supported by `stdlib_list`
+            # Since python3.10, we can use `sys.stdlib_module_names` instead
+            default_libs = list(sys.stdlib_module_names)
 
         missing_imports = []
         for project_import in project_imports:

--- a/tox.ini
+++ b/tox.ini
@@ -16,17 +16,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 [tox]
-envlist = py38, py39, py310, py311, py312, docs, pypi, linters
+envlist = py39, py310, py311, py312, py313, docs, pypi, linters
 skipdist = true
 
 # Mapping required by tox-gh-actions, only used in CI
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 commands =


### PR DESCRIPTION
- Adds `python3.13` support
- Drops `python3.8` support
- Adapts github actions to use `3.9` and `3.13` as min and max supported versions