### PR TITLE
fix(cli): handle import error of eodag.rest module

### DIFF
--- a/eodag/cli.py
+++ b/eodag/cli.py
@@ -53,10 +53,14 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Set
 import click
 
 from eodag.api.core import EODataAccessGateway
-from eodag.rest.utils import LIVENESS_PROBE_PATH
 from eodag.utils import DEFAULT_ITEMS_PER_PAGE, DEFAULT_PAGE, parse_qs
 from eodag.utils.exceptions import NoMatchingProductType, UnsupportedProvider
 from eodag.utils.logging import setup_logging
+
+try:
+    from eodag.rest.utils import LIVENESS_PROBE_PATH
+except ImportError:
+    pass
 
 if TYPE_CHECKING:
     from click import Context


### PR DESCRIPTION
Wrapped import in a try/except