### PR TITLE
feat(queryables): keep required even with default values

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -842,7 +842,8 @@ class ECMWFSearch(PostJsonSearch):
             if name in ("area_group", "global", "warning", "licences"):
                 continue
             if "type" not in element or element["type"] == "FreeEditionWidget":
-                # FreeEditionWidget used for comments ??
+                # FreeEditionWidget used to select the whole available region
+                # and to provide comments for the dataset
                 continue
 
             # ordering done by id -> set id to high value if not present -> element will be last

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -618,9 +618,10 @@ class ECMWFSearch(PostJsonSearch):
             # Pre-compute the required keywords (present in all constraint dicts)
             # when form, required keywords are extracted directly from form
             if not form:
-                required_keywords = set(constraints[0].keys())
-                for constraint in constraints[1:]:
-                    required_keywords.intersection_update(constraint.keys())
+                required_keywords = set.intersection(
+                    *(map(lambda d: set(d.keys()), constraints))
+                )
+
         else:
             values_url = getattr(self.config, "available_values_url", "")
             if not values_url:
@@ -841,6 +842,7 @@ class ECMWFSearch(PostJsonSearch):
             if name in ("area_group", "global", "warning", "licences"):
                 continue
             if "type" not in element or element["type"] == "FreeEditionWidget":
+                # FreeEditionWidget used for comments ??
                 continue
 
             # ordering done by id -> set id to high value if not present -> element will be last

--- a/eodag/types/__init__.py
+++ b/eodag/types/__init__.py
@@ -375,6 +375,24 @@ def annotated_dict_to_model(
 ) -> BaseModel:
     """Convert a dictionary of Annotated values to a Pydantic BaseModel.
 
+    >>> from pydantic import Field
+    >>> annotated_fields = {
+    ...     "field1": Annotated[str, Field(description="A string field"), "json_schema_required"],
+    ...     "field2": Annotated[int, Field(default=42, description="An integer field")],
+    ... }
+    >>> model = annotated_dict_to_model("TestModel", annotated_fields)
+    >>> json_schema = model.model_json_schema()
+    >>> json_schema["required"]
+    ['field1']
+    >>> json_schema["properties"]["field1"]
+    {'description': 'A string field', 'title': 'Field1', 'type': 'string'}
+    >>> json_schema["properties"]["field2"]
+    {'default': 42, 'description': 'An integer field', 'title': 'Field2', 'type': 'integer'}
+    >>> json_schema["title"]
+    'TestModel'
+    >>> json_schema["type"]
+    'object'
+
     :param model_name: name of the model to be created
     :param annotated_fields: dict containing the parameters and annotated values that should become
                              the properties of the model

--- a/eodag/types/__init__.py
+++ b/eodag/types/__init__.py
@@ -24,16 +24,15 @@ from typing import (
     Any,
     Literal,
     Optional,
+    Type,
     TypedDict,
     Union,
-    cast,
     get_args,
     get_origin,
 )
 
-import attr
 from annotated_types import Gt, Lt
-from pydantic import BaseModel, Field, create_model
+from pydantic import BaseModel, ConfigDict, Field, create_model
 from pydantic.annotated_handlers import GetJsonSchemaHandler
 from pydantic.fields import FieldInfo
 from pydantic.json_schema import JsonSchemaValue
@@ -204,16 +203,18 @@ def json_field_definition_to_python(
     if "$ref" in json_field_definition:
         field_type_kwargs["json_schema_extra"] = {"$ref": json_field_definition["$ref"]}
 
-    if default_value:
-        if required:
-            return Annotated[
-                python_type,
-                Field(default=default_value, **field_type_kwargs),
-                "json_schema_required",
-            ]
-        return Annotated[python_type, Field(default=default_value, **field_type_kwargs)]
+    metadata = [
+        python_type,
+        Field(
+            default_value if not required or default_value is not None else ...,
+            **field_type_kwargs,
+        ),
+    ]
 
-    return Annotated[python_type, Field(..., **field_type_kwargs)]
+    if required:
+        metadata.append("json_schema_required")
+
+    return Annotated[tuple(metadata)]
 
 
 def python_field_definition_to_json(
@@ -343,9 +344,35 @@ def model_fields_to_annotated(
     return annotated_model_fields
 
 
+class BaseModelCustomJsonSchema(BaseModel):
+    """Base class for generated models with custom json schema."""
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls: Type[BaseModel], core_schema: CoreSchema, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        """
+        Custom get json schema method to handle required fields with default values.
+        This is not supported by Pydantic by default.
+        It requires the field to be marked with the key "json_schema_required" in the metadata dict.
+        Example: Annotated[str, "json_schema_required"]
+        """
+        json_schema = BaseModel.__get_pydantic_json_schema__(core_schema, handler)
+
+        json_schema["required"] = [
+            key
+            for key, field_info in cls.model_fields.items()
+            if "json_schema_required" in field_info.metadata
+        ]
+
+        return json_schema
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
 def annotated_dict_to_model(
     model_name: str, annotated_fields: dict[str, Annotated[Any, FieldInfo]]
-) -> type[BaseModel]:
+) -> BaseModel:
     """Convert a dictionary of Annotated values to a Pydantic BaseModel.
 
     :param model_name: name of the model to be created
