### PR TITLE
docs: typo in geodes register link

### DIFF
--- a/docs/getting_started_guide/register.rst
+++ b/docs/getting_started_guide/register.rst
@@ -165,7 +165,7 @@ Then use the consumer key as `username` and the consumer secret as `password` fr
 
 ``geodes``
 ^^^^^^^^^^
-Go to `https://geodes-portal.cnes.fr <https://https://geodes-portal.cnes.fr>`_, then login or create an account by
+Go to `https://geodes-portal.cnes.fr <https://geodes-portal.cnes.fr>`_, then login or create an account by
 clicking on ``Log in`` in the top-right corner. Once logged-in, create an API key in the user settings page, and used it
 as *apikey* in EODAG provider auth credentials.
 


### PR DESCRIPTION
Fixes a typo in [Geodes register](https://eodag.readthedocs.io/en/latest/getting_started_guide/register.html#geodes) link