### PR TITLE
build: prevent pydantic v2.10.0 usage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     lxml
     orjson < 3.10.0;python_version>='3.12' and platform_system=='Windows'
     orjson;python_version<'3.12' or platform_system!='Windows'
-    pydantic >= 2.1.0
+    pydantic >= 2.1.0, != 2.10.0
     pydantic_core
     PyJWT >= 2.5.0
     pyproj >= 2.1.0


### PR DESCRIPTION
This prevents an issue raised by `mypy` with `pydantic v2.10.0`.

`BaseModel.model_fields` return type is interpreted as `Callable[[BaseModel], dict[str, FieldInfo]]` instead of `dict[str, FieldInfo]`.

See https://github.com/pydantic/pydantic/issues/10907, a patch is expected soon and filtering `pydantic != 2.10.0` should be enough on our side.