### PR TITLE
refactor(core): replace deprecated pkg_resources

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -23,13 +23,13 @@ import os
 import re
 import shutil
 import tempfile
+from importlib.metadata import version
+from importlib.resources import files as res_files
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any, Iterator, Optional, Union
 
 import geojson
-import pkg_resources
 import yaml.parser
-from pkg_resources import resource_filename
 from whoosh import analysis, fields
 from whoosh.fields import Schema
 from whoosh.index import exists_in, open_dir
@@ -119,8 +119,8 @@ class EODataAccessGateway:
         user_conf_file_path: Optional[str] = None,
         locations_conf_path: Optional[str] = None,
     ) -> None:
-        product_types_config_path = resource_filename(
-            "eodag", os.path.join("resources/", "product_types.yml")
+        product_types_config_path = str(
+            res_files("eodag") / "resources" / "product_types.yml"
         )
         self.product_types_config = SimpleYamlProxyConfig(product_types_config_path)
         self.product_types_config_md5 = obj_md5sum(self.product_types_config.source)
@@ -161,8 +161,8 @@ class EODataAccessGateway:
                 user_conf_file_path = standard_configuration_path
                 if not os.path.isfile(standard_configuration_path):
                     shutil.copy(
-                        resource_filename(
-                            "eodag", os.path.join("resources", "user_conf_template.yml")
+                        str(
+                            res_files("eodag") / "resources" / "user_conf_template.yml"
                         ),
                         standard_configuration_path,
                     )
@@ -203,9 +203,8 @@ class EODataAccessGateway:
                 locations_conf_path = os.path.join(self.conf_dir, "locations.yml")
                 if not os.path.isfile(locations_conf_path):
                     # copy locations conf file and replace path example
-                    locations_conf_template = resource_filename(
-                        "eodag",
-                        os.path.join("resources", "locations_conf_template.yml"),
+                    locations_conf_template = str(
+                        res_files("eodag") / "resources" / "locations_conf_template.yml"
                     )
                     with (
                         open(locations_conf_template) as infile,
@@ -222,14 +221,14 @@ class EODataAccessGateway:
                             outfile.write(line)
                     # copy sample shapefile dir
                     shutil.copytree(
-                        resource_filename("eodag", os.path.join("resources", "shp")),
+                        str(res_files("eodag") / "resources" / "shp"),
                         os.path.join(self.conf_dir, "shp"),
                     )
         self.set_locations_conf(locations_conf_path)
 
     def get_version(self) -> str:
         """Get eodag package version"""
-        return pkg_resources.get_distribution("eodag").version
+        return version("eodag")
 
     def build_index(self) -> None:
         """Build a `Whoosh <https://whoosh.readthedocs.io/en/latest/index.html>`_

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
+from importlib.resources import files as res_files
 from inspect import isclass
 from typing import (
     Annotated,
@@ -41,7 +42,6 @@ import yaml.constructor
 import yaml.parser
 from annotated_types import Gt
 from jsonpath_ng import JSONPath
-from pkg_resources import resource_filename
 
 from eodag.api.product.metadata_mapping import mtd_cfg_as_conversion_and_querypath
 from eodag.utils import (
@@ -671,9 +671,9 @@ def load_default_config() -> dict[str, ProviderConfig]:
 
     :returns: The default provider's configuration
     """
-    eodag_providers_cfg_file = os.getenv(
-        "EODAG_PROVIDERS_CFG_FILE"
-    ) or resource_filename("eodag", "resources/providers.yml")
+    eodag_providers_cfg_file = os.getenv("EODAG_PROVIDERS_CFG_FILE") or str(
+        res_files("eodag") / "resources" / "providers.yml"
+    )
     return load_config(eodag_providers_cfg_file)
 
 
@@ -988,9 +988,7 @@ def load_stac_config() -> dict[str, Any]:
 
     :returns: The stac configuration
     """
-    return load_yml_config(
-        resource_filename("eodag", os.path.join("resources/", "stac.yml"))
-    )
+    return load_yml_config(str(res_files("eodag") / "resources" / "stac.yml"))
 
 
 def load_stac_api_config() -> dict[str, Any]:
@@ -998,9 +996,7 @@ def load_stac_api_config() -> dict[str, Any]:
 
     :returns: The stac API configuration
     """
-    return load_yml_config(
-        resource_filename("eodag", os.path.join("resources/", "stac_api.yml"))
-    )
+    return load_yml_config(str(res_files("eodag") / "resources" / "stac_api.yml"))
 
 
 def load_stac_provider_config() -> dict[str, Any]:
@@ -1009,7 +1005,7 @@ def load_stac_provider_config() -> dict[str, Any]:
     :returns: The stac provider configuration
     """
     return SimpleYamlProxyConfig(
-        resource_filename("eodag", os.path.join("resources/", "stac_provider.yml"))
+        str(res_files("eodag") / "resources" / "stac_provider.yml")
     ).source
 
 

--- a/tests/integration/test_download_auth.py
+++ b/tests/integration/test_download_auth.py
@@ -18,10 +18,9 @@
 
 import os
 import unittest
+from importlib.resources import files as res_files
 from tempfile import TemporaryDirectory
 from unittest import mock
-
-from pkg_resources import resource_filename
 
 from tests import TEST_RESOURCES_PATH
 from tests.context import EODataAccessGateway, MisconfiguredError
@@ -49,8 +48,8 @@ class TestEODagDownloadCredentialsNotSet(unittest.TestCase):
         )
         cls.expanduser_mock.start()
 
-        default_conf_file = resource_filename(
-            "eodag", os.path.join("resources", "user_conf_template.yml")
+        default_conf_file = str(
+            res_files("eodag") / "resources" / "user_conf_template.yml"
         )
         cls.eodag = EODataAccessGateway(user_conf_file_path=default_conf_file)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,13 +22,13 @@ import re
 import unittest
 from contextlib import contextmanager
 from datetime import datetime
+from importlib.resources import files as res_files
 from tempfile import TemporaryDirectory
 
 import click
 from click.testing import CliRunner
 from faker import Faker
 from packaging import version
-from pkg_resources import resource_filename
 
 from eodag.api.search_result import SearchResult
 from eodag.utils import GENERIC_PRODUCT_TYPE
@@ -811,8 +811,8 @@ class TestEodagCli(unittest.TestCase):
         search_results_path = os.path.join(
             TEST_RESOURCES_PATH, "eodag_search_result.geojson"
         )
-        default_conf_file = resource_filename(
-            "eodag", os.path.join("resources", "user_conf_template.yml")
+        default_conf_file = str(
+            res_files("eodag") / "resources" / "user_conf_template.yml"
         )
         result = self.runner.invoke(
             eodag,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,11 +19,11 @@
 import os
 import tempfile
 import unittest
+from importlib.resources import files as res_files
 from io import StringIO
 from tempfile import TemporaryDirectory
 
 import yaml.parser
-from pkg_resources import resource_filename
 
 from tests.context import (
     EXT_PRODUCT_TYPES_CONF_URI,
@@ -510,7 +510,7 @@ class TestStacProviderConfig(unittest.TestCase):
 
     def test_existing_stac_provider_conf(self):
         """Existing / pre-configured STAC providers conf should mix providers.yml and  stac_provider.yml infos."""
-        with open(resource_filename("eodag", "resources/providers.yml"), "r") as fh:
+        with open(str(res_files("eodag") / "resources" / "providers.yml"), "r") as fh:
             providers_configs = {
                 p.name: p for p in yaml.load_all(fh, Loader=yaml.Loader)
             }

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -25,11 +25,12 @@ import shutil
 import tempfile
 import unittest
 import uuid
+from importlib.resources import files as res_files
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from lxml import html
-from pkg_resources import DistributionNotFound, resource_filename
+from pkg_resources import DistributionNotFound
 from pydantic import ValidationError
 from shapely import wkt
 from shapely.geometry import LineString, MultiPolygon, Polygon
@@ -1242,8 +1243,8 @@ class TestCore(TestCoreBase):
 
     def test_prune_providers_list(self):
         """Providers needing auth for search but without credentials must be pruned on init"""
-        empty_conf_file = resource_filename(
-            "eodag", os.path.join("resources", "user_conf_template.yml")
+        empty_conf_file = str(
+            res_files("eodag") / "resources" / "user_conf_template.yml"
         )
         try:
             # Default conf: no auth needed for search
@@ -1270,8 +1271,8 @@ class TestCore(TestCoreBase):
     @mock.patch("eodag.plugins.manager.pkg_resources.iter_entry_points", autospec=True)
     def test_prune_providers_list_skipped_plugin(self, mock_iter_ep):
         """Providers needing skipped plugin must be pruned on init"""
-        empty_conf_file = resource_filename(
-            "eodag", os.path.join("resources", "user_conf_template.yml")
+        empty_conf_file = str(
+            res_files("eodag") / "resources" / "user_conf_template.yml"
         )
 
         def skip_qssearch(topic):
@@ -1290,8 +1291,8 @@ class TestCore(TestCoreBase):
 
     def test_prune_providers_list_for_search_without_auth(self):
         """Providers needing auth for search but without auth plugin must be pruned on init"""
-        empty_conf_file = resource_filename(
-            "eodag", os.path.join("resources", "user_conf_template.yml")
+        empty_conf_file = str(
+            res_files("eodag") / "resources" / "user_conf_template.yml"
         )
         try:
             # auth needed for search with need_auth but without auth plugin
@@ -1318,8 +1319,8 @@ class TestCore(TestCoreBase):
 
     def test_prune_providers_list_without_api_or_search_plugin(self):
         """Providers without api or search plugin must be pruned on init"""
-        empty_conf_file = resource_filename(
-            "eodag", os.path.join("resources", "user_conf_template.yml")
+        empty_conf_file = str(
+            res_files("eodag") / "resources" / "user_conf_template.yml"
         )
         dag = EODataAccessGateway(user_conf_file_path=empty_conf_file)
         delattr(dag.providers_config["peps"], "search")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from importlib.resources import files as res_files
 from typing import Any, Literal, Optional
 
 # All tests files should import mock from this place
@@ -25,7 +26,6 @@ from urllib.parse import parse_qs, urlparse
 import fastapi
 import yaml
 from fastapi.datastructures import QueryParams  # noqa
-from pkg_resources import resource_filename
 
 
 def no_blanks(string):
@@ -46,8 +46,8 @@ def write_eodag_conf_with_fake_credentials(config_file):
 
     :param config_file: path to the file where the conf must be written
     """
-    empty_conf_file_path = resource_filename(
-        "eodag", os.path.join("resources", "user_conf_template.yml")
+    empty_conf_file_path = str(
+        res_files("eodag") / "resources" / "user_conf_template.yml"
     )
     with open(os.path.abspath(os.path.realpath(empty_conf_file_path)), "r") as fh:
         was_empty_conf = yaml.safe_load(fh)


### PR DESCRIPTION
Refactor the code to avoid using deprecated `pkg_resources`. See https://setuptools.pypa.io/en/latest/pkg_resources.html:
> Use of pkg_resources is deprecated in favor of [importlib.resources](https://docs.python.org/3.11/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata) and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)). Some useful APIs are also provided by [packaging](https://pypi.org/project/packaging) (e.g. requirements and version parsing). Users should refrain from new usage of pkg_resources and should work to port to importlib-based solutions.