### PR TITLE
fix(plugins): creodias_s3 search and download when no asset

### DIFF
--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -482,7 +482,8 @@ class AwsDownload(Download):
         ignore_assets: Optional[bool] = False,
     ) -> List[Tuple[str, Optional[str]]]:
         """
-        retrieves the bucket names and path prefixes for the assets
+        Retrieves the bucket names and path prefixes for the assets
+
         :param product: product for which the assets shall be downloaded
         :param asset_filter: text for which the assets should be filtered
         :param ignore_assets: if product instead of individual assets should be used

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -731,12 +731,12 @@ class AwsDownload(Download):
             else sanitize(product.properties.get("id", "download"))
         )
 
-        if len(assets_values) == 1:
+        if len(assets_values) <= 1:
             first_chunks_tuple = next(chunks_tuples)
             # update headers
             filename = os.path.basename(list(unique_product_chunks)[0].key)
             headers = {"content-disposition": f"attachment; filename={filename}"}
-            if assets_values[0].get("type", None):
+            if assets_values and assets_values[0].get("type", None):
                 headers["content-type"] = assets_values[0]["type"]
 
             return StreamResponse(
@@ -799,7 +799,6 @@ class AwsDownload(Download):
             common_path = self._get_commonpath(
                 product, unique_product_chunks, build_safe
             )
-
         for product_chunk in unique_product_chunks:
             try:
                 chunk_rel_path = self.get_chunk_dest_path(
@@ -817,8 +816,7 @@ class AwsDownload(Download):
                 # out of SAFE format chunk
                 logger.warning(e)
                 continue
-
-            if len(assets_values) == 1:
+            if len(assets_values) <= 1:
                 yield from get_chunk_parts(product_chunk, progress_callback)
             else:
                 yield (

--- a/eodag/plugins/download/creodias_s3.py
+++ b/eodag/plugins/download/creodias_s3.py
@@ -76,7 +76,8 @@ class CreodiasS3Download(AwsDownload):
         ignore_assets: Optional[bool] = False,
     ) -> List[Tuple[str, Optional[str]]]:
         """
-        retrieves the bucket names and path prefixes for the assets
+        Retrieves the bucket names and path prefixes for the assets
+
         :param product: product for which the assets shall be downloaded
         :param asset_filter: text for which the assets should be filtered
         :param ignore_assets: if product instead of individual assets should be used
@@ -108,7 +109,7 @@ class CreodiasS3Download(AwsDownload):
                     )
                 )
         else:
-            # if not assets are given, use productIdentifier to get S3 path for download
+            # if no assets are given, use productIdentifier to get S3 path for download
             s3_url = "s3:/" + product.properties["productIdentifier"]
             bucket_names_and_prefixes = [
                 self.get_product_bucket_name_and_prefix(product, s3_url)

--- a/eodag/plugins/download/creodias_s3.py
+++ b/eodag/plugins/download/creodias_s3.py
@@ -15,12 +15,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import re
+from typing import List, Optional, Tuple
 
 import boto3
 from botocore.exceptions import ClientError
 
+from eodag import EOProduct
 from eodag.plugins.download.aws import AwsDownload
-from eodag.utils.exceptions import MisconfiguredError
+from eodag.utils.exceptions import MisconfiguredError, NotAvailableError
 
 
 class CreodiasS3Download(AwsDownload):
@@ -65,3 +68,49 @@ class CreodiasS3Download(AwsDownload):
         list(objects.filter(Prefix=prefix).limit(1))
         self.s3_session = s3_session
         return objects
+
+    def _get_bucket_names_and_prefixes(
+        self,
+        product: EOProduct,
+        asset_filter: Optional[str] = None,
+        ignore_assets: Optional[bool] = False,
+    ) -> List[Tuple[str, Optional[str]]]:
+        """
+        retrieves the bucket names and path prefixes for the assets
+        :param product: product for which the assets shall be downloaded
+        :param asset_filter: text for which the assets should be filtered
+        :param ignore_assets: if product instead of individual assets should be used
+        :return: tuples of bucket names and prefixes
+        """
+        # if assets are defined, use them instead of scanning product.location
+        if len(product.assets) > 0 and not ignore_assets:
+            if asset_filter:
+                filter_regex = re.compile(asset_filter)
+                assets_keys = getattr(product, "assets", {}).keys()
+                assets_keys = list(filter(filter_regex.fullmatch, assets_keys))
+                filtered_assets = {
+                    a_key: getattr(product, "assets", {})[a_key]
+                    for a_key in assets_keys
+                }
+                assets_values = [a for a in filtered_assets.values() if "href" in a]
+                if not assets_values:
+                    raise NotAvailableError(
+                        rf"No asset key matching re.fullmatch(r'{asset_filter}') was found in {product}"
+                    )
+            else:
+                assets_values = list(product.assets.values())
+
+            bucket_names_and_prefixes = []
+            for complementary_url in assets_values:
+                bucket_names_and_prefixes.append(
+                    self.get_product_bucket_name_and_prefix(
+                        product, complementary_url.get("href", "")
+                    )
+                )
+        else:
+            # if not assets are given, use productIdentifier to get S3 path for download
+            s3_url = "s3:/" + product.properties["productIdentifier"]
+            bucket_names_and_prefixes = [
+                self.get_product_bucket_name_and_prefix(product, s3_url)
+            ]
+        return bucket_names_and_prefixes

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -2268,7 +2268,7 @@ class TestDownloadPluginCreodiasS3(BaseDownloadPluginTest):
         autospec=True,
     )
     @mock.patch("eodag.plugins.download.aws.requests.get", autospec=True)
-    def test_plugins_download_creodias_s3_withou_assets(
+    def test_plugins_download_creodias_s3_without_assets(
         self,
         mock_requests_get,
         mock_get_authenticated_objects,

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -37,7 +37,7 @@ from pydantic_core import PydanticUndefined
 from requests import RequestException
 from typing_extensions import get_args
 
-from build.lib.eodag.api.product import AssetsDict
+from eodag.api.product import AssetsDict
 from eodag.api.product.metadata_mapping import get_queryable_from_provider
 from eodag.utils import deepcopy
 from eodag.utils.exceptions import UnsupportedProductType

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2179,7 +2179,7 @@ class TestSearchPluginCreodiasS3Search(BaseSearchPluginTest):
             }
             product.register_downloader(download_plugin, auth_plugin)
         assets = res[0][0].assets
-        self.assertEquals(3, len(assets))
+        self.assertEqual(3, len(assets))
         # check if s3 links have been created correctly
         for asset in assets.values():
             self.assertIn("s3://eodata/Sentinel-1/SAR/GRD/2014/10/10", asset["href"])
@@ -2193,7 +2193,7 @@ class TestSearchPluginCreodiasS3Search(BaseSearchPluginTest):
         res[0][0].assets = AssetsDict(res[0][0])
         res[0][0].register_downloader(download_plugin, auth_plugin)
         self.assertIsNotNone(res[0][0].driver)
-        self.assertEquals(0, len(res[0][0].assets))
+        self.assertEqual(0, len(res[0][0].assets))
 
     @mock.patch(
         "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True


### PR DESCRIPTION
If a product from `creodias_s3` was stored on the s3 in a `.tar` file with the path `bucket/../product_id.tar` instead of having the structure `bucket/../product_id/asset`, the search for a request for which the response includes such a product was failing.

`CreodiasS3Search` and `CreodiasS3Download` have now been adapted to consider this case.
