### PR TITLE
fix(providers): geodes id property

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -6525,8 +6525,8 @@
         - '$.properties."spaceborne:polarization"'
       # Custom parameters (not defined in the base document referenced above)
       id:
-        - '{{"query":{{"accessService:endpointURL":{{"contains":"{id}"}}}}}}'
-        - '{$.properties."accessService:endpointURL"#replace_str(r"^.*\/(\w+)\.zip$",r"\1")}'
+        - '{{"query":{{"identifier":{{"eq":"{id}"}}}}}}'
+        - '$.properties.identifier'
       geometry:
         - '{{"intersects":{geometry#to_geojson}}}'
         - '($.geometry.`str()`.`sub(/^None$/, POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90)))`)|($.geometry[*])'


### PR DESCRIPTION
Use the new `identifier` property added by `geodes` as `id` in metadata mapping