### PR TITLE
fix(plugins): raise errors when metadata discovery is not allowed

### DIFF
--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -1300,23 +1300,15 @@ def format_query_params(
         **config.products.get(product_type, {}).get("metadata_mapping", {}),
     )
 
-    # Initialize the configuration parameter which indicates if an error must be raised while there is a search
-    # parameter which is not queryable. It is useful when the provider does not return any result if the search
-    # parameter is not a queryable without raising an error by itself.
-    # This parameter is set to False by default and the configuration at product type level has priority over the
-    # one at provider level
-    raise_mtd_discovery_error = (
-        config.products.get(product_type, {})
+    # Raise error if non-queryables parameters are used and raise_mtd_discovery_error configured
+    if (
+        raise_mtd_discovery_error := config.products.get(product_type, {})
         .get("discover_metadata", {})
         .get("raise_mtd_discovery_error")
-    )
-    raise_mtd_discovery_error = (
-        raise_mtd_discovery_error
-        if raise_mtd_discovery_error is not None
-        else getattr(config, "discover_metadata", {}).get(
+    ) is None:
+        raise_mtd_discovery_error = getattr(config, "discover_metadata", {}).get(
             "raise_mtd_discovery_error", False
         )
-    )
 
     query_params: dict[str, Any] = {}
     # Get all the search parameters that are recognised as queryables by the

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -1299,37 +1299,23 @@ def format_query_params(
         config.metadata_mapping,
         **config.products.get(product_type, {}).get("metadata_mapping", {}),
     )
+
     # Initialize the configuration parameter which indicates if an error must be raised while there is a search
     # parameter which is not queryable. It is useful when the provider does not return any result if the search
     # parameter is not a queryable without raising an error by itself.
     # This parameter is set to False by default and the configuration at product type level has priority over the
     # one at provider level
     raise_mtd_discovery_error = (
-        getattr(config, "discover_metadata", {})
-        .get("search_param", {})
-        .get("raise_mtd_discovery_error", False)
-        if isinstance(
-            getattr(config, "discover_metadata", {}).get("search_param", {}), dict
-        )
-        else False
-    )
-    raise_mtd_discovery_error = (
         config.products.get(product_type, {})
         .get("discover_metadata", {})
-        .get("search_param", {})
         .get("raise_mtd_discovery_error")
-        if isinstance(
-            config.products.get(product_type, {})
-            .get("discover_metadata", {})
-            .get("search_param", {}),
-            dict,
+    )
+    raise_mtd_discovery_error = (
+        raise_mtd_discovery_error
+        if raise_mtd_discovery_error is not None
+        else getattr(config, "discover_metadata", {}).get(
+            "raise_mtd_discovery_error", False
         )
-        and config.products.get(product_type, {})
-        .get("discover_metadata", {})
-        .get("search_param", {})
-        .get("raise_mtd_discovery_error")
-        is not None
-        else raise_mtd_discovery_error
     )
 
     query_params: dict[str, Any] = {}

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -1312,7 +1312,7 @@ def format_query_params(
         config.products.get(product_type, {})
         .get("discover_metadata", {})
         .get("search_param", {})
-        .get("raise_mtd_discovery_error", False)
+        .get("raise_mtd_discovery_error")
         if isinstance(
             config.products.get(product_type, {})
             .get("discover_metadata", {})
@@ -1322,7 +1322,8 @@ def format_query_params(
         and config.products.get(product_type, {})
         .get("discover_metadata", {})
         .get("search_param", {})
-        .get("raise_mtd_discovery_error", False)
+        .get("raise_mtd_discovery_error")
+        is not None
         else raise_mtd_discovery_error
     )
 

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -1484,7 +1484,8 @@ def _get_queryables(
             # raise an error when a query param not allowed by the provider is found
             if not isinstance(md_mapping, list) and raise_mtd_discovery_error:
                 raise ValidationError(
-                    f"Search parameters which are not queryable are disallowed: {eodag_search_key}"
+                    f"Search parameters which are not queryable are disallowed: {eodag_search_key}",
+                    {eodag_search_key},
                 )
             _, md_value = md_mapping
             # query param from defined metadata_mapping

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -1287,7 +1287,10 @@ def mtd_cfg_as_conversion_and_querypath(
 
 
 def format_query_params(
-    product_type: str, config: PluginConfig, query_dict: dict[str, Any]
+    product_type: str,
+    config: PluginConfig,
+    query_dict: dict[str, Any],
+    error_context: str = "",
 ) -> dict[str, Any]:
     """format the search parameters to query parameters"""
     if "raise_errors" in query_dict.keys():
@@ -1314,7 +1317,11 @@ def format_query_params(
     # Get all the search parameters that are recognised as queryables by the
     # provider (they appear in the queryables dictionary)
     queryables = _get_queryables(
-        query_dict, config, product_type_metadata_mapping, raise_mtd_discovery_error
+        query_dict,
+        config,
+        product_type_metadata_mapping,
+        raise_mtd_discovery_error,
+        error_context,
     )
 
     for eodag_search_key, provider_search_key in queryables.items():
@@ -1452,6 +1459,7 @@ def _get_queryables(
     config: PluginConfig,
     metadata_mapping: dict[str, Any],
     raise_mtd_discovery_error: bool,
+    error_context: str,
 ) -> dict[str, Any]:
     """Retrieve the metadata mappings that are query-able"""
     logger.debug("Retrieving queryable metadata from metadata_mapping")
@@ -1462,7 +1470,8 @@ def _get_queryables(
             # raise an error when a query param not allowed by the provider is found
             if not isinstance(md_mapping, list) and raise_mtd_discovery_error:
                 raise ValidationError(
-                    f"Search parameters which are not queryable are disallowed: {eodag_search_key}",
+                    "Search parameters which are not queryable are disallowed for this product type on this provider: "
+                    f"please remove '{eodag_search_key}' from your search parameters. {error_context}",
                     {eodag_search_key},
                 )
             _, md_value = md_mapping

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -255,8 +255,9 @@ class PluginConfig(yaml.YAMLObject):
         auto_discovery: bool
         #: Metadata regex pattern used for discovery in search result properties
         metadata_pattern: str
-        #: Configuration/template that will be used to query for a discovered parameter
-        search_param: str
+        #: Configuration/template that will be used to query for a discovered parameter,
+        #: or indication whether metadata discovery may fail the search request or not
+        search_param: str | dict[str, Any]
         #: Path to the metadata in search result
         metadata_path: str
 

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -255,11 +255,12 @@ class PluginConfig(yaml.YAMLObject):
         auto_discovery: bool
         #: Metadata regex pattern used for discovery in search result properties
         metadata_pattern: str
-        #: Configuration/template that will be used to query for a discovered parameter, or indication if
-        #: using a search parameter which is not queryable will fail the search request or not
+        #: Configuration/template that will be used to query for a discovered parameter
         search_param: str | dict[str, Any]
         #: Path to the metadata in search result
         metadata_path: str
+        #: Whether an error must be raised using a search parameter which is not queryable or not
+        raise_mtd_discovery_error: bool
 
     class DiscoverProductTypes(TypedDict, total=False):
         """Configuration for product types discovery"""

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -255,8 +255,8 @@ class PluginConfig(yaml.YAMLObject):
         auto_discovery: bool
         #: Metadata regex pattern used for discovery in search result properties
         metadata_pattern: str
-        #: Configuration/template that will be used to query for a discovered parameter,
-        #: or indication whether metadata discovery may fail the search request or not
+        #: Configuration/template that will be used to query for a discovered parameter, or indication if
+        #: using a search parameter which is not queryable will fail the search request or not
         search_param: str | dict[str, Any]
         #: Path to the metadata in search result
         metadata_path: str

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -259,7 +259,7 @@ class PluginConfig(yaml.YAMLObject):
         search_param: str | dict[str, Any]
         #: Path to the metadata in search result
         metadata_path: str
-        #: Whether an error must be raised using a search parameter which is not queryable or not
+        #: Whether an error must be raised when using a search parameter which is not queryable or not
         raise_mtd_discovery_error: bool
 
     class DiscoverProductTypes(TypedDict, total=False):

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -275,7 +275,8 @@ class Search(PluginTopic):
             if eodag_sort_order[:3] != "ASC" and eodag_sort_order[:3] != "DES":
                 raise ValidationError(
                     "Sorting order is invalid: it must be set to 'ASC' (ASCENDING) or "
-                    f"'DESC' (DESCENDING), got '{eodag_sort_order}' with '{eodag_sort_param}' instead"
+                    f"'DESC' (DESCENDING), got '{eodag_sort_order}' with '{eodag_sort_param}' instead",
+                    {eodag_sort_param},
                 )
             eodag_sort_order = eodag_sort_order[:3]
 
@@ -296,7 +297,7 @@ class Search(PluginTopic):
                     raise ValidationError(
                         f"'{eodag_sort_param}' parameter is called several times to sort results with different "
                         "sorting orders. Please set it to only one ('ASC' (ASCENDING) or 'DESC' (DESCENDING))",
-                        set([eodag_sort_param]),
+                        {eodag_sort_param},
                     )
             provider_sort_by_tuples_used.append(provider_sort_by_tuple)
 

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -722,7 +722,7 @@ class ECMWFSearch(PostJsonSearch):
                 "geometry",
             }:
                 raise ValidationError(
-                    f"{key} is not a queryable parameter for {self.provider}"
+                    f"'{key}' is not a queryable parameter for {self.provider}", {key}
                 )
 
             formated_filters[key] = v
@@ -781,7 +781,9 @@ class ECMWFSearch(PostJsonSearch):
                 and keyword.removeprefix(ECMWF_PREFIX)
                 not in set(list(available_values.keys()) + [f["name"] for f in form])
             ):
-                raise ValidationError(f"{keyword} is not a queryable parameter")
+                raise ValidationError(
+                    f"'{keyword}' is not a queryable parameter", {keyword}
+                )
 
         # generate queryables
         if form:
@@ -868,7 +870,8 @@ class ECMWFSearch(PostJsonSearch):
             # we only compare list of strings.
             if isinstance(values, dict):
                 raise ValidationError(
-                    f"Parameter value as object is not supported: {keyword}={values}"
+                    f"Parameter value as object is not supported: {keyword}={values}",
+                    {keyword},
                 )
 
             # We convert every single value to a list of string
@@ -934,7 +937,10 @@ class ECMWFSearch(PostJsonSearch):
                 raise ValidationError(
                     f"{keyword}={values} is not available"
                     f"{all_keywords_str}."
-                    f" Allowed values are {', '.join(allowed_values)}."
+                    f" Allowed values are {', '.join(allowed_values)}.",
+                    set(
+                        [keyword] + [k for k in parsed_keywords if k in input_keywords]
+                    ),
                 )
 
             parsed_keywords.append(keyword)

--- a/eodag/plugins/search/data_request_search.py
+++ b/eodag/plugins/search/data_request_search.py
@@ -32,6 +32,7 @@ from eodag.api.product.metadata_mapping import (
 )
 from eodag.plugins.search import PreparedSearch
 from eodag.plugins.search.base import Search
+from eodag.types.queryables import Queryables
 from eodag.utils import (
     DEFAULT_ITEMS_PER_PAGE,
     DEFAULT_MISSION_START_DATE,
@@ -363,9 +364,13 @@ class DataRequestSearch(Search):
                 request_body = format_query_params(
                     eodag_product_type, self.config, kwargs
                 )
-            except ValidationError:
+            except ValidationError as context:
+                not_queryable_search_param = Queryables.get_queryable_from_alias(
+                    str(context.message).split(":")[-1].strip()
+                )
                 raise ValidationError(
-                    f"Unknown parameters not allowed for {self.provider} with {product_type}"
+                    f"Search parameters which are not queryable are disallowed for {product_type} with "
+                    f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters"
                 )
             logger.debug(
                 f"Sending search job request to {url} with {str(request_body)}"

--- a/eodag/plugins/search/data_request_search.py
+++ b/eodag/plugins/search/data_request_search.py
@@ -364,15 +364,15 @@ class DataRequestSearch(Search):
                 request_body = format_query_params(
                     eodag_product_type, self.config, kwargs
                 )
-            except ValidationError as context:
+            except ValidationError as err:
                 not_queryable_search_param = Queryables.get_queryable_from_alias(
-                    str(context.message).split(":")[-1].strip()
+                    str(err.message).split(":")[-1].strip()
                 )
                 raise ValidationError(
                     f"Search parameters which are not queryable are disallowed for {product_type} on "
                     f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters",
                     {not_queryable_search_param},
-                )
+                ) from err
             logger.debug(
                 f"Sending search job request to {url} with {str(request_body)}"
             )

--- a/eodag/plugins/search/data_request_search.py
+++ b/eodag/plugins/search/data_request_search.py
@@ -369,7 +369,7 @@ class DataRequestSearch(Search):
                     str(context.message).split(":")[-1].strip()
                 )
                 raise ValidationError(
-                    f"Search parameters which are not queryable are disallowed for {product_type} with "
+                    f"Search parameters which are not queryable are disallowed for {product_type} on "
                     f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters",
                     {not_queryable_search_param},
                 )

--- a/eodag/plugins/search/data_request_search.py
+++ b/eodag/plugins/search/data_request_search.py
@@ -370,7 +370,8 @@ class DataRequestSearch(Search):
                 )
                 raise ValidationError(
                     f"Search parameters which are not queryable are disallowed for {product_type} with "
-                    f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters"
+                    f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters",
+                    {not_queryable_search_param},
                 )
             logger.debug(
                 f"Sending search job request to {url} with {str(request_body)}"

--- a/eodag/plugins/search/data_request_search.py
+++ b/eodag/plugins/search/data_request_search.py
@@ -359,7 +359,14 @@ class DataRequestSearch(Search):
         ssl_verify = getattr(self.config.ssl_verify, "ssl_verify", True)
         try:
             url = self.config.data_request_url
-            request_body = format_query_params(eodag_product_type, self.config, kwargs)
+            try:
+                request_body = format_query_params(
+                    eodag_product_type, self.config, kwargs
+                )
+            except ValidationError:
+                raise ValidationError(
+                    f"Unknown parameters not allowed for {self.provider} with {product_type}"
+                )
             logger.debug(
                 f"Sending search job request to {url} with {str(request_body)}"
             )

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -813,9 +813,13 @@ class QueryStringSearch(Search):
         logger.debug("Building the query string that will be used for search")
         try:
             query_params = format_query_params(product_type, self.config, query_dict)
-        except ValidationError:
+        except ValidationError as context:
+            not_queryable_search_param = Queryables.get_queryable_from_alias(
+                str(context.message).split(":")[-1].strip()
+            )
             raise ValidationError(
-                f"Unknown parameters not allowed for {self.provider} with {product_type}"
+                f"Search parameters which are not queryable are disallowed for {product_type} with "
+                f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters"
             )
 
         # Build the final query string, in one go without quoting it
@@ -1788,9 +1792,13 @@ class StacSearch(PostJsonSearch):
 
         try:
             query_params = format_query_params(product_type, self.config, query_dict)
-        except ValidationError:
+        except ValidationError as context:
+            not_queryable_search_param = Queryables.get_queryable_from_alias(
+                str(context.message).split(":")[-1].strip()
+            )
             raise ValidationError(
-                f"Unknown parameters not allowed for {self.provider} with {product_type}"
+                f"Search parameters which are not queryable are disallowed for {product_type} with "
+                f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters"
             )
 
         # Build the final query string, in one go without quoting it

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -811,17 +811,10 @@ class QueryStringSearch(Search):
     ) -> tuple[dict[str, Any], str]:
         """Build The query string using the search parameters"""
         logger.debug("Building the query string that will be used for search")
-        try:
-            query_params = format_query_params(product_type, self.config, query_dict)
-        except ValidationError as err:
-            not_queryable_search_param = Queryables.get_queryable_from_alias(
-                str(err.message).split(":")[-1].strip()
-            )
-            raise ValidationError(
-                f"Search parameters which are not queryable are disallowed for {product_type} on "
-                f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters",
-                {not_queryable_search_param},
-            ) from err
+        error_context = f"Product type: {product_type} / provider : {self.provider}"
+        query_params = format_query_params(
+            product_type, self.config, query_dict, error_context
+        )
 
         # Build the final query string, in one go without quoting it
         # (some providers do not operate well with urlencoded and quoted query strings)
@@ -1791,17 +1784,10 @@ class StacSearch(PostJsonSearch):
             query_dict.setdefault("startTimeFromAscendingNode", "..")
             query_dict.setdefault("completionTimeFromAscendingNode", "..")
 
-        try:
-            query_params = format_query_params(product_type, self.config, query_dict)
-        except ValidationError as err:
-            not_queryable_search_param = Queryables.get_queryable_from_alias(
-                str(err.message).split(":")[-1].strip()
-            )
-            raise ValidationError(
-                f"Search parameters which are not queryable are disallowed for {product_type} on "
-                f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters",
-                {not_queryable_search_param},
-            ) from err
+        error_context = f"Product type: {product_type} / provider : {self.provider}"
+        query_params = format_query_params(
+            product_type, self.config, query_dict, error_context
+        )
 
         # Build the final query string, in one go without quoting it
         # (some providers do not operate well with urlencoded and quoted query strings)

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -818,7 +818,7 @@ class QueryStringSearch(Search):
                 str(context.message).split(":")[-1].strip()
             )
             raise ValidationError(
-                f"Search parameters which are not queryable are disallowed for {product_type} with "
+                f"Search parameters which are not queryable are disallowed for {product_type} on "
                 f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters",
                 {not_queryable_search_param},
             )
@@ -1798,7 +1798,7 @@ class StacSearch(PostJsonSearch):
                 str(context.message).split(":")[-1].strip()
             )
             raise ValidationError(
-                f"Search parameters which are not queryable are disallowed for {product_type} with "
+                f"Search parameters which are not queryable are disallowed for {product_type} on "
                 f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters",
                 {not_queryable_search_param},
             )

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -819,7 +819,8 @@ class QueryStringSearch(Search):
             )
             raise ValidationError(
                 f"Search parameters which are not queryable are disallowed for {product_type} with "
-                f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters"
+                f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters",
+                {not_queryable_search_param},
             )
 
         # Build the final query string, in one go without quoting it
@@ -1798,7 +1799,8 @@ class StacSearch(PostJsonSearch):
             )
             raise ValidationError(
                 f"Search parameters which are not queryable are disallowed for {product_type} with "
-                f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters"
+                f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters",
+                {not_queryable_search_param},
             )
 
         # Build the final query string, in one go without quoting it

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -811,7 +811,12 @@ class QueryStringSearch(Search):
     ) -> tuple[dict[str, Any], str]:
         """Build The query string using the search parameters"""
         logger.debug("Building the query string that will be used for search")
