### PR TITLE
fix(providers): queryables fixes for some product-types

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -589,7 +589,7 @@ class ECMWFSearch(PostJsonSearch):
             ):
                 formated_kwargs[key] = kwargs[key]
             else:
-                raise ValidationError(f"{key} in not a queryable parameter")
+                raise ValidationError(f"{key} is not a queryable parameter")
 
         # we use non empty kwargs as default to integrate user inputs
         # it is needed because pydantic json schema does not represent "value"

--- a/eodag/resources/product_types.yml
+++ b/eodag/resources/product_types.yml
@@ -2758,7 +2758,7 @@ CAMS_EU_AIR_QUALITY_FORECAST:
   sensorType: ATMOSPHERIC
   license: proprietary
   title: CAMS European air quality forecasts
-  missionStartDate: "2021-11-22T00:00:00Z"
+  missionStartDate: "2022-01-03T00:00:00Z"
 
 CAMS_GFE_GFAS:
   abstract: |

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -2765,6 +2765,7 @@
       timeIntervalsAlignment:
       geometry: {"type": "Polygon", "coordinates": [[[180, -90], [180, 90], [-180, 90], [-180, -90], [180, -90]]]}
     NEMSAUTO_TCDC:
+      productType: NEMSAUTO
       queries: [{'domain':'NEMSAUTO','gapFillDomain':null,'timeResolution':'daily','codes':[{'code':71,'level':'sfc','aggregation':'mean'}]}]
       format: netCDF
       units: {'temperature':'C','velocity':'km/h','length':'metric','energy':'watts'}

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -2311,7 +2311,7 @@
     SATELLITE_SEA_ICE_EDGE_TYPE:
       "ecmwf:dataset": satellite-sea-ice-edge-type
       "ecmwf:cdr_type": cdr
-      "ecwmf:region": northern_hemisphere
+      "ecmwf:region": northern_hemisphere
       "ecmwf:variable":
         - sea_ice_edge
         - sea_ice_type


### PR DESCRIPTION
Fixes  #1446

Allow to list queryables of `SATELLITE_SEA_ICE_EDGE_TYPE` for `cop_cds` and `CAMS_EU_AIR_QUALITY_FORECAST` for `cop_ads` that did not work by correcting configurations.

Configuration of `NEMSAUTO_TCDC` for `meteoblue` is fixed but it is still impossible to list its queryables because the way they are discovered is not adapted for `meteoblue` metadata, as well as `NEMSGLOBAL_TCDC ` and all product types of `wekeo_ecmwf`. However, this issue will be solved in the PR #1427.