### PR TITLE
build: add missing cryptography requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
     orjson;python_version<'3.12' or platform_system!='Windows'
     pydantic >= 2.1.0, != 2.10.0
     pydantic_core
-    PyJWT >= 2.5.0
+    PyJWT[crypto] >= 2.5.0
     pyproj >= 2.1.0
     pyshp
     pystac >= 1.0.0b1


### PR DESCRIPTION
Use `PyJWT[crypto]` instead of `PyJWT` as dependency