### PR TITLE
fix(plugins): remove default HTTPDownload zip extension

### DIFF
--- a/docs/notebooks/tutos/tuto_cds.ipynb
+++ b/docs/notebooks/tutos/tuto_cds.ipynb
@@ -752,7 +752,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.13.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/notebooks/tutos/tuto_ecmwf.ipynb
+++ b/docs/notebooks/tutos/tuto_ecmwf.ipynb
@@ -767,7 +767,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.13.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -116,6 +116,7 @@ class EOProduct:
     properties: Dict[str, Any]
     product_type: Optional[str]
     location: str
+    filename: str
     remote_location: str
     search_kwargs: Any
     geometry: BaseGeometry

--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -202,7 +202,7 @@ class Download(PluginTopic):
             or getattr(self.config, "output_dir", tempfile.gettempdir())
             or tempfile.gettempdir()
         )
-        output_extension = kwargs.get("output_extension", None) or getattr(
+        output_extension = kwargs.get("output_extension") or getattr(
             self.config, "output_extension", ""
         )
 

--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -203,7 +203,7 @@ class Download(PluginTopic):
             or tempfile.gettempdir()
         )
         output_extension = kwargs.get("output_extension", None) or getattr(
-            self.config, "output_extension", ".zip"
+            self.config, "output_extension", ""
         )
 
         # Strong asumption made here: all products downloaded will be zip files
@@ -345,11 +345,14 @@ class Download(PluginTopic):
         )
         output_extension = kwargs.pop("output_extension", ".zip")
 
-        product_path = (
-            fs_path[: fs_path.index(output_extension)]
-            if output_extension in fs_path
-            else fs_path
-        )
+        if output_extension:
+            product_path = (
+                fs_path[: fs_path.index(output_extension)]
+                if output_extension in fs_path
+                else fs_path
+            )
+        else:
+            product_path, _ = os.path.splitext(fs_path)
         product_path_exists = os.path.exists(product_path)
         if product_path_exists and os.path.isfile(product_path):
             logger.info(

--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -343,16 +343,7 @@ class Download(PluginTopic):
             if delete_archive is not None
             else getattr(self.config, "delete_archive", True)
         )
-        output_extension = kwargs.pop("output_extension", ".zip")
-
-        if output_extension:
-            product_path = (
-                fs_path[: fs_path.index(output_extension)]
-                if output_extension in fs_path
-                else fs_path
-            )
-        else:
-            product_path, _ = os.path.splitext(fs_path)
+        product_path, _ = os.path.splitext(fs_path)
         product_path_exists = os.path.exists(product_path)
         if product_path_exists and os.path.isfile(product_path):
             logger.info(

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -587,13 +587,6 @@ class HTTPDownload(Download):
             )
             progress_callback = ProgressCallback(disable=True)
 
