### PR TITLE
fix(plugins): auth only when needed during http download

### DIFF
--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -1081,12 +1081,12 @@ class HTTPDownload(Download):
         )
         ssl_verify = getattr(self.config, "ssl_verify", True)
         matching_url = (
-            product.downloader_auth.config.matching_url
+            getattr(product.downloader_auth.config, "matching_url", "")
             if product.downloader_auth
             else ""
         )
         matching_conf = (
-            product.downloader_auth.config.matching_conf
+            getattr(product.downloader_auth.config, "matching_conf", None)
             if product.downloader_auth
             else None
         )

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -1085,6 +1085,11 @@ class HTTPDownload(Download):
             if product.downloader_auth
             else ""
         )
+        matching_conf = (
+            product.downloader_auth.config.matching_conf
+            if product.downloader_auth
+            else None
+        )
 
         # loop for assets download
         for asset in assets_values:
@@ -1093,7 +1098,9 @@ class HTTPDownload(Download):
                     f"Local asset detected. Download skipped for {asset['href']}"
                 )
                 continue
-            if matching_url and re.match(matching_url, asset["href"]):
+            if matching_conf or (
+                matching_url and re.match(matching_url, asset["href"])
+            ):
                 auth_object = auth
             else:
                 auth_object = None


### PR DESCRIPTION
- So far if the download of one asset was failing, this was logged but no error was raised which hid problems during the download and could lead to incomplete or even empty results while the response was still 200. This is changed now so that the download is interrupted when a problem at the download of one asset occurs.
- After this change it became visible that for `planetary_computer` some assets where not downloaded because, for the same product, there are assets where authentication is required for the download and assets where authentication should not be added. 
&rarr; In `HTTPDownload`, the asset url is now compared to `matching_url` from the config to check if authentication should be added to the request.
