### PR TITLE
fix(providers): remove unnecessary metadata mappings for eumtesat_ds

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -5313,7 +5313,9 @@
         - id
         - $.properties.identifier
       # The geographic extent of the product
-      geometry: '$.geometry'
+      geometry:
+        - 'geo={geometry#to_rounded_wkt}'
+        - '$.geometry'
       defaultGeometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
       # The url of the quicklook
       quicklook: '$.properties.links.previews[?(@.title="Quicklook")].href'

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -5227,28 +5227,14 @@
     - host
   url: https://data.eumetsat.int
   anchor_sentinel: &sentinel_params
-    orbitDirection:
-      - orbitdir
-      - '$.properties.acquisitionInformation[0].acquisitionParameters.orbitDirection'
-    relativeOrbitNumber:
-      - relorbit
-      - '$.properties.acquisitionInformation[0].acquisitionParameters.relativeOrbitNumber'
-    timeliness:
-      - timeliness
-      - '$.properties.productInformation.timeliness'
-    cycleNumber:
-      - cycle
-      - '$.properties.acquisitionInformation[0].acquisitionParameters.cycleNumber'
+    orbitDirection: '$.properties.acquisitionInformation[0].acquisitionParameters.orbitDirection'
+    relativeOrbitNumber: '$.properties.acquisitionInformation[0].acquisitionParameters.relativeOrbitNumber'
+    timeliness: '$.properties.productInformation.timeliness'
+    cycleNumber: '$.properties.acquisitionInformation[0].acquisitionParameters.cycleNumber'
   anchor_orbit_zone_tile: &orbit_zone_tile
     orbitNumber:
       - orbit
       - '$.properties.acquisitionInformation[0].acquisitionParameters.orbitNumber'
-    utmZone:
-      - zone
-      - '$.null'
-    tileIdentifier:
-      - t6
-      - '$.null'
   search: !plugin
     type: QueryStringSearch
     api_endpoint: 'https://api.eumetsat.int/data/search-products/1.0.0/os'
@@ -5306,17 +5292,10 @@
       productType:
         - type
         - '$.properties.productInformation.productType'
-      platform:
-        - sat
-        - '$.properties.acquisitionInformation[0].platform.platformShortName'
+      platform: '$.properties.acquisitionInformation[0].platform.platformShortName'
       instrument: '$.properties.acquisitionInformation[0].instrument.instrumentShortName'
       # INSPIRE obligated OpenSearch Parameters for Collection Search (Table 4)
-      title:
-        - title
-        - '{$.properties.title#remove_extension}'
-      publicationDate:
-        - publication
-        - '$.null'
+      title: '{$.properties.title#remove_extension}'
       # OpenSearch Parameters for Product Search (Table 5)
       parentIdentifier:
         - pi
@@ -5334,9 +5313,7 @@
         - id
         - $.properties.identifier
       # The geographic extent of the product
-      geometry:
-        - 'geo={geometry#to_rounded_wkt}'
-        - '$.geometry'
+      geometry: '$.geometry'
       defaultGeometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
       # The url of the quicklook
       quicklook: '$.properties.links.previews[?(@.title="Quicklook")].href'
@@ -5347,9 +5324,7 @@
       storageStatus: '{$.null#replace_str("Not Available","ONLINE")}'
       assets: '{$.properties.links.sip-entries#assets_list_to_dict}'
       # Additional metadata provided by the providers but that don't appear in the reference spec
-      size:
-        - size
-        - '$.properties.productInformation.size'
+      size: '$.properties.productInformation.size'
       type: '$.null'
       # set duplicate metadata due to metadata discovery to null
       acquisitionInformation: '$.null'


### PR DESCRIPTION
Based on feedback from Eumetsat that those parameters are static, all metadata mappings "eodag -> provider" for the `eumetsat_ds` provider except for `orbitNumber`, `startTimeFromAscendingNode` and `completionTimeFromAscendingNode` are removed.
So that they are not visible in the queryables anymore. If there is no mapping "provider -> eodag", the mapping is completely removed. 
`parentIdentifier` is kept although it is also static per product type because it is required in the request to `eumetsat_ds`.