-        query_params = format_query_params(product_type, self.config, query_dict)
+        try:
+            query_params = format_query_params(product_type, self.config, query_dict)
+        except ValidationError:
+            raise ValidationError(
+                f"Unknown parameters not allowed for {self.provider} with {product_type}"
+            )
 
         # Build the final query string, in one go without quoting it
         # (some providers do not operate well with urlencoded and quoted query strings)
@@ -1781,7 +1786,12 @@ class StacSearch(PostJsonSearch):
             query_dict.setdefault("startTimeFromAscendingNode", "..")
             query_dict.setdefault("completionTimeFromAscendingNode", "..")
 
-        query_params = format_query_params(product_type, self.config, query_dict)
+        try:
+            query_params = format_query_params(product_type, self.config, query_dict)
+        except ValidationError:
+            raise ValidationError(
+                f"Unknown parameters not allowed for {self.provider} with {product_type}"
+            )
 
         # Build the final query string, in one go without quoting it
         # (some providers do not operate well with urlencoded and quoted query strings)

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -813,15 +813,15 @@ class QueryStringSearch(Search):
         logger.debug("Building the query string that will be used for search")
         try:
             query_params = format_query_params(product_type, self.config, query_dict)
-        except ValidationError as context:
+        except ValidationError as err:
             not_queryable_search_param = Queryables.get_queryable_from_alias(
-                str(context.message).split(":")[-1].strip()
+                str(err.message).split(":")[-1].strip()
             )
             raise ValidationError(
                 f"Search parameters which are not queryable are disallowed for {product_type} on "
                 f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters",
                 {not_queryable_search_param},
-            )
+            ) from err
 
         # Build the final query string, in one go without quoting it
         # (some providers do not operate well with urlencoded and quoted query strings)
