### PR TITLE
fix(geodes): added relativeOrbitNumber property

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -5910,6 +5910,9 @@
       orbitNumber:
         - '{{"query":{{"spaceborne:absoluteOrbitID":{{"eq":"{orbitNumber}"}}}}}}'
         - '$.properties."spaceborne:absoluteOrbitID"'
+      relativeOrbitNumber:
+        - '{{"query":{{"spaceborne:orbitID":{{"eq":"{relativeOrbitNumber}"}}}}}}'
+        - '$.properties."spaceborne:orbitID"'
       orbitDirection:
         - '{{"query":{{"spaceborne:orbitDirection":{{"eq":"{orbitDirection}"}}}}}}'
         - '$.properties."spaceborne:orbitDirection"'


### PR DESCRIPTION
Fixes #1496

Adds `relativeOrbitNumber` queryable property in `geodes`.

Thanks [@LucHermitte](https://github.com/LucHermitte)!