### PR TITLE
test: force deps upgrade on install in tox

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -126,6 +126,7 @@ stubs =
     types-python-dateutil
     types-setuptools
     types-tqdm
+    types-urllib3
 docs =
     eodag[all,stubs]
     sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,8 @@ python =
     3.13: py313
 
 [testenv]
+install_command = uv pip install --upgrade {opts} {packages}
+
 commands =
     python -c "import os; os.makedirs('test-reports', exist_ok=True)"
     pytest -v --instafail \


### PR DESCRIPTION
Force `tox` to use latest dependencies versions with command `uv pip install --upgrade {opts} {packages}`.

Needed because `uv` installed a very old `botocore` version (1.10.84) when running tests with tox and `python3.9`, which caused tests failure.