### PR TITLE
fix(plugins): OIDC flow

### DIFF
--- a/eodag/config.py
+++ b/eodag/config.py
@@ -468,11 +468,8 @@ class PluginConfig(yaml.YAMLObject):
     #: :class:`~eodag.plugins.authentication.openid_connect.OIDCRefreshTokenBase`
     #: The OIDC provider's .well-known/openid-configuration url.
     oidc_config_url: str
-    #: :class:`~eodag.plugins.authentication.openid_connect.OIDCRefreshTokenBase` The OIDC token audiances
+    #: :class:`~eodag.plugins.authentication.openid_connect.OIDCRefreshTokenBase` The OIDC token audiences
     allowed_audiences: List[str]
-    #: :class:`~eodag.plugins.authentication.openid_connect.OIDCRefreshTokenBase` use refresh token
-    #: (hopefully) temporary solution to not use refresh token for dedt_lumi because it is very strange
-    use_refresh_token: bool
     #: :class:`~eodag.plugins.authentication.keycloak.KeycloakOIDCPasswordAuth`
     #: Base url used in the request to fetch the token
     auth_base_uri: str

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -466,10 +466,13 @@ class PluginConfig(yaml.YAMLObject):
     #: :class:`~eodag.plugins.authentication.openid_connect.OIDCRefreshTokenBase` The OIDC provider's client secret
     client_secret: str
     #: :class:`~eodag.plugins.authentication.openid_connect.OIDCRefreshTokenBase`
-    # The OIDC provider's .well-known/openid-configuration url.
+    #: The OIDC provider's .well-known/openid-configuration url.
     oidc_config_url: str
     #: :class:`~eodag.plugins.authentication.openid_connect.OIDCRefreshTokenBase` The OIDC token audiances
-    allowed_audiances: List[str]
+    allowed_audiences: List[str]
+    #: :class:`~eodag.plugins.authentication.openid_connect.OIDCRefreshTokenBase` use refresh token
+    #: (hopefully) temporary solution to not use refresh token for dedt_lumi because it is very strange
+    use_refresh_token: bool
     #: :class:`~eodag.plugins.authentication.keycloak.KeycloakOIDCPasswordAuth`
     #: Base url used in the request to fetch the token
     auth_base_uri: str

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -465,6 +465,11 @@ class PluginConfig(yaml.YAMLObject):
     client_id: str
     #: :class:`~eodag.plugins.authentication.openid_connect.OIDCRefreshTokenBase` The OIDC provider's client secret
     client_secret: str
+    #: :class:`~eodag.plugins.authentication.openid_connect.OIDCRefreshTokenBase`
+    # The OIDC provider's .well-known/openid-configuration url.
+    oidc_config_url: str
+    #: :class:`~eodag.plugins.authentication.openid_connect.OIDCRefreshTokenBase` The OIDC token audiances
+    allowed_audiances: List[str]
     #: :class:`~eodag.plugins.authentication.keycloak.KeycloakOIDCPasswordAuth`
     #: Base url used in the request to fetch the token
     auth_base_uri: str

--- a/eodag/plugins/authentication/keycloak.py
+++ b/eodag/plugins/authentication/keycloak.py
@@ -79,7 +79,6 @@ class KeycloakOIDCPasswordAuth(OIDCRefreshTokenBase):
     """
 
     GRANT_TYPE = "password"
-    TOKEN_URL_TEMPLATE = "{auth_base_uri}/realms/{realm}/protocol/openid-connect/token"
     REQUIRED_PARAMS = ["auth_base_uri", "client_id", "client_secret", "token_provision"]
 
     def __init__(self, provider: str, config: PluginConfig) -> None:
@@ -101,10 +100,9 @@ class KeycloakOIDCPasswordAuth(OIDCRefreshTokenBase):
         Makes authentication request
         """
         self.validate_config_credentials()
-        access_token = self._get_access_token()
-        self.token_info["access_token"] = access_token
+        self._get_access_token()
         return CodeAuthorizedAuth(
-            self.token_info["access_token"],
+            self.access_token,
             self.config.token_provision,
             key=getattr(self.config, "token_qs_key", None),
         )
