### PR TITLE
fix(core): ssl_verify setting for get_quicklook

### DIFF
--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -377,7 +377,7 @@ class EOProduct:
         self,
         filename: Optional[str] = None,
         output_dir: Optional[str] = None,
-        progress_callback: Optional[ProgressCallback] = None,
+        progress_callback: Optional[ProgressCallback] = None
     ) -> str:
         """Download the quicklook image of a given EOProduct from its provider if it
         exists.
@@ -465,12 +465,16 @@ class EOProduct:
             )
             if not isinstance(auth, AuthBase):
                 auth = None
+            # If the provider certificate is valid but cannot be authenticated due to a python misconfiguration of certifi.
+            # We can download the product anyway as the certificate is valid
+            ssl_verify = getattr(self.downloader.config, "ssl_verify",True)
             with requests.get(
                 self.properties["quicklook"],
                 stream=True,
                 auth=auth,
                 headers=USER_AGENT,
                 timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
+                verify=ssl_verify
             ) as stream:
                 try:
                     stream.raise_for_status()

--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -377,7 +377,7 @@ class EOProduct:
         self,
         filename: Optional[str] = None,
         output_dir: Optional[str] = None,
-        progress_callback: Optional[ProgressCallback] = None
+        progress_callback: Optional[ProgressCallback] = None,
     ) -> str:
         """Download the quicklook image of a given EOProduct from its provider if it
         exists.
@@ -465,16 +465,16 @@ class EOProduct:
             )
             if not isinstance(auth, AuthBase):
                 auth = None
-            # If the provider certificate is valid but cannot be authenticated due to a python misconfiguration of certifi.
-            # We can download the product anyway as the certificate is valid
-            ssl_verify = getattr(self.downloader.config, "ssl_verify",True)
+            # Read the ssl_verify parameter used on the provider config
+            # to ensure the same behavior for get_quicklook as other download functions
+            ssl_verify = getattr(self.downloader.config, "ssl_verify", True)
             with requests.get(
                 self.properties["quicklook"],
                 stream=True,
                 auth=auth,
                 headers=USER_AGENT,
                 timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
-                verify=ssl_verify
+                verify=ssl_verify,
             ) as stream:
                 try:
                     stream.raise_for_status()

--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -467,7 +467,11 @@ class EOProduct:
                 auth = None
             # Read the ssl_verify parameter used on the provider config
             # to ensure the same behavior for get_quicklook as other download functions
-            ssl_verify = getattr(self.downloader.config, "ssl_verify", True)
+            ssl_verify = (
+                getattr(self.downloader.config, "ssl_verify", True)
+                if self.downloader
+                else True
+            )
             with requests.get(
                 self.properties["quicklook"],
                 stream=True,

--- a/tests/units/test_eoproduct.py
+++ b/tests/units/test_eoproduct.py
@@ -184,6 +184,7 @@ class TestEOProduct(EODagTestCase):
             auth=None,
             headers=USER_AGENT,
             timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
+            verify=True,
         )
         self.assertEqual(quicklook_file_path, "")
 
@@ -208,6 +209,7 @@ class TestEOProduct(EODagTestCase):
             auth=None,
             headers=USER_AGENT,
             timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
+            verify=True,
         )
         self.assertEqual(
             os.path.basename(quicklook_file_path), product.properties["id"]
@@ -226,6 +228,7 @@ class TestEOProduct(EODagTestCase):
             auth=None,
             headers=USER_AGENT,
             timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
+            verify=True,
         )
         self.assertEqual(self.requests_http_get.call_count, 2)
         self.assertEqual(os.path.basename(quicklook_file_path), "the_quicklook.png")


### PR DESCRIPTION
The `get_quicklook` function is useful to preview products on an HMI, but for geodes provider the function returned an error because of a certificate problem. The parameter `ssl_verify` is `False` in the provider config but was not read in `get_quicklook`. This fixes the problem.

Fixes #1439 
