### PR TITLE
fix: convert_to_bounds for multipolygons

### DIFF
--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -344,10 +344,10 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
                 max_lon = -180
                 max_lat = -90
                 for geom in geoms:
-                    min_lon = min(min_lon, geom.bound[0])
-                    min_lat = min(min_lat, geom.bound[1])
-                    max_lon = max(max_lon, geom.bound[2])
-                    max_lat = max(max_lat, geom.bound[3])
+                    min_lon = min(min_lon, geom.bounds[0])
+                    min_lat = min(min_lat, geom.bounds[1])
+                    max_lon = max(max_lon, geom.bounds[2])
+                    max_lat = max(max_lat, geom.bounds[3])
                 return [min_lon, min_lat, max_lon, max_lat]
             else:
                 return list(input_geom.bounds[0:4])

--- a/tests/units/test_metadata_mapping.py
+++ b/tests/units/test_metadata_mapping.py
@@ -119,6 +119,19 @@ class TestMetadataFormatter(unittest.TestCase):
             "[[2.23, 43.42, 3.68, 43.76], [1.23, 43.42, 1.68, 43.76]]",
         )
 
+    def test_convert_to_bounds(self):
+        to_format = "{fieldname#to_bounds}"
+        geom = get_geometry_from_various(
+            geometry="""MULTIPOLYGON (
+                ((1.23 43.42, 1.23 43.76, 1.68 43.76, 1.68 43.42, 1.23 43.42)),
+                ((2.23 43.42, 2.23 43.76, 3.68 43.76, 3.68 43.42, 2.23 43.42))
+            )"""
+        )
+        self.assertEqual(
+            format_metadata(to_format, fieldname=geom),
+            "[1.23, 43.42, 3.68, 43.76]",
+        )
+
     def test_convert_to_geojson(self):
         to_format = "{fieldname#to_geojson}"
         geom = get_geometry_from_various(geometry="POINT (0.11 1.22)")

--- a/tests/units/test_metadata_mapping.py
+++ b/tests/units/test_metadata_mapping.py
@@ -121,6 +121,7 @@ class TestMetadataFormatter(unittest.TestCase):
 
     def test_convert_to_bounds(self):
         to_format = "{fieldname#to_bounds}"
+        # multi-geometry
         geom = get_geometry_from_various(
             geometry="""MULTIPOLYGON (
                 ((1.23 43.42, 1.23 43.76, 1.68 43.76, 1.68 43.42, 1.23 43.42)),
@@ -130,6 +131,12 @@ class TestMetadataFormatter(unittest.TestCase):
         self.assertEqual(
             format_metadata(to_format, fieldname=geom),
             "[1.23, 43.42, 3.68, 43.76]",
+        )
+        # single geometry
+        geom = get_geometry_from_various(geometry="POINT (0.1111 1.2222)")
+        self.assertEqual(
+            format_metadata(to_format, fieldname=geom),
+            "[0.1111, 1.2222, 0.1111, 1.2222]",
         )
 
     def test_convert_to_geojson(self):


### PR DESCRIPTION
fixes the `convert_to_bounds()` method used in metadata mappings for `shapely.geometry.MultiPolygon` geometries