@@ -1793,15 +1793,15 @@ class StacSearch(PostJsonSearch):
 
         try:
             query_params = format_query_params(product_type, self.config, query_dict)
-        except ValidationError as context:
+        except ValidationError as err:
             not_queryable_search_param = Queryables.get_queryable_from_alias(
-                str(context.message).split(":")[-1].strip()
+                str(err.message).split(":")[-1].strip()
             )
             raise ValidationError(
                 f"Search parameters which are not queryable are disallowed for {product_type} on "
                 f"{self.provider}: please remove '{not_queryable_search_param}' from your search parameters",
                 {not_queryable_search_param},
-            )
+            ) from err
 
         # Build the final query string, in one go without quoting it
         # (some providers do not operate well with urlencoded and quoted query strings)

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3396,6 +3396,9 @@
       productType: EO:EEA:DAT:CORINE
       providerProductType: Corine Land Cover 2018
       format: GeoTiff100mt
+      discover_metadata:
+        search_param:
+          raise_mtd_discovery_error: true
       metadata_mapping:
         id: '$.id'
         providerProductType:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3397,8 +3397,7 @@
       providerProductType: Corine Land Cover 2018
       format: GeoTiff100mt
       discover_metadata:
-        search_param:
-          raise_mtd_discovery_error: true
+        raise_mtd_discovery_error: true
       metadata_mapping:
         id: '$.id'
         providerProductType:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3401,6 +3401,8 @@
         providerProductType:
           - '{{"product_type": "{providerProductType}"}}'
           - '$.null'
