### PR TITLE
fix(plugins): Validation error if 400 error during order

### DIFF
--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -80,8 +80,8 @@ from eodag.utils.exceptions import (
     DownloadError,
     MisconfiguredError,
     NotAvailableError,
-    RequestError,
     TimeOutError,
+    ValidationError,
 )
 
 if TYPE_CHECKING:
@@ -226,9 +226,11 @@ class HTTPDownload(Download):
                     product.properties["storageStatus"] = STAGING_STATUS
                 except RequestException as e:
                     self._check_auth_exception(e)
-                    title = product.properties["title"]
-                    message = f"{title} could not be ordered"
-                    raise RequestError.from_error(e, message) from e
+                    msg = f'{product.properties["title"]} could not be ordered'
+                    if e.response.status_code == 400:
+                        raise ValidationError.from_error(e, msg) from e
+                    else:
+                        raise DownloadError.from_error(e, msg) from e
 
                 return self.order_response_process(response, product)
         except requests.exceptions.Timeout as exc:
@@ -398,13 +400,11 @@ class HTTPDownload(Download):
                     # success and no need to get status response content
                     skip_parsing_status_response = True
             except RequestException as e:
-                raise DownloadError(
-                    "%s order status could not be checked, request returned %s"
-                    % (
-                        product.properties["title"],
-                        e,
-                    )
-                ) from e
+                msg = f'{product.properties["title"]} order status could not be checked'
+                if e.response.status_code == 400:
+                    raise ValidationError.from_error(e, msg) from e
+                else:
+                    raise DownloadError.from_error(e, msg) from e
 
         if not skip_parsing_status_response:
             # status request

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -227,7 +227,7 @@ class HTTPDownload(Download):
                 except RequestException as e:
                     self._check_auth_exception(e)
                     msg = f'{product.properties["title"]} could not be ordered'
-                    if e.response.status_code == 400:
+                    if e.response is not None and e.response.status_code == 400:
                         raise ValidationError.from_error(e, msg) from e
                     else:
                         raise DownloadError.from_error(e, msg) from e
@@ -401,7 +401,7 @@ class HTTPDownload(Download):
                     skip_parsing_status_response = True
             except RequestException as e:
                 msg = f'{product.properties["title"]} order status could not be checked'
-                if e.response.status_code == 400:
+                if e.response is not None and e.response.status_code == 400:
                     raise ValidationError.from_error(e, msg) from e
                 else:
                     raise DownloadError.from_error(e, msg) from e

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -84,6 +84,7 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import Unpack  # noqa
 
+
 import click
 import orjson
 import shapefile
