### PR TITLE
fix(plugins): cop_marine - handling of ids with points

### DIFF
--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import copy
 import logging
+import os
 import re
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
@@ -202,7 +203,7 @@ class CopMarineSearch(StaticStacSearch):
         use_dataset_dates: bool = False,
     ) -> Optional[EOProduct]:
 
-        item_id = item_key.split("/")[-1].split(".")[0]
+        item_id = os.path.splitext(item_key.split("/")[-1])[0]
         download_url = s3_url + "/" + item_key
         properties = {
             "id": item_id,
@@ -391,7 +392,7 @@ class CopMarineSearch(StaticStacSearch):
 
                 for obj in s3_objects["Contents"]:
                     item_key = obj["Key"]
-                    item_id = item_key.split("/")[-1].split(".")[0]
+                    item_id = os.path.splitext(item_key.split("/")[-1])[0]
                     # filter according to date(s) in item id
                     item_dates = re.findall(r"(\d{4})(0[1-9]|1[0-2])([0-3]\d)", item_id)
                     if not item_dates:

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2776,13 +2776,13 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
         self.list_objects_response1 = {
             "Contents": [
                 {
-                    "Key": "native/PRODUCT_A/dataset-number-one/item_20200102_20200103_hdkIFEKFNEDNF_20210101.nc"
+                    "Key": "native/PRODUCT_A/dataset-number-one/item_20200102_20200103_hdkIFE.KFNEDNF_20210101.nc"
                 },
                 {
                     "Key": "native/PRODUCT_A/dataset-number-one/item_20200104_20200105_hdkIFEKFNEDNF_20210101.nc"
                 },
                 {
-                    "Key": "native/PRODUCT_A/dataset-number-one/item_20200302_20200303_hdkIFEKFNEDNF_20210101.nc"
+                    "Key": "native/PRODUCT_A/dataset-number-one/item_20200302_20200303_hdkIFEKFNEDN_20210101.nc"
                 },
             ]
         }
@@ -2972,6 +2972,9 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
             self.product_data,
             self.dataset1_data,
             self.dataset2_data,
+            self.product_data,
+            self.dataset1_data,
+            self.dataset2_data,
         ]
 
         search_plugin = self.get_search_plugin("PRODUCT_A", self.provider)
@@ -2979,25 +2982,35 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
         with mock.patch("eodag.plugins.search.cop_marine._get_s3_client") as s3_stub:
             s3_stub.return_value = self.s3
             stubber = Stubber(self.s3)
-            stubber.add_response(
-                "list_objects",
-                self.list_objects_response1,
-                {"Bucket": "bucket1", "Prefix": "native/PRODUCT_A/dataset-number-one"},
-            )
-            stubber.add_response(
-                "list_objects",
-                {},
-                {
-                    "Bucket": "bucket1",
-                    "Marker": "native/PRODUCT_A/dataset-number-one/item_20200302_20200303_hdkIFEKFNEDNF_20210101.nc",
-                    "Prefix": "native/PRODUCT_A/dataset-number-one",
-                },
-            )
-            stubber.add_response(
-                "list_objects",
-                self.list_objects_response2,
-                {"Bucket": "bucket1", "Prefix": "native/PRODUCT_A/dataset-number-two"},
-            )
+            for i in [
+                0,
+                1,
+            ]:  # add responses twice because 2 search requests will be executed
+                stubber.add_response(
+                    "list_objects",
+                    self.list_objects_response1,
+                    {
+                        "Bucket": "bucket1",
+                        "Prefix": "native/PRODUCT_A/dataset-number-one",
+                    },
+                )
+                stubber.add_response(
+                    "list_objects",
+                    {},
+                    {
+                        "Bucket": "bucket1",
+                        "Marker": "native/PRODUCT_A/dataset-number-one/item_20200302_20200303_hdkIFEKFNEDN_20210101.nc",
+                        "Prefix": "native/PRODUCT_A/dataset-number-one",
+                    },
+                )
+                stubber.add_response(
+                    "list_objects",
+                    self.list_objects_response2,
+                    {
+                        "Bucket": "bucket1",
+                        "Prefix": "native/PRODUCT_A/dataset-number-two",
+                    },
+                )
             stubber.activate()
             result, num_total = search_plugin.query(
                 productType="PRODUCT_A",
@@ -3006,6 +3019,15 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
             self.assertEqual(1, num_total)
             self.assertEqual(
                 "item_20200204_20200205_niznjvnqkrf_20210101",
+                result[0].properties["id"],
+            )
+            result, num_total = search_plugin.query(
+                productType="PRODUCT_A",
+                id="item_20200102_20200103_hdkIFE.KFNEDNF_20210101",
+            )
+            self.assertEqual(1, num_total)
+            self.assertEqual(
+                "item_20200102_20200103_hdkIFE.KFNEDNF_20210101",
                 result[0].properties["id"],
             )
 


### PR DESCRIPTION
This PR fixes a problem with the ids of cop_marine products. If the filename of a product in the cop_marine s3 contained a "." somewhere in the middle (for example ids of product type MO_GLOBAL_MULTIYEAR_BGC_001_033), the id created from the filename was not correct (only the part until the "." was used). This is now fixed.