+        startTimeFromAscendingNode: '$.properties.startdate'
+        completionTimeFromAscendingNode: '$.properties.enddate'
         defaultGeometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
         orderLink: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{downloadLink}","product_id":"{id}", "dataset_id": "EO:EEA:DAT:CORINE"}}'
     CLMS_GLO_FCOVER_333M:

--- a/eodag/rest/errors.py
+++ b/eodag/rest/errors.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import re
 from typing import Union
 
 from fastapi import FastAPI, Request
@@ -95,10 +96,14 @@ class ResponseSearchError(Exception):
 
             if type(exception) is ValidationError:
                 for error_param in exception.parameters:
-                    stac_param = EODAGSearch.to_stac(error_param)
-                    exception.message = exception.message.replace(
-                        error_param, stac_param
-                    )
+                    error_param_pattern = rf"\b{error_param}\b"
+                    if re.search(error_param_pattern, exception.message):
+                        stac_param = EODAGSearch.to_stac(error_param)
+                        exception.message = re.sub(
+                            error_param_pattern,
+                            stac_param,
+                            exception.message,
+                        )
                 error_dict["message"] = exception.message
 
             error_list.append(error_dict)

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -339,6 +339,62 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
         mock__request.assert_called()
         self.assertNotIn("cloudCover", mock__request.call_args_list[-1][0][1].url)
 
