### PR TITLE
fix(providers): geodes conf fixes

### DIFF
--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -1817,8 +1817,14 @@ class PostJsonSearch(QueryStringSearch):
                 prep.query_params = self.next_page_query_obj
             if info_message:
                 logger.info(info_message)
-            logger.debug("Query parameters: %s" % geojson.dumps(prep.query_params))
-            logger.debug("Query kwargs: %s" % geojson.dumps(kwargs))
+            try:
+                logger.debug("Query parameters: %s" % geojson.dumps(prep.query_params))
+            except TypeError:
+                logger.debug("Query parameters: %s" % prep.query_params)
+            try:
+                logger.debug("Query kwargs: %s" % geojson.dumps(kwargs))
+            except TypeError:
+                logger.debug("Query kwargs: %s" % kwargs)
             response = requests.post(
                 url,
                 json=prep.query_params,

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -1817,8 +1817,8 @@ class PostJsonSearch(QueryStringSearch):
                 prep.query_params = self.next_page_query_obj
             if info_message:
                 logger.info(info_message)
-            logger.debug("Query parameters: %s" % prep.query_params)
-            logger.debug("Query kwargs: %s" % kwargs)
+            logger.debug("Query parameters: %s" % geojson.dumps(prep.query_params))
+            logger.debug("Query kwargs: %s" % geojson.dumps(kwargs))
             response = requests.post(
                 url,
                 json=prep.query_params,

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -7516,8 +7516,8 @@
         - '{{"query":{{"spaceborne:productType":{{"eq":"{providerProductType}"}}}}}}'
         - '$.null'
       downloadLink: '$.assets[?(@.roles[0] == "data")].href'
-      quicklook: '$.assets[?(@.roles[0] == "overview")].href'
-      thumbnail: '$.assets[?(@.roles[0] == "overview")].href'
+      quicklook: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
+      thumbnail: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
       # storageStatus set to ONLINE for consistency between providers
       storageStatus: '{$.null#replace_str("Not Available","ONLINE")}'
   products:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -7497,10 +7497,10 @@
         - '$.properties."spaceborne:sensorMode"'
       # OpenSearch Parameters for Acquistion Parameters Search (Table 6)
       startTimeFromAscendingNode:
-        - '{{"query":{{"temporal:endDate":{{"lte":"{startTimeFromAscendingNode#to_iso_utc_datetime}"}}}}}}'
+        - '{{"query":{{"temporal:endDate":{{"gte":"{startTimeFromAscendingNode#to_iso_utc_datetime}"}}}}}}'
         - '$.properties."temporal:startDate"'
       completionTimeFromAscendingNode:
-        - '{{"query":{{"temporal:startDate":{{"gte":"{completionTimeFromAscendingNode#to_iso_utc_datetime}"}}}}}}'
+        - '{{"query":{{"temporal:startDate":{{"lte":"{completionTimeFromAscendingNode#to_iso_utc_datetime}"}}}}}}'
         - '$.properties."temporal:endDate"'
       polarizationChannels:
         - '{{"query":{{"spaceborne:polarization":{{"eq":"{polarizationChannels}"}}}}}}'

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -55,6 +55,13 @@ PEPS_SEARCH_ARGS = [
     "2020-08-16",
     [137.772897, 13.134202, 153.749135, 23.885986],
 ]
+GEODES_SEARCH_ARGS = [
+    "geodes",
+    "S2_MSI_L1C",
+    "2024-08-08",
+    "2024-08-16",
+    [0.2563590566012408, 43.19555008715042, 2.379835675499976, 43.907759172380565],
+]
 AWSEOS_SEARCH_ARGS = [
     "aws_eos",
     "S2_MSI_L1C",
@@ -426,6 +433,11 @@ class TestEODagEndToEnd(EndToEndBase):
     # @unittest.skip("service unavailable for the moment")
     def test_end_to_end_search_download_theia(self):
         product = self.execute_search(*THEIA_SEARCH_ARGS)
+        expected_filename = "{}.zip".format(product.properties["title"])
+        self.execute_download(product, expected_filename)
+
+    def test_end_to_end_search_download_geodes(self):
+        product = self.execute_search(*GEODES_SEARCH_ARGS)
         expected_filename = "{}.zip".format(product.properties["title"])
         self.execute_download(product, expected_filename)
 


### PR DESCRIPTION
Adds some fixes in `geodes` configuration for:
- search dates operators
- `thumbnail`/`quicklook` url

Adds missing end-to-end test for `geodes`.

Also logs `PostJsonSearch` query body as json.