### PR TITLE
feat(server): add dedicated liveness endpoint

### DIFF
--- a/charts/eodag-server/templates/deployment.yaml
+++ b/charts/eodag-server/templates/deployment.yaml
@@ -111,7 +111,7 @@ spec:
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /
+              path: /_mgmt/ping/
               port: {{ .Values.containerPorts.http }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}

--- a/eodag/cli.py
+++ b/eodag/cli.py
@@ -53,7 +53,12 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Set
 import click
 
 from eodag.api.core import EODataAccessGateway
-from eodag.utils import DEFAULT_ITEMS_PER_PAGE, DEFAULT_PAGE, parse_qs
+from eodag.utils import (
+    DEFAULT_ITEMS_PER_PAGE,
+    DEFAULT_PAGE,
+    LIVENESS_PROBE_PATH,
+    parse_qs,
+)
 from eodag.utils.exceptions import NoMatchingProductType, UnsupportedProvider
 from eodag.utils.logging import setup_logging
 
@@ -68,6 +73,18 @@ CRUNCHERS = [
     "FilterProperty",
     "FilterDate",
 ]
+
+
+class LivenessFilter:
+    """
+    Filter out requests to the liveness probe endpoint
+    """
+
+    def filter(self, record):
+        """
+        Filter method required by the Python logging API.
+        """
+        return LIVENESS_PROBE_PATH not in record.getMessage()
 
 
 class MutuallyExclusiveOption(click.Option):
@@ -691,8 +708,10 @@ def serve_rest(
 
         logging_config = uvicorn.config.LOGGING_CONFIG
         uvicorn_fmt = "%(asctime)-15s %(name)-32s [%(levelname)-8s] %(message)s"
+        logging_config["filters"] = {"liveness": {"()": LivenessFilter}}
         logging_config["formatters"]["access"]["fmt"] = uvicorn_fmt
         logging_config["formatters"]["default"]["fmt"] = uvicorn_fmt
+        logging_config["loggers"]["uvicorn.access"]["filters"] = ["liveness"]
 
         eodag_formatter = logging.Formatter(
             "%(asctime)-15s %(name)-32s [%(levelname)-8s] (tid=%(thread)d) %(message)s"

--- a/eodag/cli.py
+++ b/eodag/cli.py
@@ -53,12 +53,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Set
 import click
 
 from eodag.api.core import EODataAccessGateway
-from eodag.utils import (
-    DEFAULT_ITEMS_PER_PAGE,
-    DEFAULT_PAGE,
-    LIVENESS_PROBE_PATH,
-    parse_qs,
-)
+from eodag.rest.utils import LIVENESS_PROBE_PATH
+from eodag.utils import DEFAULT_ITEMS_PER_PAGE, DEFAULT_PAGE, parse_qs
 from eodag.utils.exceptions import NoMatchingProductType, UnsupportedProvider
 from eodag.utils.logging import setup_logging
 

--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -121,6 +121,17 @@ stac_api_config = load_stac_api_config()
 
 
 @router.api_route(
+    methods=["GET", "HEAD"],
+    path="/_mgmt/ping",
+    include_in_schema=False,
+    status_code=200,
+)
+async def liveness_probe(request: Request) -> Dict[str, bool]:
+    "Endpoint meant to be used as liveness probe by deployment platforms"
+    return {"success": True}
+
+
+@router.api_route(
     methods=["GET", "HEAD"], path="/api", tags=["Capabilities"], include_in_schema=False
 )
 async def eodag_openapi(request: Request) -> Dict[str, Any]:

--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -62,7 +62,7 @@ from eodag.rest.errors import add_exception_handlers
 from eodag.rest.types.queryables import QueryablesGetParams
 from eodag.rest.types.stac_search import SearchPostRequest, sortby2list
 from eodag.rest.utils import format_pydantic_error, str2json, str2list
-from eodag.utils import parse_header, update_nested_dict
+from eodag.utils import LIVENESS_PROBE_PATH, parse_header, update_nested_dict
 
 if TYPE_CHECKING:
     from fastapi.types import DecoratedCallable
@@ -122,7 +122,7 @@ stac_api_config = load_stac_api_config()
 
 @router.api_route(
     methods=["GET", "HEAD"],
-    path="/_mgmt/ping",
+    path=LIVENESS_PROBE_PATH,
     include_in_schema=False,
     status_code=200,
 )

--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -61,8 +61,13 @@ from eodag.rest.core import (
 from eodag.rest.errors import add_exception_handlers
 from eodag.rest.types.queryables import QueryablesGetParams
 from eodag.rest.types.stac_search import SearchPostRequest, sortby2list
-from eodag.rest.utils import format_pydantic_error, str2json, str2list
-from eodag.utils import LIVENESS_PROBE_PATH, parse_header, update_nested_dict
+from eodag.rest.utils import (
+    LIVENESS_PROBE_PATH,
+    format_pydantic_error,
+    str2json,
+    str2list,
+)
+from eodag.utils import parse_header, update_nested_dict
 
 if TYPE_CHECKING:
     from fastapi.types import DecoratedCallable

--- a/eodag/rest/utils/__init__.py
+++ b/eodag/rest/utils/__init__.py
@@ -55,6 +55,9 @@ __all__ = ["get_date", "get_datetime"]
 
 logger = logging.getLogger("eodag.rest.utils")
 
+# Path of the liveness endpoint
+LIVENESS_PROBE_PATH = "/_mgmt/ping"
+
 
 class Cruncher(NamedTuple):
     """Type hinted Cruncher namedTuple"""

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -138,6 +138,9 @@ DEFAULT_MAX_ITEMS_PER_PAGE = 50
 # default product-types start date
 DEFAULT_MISSION_START_DATE = "2015-01-01T00:00:00Z"
 
+# Path of the liveness endpoint
+LIVENESS_PROBE_PATH = "/_mgmt/ping"
+
 
 def _deprecated(reason: str = "", version: Optional[str] = None) -> Callable[..., Any]:
     """Simple decorator to mark functions/methods/classes as deprecated.

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -138,9 +138,6 @@ DEFAULT_MAX_ITEMS_PER_PAGE = 50
 # default product-types start date
 DEFAULT_MISSION_START_DATE = "2015-01-01T00:00:00Z"
 
-# Path of the liveness endpoint
-LIVENESS_PROBE_PATH = "/_mgmt/ping"
-
 
 def _deprecated(reason: str = "", version: Optional[str] = None) -> Callable[..., Any]:
     """Simple decorator to mark functions/methods/classes as deprecated.

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -171,6 +171,11 @@ class RequestTestCase(unittest.TestCase):
         resp_json = json.loads(response.content.decode("utf-8"))
         self.assertEqual(resp_json["links"][0]["href"], "httpz://bar/")
 
+    def test_liveness_probe(self):
+        response = self.app.get("/_mgmt/ping")
+        self.assertEqual(200, response.status_code)
+        self.assertTrue(response.json()["success"])
+
     def mock_search_result(self):
         """generate eodag_api.search mock results"""
         search_result = SearchResult.from_geojson(


### PR DESCRIPTION
At the moment we query / to ensure that the rest api is alive. This results in a lot of requests which can't be filtered out from the logs because we want to log requests to / coming from real users.

- [x] add endpoint to rest API
- [x] Modify the EO Catalogue Helm chart to use the proper endpoint to check the liveness/readiness of the STAC API component: /_mgmt/ping