+    def test_plugins_search_querystringsearch_search_peps_ko(self):
+        """A query with an unknown parameter must raise an error if the provider does not allow it"""  # noqa
+        # with raising error parameter in the global config of the provider
+        provider_search_plugin_config = deepcopy(self.peps_search_plugin.config)
+        self.peps_search_plugin.config.discover_metadata = {
+            "search_param": {"raise_mtd_discovery_error": True}
+        }
+
+        with self.assertRaises(ValidationError) as context:
+            self.peps_search_plugin.query(
+                prep=PreparedSearch(
+                    page=1,
+                    items_per_page=2,
+                    auth_plugin=self.peps_auth_plugin,
+                ),
+                **{**self.search_criteria_s2_msi_l1c, **{"foo": "bar"}},
+            )
+        self.assertEqual(
+            f"Unknown parameters not allowed for {self.peps_search_plugin.provider} "
+            f"with {self.search_criteria_s2_msi_l1c['productType']}",
+            str(context.exception),
+        )
+
+        # restore the original config
+        self.peps_search_plugin.config = provider_search_plugin_config
+
+        # with raising error parameter in the config of the product type of the provider
+        provider_product_type_config = deepcopy(
+            self.peps_search_plugin.config.products[
+                self.search_criteria_s2_msi_l1c["productType"]
+            ]
+        )
+        self.peps_search_plugin.config.products[
+            self.search_criteria_s2_msi_l1c["productType"]
+        ]["discover_metadata"] = {"search_param": {"raise_mtd_discovery_error": True}}
+
+        with self.assertRaises(ValidationError) as context:
+            self.peps_search_plugin.query(
+                prep=PreparedSearch(
+                    page=1,
+                    items_per_page=2,
+                    auth_plugin=self.peps_auth_plugin,
+                ),
+                **{**self.search_criteria_s2_msi_l1c, **{"foo": "bar"}},
+            )
+        self.assertEqual(
+            f"Unknown parameters not allowed for {self.peps_search_plugin.provider} "
+            f"with {self.search_criteria_s2_msi_l1c['productType']}",
+            str(context.exception),
+        )
+
+        # restore the original config
+        self.peps_search_plugin.config.products[
+            self.search_criteria_s2_msi_l1c["productType"]
+        ] = provider_product_type_config
+
     @mock.patch(
         "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
     )
