### PR TITLE
build: usgs last version from git repo

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ csw =
 ecmwf =
     ecmwf-api-client
 usgs =
-    usgs >= 0.3.1
+    usgs @ git+https://github.com/kapadia/usgs@master
 server =
     fastapi >= 0.93.0
     pygeofilter


### PR DESCRIPTION
Following #1485 , update `usgs` dependency to install from its github repository until a new version is released.