### PR TITLE
fix(plugins): ECMWFSearch strip_quotes implementation for dicts

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -237,6 +237,8 @@ def strip_quotes(value: Any) -> Any:
     'abc'
     >>> strip_quotes(["'abc'", '"def'])
     ['abc', 'def']
+    >>> strip_quotes({"'abc'": 'def"'})
+    {'abc': 'def'}
 
     :param value: value from which quotes should be removed (should be either str or list)
     :return: value without quotes
@@ -245,7 +247,7 @@ def strip_quotes(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [strip_quotes(v) for v in value]
     elif isinstance(value, dict):
-        raise NotImplementedError("Dict value is not supported.")
+        return {strip_quotes(k): strip_quotes(v) for k, v in value.items()}
     else:
         return str(value).strip("'\"")
 


### PR DESCRIPTION
Fixes: #1476

Adds an implementation of `strip_quotes()` to dicts so that metadata mappings containing a dict (like `CAMS_SOLAR_RADIATION`) don't cause an error in the search (see referenced bug)