@@ -3570,7 +3626,7 @@ class TestSearchPluginPostJsonSearchWithStacQueryables(BaseSearchPluginTest):
         mock_build_qs_stacsearch,
         mock_normalize_results,
     ):
-        """A query with a PostJsonSearchWithStacQueryables (here wekeo_main) must use build_query_string() of PostJsonSearch"""  # noqa
+        """A query with a PostJsonSearchWithStacQueryables provider (here wekeo_main) must use build_query_string() of PostJsonSearch"""  # noqa
         mock_build_qs_postjsonsearch.return_value = (
             mock_build_qs_stacsearch.return_value
         ) = (
@@ -3596,6 +3652,62 @@ class TestSearchPluginPostJsonSearchWithStacQueryables(BaseSearchPluginTest):
         mock__request.assert_called()
         mock_build_qs_postjsonsearch.assert_called()
         mock_build_qs_stacsearch.assert_not_called()
+
+    def test_plugins_search_postjsonsearchwithstacqueryables_search_wekeomain_ko(self):
+        """A query with an unknown parameter must raise an error if the provider does not allow it"""  # noqa
+        # with raising error parameter in the global config of the provider
+        provider_search_plugin_config = deepcopy(self.wekeomain_search_plugin.config)
+        self.wekeomain_search_plugin.config.discover_metadata = {
+            "search_param": {"raise_mtd_discovery_error": True}
+        }
+
+        with self.assertRaises(ValidationError) as context:
+            self.wekeomain_search_plugin.query(
+                prep=PreparedSearch(
+                    page=1,
+                    items_per_page=2,
+                    auth_plugin=self.wekeomain_auth_plugin,
+                ),
+                **{**self.search_criteria_s2_msi_l1c, **{"foo": "bar"}},
+            )
+        self.assertEqual(
+            f"Unknown parameters not allowed for {self.wekeomain_search_plugin.provider} "
+            f"with {self.search_criteria_s2_msi_l1c['productType']}",
+            str(context.exception),
+        )
+
+        # restore the original config
+        self.wekeomain_search_plugin.config = provider_search_plugin_config
+
+        # with raising error parameter in the config of the product type of the provider
+        provider_product_type_config = deepcopy(
+            self.wekeomain_search_plugin.config.products[
+                self.search_criteria_s2_msi_l1c["productType"]
+            ]
+        )
+        self.wekeomain_search_plugin.config.products[
+            self.search_criteria_s2_msi_l1c["productType"]
+        ]["discover_metadata"] = {"search_param": {"raise_mtd_discovery_error": True}}
+
+        with self.assertRaises(ValidationError) as context:
+            self.wekeomain_search_plugin.query(
+                prep=PreparedSearch(
+                    page=1,
+                    items_per_page=2,
+                    auth_plugin=self.wekeomain_auth_plugin,
+                ),
+                **{**self.search_criteria_s2_msi_l1c, **{"foo": "bar"}},
+            )
+        self.assertEqual(
+            f"Unknown parameters not allowed for {self.wekeomain_search_plugin.provider} "
+            f"with {self.search_criteria_s2_msi_l1c['productType']}",
+            str(context.exception),
+        )
+
+        # restore the original config
+        self.wekeomain_search_plugin.config.products[
+            self.search_criteria_s2_msi_l1c["productType"]
+        ] = provider_product_type_config
 
     @mock.patch(
         "eodag.plugins.search.qssearch.PostJsonSearch.discover_queryables",

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -361,7 +361,7 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
             "Search parameters which are not queryable are disallowed for "
             f"{self.search_criteria_s2_msi_l1c['productType']} with {self.peps_search_plugin.provider}: "
             "please remove 'foo' from your search parameters",
-            str(context.exception),
+            context.exception.message,
         )
 
         # restore the original config
@@ -390,7 +390,7 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
             "Search parameters which are not queryable are disallowed for "
             f"{self.search_criteria_s2_msi_l1c['productType']} with {self.peps_search_plugin.provider}: "
             "please remove 'foo' from your search parameters",
-            str(context.exception),
+            context.exception.message,
         )
 
         # restore the original config
@@ -2904,8 +2904,8 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         with self.assertRaises(ValidationError) as context:
             self.search_plugin.discover_queryables(**params)
         self.assertEqual(
-            f"{wrong_queryable} is not a queryable parameter for {self.provider}",
-            str(context.exception),
+            f"'{wrong_queryable}' is not a queryable parameter for {self.provider}",
+            context.exception.message,
         )
 
     @mock.patch("eodag.utils.requests.requests.sessions.Session.get", autospec=True)
@@ -3678,7 +3678,7 @@ class TestSearchPluginPostJsonSearchWithStacQueryables(BaseSearchPluginTest):
             "Search parameters which are not queryable are disallowed for "
             f"{self.search_criteria_s2_msi_l1c['productType']} with {self.wekeomain_search_plugin.provider}: "
             "please remove 'foo' from your search parameters",
