### PR TITLE
fix(plugins): raise error on failed empty stream_zip

### DIFF
--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -778,13 +778,17 @@ class HTTPDownload(Download):
                     )
 
                 else:
+                    # get first chunk to check if it does not contain an error (if it does, that error will be raised)
+                    first_chunks_tuple = next(chunks_tuples)
                     outputs_filename = (
                         sanitize(product.properties["title"])
                         if "title" in product.properties
                         else sanitize(product.properties.get("id", "download"))
                     )
                     return StreamResponse(
-                        content=stream_zip(chunks_tuples),
+                        content=stream_zip(
+                            chain(iter([first_chunks_tuple]), chunks_tuples)
+                        ),
                         media_type="application/zip",
                         headers={
                             "content-disposition": f"attachment; filename={outputs_filename}.zip",

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -728,7 +728,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
     def test_plugins_download_http_assets_stream_zip_interrupt(
         self, mock_requests_get, mock_requests_head, mock_progress_callback
     ):
-        """HTTPDownload.download() must download assets to a temporary file"""
+        """HTTPDownload._stream_download_dict() must raise an error if an error is returned by the provider"""
 
         plugin = self.get_download_plugin(self.product)
         self.product.location = self.product.remote_location = "http://somewhere"


### PR DESCRIPTION
There were situations where in server mode the response at the download was empty but the response code was 200. 
This problem occurred when a zip was created and streamed and the download of the first file failed. In that case, the download was stopped, so the result was empty, but the `stream_zip` function was hiding the raised error from the user. This problem is now fixed, an error will be returned if the download fails.