-        output_extension = getattr(self.config, "products", {}).get(
-            product.product_type, {}
-        ).get("output_extension", None) or getattr(
-            self.config, "output_extension", None
-        )
-        kwargs["output_extension"] = kwargs.get("output_extension", output_extension)
-
         fs_path, record_filename = self._prepare_download(
             product,
             progress_callback=progress_callback,

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -124,8 +124,6 @@ class HTTPDownload(Download):
           default: ``5``
         * :attr:`~eodag.config.PluginConfig.ssl_verify` (``bool``): if the ssl certificates should be verified in
           requests; default: ``True``
-        * :attr:`~eodag.config.PluginConfig.output_extension` (``str``): which extension should be used for the
-          downloaded file
         * :attr:`~eodag.config.PluginConfig.no_auth_download` (``bool``): if the download should be done without
           authentication; default: ``True``
         * :attr:`~eodag.config.PluginConfig.order_enabled` (``bool``): if the product has to be ordered to download it;
@@ -142,9 +140,8 @@ class HTTPDownload(Download):
           configuration to handle the order status; contains information which method to use, how the response data is
           interpreted, which status corresponds to success, ordered and error and what should be done on success.
         * :attr:`~eodag.config.PluginConfig.products` (``Dict[str, Dict[str, Any]``): product type specific config; the
-          keys are the product types, the values are dictionaries which can contain the keys
-          :attr:`~eodag.config.PluginConfig.output_extension` and :attr:`~eodag.config.PluginConfig.extract` to
-          overwrite the provider config for a specific product type
+          keys are the product types, the values are dictionaries which can contain the key
+          :attr:`~eodag.config.PluginConfig.extract` to overwrite the provider config for a specific product type
 
     """
 
@@ -718,15 +715,6 @@ class HTTPDownload(Download):
                     ext = guess_extension(content_type)
                     if ext:
                         filename += ext
-                else:
-                    output_extension: Optional[str] = (
-                        getattr(self.config, "products", {})
-                        .get(product.product_type, {})
-                        .get("output_extension")
-                    )
-                    if output_extension:
-                        filename += output_extension
-
         return filename
 
     def _stream_download_dict(

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -21,12 +21,11 @@ import logging
 import os
 import re
 import shutil
-import tarfile
-import zipfile
 from datetime import datetime
 from email.message import Message
 from itertools import chain
 from json import JSONDecodeError
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -610,7 +609,7 @@ class HTTPDownload(Download):
             try:
                 fs_path = self._download_assets(
                     product,
-                    fs_path.replace(".zip", ""),
+                    fs_path,
                     record_filename,
                     auth,
                     progress_callback,
@@ -636,73 +635,37 @@ class HTTPDownload(Download):
             timeout: float,
             **kwargs: Unpack[DownloadConf],
         ) -> None:
-            chunks = self._stream_download(product, auth, progress_callback, **kwargs)
+            filename, chunk_iterator = self._stream_download(
+                product, auth, progress_callback, **kwargs
+            )
             is_empty = True
 
-            with open(fs_path, "wb") as fhandle:
+            ext = Path(filename).suffix
+            path = Path(fs_path).with_suffix(ext)
+
+            with open(path, "wb") as fhandle:
+                chunks = chunk_iterator()
                 for chunk in chunks:
                     is_empty = False
                     fhandle.write(chunk)
 
+            self.stream.close()  # Closing response stream
+
             if is_empty:
                 raise DownloadError(f"product {product.properties['id']} is empty")
 
-        download_request(product, auth, progress_callback, wait, timeout, **kwargs)
+            return path
+
+        path = download_request(
+            product, auth, progress_callback, wait, timeout, **kwargs
+        )
 
         with open(record_filename, "w") as fh:
             fh.write(url)
         logger.debug("Download recorded in %s", record_filename)
 
-        # Check that the downloaded file is really a zip file
-        if not zipfile.is_zipfile(fs_path) and output_extension == ".zip":
-            logger.warning(
-                "Downloaded product is not a Zip File. Please check its file type before using it"
-            )
-            new_fs_path = os.path.join(
-                os.path.dirname(fs_path),
-                sanitize(product.properties["title"]),
-            )
-            if os.path.isfile(fs_path) and not tarfile.is_tarfile(fs_path):
-                if not os.path.isdir(new_fs_path):
-                    os.makedirs(new_fs_path)
-                shutil.move(fs_path, new_fs_path)
-                file_path = os.path.join(new_fs_path, os.path.basename(fs_path))
-                new_file_path = file_path[: file_path.index(".zip")]
-                shutil.move(file_path, new_file_path)
-            # in the case where the outputs extension has not been set
-            # to ".tar" in the product type nor provider configuration
-            elif tarfile.is_tarfile(fs_path):
-                if not new_fs_path.endswith(".tar"):
-                    new_fs_path += ".tar"
-                shutil.move(fs_path, new_fs_path)
-                kwargs["output_extension"] = ".tar"
-                product_path = self._finalize(
-                    new_fs_path,
-                    progress_callback=progress_callback,
-                    **kwargs,
-                )
-                product.location = path_to_uri(product_path)
-                return product_path
-            else:
-                # not a file (dir with zip extension)
-                shutil.move(fs_path, new_fs_path)
-            product.location = path_to_uri(new_fs_path)
-            return new_fs_path
-
-        if os.path.isfile(fs_path) and not (
-            zipfile.is_zipfile(fs_path) or tarfile.is_tarfile(fs_path)
-        ):
-            new_fs_path = os.path.join(
-                os.path.dirname(fs_path),
-                sanitize(product.properties["title"]),
-            )
-            if not os.path.isdir(new_fs_path):
-                os.makedirs(new_fs_path)
-            shutil.move(fs_path, new_fs_path)
-            product.location = path_to_uri(new_fs_path)
-            return new_fs_path
         product_path = self._finalize(
-            fs_path,
+            str(path),
             progress_callback=progress_callback,
             **kwargs,
         )
@@ -946,7 +909,7 @@ class HTTPDownload(Download):
         auth: Optional[AuthBase] = None,
         progress_callback: Optional[ProgressCallback] = None,
         **kwargs: Unpack[DownloadConf],
-    ) -> Iterator[Any]:
+    ):
         """
         Fetches a zip file containing the assets of a given product as a stream
         and returns a generator yielding the chunks of the file
@@ -998,7 +961,7 @@ class HTTPDownload(Download):
             auth = None
 
         s = requests.Session()
-        with s.request(
+        self.stream = s.request(
             req_method,
             req_url,
             stream=True,
@@ -1008,48 +971,48 @@ class HTTPDownload(Download):
             timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
             verify=ssl_verify,
             **req_kwargs,
-        ) as self.stream:
-            try:
-                self.stream.raise_for_status()
-            except requests.exceptions.Timeout as exc:
-                raise TimeOutError(
-                    exc, timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT
-                ) from exc
-            except RequestException as e:
-                self._process_exception(e, product, ordered_message)
-            else:
-                # check if product was ordered
+        )
+        try:
+            self.stream.raise_for_status()
+        except requests.exceptions.Timeout as exc:
+            raise TimeOutError(exc, timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT) from exc
+        except RequestException as e:
+            self._process_exception(e, product, ordered_message)
+        else:
+            # check if product was ordered
 
-                if getattr(
-                    self.stream, "status_code", None
-                ) is not None and self.stream.status_code == getattr(
-                    self.config, "order_status", {}
-                ).get(
-                    "ordered", {}
-                ).get(
-                    "http_code"
-                ):
-                    product.properties["storageStatus"] = "ORDERED"
-                    self._process_exception(None, product, ordered_message)
-                stream_size = self._check_stream_size(product) or None
+            if getattr(
+                self.stream, "status_code", None
+            ) is not None and self.stream.status_code == getattr(
+                self.config, "order_status", {}
+            ).get(
+                "ordered", {}
+            ).get(
+                "http_code"
+            ):
+                product.properties["storageStatus"] = "ORDERED"
+                self._process_exception(None, product, ordered_message)
+            stream_size = self._check_stream_size(product) or None
 
-                product.headers = self.stream.headers
-                filename = self._check_product_filename(product) or None
-                product.headers[
-                    "content-disposition"
-                ] = f"attachment; filename={filename}"
-                content_type = product.headers.get("Content-Type")
-                guessed_content_type = (
-                    guess_file_type(filename) if filename and not content_type else None
-                )
-                if guessed_content_type is not None:
-                    product.headers["Content-Type"] = guessed_content_type
+            product.headers = self.stream.headers
+            filename = self._check_product_filename(product) or None
+            product.headers["content-disposition"] = f"attachment; filename={filename}"
+            content_type = product.headers.get("Content-Type")
+            guessed_content_type = (
+                guess_file_type(filename) if filename and not content_type else None
+            )
+            if guessed_content_type is not None:
+                product.headers["Content-Type"] = guessed_content_type
 
-                progress_callback.reset(total=stream_size)
+            progress_callback.reset(total=stream_size)
+
+            def iteration_wrapper():
                 for chunk in self.stream.iter_content(chunk_size=64 * 1024):
                     if chunk:
                         progress_callback(len(chunk))
                         yield chunk
+
+            return filename, iteration_wrapper
 
     def _stream_download_assets(
         self,

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -913,7 +913,7 @@ class HTTPDownload(Download):
         auth: Optional[AuthBase] = None,
         progress_callback: Optional[ProgressCallback] = None,
         **kwargs: Unpack[DownloadConf],
-    ) -> tuple[str, Callable[[], Any]] | None:
+    ) -> Union[tuple[str, Callable[[], Any]], None]:
         """
         Fetches a zip file containing the assets of a given product as a stream
         and returns a generator yielding the chunks of the file

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     Iterator,
     List,
@@ -636,26 +637,30 @@ class HTTPDownload(Download):
             wait: float,
             timeout: float,
             **kwargs: Unpack[DownloadConf],
-        ) -> None:
-            result = self._stream_download(product, auth, progress_callback, **kwargs)
-            filename, chunk_iterator = result
+        ) -> os.PathLike:
             is_empty = True
+            result = self._stream_download(product, auth, progress_callback, **kwargs)
+            if result is not None and fs_path is not None:
+                filename, chunk_iterator = result
 
-            ext = Path(filename).suffix
-            path = Path(fs_path).with_suffix(ext)
+                ext = Path(filename).suffix
+                path = Path(fs_path).with_suffix(ext)
 
-            with open(path, "wb") as fhandle:
-                chunks = chunk_iterator()
-                for chunk in chunks:
-                    is_empty = False
-                    fhandle.write(chunk)
+                with open(path, "wb") as fhandle:
+                    chunks = chunk_iterator()
+                    for chunk in chunks:
+                        is_empty = False
+                        fhandle.write(chunk)
+                self.stream.close()  # Closing response stream
 
-            self.stream.close()  # Closing response stream
+                if is_empty:
+                    raise DownloadError(f"product {product.properties['id']} is empty")
 
-            if is_empty:
-                raise DownloadError(f"product {product.properties['id']} is empty")
-
-            return path
+                return path
+            else:
+                raise DownloadError(
+                    f"download of product {product.properties['id']} failed"
+                )
 
         path = download_request(
             product, auth, progress_callback, wait, timeout, **kwargs
@@ -811,9 +816,13 @@ class HTTPDownload(Download):
                 else:
                     pass
 
-        chunks = self._stream_download(product, auth, progress_callback, **kwargs)
+        result = self._stream_download(product, auth, progress_callback, **kwargs)
+        if result is None:
+            raise DownloadError(f"download of {product.properties['id']} is empty")
+        filename, chunk_iterator = result
         # start reading chunks to set product.headers
         try:
+            chunks = chunk_iterator()
             first_chunk = next(chunks)
         except StopIteration:
             # product is empty file
@@ -923,7 +932,7 @@ class HTTPDownload(Download):
         auth: Optional[AuthBase] = None,
         progress_callback: Optional[ProgressCallback] = None,
         **kwargs: Unpack[DownloadConf],
-    ):
+    ) -> tuple[str, Callable[[], Any]] | None:
         """
         Fetches a zip file containing the assets of a given product as a stream
         and returns a generator yielding the chunks of the file
@@ -992,6 +1001,7 @@ class HTTPDownload(Download):
             raise TimeOutError(exc, timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT) from exc
         except RequestException as e:
             self._process_exception(e, product, ordered_message)
+            return None
         else:
             # check if product was ordered
 
@@ -1009,7 +1019,7 @@ class HTTPDownload(Download):
             stream_size = self._check_stream_size(product) or None
 
             product.headers = self.stream.headers
-            filename = self._check_product_filename(product) or None
+            filename = self._check_product_filename(product)
             product.headers["content-disposition"] = f"attachment; filename={filename}"
             content_type = product.headers.get("Content-Type")
             guessed_content_type = (

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -21,6 +21,8 @@ import logging
 import os
 import re
 import shutil
+import tarfile
+import zipfile
 from datetime import datetime
 from email.message import Message
 from itertools import chain
@@ -587,7 +589,7 @@ class HTTPDownload(Download):
         output_extension = getattr(self.config, "products", {}).get(
             product.product_type, {}
         ).get("output_extension", None) or getattr(
-            self.config, "output_extension", ".zip"
+            self.config, "output_extension", None
         )
         kwargs["output_extension"] = kwargs.get("output_extension", output_extension)
 
@@ -635,9 +637,8 @@ class HTTPDownload(Download):
             timeout: float,
             **kwargs: Unpack[DownloadConf],
         ) -> None:
-            filename, chunk_iterator = self._stream_download(
-                product, auth, progress_callback, **kwargs
-            )
+            result = self._stream_download(product, auth, progress_callback, **kwargs)
+            filename, chunk_iterator = result
             is_empty = True
 
             ext = Path(filename).suffix
@@ -663,6 +664,19 @@ class HTTPDownload(Download):
         with open(record_filename, "w") as fh:
             fh.write(url)
         logger.debug("Download recorded in %s", record_filename)
+
+        if os.path.isfile(path) and not (
+            zipfile.is_zipfile(path) or tarfile.is_tarfile(path)
+        ):
+            new_fs_path = os.path.join(
+                os.path.dirname(path),
+                sanitize(product.properties["title"]),
+            )
+            if not os.path.isdir(new_fs_path):
+                os.makedirs(new_fs_path)
+            shutil.move(path, new_fs_path)
+            product.location = path_to_uri(new_fs_path)
+            return new_fs_path
 
         product_path = self._finalize(
             str(path),

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1943,23 +1943,14 @@
         metadata_mapping:
           downloadLink: $.json.asset.value.href
     products:
-      CAMS_GAC_FORECAST:
-      CAMS_GFE_GFAS:
-      CAMS_EU_AIR_QUALITY_FORECAST:
       CAMS_EU_AIR_QUALITY_RE:
         extract: true
       CAMS_GRF:
         extract: true
       CAMS_GRF_AUX:
         extract: true
-      CAMS_SOLAR_RADIATION:
-      CAMS_GREENHOUSE_EGG4_MONTHLY:
-      CAMS_GREENHOUSE_EGG4:
-      CAMS_GREENHOUSE_INVERSION:
       CAMS_GLOBAL_EMISSIONS:
         extract: true
-      CAMS_EAC4:
-      CAMS_EAC4_MONTHLY:
   search: !plugin
     type: ECMWFSearch
     ssl_verify: true
@@ -2188,7 +2179,10 @@
     products:
       AG_ERA5:
         extract: true
+<<<<<<< HEAD
       UERRA_EUROPE_SL:
+=======
+>>>>>>> be1be030 (fix(providers): remove empty products)
       GLACIERS_DIST_RANDOLPH:
         extract: true
       SATELLITE_CARBON_DIOXIDE:
@@ -2197,12 +2191,6 @@
         extract: true
       SATELLITE_METHANE:
         extract: true
-      SEASONAL_POSTPROCESSED_PL:
-      SEASONAL_POSTPROCESSED_SL:
-      SEASONAL_ORIGINAL_SL:
-      SEASONAL_ORIGINAL_PL:
-      SEASONAL_MONTHLY_PL:
-      SEASONAL_MONTHLY_SL:
       SIS_HYDRO_MET_PROJ:
         extract: true
   search: !plugin
@@ -5520,10 +5508,6 @@
       on_success:
         metadata_mapping:
           downloadLink: '{orderStatusLink}'
-    products:
-      DT_EXTREMES:
-      DT_CLIMATE_ADAPTATION:
-      FIRE_HISTORICAL:
   auth: !plugin
     type: OIDCTokenExchangeAuth
     matching_url: https://[-\w\.]+.data.destination-earth.eu
@@ -6607,8 +6591,6 @@
         need_search: true
         metadata_mapping:
           downloadLink: $.json.asset.value.href
-    products:
-      FIRE_HISTORICAL:
   search: !plugin
     type: ECMWFSearch
     ssl_verify: true

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -2179,10 +2179,6 @@
     products:
       AG_ERA5:
         extract: true
-<<<<<<< HEAD
-      UERRA_EUROPE_SL:
-=======
->>>>>>> be1be030 (fix(providers): remove empty products)
       GLACIERS_DIST_RANDOLPH:
         extract: true
       SATELLITE_CARBON_DIOXIDE:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1920,7 +1920,6 @@
     type: HTTPDownload
     timeout: 30
     ssl_verify: true
-    extract: false
     auth_error_code: 401
     order_enabled: true
     order_method: POST
@@ -1942,15 +1941,6 @@
         need_search: true
         metadata_mapping:
           downloadLink: $.json.asset.value.href
-    products:
-      CAMS_EU_AIR_QUALITY_RE:
-        extract: true
-      CAMS_GRF:
-        extract: true
-      CAMS_GRF_AUX:
-        extract: true
-      CAMS_GLOBAL_EMISSIONS:
-        extract: true
   search: !plugin
     type: ECMWFSearch
     ssl_verify: true
@@ -2154,7 +2144,6 @@
     type: HTTPDownload
     timeout: 30
     ssl_verify: true
-    extract: false
     auth_error_code: 401
     order_enabled: true
     order_method: POST
@@ -2176,19 +2165,6 @@
         need_search: true
         metadata_mapping:
           downloadLink: $.json.asset.value.href
-    products:
-      AG_ERA5:
-        extract: true
-      GLACIERS_DIST_RANDOLPH:
-        extract: true
-      SATELLITE_CARBON_DIOXIDE:
-        extract: true
-      SATELLITE_FIRE_BURNED_AREA:
-        extract: true
-      SATELLITE_METHANE:
-        extract: true
-      SIS_HYDRO_MET_PROJ:
-        extract: true
   search: !plugin
     type: ECMWFSearch
     ssl_verify: true

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -55,31 +55,22 @@
     # see also https://dds.cr.usgs.gov/ee-data/coveragemaps/shp/ee/
     LANDSAT_C2L1:
       dataset: landsat_ot_c2_l1
-      output_extension: .tar.gz
     LANDSAT_C2L2:
       dataset: landsat_ot_c2_l2
-      output_extension: .tar.gz
     LANDSAT_TM_C1:
       dataset: landsat_tm_c1
-      output_extension: .tar.gz
     LANDSAT_TM_C2L1:
       dataset: landsat_tm_c2_l1
-      output_extension: .tar.gz
     LANDSAT_TM_C2L2:
       dataset: landsat_tm_c2_l2
-      output_extension: .tar.gz
     LANDSAT_ETM_C1:
       dataset: landsat_etm_c1
-      output_extension: .tar.gz
     LANDSAT_ETM_C2L1:
       dataset: landsat_etm_c2_l1
-      output_extension: .tar.gz
     LANDSAT_ETM_C2L2:
       dataset: landsat_etm_c2_l2
-      output_extension: .tar.gz
     S2_MSI_L1C:
       dataset: SENTINEL_2A
-      output_extension: .zip
     GENERIC_PRODUCT_TYPE:
       dataset: '{productType}'
 
@@ -1953,35 +1944,22 @@
           downloadLink: $.json.asset.value.href
     products:
       CAMS_GAC_FORECAST:
-        output_extension: .grib
       CAMS_GFE_GFAS:
-        output_extension: .grib
       CAMS_EU_AIR_QUALITY_FORECAST:
-        output_extension: .grib
       CAMS_EU_AIR_QUALITY_RE:
-        output_extension: .zip
         extract: true
       CAMS_GRF:
-        output_extension: .zip
         extract: true
       CAMS_GRF_AUX:
-        output_extension: .zip
         extract: true
       CAMS_SOLAR_RADIATION:
-        output_extension: .csv
       CAMS_GREENHOUSE_EGG4_MONTHLY:
-        output_extension: .grib
       CAMS_GREENHOUSE_EGG4:
-        output_extension: .grib
       CAMS_GREENHOUSE_INVERSION:
-        output_extension: .grib
       CAMS_GLOBAL_EMISSIONS:
-        output_extension: .zip
         extract: true
       CAMS_EAC4:
-        output_extension: .grib
       CAMS_EAC4_MONTHLY:
-        output_extension: .grib
   search: !plugin
     type: ECMWFSearch
     ssl_verify: true
@@ -2209,36 +2187,23 @@
           downloadLink: $.json.asset.value.href
     products:
       AG_ERA5:
-        output_extension: .zip
         extract: true
       UERRA_EUROPE_SL:
-        output_extension: .grib
       GLACIERS_DIST_RANDOLPH:
-        output_extension: .zip
         extract: true
       SATELLITE_CARBON_DIOXIDE:
-        output_extension: .zip
         extract: true
       SATELLITE_FIRE_BURNED_AREA:
-        output_extension: .zip
         extract: true
       SATELLITE_METHANE:
-        output_extension: .zip
         extract: true
       SEASONAL_POSTPROCESSED_PL:
-        output_extension: .grib
       SEASONAL_POSTPROCESSED_SL:
-        output_extension: .grib
       SEASONAL_ORIGINAL_SL:
-        output_extension: .grib
       SEASONAL_ORIGINAL_PL:
-        output_extension: .grib
       SEASONAL_MONTHLY_PL:
-        output_extension: .grib
       SEASONAL_MONTHLY_SL:
-        output_extension: .grib
       SIS_HYDRO_MET_PROJ:
-        output_extension: .zip
         extract: true
   search: !plugin
     type: ECMWFSearch
@@ -2872,7 +2837,6 @@
           orderId: '$.json.id'
           downloadLink: 'http://queueresults.meteoblue.com/{orderId}'
           downloadMethod: '{$.null#replace_str("Not Available","GET")}'
-    output_extension: .nc
   auth: !plugin
     type: HttpQueryStringAuth
     matching_url: https?://[a-z]+.meteoblue.com
@@ -5472,9 +5436,7 @@
     no_auth_download: True
     products:
       DT_EXTREMES:
-        output_extension: .grib
       DT_CLIMATE_ADAPTATION:
-        output_extension: .grib
   auth: !plugin
     type: OIDCAuthorizationCodeFlowAuth
     matching_url: https://[-\w\.]+.dte.destination-earth.eu
@@ -5560,11 +5522,8 @@
           downloadLink: '{orderStatusLink}'
     products:
       DT_EXTREMES:
-        output_extension: .grib
       DT_CLIMATE_ADAPTATION:
-        output_extension: .grib
       FIRE_HISTORICAL:
-        output_extension: .grib
   auth: !plugin
     type: OIDCTokenExchangeAuth
     matching_url: https://[-\w\.]+.data.destination-earth.eu
@@ -6650,7 +6609,6 @@
           downloadLink: $.json.asset.value.href
     products:
       FIRE_HISTORICAL:
-        output_extension: .grib
   search: !plugin
     type: ECMWFSearch
     ssl_verify: true

--- a/eodag/types/download_args.py
+++ b/eodag/types/download_args.py
@@ -33,7 +33,7 @@ class DownloadConf(TypedDict, total=False):
     """
 
     output_dir: str
-    output_extension: str
+    output_extension: str | None
     extract: bool
     dl_url_params: Dict[str, str]
     delete_archive: bool

--- a/eodag/types/download_args.py
+++ b/eodag/types/download_args.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import Dict, Optional, TypedDict
+from typing import Dict, Optional, TypedDict, Union
 
 
 class DownloadConf(TypedDict, total=False):
@@ -33,7 +33,7 @@ class DownloadConf(TypedDict, total=False):
     """
 
     output_dir: str
-    output_extension: str | None
+    output_extension: Union[str, None]
     extract: bool
     dl_url_params: Dict[str, str]
     delete_archive: bool

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -331,17 +331,14 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             eoproduct_props,
             product_type,
         )
-        output_extension = getattr(
-            product.downloader.config, "output_extension", ".zip"
-        )
         path = product.download()
 
-        self.assertTrue(
-            path == os.path.join(self.output_dir, product.properties["title"] + ".zip")
-            and os.path.isfile(path)
-            and output_extension == ".zip"
-            and zipfile.is_zipfile(path)
+        expected_path = os.path.join(
+            self.output_dir, product.properties["title"] + ".zip"
         )
+        self.assertEqual(path, expected_path)
+        self.assertTrue(os.path.isfile(path))
+        self.assertTrue(zipfile.is_zipfile(path))
 
         # check if the hidden directory ".downloaded" have been created with the product zip file
         self.assertEqual(len(os.listdir(self.output_dir)), 2)

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -369,11 +369,8 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         self.product.location = self.product.remote_location = "http://somewhere"
         self.product.properties["id"] = "someproduct"
 
-        def gen():
-            yield b"a"
-
         self.product.filename = "dummy_product.nc"
-        mock_stream_download.return_value = gen
+        mock_stream_download.return_value = [b"a"]
         progress_callback = ProgressCallback(disable=True)
 
         path = plugin.download(
@@ -424,11 +421,8 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             ),
         )
 
-        def gen():
-            yield b"a"
-
         product.filename = "dummy_product.nc"
-        mock_stream_download.return_value = gen
+        mock_stream_download.return_value = [b"a"]
 
         plugin = self.get_download_plugin(product)
         product.location = product.remote_location = "http://somewhere"
@@ -487,10 +481,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             b"some content"
         )
 