-            str(context.exception),
+            context.exception.message,
         )
 
         # restore the original config
@@ -3707,7 +3707,7 @@ class TestSearchPluginPostJsonSearchWithStacQueryables(BaseSearchPluginTest):
             "Search parameters which are not queryable are disallowed for "
             f"{self.search_criteria_s2_msi_l1c['productType']} with {self.wekeomain_search_plugin.provider}: "
             "please remove 'foo' from your search parameters",
-            str(context.exception),
+            context.exception.message,
         )
 
         # restore the original config

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -359,9 +359,9 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
                 **{**self.search_criteria_s2_msi_l1c, **{"foo": "bar"}},
             )
         self.assertEqual(
-            "Search parameters which are not queryable are disallowed for "
-            f"{self.search_criteria_s2_msi_l1c['productType']} on {self.peps_search_plugin.provider}: "
-            "please remove 'foo' from your search parameters",
+            "Search parameters which are not queryable are disallowed for this product type on this provider: "
+            f"please remove 'foo' from your search parameters. Product type: "
+            f"{self.search_criteria_s2_msi_l1c['productType']} / provider : {self.peps_search_plugin.provider}",
             context.exception.message,
         )
 
@@ -387,9 +387,9 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
                 **{**self.search_criteria_s2_msi_l1c, **{"foo": "bar"}},
             )
         self.assertEqual(
-            "Search parameters which are not queryable are disallowed for "
-            f"{self.search_criteria_s2_msi_l1c['productType']} on {self.peps_search_plugin.provider}: "
-            "please remove 'foo' from your search parameters",
+            "Search parameters which are not queryable are disallowed for this product type on this provider: "
+            f"please remove 'foo' from your search parameters. Product type: "
+            f"{self.search_criteria_s2_msi_l1c['productType']} / provider : {self.peps_search_plugin.provider}",
             context.exception.message,
         )
 
@@ -3675,9 +3675,9 @@ class TestSearchPluginPostJsonSearchWithStacQueryables(BaseSearchPluginTest):
                 **{**self.search_criteria_s2_msi_l1c, **{"foo": "bar"}},
             )
         self.assertEqual(
-            "Search parameters which are not queryable are disallowed for "
-            f"{self.search_criteria_s2_msi_l1c['productType']} on {self.wekeomain_search_plugin.provider}: "
-            "please remove 'foo' from your search parameters",
+            "Search parameters which are not queryable are disallowed for this product type on this provider: "
+            f"please remove 'foo' from your search parameters. Product type: "
+            f"{self.search_criteria_s2_msi_l1c['productType']} / provider : {self.wekeomain_search_plugin.provider}",
             context.exception.message,
         )
 
@@ -3703,9 +3703,9 @@ class TestSearchPluginPostJsonSearchWithStacQueryables(BaseSearchPluginTest):
                 **{**self.search_criteria_s2_msi_l1c, **{"foo": "bar"}},
             )
         self.assertEqual(
-            "Search parameters which are not queryable are disallowed for "
-            f"{self.search_criteria_s2_msi_l1c['productType']} on {self.wekeomain_search_plugin.provider}: "
-            "please remove 'foo' from your search parameters",
+            "Search parameters which are not queryable are disallowed for this product type on this provider: "
+            f"please remove 'foo' from your search parameters. Product type: "
+            f"{self.search_criteria_s2_msi_l1c['productType']} / provider : {self.wekeomain_search_plugin.provider}",
             context.exception.message,
         )
 

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -340,7 +340,8 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
         self.assertNotIn("cloudCover", mock__request.call_args_list[-1][0][1].url)
 
     def test_plugins_search_querystringsearch_search_peps_ko(self):
-        """A query with an unknown parameter must raise an error if the provider does not allow it"""  # noqa
+        """A query with a parameter which is not queryable must
+        raise an error if the provider does not allow it"""  # noqa
         # with raising error parameter in the global config of the provider
         provider_search_plugin_config = deepcopy(self.peps_search_plugin.config)
         self.peps_search_plugin.config.discover_metadata = {
@@ -357,8 +358,9 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
                 **{**self.search_criteria_s2_msi_l1c, **{"foo": "bar"}},
             )
         self.assertEqual(
-            f"Unknown parameters not allowed for {self.peps_search_plugin.provider} "
-            f"with {self.search_criteria_s2_msi_l1c['productType']}",
+            "Search parameters which are not queryable are disallowed for "
+            f"{self.search_criteria_s2_msi_l1c['productType']} with {self.peps_search_plugin.provider}: "
+            "please remove 'foo' from your search parameters",
             str(context.exception),
         )
 
@@ -385,8 +387,9 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
                 **{**self.search_criteria_s2_msi_l1c, **{"foo": "bar"}},
             )
         self.assertEqual(
-            f"Unknown parameters not allowed for {self.peps_search_plugin.provider} "
-            f"with {self.search_criteria_s2_msi_l1c['productType']}",
+            "Search parameters which are not queryable are disallowed for "
+            f"{self.search_criteria_s2_msi_l1c['productType']} with {self.peps_search_plugin.provider}: "
+            "please remove 'foo' from your search parameters",
             str(context.exception),
         )
 
