### PR TITLE
fix(providers): FIRE_HISTORICAL on wekeo_ecmwf

### DIFF
--- a/eodag/resources/product_types.yml
+++ b/eodag/resources/product_types.yml
@@ -3634,7 +3634,7 @@ FIRE_HISTORICAL:
   sensorType: ATMOSPHERIC
   license: proprietary
   title: Fire danger indices historical data from the Copernicus Emergency Management Service
-  missionStartDate: "1940-01-03T00:00:00Z"
+  missionStartDate: "1940-03-01T00:00:00Z"
 
 FIRE_SEASONAL:
   abstract: |

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -4828,11 +4828,10 @@
       productType: EO:ECMWF:DAT:CEMS_FIRE_HISTORICAL_V1
       providerProductType: reanalysis
       variable:
-        - fire_danger_index
+        - fire_weather_index
       version:
         - "4_1"
-      format:
-        - "grib"
+      format: '"grib"'
       grid: original_grid
       type: consolidated_dataset
       metadata_mapping:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -2501,6 +2501,8 @@
       GLACIERS_DIST_RANDOLPH:
         output_extension: .zip
         extract: true
+      FIRE_HISTORICAL:
+        output_extension: .grib
       SATELLITE_CARBON_DIOXIDE:
         output_extension: .zip
         extract: true
@@ -2782,6 +2784,16 @@
               "hydrological_year": {completionTimeFromAscendingNode#get_hydrological_year}
             }}
           - '{$.completionTimeFromAscendingNode#get_hydrological_year}'
+    FIRE_HISTORICAL:
+      dataset: cems-fire-historical-v1
+      grid: original_grid
+      dataset_type: consolidated_dataset
+      api_product_type: reanalysis
+      variable: build_up_index
+      system_version: '4_1'
+      format: grib
+      metadata_mapping:
+        <<: *day_month_year
     SATELLITE_CARBON_DIOXIDE:
       dataset: satellite-carbon-dioxide
       processing_level: level_2
@@ -4812,6 +4824,35 @@
         <<: *variable_list
         defaultGeometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
         orderLink: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{downloadLink}","product_id":"{id}", "dataset_id": "EO:ECMWF:DAT:INSITU_GLACIERS_EXTENT"}}'
+    FIRE_HISTORICAL:
+      productType: EO:ECMWF:DAT:CEMS_FIRE_HISTORICAL_V1
+      providerProductType: reanalysis
+      variable:
+        - fire_danger_index
+      version:
+        - "4_1"
+      format:
+        - "grib"
+      grid: original_grid
+      type: consolidated_dataset
+      metadata_mapping:
+        id: '$.id'
+        <<: *day_month_year
+        providerProductType:
+          - '{{"product_type": "{providerProductType}"}}'
+          - '$.null'
+        version:
+          - '{{"system_version": {version}}}'
+          - '$.null'
+        format:
+          - '{{"data_format": {format}}}'
+          - '$.null'
+        type:
+          - '{{"dataset_type": "{type}"}}'
+          - '$.null'
+        <<: *variable_list
+        defaultGeometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
+        orderLink: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{downloadLink}","product_id":"{id}", "dataset_id": "EO:ECMWF:DAT:CEMS_FIRE_HISTORICAL_V1"}}'
     GRIDDED_GLACIERS_MASS_CHANGE:
       productType: EO:ECMWF:DAT:DERIVED_GRIDDED_GLACIER_MASS_CHANGE
       variable: glacier_mass_change

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -5308,6 +5308,9 @@
         metadata_mapping:
           download_id: $.json.features[0]._id
           downloadLink: https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download/{download_id}
+    products:
+      FIRE_HISTORICAL:
+        output_extension: .grib
 
 ---
 !provider  # MARK: wekeo_cmems
@@ -6012,6 +6015,8 @@
       DT_EXTREMES:
         output_extension: .grib
       DT_CLIMATE_ADAPTATION:
+        output_extension: .grib
+      FIRE_HISTORICAL:
         output_extension: .grib
   auth: !plugin
     type: OIDCTokenExchangeAuth

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -2501,8 +2501,6 @@
       GLACIERS_DIST_RANDOLPH:
         output_extension: .zip
         extract: true
-      FIRE_HISTORICAL:
-        output_extension: .grib
       SATELLITE_CARBON_DIOXIDE:
         output_extension: .zip
         extract: true
@@ -2784,16 +2782,6 @@
               "hydrological_year": {completionTimeFromAscendingNode#get_hydrological_year}
             }}
           - '{$.completionTimeFromAscendingNode#get_hydrological_year}'
-    FIRE_HISTORICAL:
-      dataset: cems-fire-historical-v1
-      grid: original_grid
-      dataset_type: consolidated_dataset
-      api_product_type: reanalysis
-      variable: build_up_index
-      system_version: '4_1'
-      format: grib
-      metadata_mapping:
-        <<: *day_month_year
     SATELLITE_CARBON_DIOXIDE:
       dataset: satellite-carbon-dioxide
       processing_level: level_2

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -4831,7 +4831,7 @@
         - fire_weather_index
       version:
         - "4_1"
-      format: '"grib"'
+      format: grib
       grid: original_grid
       type: consolidated_dataset
       metadata_mapping:
@@ -4844,7 +4844,7 @@
           - '{{"system_version": {version}}}'
           - '$.null'
         format:
-          - '{{"data_format": {format}}}'
+          - '{{"data_format": "{format}"}}'
           - '$.null'
         type:
           - '{{"dataset_type": "{type}"}}'

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -151,7 +151,7 @@ class TestCore(TestCoreBase):
         "ERA5_PL_MONTHLY": ["cop_cds", "dedl", "wekeo_ecmwf"],
         "ERA5_SL": ["cop_cds", "dedl", "wekeo_ecmwf"],
         "ERA5_SL_MONTHLY": ["cop_cds", "dedl", "wekeo_ecmwf"],
-        "FIRE_HISTORICAL": ["cop_ewds", "cop_cds", "dedl", "wekeo_ecmwf"],
+        "FIRE_HISTORICAL": ["cop_ewds", "dedl", "wekeo_ecmwf"],
         "FIRE_SEASONAL": ["cop_ewds"],
         "GLACIERS_DIST_RANDOLPH": ["cop_cds", "dedl", "wekeo_ecmwf"],
         "GLOFAS_FORECAST": ["cop_ewds", "dedl"],

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -151,7 +151,7 @@ class TestCore(TestCoreBase):
         "ERA5_PL_MONTHLY": ["cop_cds", "dedl", "wekeo_ecmwf"],
         "ERA5_SL": ["cop_cds", "dedl", "wekeo_ecmwf"],
         "ERA5_SL_MONTHLY": ["cop_cds", "dedl", "wekeo_ecmwf"],
-        "FIRE_HISTORICAL": ["cop_ewds", "dedl"],
+        "FIRE_HISTORICAL": ["cop_ewds", "cop_cds", "dedl", "wekeo_ecmwf"],
         "FIRE_SEASONAL": ["cop_ewds"],
         "GLACIERS_DIST_RANDOLPH": ["cop_cds", "dedl", "wekeo_ecmwf"],
         "GLOFAS_FORECAST": ["cop_ewds", "dedl"],


### PR DESCRIPTION
Bring back `FIRE_HISTORICAL` via `wekeo_ecmwf`, now with correct default values and start date.