### PR TITLE
fix(plugins): handle InvalidRequest in AwsDownload

### DIFF
--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -195,6 +195,7 @@ AWS_AUTH_ERROR_MESSAGES = [
     "AccessDenied",
     "InvalidAccessKeyId",
     "SignatureDoesNotMatch",
+    "InvalidRequest",
 ]
 
 


### PR DESCRIPTION
Handle `InvalidRequest` in `AwsDownload`, that must be skipped during the authentication methods try loop