@@ -3654,7 +3657,8 @@ class TestSearchPluginPostJsonSearchWithStacQueryables(BaseSearchPluginTest):
         mock_build_qs_stacsearch.assert_not_called()
 
     def test_plugins_search_postjsonsearchwithstacqueryables_search_wekeomain_ko(self):
-        """A query with an unknown parameter must raise an error if the provider does not allow it"""  # noqa
+        """A query with a parameter which is not queryable must
+        raise an error if the provider does not allow it"""  # noqa
         # with raising error parameter in the global config of the provider
         provider_search_plugin_config = deepcopy(self.wekeomain_search_plugin.config)
         self.wekeomain_search_plugin.config.discover_metadata = {
@@ -3671,8 +3675,9 @@ class TestSearchPluginPostJsonSearchWithStacQueryables(BaseSearchPluginTest):
                 **{**self.search_criteria_s2_msi_l1c, **{"foo": "bar"}},
             )
         self.assertEqual(
-            f"Unknown parameters not allowed for {self.wekeomain_search_plugin.provider} "
-            f"with {self.search_criteria_s2_msi_l1c['productType']}",
+            "Search parameters which are not queryable are disallowed for "
+            f"{self.search_criteria_s2_msi_l1c['productType']} with {self.wekeomain_search_plugin.provider}: "
+            "please remove 'foo' from your search parameters",
             str(context.exception),
         )
 
@@ -3699,8 +3704,9 @@ class TestSearchPluginPostJsonSearchWithStacQueryables(BaseSearchPluginTest):
                 **{**self.search_criteria_s2_msi_l1c, **{"foo": "bar"}},
             )
         self.assertEqual(
-            f"Unknown parameters not allowed for {self.wekeomain_search_plugin.provider} "
-            f"with {self.search_criteria_s2_msi_l1c['productType']}",
+            "Search parameters which are not queryable are disallowed for "
+            f"{self.search_criteria_s2_msi_l1c['productType']} with {self.wekeomain_search_plugin.provider}: "
+            "please remove 'foo' from your search parameters",
             str(context.exception),
         )
 

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -360,7 +360,7 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
             )
         self.assertEqual(
             "Search parameters which are not queryable are disallowed for "
-            f"{self.search_criteria_s2_msi_l1c['productType']} with {self.peps_search_plugin.provider}: "
+            f"{self.search_criteria_s2_msi_l1c['productType']} on {self.peps_search_plugin.provider}: "
             "please remove 'foo' from your search parameters",
             context.exception.message,
         )
@@ -388,7 +388,7 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
             )
         self.assertEqual(
             "Search parameters which are not queryable are disallowed for "
-            f"{self.search_criteria_s2_msi_l1c['productType']} with {self.peps_search_plugin.provider}: "
+            f"{self.search_criteria_s2_msi_l1c['productType']} on {self.peps_search_plugin.provider}: "
             "please remove 'foo' from your search parameters",
             context.exception.message,
         )
@@ -3676,7 +3676,7 @@ class TestSearchPluginPostJsonSearchWithStacQueryables(BaseSearchPluginTest):
             )
         self.assertEqual(
             "Search parameters which are not queryable are disallowed for "
-            f"{self.search_criteria_s2_msi_l1c['productType']} with {self.wekeomain_search_plugin.provider}: "
+            f"{self.search_criteria_s2_msi_l1c['productType']} on {self.wekeomain_search_plugin.provider}: "
             "please remove 'foo' from your search parameters",
             context.exception.message,
         )
@@ -3704,7 +3704,7 @@ class TestSearchPluginPostJsonSearchWithStacQueryables(BaseSearchPluginTest):
             )
         self.assertEqual(
             "Search parameters which are not queryable are disallowed for "
-            f"{self.search_criteria_s2_msi_l1c['productType']} with {self.wekeomain_search_plugin.provider}: "
+            f"{self.search_criteria_s2_msi_l1c['productType']} on {self.wekeomain_search_plugin.provider}: "
             "please remove 'foo' from your search parameters",
             context.exception.message,
         )


### PR DESCRIPTION
Fixes #1531

For `MO_OCEANCOLOUR_GLO_BGC_L3_NRT_009_101` and `MO_OCEANCOLOUR_GLO_BGC_L4_NRT_009_102` product types, the range was not wide enought and only very recent products are available.

For `CLMS_CORINE`, `wekeo` does not accept date parameters but does not raise an error. Then, it has been handled in two steps:
- now `startTimeFromAscendingNode` and `completionTimeFromAscendingNode` are only mapped for this product type with this provider
- the keyword `raise_mtd_discovery_error` has been set up in `discover_metadata` configuration. It is a boolean parameter, and if it is instantiated  to `True` and the user searches a product type with a parameter not among the queryables of this product type, an error is raised before the search request. It would make sure that the user knows his request is wrong instead of wondering the reason why he does have any result. The value by default of `raise_mtd_discovery_error` is `False`. This keyword can be used at provider search plugin or at product type configuration level, the last one having the priority over the first one.