@@ -355,50 +382,19 @@ def annotated_dict_to_model(
     """
     fields = {}
     for name, field in annotated_fields.items():
-        metadata = field.__metadata__[1:]
+        base_type, field_info, *metadata = get_args(field)
         fields[name] = (
-            Annotated[field.__args__[0], *metadata] if metadata else field.__args__[0],
-            field.__metadata__[0],
+            Annotated[tuple([base_type] + metadata)] if metadata else base_type,
+            field_info,
         )
 
     custom_model = create_model(
         model_name,
+        __base__=BaseModelCustomJsonSchema,
         **fields,  # type: ignore
-        __config__={"arbitrary_types_allowed": True},
     )
 
-    def custom_get_json_schema(
-        cls: type[BaseModel], core_schema: CoreSchema, handler: GetJsonSchemaHandler
-    ) -> JsonSchemaValue:
-        """
-        Custom get json schema method to handle required fields with default values.
-        This is not supported by Pydantic by default.
-        It requires the field to be marked with the key "json_schema_required" in the metadata dict.
-        Example: Annotated[str, "json_schema_required"]
-        """
-        json_schema = cast(BaseModel, cls.__base__).__get_pydantic_json_schema__(
-            core_schema, handler
-        )
-
-        required = [
-            key
-            for key, field_info in cls.model_fields.items()
-            if "json_schema_required" in field_info.metadata
-        ]
-        json_schema["required"] = json_schema.get("required", []) + required
-
-        return json_schema
-
-    custom_class = attr.make_class(
-        model_name,
-        attrs={},
-        bases=(custom_model,),
-        class_body={
-            "__get_pydantic_json_schema__": classmethod(custom_get_json_schema),
-        },
-    )
-
-    return custom_class
+    return custom_model
 
 
 class ProviderSortables(TypedDict):

--- a/eodag/types/__init__.py
+++ b/eodag/types/__init__.py
@@ -357,7 +357,7 @@ class BaseModelCustomJsonSchema(BaseModel):
         It requires the field to be marked with the key "json_schema_required" in the metadata dict.
         Example: Annotated[str, "json_schema_required"]
         """
-        json_schema = BaseModel.__get_pydantic_json_schema__(core_schema, handler)
+        json_schema = handler.resolve_ref_schema(handler(core_schema))
 
         json_schema["required"] = [
             key

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -1667,6 +1667,7 @@ class RequestTestCase(unittest.TestCase):
                 "title",
                 "description",
                 "properties",
+                "required",
                 "additionalProperties",
             ],
         )

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -185,8 +185,7 @@ class RequestTestCase(unittest.TestCase):
                         "properties": {
                             "snowCover": None,
                             "resolution": None,
-                            "completionTimeFromAscendingNode": "2018-02-16T00:12:14"
-                            ".035Z",
+                            "completionTimeFromAscendingNode": "2018-02-16T00:12:14.035Z",
                             "keyword": {},
                             "productType": "OCN",
                             "downloadLink": (
@@ -215,7 +214,7 @@ class RequestTestCase(unittest.TestCase):
                                 "type": "Polygon",
                             },
                             "organisationName": None,
-                            "startTimeFromAscendingNode": "2018-02-15T23:53:22" ".871Z",
+                            "startTimeFromAscendingNode": "2018-02-15T23:53:22.871Z",
                             "platform": None,
                             "sensorType": None,
                             "processingLevel": None,
@@ -247,8 +246,7 @@ class RequestTestCase(unittest.TestCase):
                         "properties": {
                             "snowCover": None,
                             "resolution": None,
-                            "completionTimeFromAscendingNode": "2018-02-17T00:12:14"
-                            ".035Z",
+                            "completionTimeFromAscendingNode": "2018-02-17T00:12:14.035Z",
                             "keyword": {},
                             "productType": "OCN",
                             "downloadLink": (
@@ -277,7 +275,7 @@ class RequestTestCase(unittest.TestCase):
                                 "type": "Polygon",
                             },
                             "organisationName": None,
-                            "startTimeFromAscendingNode": "2018-02-16T23:53:22" ".871Z",
+                            "startTimeFromAscendingNode": "2018-02-16T23:53:22.871Z",
                             "platform": None,
                             "sensorType": None,
                             "processingLevel": None,
@@ -863,7 +861,10 @@ class RequestTestCase(unittest.TestCase):
             },
         }
         mock_search.return_value = SearchResult.from_geojson(
-            {"features": [], "type": "FeatureCollection"}
+            {
+                "features": [],
+                "type": "FeatureCollection",
+            }
         )
         self.app.request(
             method="POST",


### PR DESCRIPTION
Populate `required[]` in JSON schema even when the variable has a default value.
