### PR TITLE
fix(crunch): skip missing key in filter_property

### DIFF
--- a/eodag/plugins/crunch/filter_property.py
+++ b/eodag/plugins/crunch/filter_property.py
@@ -78,10 +78,9 @@ class FilterProperty(Crunch):
         for product in products:
             if property_key not in product.properties.keys():
                 logger.warning(
-                    "%s not found in product.properties, filtering disabled.",
-                    property_key,
+                    f"{property_key} not found in {product}.properties, product skipped",
                 )
-                return products
+                continue
             if operator_method(product.properties[property_key], property_value):
                 add_to_filtered(product)
 

--- a/tests/integration/test_search_stac_static.py
+++ b/tests/integration/test_search_stac_static.py
@@ -382,6 +382,11 @@ class TestSearchStacStatic(unittest.TestCase):
         )
         self.assertEqual(len(filtered_items), 1)
 
+        with self.assertLogs(level="WARNING") as cm:
+            filtered_items = items.filter_property(foo="bar")
+            self.assertIn("foo not found in EOProduct", str(cm.output))
+            self.assertEqual(len(filtered_items), 0)
+
     @mock.patch(
         "eodag.api.core.EODataAccessGateway.fetch_product_types_list", autospec=True
     )


### PR DESCRIPTION
Do not return product when the property is not found using [SearchResult.filter_property()](https://eodag.readthedocs.io/en/latest/api_reference/searchresult.html#eodag.api.search_result.SearchResult.filter_property) instead of cancelling crunch 