### PR TITLE
fix(providers): default values and dates for GLOFAS and EFAS product types

### DIFF
--- a/eodag/resources/product_types.yml
+++ b/eodag/resources/product_types.yml
@@ -4097,8 +4097,8 @@ GLOFAS_REFORECAST:
   sensorType: ATMOSPHERIC
   license: proprietary
   title: Reforecasts of river discharge and related data by the Global Flood Awareness System
-  missionStartDate: "2003-03-27T00:00:00Z"
-  missionEndDate: "2018-12-30T23:59:00Z"
+  missionStartDate: "1999-01-03T00:00:00Z"
+  missionEndDate: "2023-11-25T23:59:59Z"
 
 GLOFAS_SEASONAL:
   abstract: |
@@ -4128,7 +4128,7 @@ GLOFAS_SEASONAL:
   sensorType: ATMOSPHERIC
   license: proprietary
   title: Seasonal forecasts of river discharge and related data by the Global Flood Awareness System
-  missionStartDate: "2021-06-01T00:00:00Z"
+  missionStartDate: "2020-12-01T00:00:00Z"
 
 GLOFAS_SEASONAL_REFORECAST:
   abstract: |
@@ -4233,7 +4233,7 @@ EFAS_HISTORICAL:
   sensorType: ATMOSPHERIC
   license: proprietary
   title: River discharge and related historical data from the European Flood Awareness System
-  missionStartDate: "1992-01-02T00:00:00Z"
+  missionStartDate: "1991-01-01T00:00:00Z"
 
 EFAS_REFORECAST:
   abstract: |
@@ -4269,8 +4269,8 @@ EFAS_REFORECAST:
   sensorType: ATMOSPHERIC
   license: proprietary
   title: Reforecasts of river discharge and related data by the European Flood Awareness System
-  missionStartDate: "2003-03-27T00:00:00Z"
-  missionEndDate: "2018-12-30T00:00:00Z"
+  missionStartDate: "1999-01-03T00:00:00Z"
+  missionEndDate: "2023-11-21T23:59:59Z"
 
 EFAS_SEASONAL:
   abstract: |

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -6637,8 +6637,8 @@
       "ecmwf:download_format": zip
       "ecmwf:model_levels": surface_level
       "ecmwf:variable": snow_depth_water_equivalent
-      "ecmwf:system_version": version_5_0
-      "ecmwf:time": 00:00
+      "ecmwf:system_version": version_4_0
+      "ecmwf:time": 06:00
       metadata_mapping:
         <<: *hday_hmonth_hyear
     EFAS_FORECAST:
@@ -6668,14 +6668,14 @@
         <<: *month_year
     EFAS_REFORECAST:
       "ecmwf:dataset": efas-reforecast
-      "ecmwf:system_version": version_5_0
+      "ecmwf:system_version": version_4_0
       "ecmwf:data_format": grib
       "ecmwf:download_format": zip
       "ecmwf:product_type": control_forecast
       "ecmwf:variable": river_discharge_in_the_last_6_hours
       "ecmwf:model_levels": surface_level
-      "ecmwf:leadtime_hour": '6'
-      "ecmwf:day": '27'
+      "ecmwf:leadtime_hour": '0'
+      "ecmwf:hday": '03'
       metadata_mapping:
         <<: *hmonth_hyear
     EFAS_SEASONAL_REFORECAST:
@@ -6715,7 +6715,7 @@
       "ecmwf:data_format": grib2
       "ecmwf:download_format": zip
       "ecmwf:system_version": operational
-      "ecmwf:hydrological_model": lisflood
+      "ecmwf:hydrological_model": htessel_lisflood
       "ecmwf:leadtime_hour": '24'
       metadata_mapping:
         <<: *month_year
@@ -6727,7 +6727,7 @@
       "ecmwf:system_version": version_4_0
       "ecmwf:hydrological_model": lisflood
       "ecmwf:leadtime_hour": '24'
-      "ecmwf:day": '27'
+      "ecmwf:hday": '27'
       metadata_mapping:
         <<: *hmonth_hyear
     GLOFAS_REFORECAST:
@@ -6735,10 +6735,11 @@
       "ecmwf:variable": river_discharge_in_the_last_24_hours
       "ecmwf:data_format": grib2
       "ecmwf:download_format": zip
-      "ecmwf:system_version": version_4_0
+      "ecmwf:system_version": version_3_1
       "ecmwf:hydrological_model": lisflood
       "ecmwf:product_type": control_reforecast
       "ecmwf:leadtime_hour": '24'
+      "ecmwf:hday": '03'
       metadata_mapping:
         <<: *hmonth_hyear
     FIRE_HISTORICAL:


### PR DESCRIPTION
Adaptions in default values and mission start/end dates for `GLOFAS` and `EFAS` product types:
- changes the default values of `model` and `version` so that the earliest possible dates can be selected
- updates the values of `missionStartDate` and `missionEndDate`