@@ -120,10 +118,7 @@ class KeycloakOIDCPasswordAuth(OIDCRefreshTokenBase):
         ssl_verify = getattr(self.config, "ssl_verify", True)
         try:
             response = self.session.post(
-                self.TOKEN_URL_TEMPLATE.format(
-                    auth_base_uri=self.config.auth_base_uri.rstrip("/"),
-                    realm=self.config.realm,
-                ),
+                self.token_endpoint,
                 data=dict(req_data, **credentials),
                 headers=USER_AGENT,
                 timeout=HTTP_REQ_TIMEOUT,
@@ -142,15 +137,12 @@ class KeycloakOIDCPasswordAuth(OIDCRefreshTokenBase):
             "client_id": self.config.client_id,
             "client_secret": self.config.client_secret,
             "grant_type": "refresh_token",
-            "refresh_token": self.token_info["refresh_token"],
+            "refresh_token": self.refresh_token,
         }
         ssl_verify = getattr(self.config, "ssl_verify", True)
         try:
             response = self.session.post(
-                self.TOKEN_URL_TEMPLATE.format(
-                    auth_base_uri=self.config.auth_base_uri.rstrip("/"),
-                    realm=self.config.realm,
-                ),
+                self.token_endpoint,
                 data=req_data,
                 headers=USER_AGENT,
                 timeout=HTTP_REQ_TIMEOUT,

--- a/eodag/plugins/authentication/keycloak.py
+++ b/eodag/plugins/authentication/keycloak.py
@@ -52,7 +52,7 @@ class KeycloakOIDCPasswordAuth(OIDCRefreshTokenBase):
             ...
             auth:
                 plugin: KeycloakOIDCPasswordAuth
-                auth_base_uri: 'https://somewhere/auth'
+                oidc_config_url: 'https://somewhere/auth/realms/realm/.well-known/openid-configuration'
                 realm: 'the-realm'
                 client_id: 'SOME_ID'
                 client_secret: '01234-56789'
@@ -69,7 +69,7 @@ class KeycloakOIDCPasswordAuth(OIDCRefreshTokenBase):
             ...
             auth:
                 plugin: KeycloakOIDCPasswordAuth
-                auth_base_uri: 'https://somewhere/auth'
+                oidc_config_url: 'https://somewhere/auth/realms/realm/.well-known/openid-configuration'
                 realm: 'the-realm'
                 client_id: 'SOME_ID'
                 client_secret: '01234-56789'
@@ -79,7 +79,12 @@ class KeycloakOIDCPasswordAuth(OIDCRefreshTokenBase):
     """
 
     GRANT_TYPE = "password"
-    REQUIRED_PARAMS = ["client_id", "client_secret", "token_provision"]
+    REQUIRED_PARAMS = [
+        "oidc_config_url",
+        "client_id",
+        "client_secret",
+        "token_provision",
+    ]
 
     def __init__(self, provider: str, config: PluginConfig) -> None:
         super(KeycloakOIDCPasswordAuth, self).__init__(provider, config)

--- a/eodag/plugins/authentication/keycloak.py
+++ b/eodag/plugins/authentication/keycloak.py
@@ -79,7 +79,7 @@ class KeycloakOIDCPasswordAuth(OIDCRefreshTokenBase):
     """
 
     GRANT_TYPE = "password"
-    REQUIRED_PARAMS = ["auth_base_uri", "client_id", "client_secret", "token_provision"]
+    REQUIRED_PARAMS = ["client_id", "client_secret", "token_provision"]
 
     def __init__(self, provider: str, config: PluginConfig) -> None:
         super(KeycloakOIDCPasswordAuth, self).__init__(provider, config)

--- a/eodag/plugins/authentication/openid_connect.py
+++ b/eodag/plugins/authentication/openid_connect.py
@@ -20,10 +20,11 @@ from __future__ import annotations
 import logging
 import re
 import string
-from datetime import datetime
+from datetime import UTC, datetime
 from random import SystemRandom
-from typing import TYPE_CHECKING, Any, Dict, Optional, TypedDict
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
+import jwt
 import requests
 from lxml import etree
 from requests.auth import AuthBase
@@ -47,67 +48,86 @@ class OIDCRefreshTokenBase(Authentication):
     Common mechanism to handle refresh token from all OIDC auth plugins.
     """
 
-    class TokenInfo(TypedDict, total=False):
-        """Token infos"""
+    jwks_client: jwt.PyJWKClient
 
-        refresh_token: str
-        refresh_time: datetime
-        token_time: datetime
-        access_token: str
-        access_token_expiration: float
-        refresh_token_expiration: float
+    access_token: str
+    access_token_expiration: datetime
+
+    refresh_token: str
+    refresh_token_expiration: datetime
+
+    token_endpoint: str
+    authorization_endpoint: str
 
     def __init__(self, provider: str, config: PluginConfig) -> None:
         super(OIDCRefreshTokenBase, self).__init__(provider, config)
         self.session = requests.Session()
-        # already retrieved token info store
-        self.token_info: OIDCRefreshTokenBase.TokenInfo = {}
+
+        self.jwks_client = jwt.PyJWKClient(config.oidc_config_url)
+
+        self.access_token = ""
+        self.access_token_expiration = datetime.min
+
+        self.refresh_token = ""
+        self.refresh_token_expiration = datetime.min
+
+        try:
+            response = requests.get(self.config.oidc_config_url)
+            response.raise_for_status()
+            auth_config = response.json()
+        except requests.HTTPError as e:
+            raise MisconfiguredError(
+                f"Cannot obtain OIDC endpoints from {self.config.oidc_config_url}"
+                f"Request returned {e.response.text}."
+            )
+
+        self.token_endpoint = auth_config["token_endpoint"]
+        self.authorization_endpoint = auth_config["authorization_endpoint"]
+
+    def decode_jwt_token(self, token: str) -> Dict[str, Any]:
+        """Decode JWT token."""
+        try:
+            key = self.jwks_client.get_signing_key_from_jwt(token).key
+            return jwt.decode(
+                token,
+                key,
+                algorithms=["RS256"],
+                # NOTE: Audience validation MUST match audience claim if set in token
+                # (https://pyjwt.readthedocs.io/en/stable/changelog.html?highlight=audience#id40)
+                audience=self.config.allowed_audiances,
+            )
+        except (jwt.exceptions.InvalidTokenError, jwt.exceptions.DecodeError) as e:
+            raise AuthenticationError(e)
 
     def _get_access_token(self) -> str:
-        current_time = datetime.now()
-        if (
-            # No info: first time
-            not self.token_info
-            # Refresh token available but expired
-            or (
-                "refresh_token" in self.token_info
-                and self.token_info["refresh_token_expiration"] > 0
-                and (current_time - self.token_info["token_time"]).seconds
-                >= self.token_info["refresh_token_expiration"]
+        now = datetime.now(UTC)
+        if self.access_token and now < self.access_token_expiration:
+            logger.debug(
+                f"Existing access_token is still valid until {self.access_token_expiration.isoformat()}."
             )
-            # Refresh token *not* available and access token expired
-            or (
-                "refresh_token" not in self.token_info
-                and (current_time - self.token_info["token_time"]).seconds
-                >= self.token_info["access_token_expiration"]
-            )
-        ):
-            # Request *new* token on first attempt or if token expired
-            res = self._request_new_token()
-            self.token_info["token_time"] = current_time
-            self.token_info["access_token_expiration"] = float(res["expires_in"])
-            if "refresh_token" in res:
-                self.token_info["refresh_time"] = current_time
-                self.token_info["refresh_token_expiration"] = float(
-                    res["refresh_expires_in"]
-                )
-                self.token_info["refresh_token"] = str(res["refresh_token"])
-            return str(res["access_token"])
+            return self.access_token
 
-        elif (
-            # Refresh token available and access token expired
-            "refresh_token" in self.token_info
-            and (current_time - self.token_info["refresh_time"]).seconds
-            >= self.token_info["access_token_expiration"]
-        ):
-            # Use refresh token
-            res = self._get_token_with_refresh_token()
-            self.token_info["refresh_token"] = res["refresh_token"]
-            self.token_info["refresh_time"] = current_time
-            return res["access_token"]
+        elif self.refresh_token and now < self.refresh_token_expiration:
+            response = self._get_token_with_refresh_token()
 
-        logger.debug("Using already retrieved access token")
-        return self.token_info["access_token"]
+        else:
+            response = self._request_new_token()
+
+        self.access_token = response[self.config.token_key or "access_token"]
+        self.access_token_expiration = datetime.fromtimestamp(
+            self.decode_jwt_token(self.access_token)["exp"]
+        )
+
+        self.refresh_token = response.get(
+            self.config.refresh_token_key or "refresh_token", ""
+        )
+        self.refresh_token_expiration = datetime.fromtimestamp(
+            self.decode_jwt_token(self.refresh_token)["exp"]
+            if self.refresh_token
+            else 0
+        )
+
+        return self.access_token
 
     def _request_new_token(self) -> Dict[str, str]:
         """Fetch the access token with a new authentcation"""
@@ -117,18 +137,12 @@ class OIDCRefreshTokenBase(Authentication):
 
     def _request_new_token_error(self, e: requests.RequestException) -> Dict[str, str]:
         """Handle RequestException raised by `self._request_new_token()`"""
-        if self.token_info.get("access_token"):
+        if self.access_token:
             # try using already retrieved token if authenticate() fails (OTP use-case)
-            if "access_token_expiration" in self.token_info:
-                return {
-                    "access_token": self.token_info["access_token"],
-                    "expires_in": str(self.token_info["access_token_expiration"]),
-                }
-            else:
-                return {
-                    "access_token": self.token_info["access_token"],
-                    "expires_in": "0",
-                }
+            return {
+                "access_token": self.access_token,
+                "expires_in": self.access_token_expiration.isoformat(),
+            }
         response_text = getattr(e.response, "text", "").strip()
         # check if error is identified as auth_error in provider conf
         auth_errors = getattr(self.config, "auth_error_code", [None])
@@ -182,15 +196,11 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
 
     The configuration keys of this plugin are as follows (they have no defaults)::
 
-        # (mandatory) The authorization url of the server (where to query for grants)
-        authorization_uri:
-
         # (mandatory) The callback url that will handle the code given by the OIDC provider
         redirect_uri:
 
-        # (mandatory) The url to query to exchange the authorization code obtained from the OIDC provider
-        # for an authorized token
-        token_uri:
+        # (mandatory) The url to get the OIDC Provider's endpoints
+        oidc_config_url:
 
         # (mandatory) The OIDC provider's client ID of the eodag provider
         client_id:
@@ -203,7 +213,8 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
         # of the Python `requests <http://docs.python-requests.org/>`_ library
         token_exchange_post_data_method:
 
-        # (mandatory) The key pointing to the token in the json response to the POST request to the token server
+        # (optional) The key pointing to the token in the json response to the POST request to the token server
+        # default to access_token
         token_key:
 
         # (mandatory) One of qs or header. This is how the token obtained will be used to authenticate the user
@@ -256,6 +267,7 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
         token_qs_key:
 
         # (optional) The key pointing to the refresh_token in the json response to the POST request to the token server
+        # default to refresh_token.
         refresh_token_key:
     """
 
@@ -283,16 +295,16 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
 
     def authenticate(self) -> CodeAuthorizedAuth:
         """Authenticate"""
-        self.token_info["access_token"] = self._get_access_token()
+        self._get_access_token()
 
         return CodeAuthorizedAuth(
-            self.token_info["access_token"],
+            self.access_token,
             self.config.token_provision,
             key=getattr(self.config, "token_qs_key", None),
         )
 
     def _request_new_token(self) -> Dict[str, str]:
-        """Fetch the access token with a new authentcation"""
+        """Fetch the access token with a new authentication"""
         logger.debug("Fetching access token from %s", self.config.token_uri)
         state = self.compute_state()
         authentication_response = self.authenticate_user(state)
@@ -322,10 +334,10 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
     def _get_token_with_refresh_token(self) -> Dict[str, str]:
         """Fetch the access token with the refresh token"""
         logger.debug(
-            "Fetching access token with refresh token from %s", self.config.token_uri
+            "Fetching access token with refresh token from %s.", self.token_endpoint
         )
         token_data: Dict[str, Any] = {
-            "refresh_token": self.token_info["refresh_token"],
+            "refresh_token": self.refresh_token,
             "grant_type": "refresh_token",
         }
         token_data = self._prepare_token_post_data(token_data)
@@ -335,7 +347,7 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
         ssl_verify = getattr(self.config, "ssl_verify", True)
         try:
             token_response = self.session.post(
-                self.config.token_uri,
+                self.token_endpoint,
                 timeout=HTTP_REQ_TIMEOUT,
                 verify=ssl_verify,
                 **post_request_kwargs,
@@ -363,7 +375,7 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
         }
         ssl_verify = getattr(self.config, "ssl_verify", True)
         authorization_response = self.session.get(
-            self.config.authorization_uri,
+            self.authorization_endpoint,
             params=params,
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
@@ -421,7 +433,7 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
         }
         ssl_verify = getattr(self.config, "ssl_verify", True)
         return self.session.post(
-            self.config.authorization_uri,
+            self.authorization_endpoint,
             data=user_consent_data,
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,

--- a/eodag/plugins/authentication/openid_connect.py
+++ b/eodag/plugins/authentication/openid_connect.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 import re
 import string
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from random import SystemRandom
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
@@ -82,6 +82,7 @@ class OIDCRefreshTokenBase(Authentication):
         self.jwks_client = jwt.PyJWKClient(auth_config["jwks_uri"])
         self.token_endpoint = auth_config["token_endpoint"]
         self.authorization_endpoint = auth_config["authorization_endpoint"]
+        self.algorithms = auth_config["id_token_signing_alg_values_supported"]
 
     def decode_jwt_token(self, token: str) -> Dict[str, Any]:
         """Decode JWT token."""
@@ -91,7 +92,7 @@ class OIDCRefreshTokenBase(Authentication):
                 return jwt.decode(
                     token,
                     key,
-                    algorithms=["RS256", "HS512"],
+                    algorithms=self.algorithms,
                     # NOTE: Audience validation MUST match audience claim if set in token
                     # (https://pyjwt.readthedocs.io/en/stable/changelog.html?highlight=audience#id40)
                     audience=self.config.allowed_audiences,
@@ -100,13 +101,13 @@ class OIDCRefreshTokenBase(Authentication):
                 return jwt.decode(
                     token,
                     key,
-                    algorithms=["RS256", "HS512"],
+                    algorithms=self.algorithms,
                 )
         except (jwt.exceptions.InvalidTokenError, jwt.exceptions.DecodeError) as e:
             raise AuthenticationError(e)
 
     def _get_access_token(self) -> str:
-        now = datetime.now(UTC)
+        now = datetime.now(timezone.utc)
         if self.access_token and now < self.access_token_expiration:
             logger.debug(
                 f"Existing access_token is still valid until {self.access_token_expiration.isoformat()}."
@@ -124,7 +125,7 @@ class OIDCRefreshTokenBase(Authentication):
 
         self.access_token = response[getattr(self.config, "token_key", "access_token")]
         self.access_token_expiration = datetime.fromtimestamp(
-            self.decode_jwt_token(self.access_token)["exp"], UTC
+            self.decode_jwt_token(self.access_token)["exp"], timezone.utc
         )
         self.refresh_token = response.get(
             getattr(self.config, "refresh_token_key", "refresh_token"), ""
@@ -135,7 +136,7 @@ class OIDCRefreshTokenBase(Authentication):
             )
         else:
             # refresh token does not expire but will be changed at each request
-            self.refresh_token_expiration = datetime.max
+            self.refresh_token_expiration = now + timedelta(days=1000)
 
         return self.access_token
 

--- a/eodag/plugins/authentication/openid_connect.py
+++ b/eodag/plugins/authentication/openid_connect.py
@@ -63,8 +63,6 @@ class OIDCRefreshTokenBase(Authentication):
         super(OIDCRefreshTokenBase, self).__init__(provider, config)
         self.session = requests.Session()
 
-        self.jwks_client = jwt.PyJWKClient(config.oidc_config_url)
-
         self.access_token = ""
         self.access_token_expiration = datetime.min
 
@@ -81,6 +79,7 @@ class OIDCRefreshTokenBase(Authentication):
                 f"Request returned {e.response.text}."
             )
 
+        self.jwks_client = jwt.PyJWKClient(auth_config["jwks_uri"])
         self.token_endpoint = auth_config["token_endpoint"]
         self.authorization_endpoint = auth_config["authorization_endpoint"]
 
@@ -88,14 +87,21 @@ class OIDCRefreshTokenBase(Authentication):
         """Decode JWT token."""
         try:
             key = self.jwks_client.get_signing_key_from_jwt(token).key
-            return jwt.decode(
-                token,
-                key,
-                algorithms=["RS256"],
-                # NOTE: Audience validation MUST match audience claim if set in token
-                # (https://pyjwt.readthedocs.io/en/stable/changelog.html?highlight=audience#id40)
-                audience=self.config.allowed_audiances,
-            )
+            if getattr(self.config, "allowed_audiences", None):
+                return jwt.decode(
+                    token,
+                    key,
+                    algorithms=["RS256", "HS512"],
+                    # NOTE: Audience validation MUST match audience claim if set in token
+                    # (https://pyjwt.readthedocs.io/en/stable/changelog.html?highlight=audience#id40)
+                    audience=self.config.allowed_audiences,
+                )
+            else:
+                return jwt.decode(
+                    token,
+                    key,
+                    algorithms=["RS256", "HS512"],
+                )
         except (jwt.exceptions.InvalidTokenError, jwt.exceptions.DecodeError) as e:
             raise AuthenticationError(e)
 
@@ -109,28 +115,32 @@ class OIDCRefreshTokenBase(Authentication):
 
         elif self.refresh_token and now < self.refresh_token_expiration:
             response = self._get_token_with_refresh_token()
-
+            logger.debug(
+                "access_token expired, fetching new access_token using refresh_token"
+            )
         else:
+            logger.debug("access_token expired or not available yet, new token request")
             response = self._request_new_token()
 
-        self.access_token = response[self.config.token_key or "access_token"]
+        self.access_token = response[getattr(self.config, "token_key", "access_token")]
         self.access_token_expiration = datetime.fromtimestamp(
-            self.decode_jwt_token(self.access_token)["exp"]
+            self.decode_jwt_token(self.access_token)["exp"], UTC
         )
-
-        self.refresh_token = response.get(
-            self.config.refresh_token_key or "refresh_token", ""
-        )
-        self.refresh_token_expiration = datetime.fromtimestamp(
-            self.decode_jwt_token(self.refresh_token)["exp"]
-            if self.refresh_token
-            else 0
-        )
+        if getattr(self.config, "use_refresh_token", True):
+            self.refresh_token = response.get(
+                getattr(self.config, "refresh_token_key", "refresh_token"), ""
+            )
+            self.refresh_token_expiration = datetime.fromtimestamp(
+                self.decode_jwt_token(self.refresh_token)["exp"]
+                if self.refresh_token
+                else 0,
+                UTC,
+            )
 
         return self.access_token
 
     def _request_new_token(self) -> Dict[str, str]:
-        """Fetch the access token with a new authentcation"""
+        """Fetch the access token with a new authentication"""
         raise NotImplementedError(
             "Incomplete OIDC refresh token retrieval mechanism implementation"
         )
@@ -305,7 +315,7 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
 
     def _request_new_token(self) -> Dict[str, str]:
         """Fetch the access token with a new authentication"""
-        logger.debug("Fetching access token from %s", self.config.token_uri)
+        logger.debug("Fetching access token from %s", self.token_endpoint)
         state = self.compute_state()
         authentication_response = self.authenticate_user(state)
         exchange_url = authentication_response.url
@@ -487,7 +497,7 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
         }
         ssl_verify = getattr(self.config, "ssl_verify", True)
         r = self.session.post(
-            self.config.token_uri,
+            self.token_endpoint,
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
             verify=ssl_verify,

--- a/eodag/plugins/authentication/openid_connect.py
+++ b/eodag/plugins/authentication/openid_connect.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 import re
 import string
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from random import SystemRandom
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
@@ -126,16 +126,16 @@ class OIDCRefreshTokenBase(Authentication):
         self.access_token_expiration = datetime.fromtimestamp(
             self.decode_jwt_token(self.access_token)["exp"], UTC
         )
-        if getattr(self.config, "use_refresh_token", True):
-            self.refresh_token = response.get(
-                getattr(self.config, "refresh_token_key", "refresh_token"), ""
+        self.refresh_token = response.get(
+            getattr(self.config, "refresh_token_key", "refresh_token"), ""
+        )
+        if self.refresh_token and response.get("refresh_expires_in", 0):
+            self.refresh_token_expiration = now + timedelta(
+                seconds=int(response["refresh_expires_in"])
             )
-            self.refresh_token_expiration = datetime.fromtimestamp(
-                self.decode_jwt_token(self.refresh_token)["exp"]
-                if self.refresh_token
-                else 0,
-                UTC,
-            )
+        else:
+            # refresh token does not expire but will be changed at each request
+            self.refresh_token_expiration = datetime.max
 
         return self.access_token
 

--- a/eodag/plugins/authentication/token_exchange.py
+++ b/eodag/plugins/authentication/token_exchange.py
@@ -71,7 +71,7 @@ class OIDCTokenExchangeAuth(Authentication):
     ]
 
     def __init__(self, provider: str, config: PluginConfig) -> None:
-        super(OIDCTokenExchangeAuth, self).__init__(provider, config)
+        super().__init__(provider, config)
         for required_key in self.REQUIRED_KEYS:
             if getattr(self.config, required_key, None) is None:
                 raise MisconfiguredError(

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1054,6 +1054,7 @@
     token_qs_key: 'token'
     auth_error_code: 401
     ssl_verify: true
+    allowed_audiences: ["CLOUDFERRO_PUBLIC"]
   products:
       # S1
     S1_SAR_RAW:
@@ -3781,6 +3782,7 @@
     token_qs_key: 'token'
     auth_error_code: 401
     ssl_verify: true
+    allowed_audiences: ["CLOUDFERRO_PUBLIC"]
   products:
     # S2
     S2_MSI_L1C:
@@ -6631,7 +6633,6 @@
     token_provision: header
     login_form_xpath: //form[@id='kc-form-login']
     authentication_uri_source: login-form
-    use_refresh_token: false  # don't use refresh token atm because it is very strange
 ---
 
 !provider # MARK: dedl

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -6623,17 +6623,15 @@
   auth: !plugin
     type: OIDCAuthorizationCodeFlowAuth
     matching_url: https://[-\w\.]+.dte.destination-earth.eu
-    oidc_config_url: https://identity.cloudferro.com/auth/realms/Creodias-new/.well-known/openid-configuration
+    oidc_config_url: https://auth.destine.eu/realms/desp/.well-known/openid-configuration
     redirect_uri: https://polytope.lumi.apps.dte.destination-earth.eu/
-    token_uri: https://auth.destine.eu/realms/desp/protocol/openid-connect/token
     client_id: polytope-api-public
     user_consent_needed: false
     token_exchange_post_data_method: data
-    token_key: access_token
-    refresh_token_key: refresh_token
     token_provision: header
     login_form_xpath: //form[@id='kc-form-login']
     authentication_uri_source: login-form
+    use_refresh_token: false  # don't use refresh token atm because it is very strange
 ---
 
 !provider # MARK: dedl

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1047,8 +1047,7 @@
   auth: !plugin
     type: KeycloakOIDCPasswordAuth
     matching_url: https://[-\w]+.creodias.eu
-    auth_base_uri: 'https://identity.cloudferro.com/auth'
-    realm: 'Creodias-new'
+    oidc_config_url: https://identity.cloudferro.com/auth/realms/Creodias-new/.well-known/openid-configuration
     client_id: 'CLOUDFERRO_PUBLIC'
     client_secret: 'dc0aca03-2dc6-4798-a5de-fc5aeb6c8ee1'
     token_provision: qs
@@ -3775,8 +3774,7 @@
   auth: !plugin
     type: KeycloakOIDCPasswordAuth
     matching_url: https://catalogue.dataspace.copernicus.eu
-    auth_base_uri: 'https://identity.dataspace.copernicus.eu/auth'
-    realm: 'CDSE'
+    oidc_config_url: https://identity.dataspace.copernicus.eu/auth/realms/CDSE/.well-known/openid-configuration
     client_id: 'cdse-public'
     client_secret: null
     token_provision: qs
@@ -6625,7 +6623,7 @@
   auth: !plugin
     type: OIDCAuthorizationCodeFlowAuth
     matching_url: https://[-\w\.]+.dte.destination-earth.eu
-    authorization_uri: https://auth.destine.eu/realms/desp/protocol/openid-connect/auth
+    oidc_config_url: https://identity.cloudferro.com/auth/realms/Creodias-new/.well-known/openid-configuration
     redirect_uri: https://polytope.lumi.apps.dte.destination-earth.eu/
     token_uri: https://auth.destine.eu/realms/desp/protocol/openid-connect/token
     client_id: polytope-api-public
@@ -6717,9 +6715,8 @@
     type: OIDCTokenExchangeAuth
     matching_url: https://[-\w\.]+.data.destination-earth.eu
     subject:
-      authorization_uri: https://auth.destine.eu/realms/desp/protocol/openid-connect/auth
+      oidc_config_url: https://auth.destine.eu/realms/desp/.well-known/openid-configuration
       redirect_uri: https://hda.data.destination-earth.eu/stac
-      token_uri: https://auth.destine.eu/realms/desp/protocol/openid-connect/token
       client_id: dedl-hda
       user_consent_needed: false
       exchange_url_error_pattern:

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ install_requires =
     orjson;python_version<'3.12' or platform_system!='Windows'
     pydantic >= 2.1.0
     pydantic_core
+    pyjwt
     pyproj >= 2.1.0
     pyshp
     pystac >= 1.0.0b1

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
     orjson;python_version<'3.12' or platform_system!='Windows'
     pydantic >= 2.1.0
     pydantic_core
-    pyjwt
+    pyjwt >= 2.5.0
     pyproj >= 2.1.0
     pyshp
     pystac >= 1.0.0b1

--- a/tests/integration/test_download_auth.py
+++ b/tests/integration/test_download_auth.py
@@ -81,7 +81,10 @@ class TestEODagDownloadCredentialsNotSet(unittest.TestCase):
         with self.assertRaises(MisconfiguredError):
             self.eodag.download_all(products)
 
-    def test_eodag_download_missing_credentials_creodias(self):
+    @mock.patch(
+        "eodag.plugins.authentication.openid_connect.requests.get", autospec=True
+    )
+    def test_eodag_download_missing_credentials_creodias(self, mock_requests):
         search_resuls = os.path.join(
             TEST_RESOURCES_PATH, "eodag_search_result_creodias.geojson"
         )

--- a/tests/units/test_auth_plugins.py
+++ b/tests/units/test_auth_plugins.py
@@ -688,6 +688,7 @@ class TestAuthPluginKeycloakOIDCPasswordAuth(BaseAuthPluginTest):
             "authorization_endpoint": "http://foo.bar/auth/realms/myrealm/protocol/openid-connect/auth",
             "token_endpoint": "http://foo.bar/auth/realms/myrealm/protocol/openid-connect/token",
             "jwks_uri": "http://foo.bar/auth/realms/myrealm/protocol/openid-connect/certs",
+            "id_token_signing_alg_values_supported": ["RS256", "HS512"],
         }
         with mock.patch(
             "eodag.plugins.authentication.openid_connect.requests.get", autospec=True
@@ -1076,6 +1077,7 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
                 "authorization_endpoint": "http://foo.bar/auth/realms/myrealm/protocol/openid-connect/auth",
                 "token_endpoint": "http://foo.bar/auth/realms/myrealm/protocol/openid-connect/token",
                 "jwks_uri": "http://foo.bar/auth/realms/myrealm/protocol/openid-connect/certs",
+                "id_token_signing_alg_values_supported": ["RS256", "HS512"],
             }
             mock_request.return_value.json.side_effect = [oidc_config, oidc_config]
             auth_plugin = super(


### PR DESCRIPTION
- fixes the logic for fetching a new access token to avoid authentication errors during the download due to an expired token
- refactors the configuration of the plugins using OIDCRefreshTokenBase (OIDCAuthorizationCodeFlowAuth and KeycloakOIDCPasswordAuth) to use oidc_config_url instead of realm, auth_uri and token_uri 