@@ -1120,7 +1121,7 @@ def get_geometry_from_various(
 class MockResponse:
     """Fake requests response"""
 
-    def __init__(self, json_data: Any, status_code: int) -> None:
+    def __init__(self, json_data: Any = None, status_code: int = 200) -> None:
         self.json_data = json_data
         self.status_code = status_code
         self.content = json_data
@@ -1129,10 +1130,21 @@ class MockResponse:
         """Return json data"""
         return self.json_data
 
+    def __iter__(self):
+        yield self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
     def raise_for_status(self) -> None:
         """raises an exception when the status is not ok"""
         if self.status_code != 200:
-            raise HTTPError(response=Response())
+            response = Response()
+            response.status_code = self.status_code
+            raise HTTPError(response=response)
 
 
 def md5sum(file_path: str) -> str:

--- a/eodag/utils/exceptions.py
+++ b/eodag/utils/exceptions.py
@@ -29,14 +29,6 @@ class EodagError(Exception):
     """General EODAG error"""
 
 
-class ValidationError(EodagError):
-    """Error validating data"""
-
-    def __init__(self, message: str, parameters: Set[str] = set()) -> None:
-        self.message = message
-        self.parameters = parameters
-
-
 class PluginNotFoundError(EodagError):
     """Error when looking for a plugin class that was not defined"""
 
@@ -74,38 +66,8 @@ class AuthenticationError(EodagError):
     authenticating a user"""
 
 
-class DownloadError(EodagError):
-    """An error indicating something wrong with the download process"""
-
-
 class NotAvailableError(EodagError):
     """An error indicating that the product is not available for download"""
-
-
-class RequestError(EodagError):
-    """An error indicating that a request has failed. Usually eodag functions
-    and methods should catch and skip this"""
-
-    status_code: Annotated[Optional[int], Doc("HTTP status code")] = None
-
-    @classmethod
-    def from_error(cls, error: Exception, msg: Optional[str] = None):
-        """Generate a RequestError from an Exception"""
-        status_code = getattr(error, "code", None)
-        text = getattr(error, "msg", None)
-
-        response = getattr(error, "response", None)
-        # Explicitly test for None because response objects are considered false if they
-        # have a status code other than 200
-        if response is not None:
-            status_code = response.status_code
-            text = response.text
-
-        text = text or str(error)
-
-        e = cls(msg, text) if msg else cls(text)
-        e.status_code = status_code
-        return e
 
 
 class NoMatchingProductType(EodagError):
@@ -115,6 +77,50 @@ class NoMatchingProductType(EodagError):
 
 class STACOpenerError(EodagError):
     """An error indicating that a STAC file could not be opened"""
+
+
+class RequestError(EodagError):
+    """An error indicating that a request has failed. Usually eodag functions
+    and methods should catch and skip this"""
+
+    status_code: Annotated[Optional[int], Doc("HTTP status code")] = None
+
+    @classmethod
+    def from_error(cls, error: Exception, msg: Optional[str] = None) -> RequestError:
+        """Generate a RequestError from an Exception"""
+        status_code = getattr(error, "code", None)
+        text = getattr(error, "msg", None)
+
+        response = getattr(error, "response", None)
+        # Explicitly test for None because response objects are considered false if they
+        # have a status code other than 200
+        if response is not None:
+            status_code = response.status_code
+            text = " ".join([text, response.text])
+
+        text = text or str(error)
+
+        e = cls(msg, text) if msg else cls(text)
+        e.status_code = status_code
+        return e
+
+
+class ValidationError(RequestError):
+    """Error validating data"""
+
+    def __init__(self, message: str, parameters: Set[str] = set()) -> None:
+        self.message = message
+        self.parameters = parameters
+
+    @classmethod
+    def from_error(cls, error: Exception, msg: Optional[str] = None) -> ValidationError:
+        """Override parent from_error to handle ValidationError specificities."""
+        error.msg = msg
+        return super().from_error(error)
+
+
+class DownloadError(RequestError):
+    """An error indicating something wrong with the download process"""
 
 
 class TimeOutError(RequestError):

--- a/eodag/utils/exceptions.py
+++ b/eodag/utils/exceptions.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Annotated
 if TYPE_CHECKING:
     from typing import Optional, Set
 
-    from typing_extensions import Doc
+    from typing_extensions import Doc, Self
 
 
 class EodagError(Exception):
@@ -86,7 +86,7 @@ class RequestError(EodagError):
     status_code: Annotated[Optional[int], Doc("HTTP status code")] = None
 
     @classmethod
-    def from_error(cls, error: Exception, msg: Optional[str] = None) -> RequestError:
+    def from_error(cls, error: Exception, msg: Optional[str] = None) -> Self:
         """Generate a RequestError from an Exception"""
         status_code = getattr(error, "code", None)
         text = getattr(error, "msg", None)
@@ -96,7 +96,7 @@ class RequestError(EodagError):
         # have a status code other than 200
         if response is not None:
             status_code = response.status_code
-            text = " ".join([text, response.text])
+            text = " ".join([text or "", response.text])
 
         text = text or str(error)
 
@@ -113,10 +113,11 @@ class ValidationError(RequestError):
         self.parameters = parameters
 
     @classmethod
-    def from_error(cls, error: Exception, msg: Optional[str] = None) -> ValidationError:
+    def from_error(cls, error: Exception, msg: Optional[str] = None) -> Self:
         """Override parent from_error to handle ValidationError specificities."""
-        error.msg = msg
-        return super().from_error(error)
+        setattr(error, "msg", msg)
+        validation_error = super().from_error(error)
+        return validation_error
 
 
 class DownloadError(RequestError):


### PR DESCRIPTION
Modify `order_download` and `order_download_status` methods from `HTTPDownload` plugin:

- Raise a `ValidationError` if response status code is `400`. Otherwise raise a `DownloadError` if any other error occured.
- Inherit `ValidationError` and `DownloadError` from `RequestError` to include provider's error in the description