### PR TITLE
fix(providers): default search timeout to 20s

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -52,7 +52,7 @@ from eodag.plugins.search.qssearch import PostJsonSearch, QueryStringSearch
 from eodag.types import json_field_definition_to_python
 from eodag.types.queryables import Queryables, QueryablesDict
 from eodag.utils import (
-    HTTP_REQ_TIMEOUT,
+    DEFAULT_SEARCH_TIMEOUT,
     deepcopy,
     dict_items_recursive_sort,
     get_geometry_from_various,
@@ -978,7 +978,7 @@ class ECMWFSearch(PostJsonSearch):
             if hasattr(self, "auth") and isinstance(self.auth, AuthBase)
             else None
         )
-        timeout = getattr(self.config, "timeout", HTTP_REQ_TIMEOUT)
+        timeout = getattr(self.config, "timeout", DEFAULT_SEARCH_TIMEOUT)
         return fetch_json(url, auth=auth, timeout=timeout)
 
     def normalize_results(

--- a/eodag/plugins/search/data_request_search.py
+++ b/eodag/plugins/search/data_request_search.py
@@ -36,6 +36,7 @@ from eodag.utils import (
     DEFAULT_ITEMS_PER_PAGE,
     DEFAULT_MISSION_START_DATE,
     DEFAULT_PAGE,
+    DEFAULT_SEARCH_TIMEOUT,
     GENERIC_PRODUCT_TYPE,
     HTTP_REQ_TIMEOUT,
     USER_AGENT,
@@ -308,7 +309,7 @@ class DataRequestSearch(Search):
             request_finished = True
 
         # loop to check search job status
-        search_timeout = int(getattr(self.config, "timeout", HTTP_REQ_TIMEOUT))
+        search_timeout = int(getattr(self.config, "timeout", DEFAULT_SEARCH_TIMEOUT))
         logger.info(
             f"checking status of request job {data_request_id} (timeout={search_timeout}s)"
         )

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -74,6 +74,7 @@ from eodag.types import json_field_definition_to_python, model_fields_to_annotat
 from eodag.types.search_args import SortByList
 from eodag.utils import (
     DEFAULT_MISSION_START_DATE,
+    DEFAULT_SEARCH_TIMEOUT,
     GENERIC_PRODUCT_TYPE,
     HTTP_REQ_TIMEOUT,
     REQ_RETRY_BACKOFF_FACTOR,
@@ -1190,7 +1191,7 @@ class QueryStringSearch(Search):
         info_message = prep.info_message
         exception_message = prep.exception_message
         try:
-            timeout = getattr(self.config, "timeout", HTTP_REQ_TIMEOUT)
+            timeout = getattr(self.config, "timeout", DEFAULT_SEARCH_TIMEOUT)
             ssl_verify = getattr(self.config, "ssl_verify", True)
 
             retry_total = getattr(self.config, "retry_total", REQ_RETRY_TOTAL)
@@ -1753,7 +1754,7 @@ class PostJsonSearch(QueryStringSearch):
             raise ValidationError("Cannot request empty URL")
         info_message = prep.info_message
         exception_message = prep.exception_message
-        timeout = getattr(self.config, "timeout", HTTP_REQ_TIMEOUT)
+        timeout = getattr(self.config, "timeout", DEFAULT_SEARCH_TIMEOUT)
         ssl_verify = getattr(self.config, "ssl_verify", True)
         try:
             # auth if needed

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -115,6 +115,7 @@ eodag_version = metadata("eodag")["Version"]
 USER_AGENT = {"User-Agent": f"eodag/{eodag_version}"}
 
 HTTP_REQ_TIMEOUT = 5  # in seconds
+DEFAULT_SEARCH_TIMEOUT = 20  # in seconds
 DEFAULT_STREAM_REQUESTS_TIMEOUT = 60  # in seconds
 
 REQ_RETRY_TOTAL = 3

--- a/tests/context.py
+++ b/tests/context.py
@@ -75,6 +75,7 @@ from eodag.utils import (
     DEFAULT_MISSION_START_DATE,
     DEFAULT_STREAM_REQUESTS_TIMEOUT,
     HTTP_REQ_TIMEOUT,
+    DEFAULT_SEARCH_TIMEOUT,
     USER_AGENT,
     get_bucket_name_and_prefix,
     get_geometry_from_various,

--- a/tests/integration/test_core_config.py
+++ b/tests/integration/test_core_config.py
@@ -22,7 +22,7 @@ from unittest import TestCase, mock
 from jsonpath_ng.jsonpath import Child, Fields, Root
 
 from tests.context import (
-    HTTP_REQ_TIMEOUT,
+    DEFAULT_SEARCH_TIMEOUT,
     USER_AGENT,
     AuthenticationError,
     EODataAccessGateway,
@@ -454,7 +454,7 @@ class TestCoreProductTypesConfig(TestCase):
             ],
             auth=mock.ANY,
             headers=USER_AGENT,
-            timeout=HTTP_REQ_TIMEOUT,
+            timeout=DEFAULT_SEARCH_TIMEOUT,
             verify=True,
         )
 

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -43,7 +43,7 @@ from eodag.utils.exceptions import RequestError, TimeOutError, ValidationError
 from tests import mock, temporary_environment
 from tests.context import (
     DEFAULT_ITEMS_PER_PAGE,
-    HTTP_REQ_TIMEOUT,
+    DEFAULT_SEARCH_TIMEOUT,
     OFFLINE_STATUS,
     ONLINE_STATUS,
     TEST_RESOURCES_PATH,
@@ -1296,7 +1296,7 @@ class RequestTestCase(unittest.TestCase):
         mock_requests_get.assert_called_once_with(
             mock.ANY,
             url="https://planetarycomputer.microsoft.com/api/stac/v1/search/../queryables",
-            timeout=HTTP_REQ_TIMEOUT,
+            timeout=DEFAULT_SEARCH_TIMEOUT,
             headers=USER_AGENT,
             verify=True,
         )
@@ -1393,7 +1393,10 @@ class RequestTestCase(unittest.TestCase):
             self.assertEqual(
                 norm_planetary_computer_queryables_url, responses.calls[0].request.url
             )
-            self.assertIn(("timeout", 5), responses.calls[0].request.req_kwargs.items())
+            self.assertIn(
+                ("timeout", DEFAULT_SEARCH_TIMEOUT),
+                responses.calls[0].request.req_kwargs.items(),
+            )
             self.assertIn(
                 list(USER_AGENT.items())[0], responses.calls[0].request.headers.items()
             )
@@ -1519,7 +1522,7 @@ class RequestTestCase(unittest.TestCase):
         mock_requests_get.assert_called_once_with(
             mock.ANY,
             url=planetary_computer_queryables_url,
-            timeout=HTTP_REQ_TIMEOUT,
+            timeout=DEFAULT_SEARCH_TIMEOUT,
             headers=USER_AGENT,
             verify=True,
         )
@@ -1636,7 +1639,7 @@ class RequestTestCase(unittest.TestCase):
                     "reanalysis-era5-single-levels/constraints.json",
                     headers=USER_AGENT,
                     auth=None,
-                    timeout=5,
+                    timeout=DEFAULT_SEARCH_TIMEOUT,
                 ),
                 call().raise_for_status(),
                 call().json(),
@@ -1646,7 +1649,7 @@ class RequestTestCase(unittest.TestCase):
                     "reanalysis-era5-single-levels/form.json",
                     headers=USER_AGENT,
                     auth=None,
-                    timeout=5,
+                    timeout=DEFAULT_SEARCH_TIMEOUT,
                 ),
                 call().raise_for_status(),
                 call().json(),

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -43,6 +43,7 @@ from eodag.utils import deepcopy
 from eodag.utils.exceptions import UnsupportedProductType
 from tests.context import (
     DEFAULT_MISSION_START_DATE,
+    DEFAULT_SEARCH_TIMEOUT,
     HTTP_REQ_TIMEOUT,
     NOT_AVAILABLE,
     TEST_RESOURCES_PATH,
@@ -1767,7 +1768,7 @@ class TestSearchPluginMeteoblueSearch(BaseSearchPluginTest):
             self.search_plugin.config.api_endpoint,
             json=mock.ANY,
             headers=USER_AGENT,
-            timeout=HTTP_REQ_TIMEOUT,
+            timeout=DEFAULT_SEARCH_TIMEOUT,
             auth=self.auth,
             verify=True,
         )
@@ -2386,7 +2387,7 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
                     "cams-europe-air-quality-reanalyses/constraints.json",
                     headers=USER_AGENT,
                     auth=None,
-                    timeout=5,
+                    timeout=DEFAULT_SEARCH_TIMEOUT,
                 ),
                 call().raise_for_status(),
                 call().json(),
@@ -2396,7 +2397,7 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
                     "cams-europe-air-quality-reanalyses/form.json",
                     headers=USER_AGENT,
                     auth=None,
-                    timeout=5,
+                    timeout=DEFAULT_SEARCH_TIMEOUT,
                 ),
                 call().raise_for_status(),
                 call().json(),


### PR DESCRIPTION
Default providers search [timeout](https://eodag.readthedocs.io/en/stable/plugins.html#eodag.config.PluginConfig.timeout) from 5s to 20s