### PR TITLE
fix(server): add default datetime in dedt_lumi generated items

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -4785,6 +4785,7 @@
   search: !plugin
     type: ECMWFSearch
     ssl_verify: true
+    dates_required: True
     discover_queryables:
       fetch_url: null
       product_type_fetch_url: null

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -82,6 +82,8 @@ COLLECTION_PROPERTIES = [
     "missionEndDate",
     "keywords",
     "stacCollection",
+    "alias",
+    "productType",
 ]
 IGNORED_ITEM_PROPERTIES = [
     "_id",


### PR DESCRIPTION
- include default datetime in `dedt_lumi` generated items
- in server-mode, remove `alias` and `productType` from item metadata
