### PR TITLE
fix(EcmwfSearch): map geometry metadata

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -322,6 +322,7 @@ class ECMWFSearch(PostJsonSearch):
                 "title": "$.id",
                 "storageStatus": OFFLINE_STATUS,
                 "downloadLink": "$.null",
+                "geometry": ["feature", "$.geometry"],
                 "defaultGeometry": "POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))",
             },
             **config.metadata_mapping,


### PR DESCRIPTION
A geometry is required with EODAG and the mapping was missing for ECMWFSearch providers.