-        def gen():
-            yield b"a"
-
-        mock_stream_download.return_value = gen
+        mock_stream_download.return_value = [b"a"]
         self.product.filename = "dummy_product.nc"
 
         # download asset if ignore_assets = False

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -372,7 +372,8 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         def gen():
             yield b"a"
 
-        mock_stream_download.return_value = ("dummy_product.nc", gen)
+        self.product.filename = "dummy_product.nc"
+        mock_stream_download.return_value = gen
         progress_callback = ProgressCallback(disable=True)
 
         path = plugin.download(
@@ -426,7 +427,8 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         def gen():
             yield b"a"
 
-        mock_stream_download.return_value = ("dummy_product.nc", gen)
+        product.filename = "dummy_product.nc"
+        mock_stream_download.return_value = gen
 
         plugin = self.get_download_plugin(product)
         product.location = product.remote_location = "http://somewhere"
@@ -488,7 +490,8 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         def gen():
             yield b"a"
 
-        mock_stream_download.return_value = ("dummy_product.nc", gen)
+        mock_stream_download.return_value = gen
+        self.product.filename = "dummy_product.nc"
 
         # download asset if ignore_assets = False
         plugin.config.ignore_assets = False

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -369,7 +369,6 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         when the result is a non-zip file with a '.zip' outputs extension"""
 
         plugin = self.get_download_plugin(self.product)
-        output_extension = getattr(plugin.config, "output_extension", ".zip")
         self.product.location = self.product.remote_location = "http://somewhere"
         self.product.properties["id"] = "someproduct"
 
@@ -385,19 +384,16 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             progress_callback=progress_callback,
         )
 
-        self.assertTrue(
-            path == os.path.join(self.output_dir, "dummy_product")
-            and os.path.isdir(path)
-            and output_extension == ".zip"
-        )
+        # Verify output directory
+        self.assertEqual(path, os.path.join(self.output_dir, "dummy_product"))
+        self.assertTrue(os.path.isdir(path))
 
+        # Verify output file
         file_path = os.path.join(path, os.listdir(path)[0])
-        self.assertTrue(
-            len(os.listdir(path)) == 1
-            and os.path.isfile(file_path)
-            and file_path.find(".zip") == -1
-            and not (zipfile.is_zipfile(file_path) or tarfile.is_tarfile(file_path))
-        )
+        self.assertEqual(len(os.listdir(path)), 1)
+        self.assertNotIn(".zip", file_path)
+        self.assertFalse(zipfile.is_zipfile(file_path))
+        self.assertFalse(tarfile.is_tarfile(file_path))
 
         # check if the hidden directory ".downloaded" have been created with the one of the product
         self.assertEqual(len(os.listdir(self.output_dir)), 2)
@@ -408,7 +404,6 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             None,
             progress_callback,
             output_dir=self.output_dir,
-            output_extension=None,
         )
 
     @mock.patch(
@@ -437,7 +432,6 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         mock_stream_download.return_value = ("dummy_product.nc", gen)
 
         plugin = self.get_download_plugin(product)
-        output_extension = getattr(plugin.config, "output_extension", ".zip")
         product.location = product.remote_location = "http://somewhere"
         product.properties["id"] = "someproduct"
         progress_callback = ProgressCallback(disable=True)
@@ -446,21 +440,22 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             product, output_dir=self.output_dir, progress_callback=progress_callback
         )
 
-        self.assertTrue(
-            path == os.path.join(self.output_dir, "dummy_product")
-            and os.path.isdir(path)
-            and not output_extension == ".zip"
-        )
+        # Verify output directory
+        expected_path = os.path.join(self.output_dir, "dummy_product")
+        self.assertIsNotNone(path)
+        self.assertEqual(path, expected_path)
+        self.assertTrue(os.path.isdir(path))
 
+        # Verify output file
         file_path = os.path.join(path, os.listdir(path)[0])
-        self.assertTrue(
-            len(os.listdir(path)) == 1
-            and os.path.isfile(file_path)
-            and file_path.find(".zip") == -1
-            and not (zipfile.is_zipfile(file_path) or tarfile.is_tarfile(file_path))
-        )
+        self.assertEqual(len(os.listdir(path)), 1)
+        self.assertTrue(os.path.isfile(file_path))
+        self.assertNotIn(".zip", file_path)
+        self.assertFalse(zipfile.is_zipfile(file_path))
+        self.assertFalse(tarfile.is_tarfile(file_path))
 
-        # check if the hidden directory ".downloaded" have been created with the one of the product
+        # check if the hidden directory ".downloaded" have been created with the one of
+        # the product
         self.assertEqual(len(os.listdir(self.output_dir)), 2)
 
         mock_stream_download.assert_called_once_with(
@@ -469,7 +464,6 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             None,
             progress_callback,
             output_dir=self.output_dir,
-            output_extension=output_extension,
         )
 
     @mock.patch(


### PR DESCRIPTION
- [x] Remove default `.zip` extensions used when a file to download extension is unknown.
- [x] In `HTTPDownload`, use the value obtained with  `_check_product_filename()` to set the downloaded file extension.
- [x] remove `output_extension` from `providers.yaml`