### PR TITLE
fix(cop_marine): search_by_id for products without date in id

### DIFF
--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -186,10 +186,20 @@ class CopMarineSearch(StaticStacSearch):
         dataset_item: Dict[str, Any],
         collection_dict: Dict[str, Any],
     ):
+        # try to find date(s) in product id
+        item_dates = re.findall(r"(\d{4})(0[1-9]|1[0-2])([0-3]\d)", product_id)
+        if not item_dates:
+            item_dates = re.findall(r"_(\d{4})(0[1-9]|1[0-2])", product_id)
+        use_dataset_dates = not bool(item_dates)
         for obj in collection_objects["Contents"]:
             if product_id in obj["Key"]:
                 return self._create_product(
-                    product_type, obj["Key"], s3_url, dataset_item, collection_dict
+                    product_type,
+                    obj["Key"],
+                    s3_url,
+                    dataset_item,
+                    collection_dict,
+                    use_dataset_dates,
                 )
         return None
 


### PR DESCRIPTION
The search by id for `cop_marine` was not working correctly for products which don't have a date in the id because at the creation of the result the date is parsed to get the start/end datetime which failed for those products. Now, the dataset dates are used in that case.
