### PR TITLE
fix(providers): update wekeo config for COP-DEM product types

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3698,25 +3698,25 @@
           - '$.null'
         orderLink: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{downloadLink}","product_id":"{id}", "dataset_id": "EO:EEA:DAT:CLMS_HRVPP_VI"}}'
     COP_DEM_GLO30_DGED:
-      productType: EO:DEM:DAT:COP-DEM_GLO-30-DGED__2023_1
+      productType: EO:ESA:DAT:COP-DEM
+      providerProductType: DGE_30
       metadata_mapping:
-        id: '$.id'
-        orderLink: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{downloadLink}","product_id":"{id}", "dataset_id": "EO:DEM:DAT:COP-DEM_GLO-30-DGED__2023_1"}}'
+        orderLink: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{downloadLink}","product_id":"{id}", "dataset_id": "EO:ESA:DAT:COP-DEM"}}'
     COP_DEM_GLO30_DTED:
-      productType: EO:DEM:DAT:COP-DEM_GLO-30-DTED__2023_1
+      productType: EO:ESA:DAT:COP-DEM
+      providerProductType: DTE_30
       metadata_mapping:
-        id: '$.id'
-        orderLink: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{downloadLink}","product_id":"{id}", "dataset_id": "EO:DEM:DAT:COP-DEM_GLO-30-DTED__2023_1"}}'
+        orderLink: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{downloadLink}","product_id":"{id}", "dataset_id": "EO:ESA:DAT:COP-DEM"}}'
     COP_DEM_GLO90_DGED:
-      productType: EO:DEM:DAT:COP-DEM_GLO-90-DGED__2023_1
+      productType: EO:ESA:DAT:COP-DEM
+      providerProductType: DGE_90
       metadata_mapping:
-        id: '$.id'
-        orderLink: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{downloadLink}","product_id":"{id}", "dataset_id": "EO:DEM:DAT:COP-DEM_GLO-90-DGED__2023_1"}}'
+        orderLink: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{downloadLink}","product_id":"{id}", "dataset_id": "EO:ESA:DAT:COP-DEM"}}'
     COP_DEM_GLO90_DTED:
-      productType: EO:DEM:DAT:COP-DEM_GLO-90-DTED__2023_1
+      productType: EO:ESA:DAT:COP-DEM
+      providerProductType: DTE_90
       metadata_mapping:
-        id: '$.id'
-        orderLink: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{downloadLink}","product_id":"{id}", "dataset_id": "EO:DEM:DAT:COP-DEM_GLO-90-DTED__2023_1"}}'
+        orderLink: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{downloadLink}","product_id":"{id}", "dataset_id": "EO:ESA:DAT:COP-DEM"}}'
     CLMS_GLO_NDVI_333M:
       productType: EO:CLMS:DAT:CLMS_GLOBAL_NDVI_300M_V1_10DAILY_NETCDF
       metadata_mapping:


### PR DESCRIPTION
`wekeo` now offers only one dataset `EO:ESA:DAT:COP-DEM` for all `COP-DEM` products, so a filter by `providerProductType` has to be added to get the different product types; search by id is possible with the new dataset
