### PR TITLE
feat(core): add EODAG_PRODUCT_TYPES_CFG_FILE env var

### DIFF
--- a/docs/getting_started_guide/configure.rst
+++ b/docs/getting_started_guide/configure.rst
@@ -149,6 +149,7 @@ Some EODAG core settings can be overriden using environment variables:
   `locations <https://eodag.readthedocs.io/en/stable/notebooks/api_user_guide/4_search.html#Locations-search>`_
   configuration file
 * ``EODAG_PROVIDERS_CFG_FILE`` for defining the desired path to the providers configuration file
+* ``EODAG_PRODUCT_TYPES_CFG_FILE`` for defining the desired path to the product types configuration file
 * ``EODAG_EXT_PRODUCT_TYPES_CFG_FILE`` for defining the desired path to the `external product types configuration file\
   <https://eodag.readthedocs.io/en/stable/notebooks/api_user_guide/2_providers_products_available.html#Product-types-discovery>`_
 

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -119,7 +119,7 @@ class EODataAccessGateway:
         user_conf_file_path: Optional[str] = None,
         locations_conf_path: Optional[str] = None,
     ) -> None:
-        product_types_config_path = str(
+        product_types_config_path = os.getenv("EODAG_PRODUCT_TYPES_CFG_FILE") or str(
             res_files("eodag") / "resources" / "product_types.yml"
         )
         self.product_types_config = SimpleYamlProxyConfig(product_types_config_path)

--- a/tests/resources/file_product_types_override.yml
+++ b/tests/resources/file_product_types_override.yml
@@ -1,0 +1,25 @@
+TEST_PRODUCT_1:
+  abstract: |
+    This is the first test product.
+  instrument: I1
+  platform: Platform1
+  platformSerialIdentifier: P1
+  processingLevel: L1
+  keywords: TEST,PRODUCT1
+  sensorType: test
+  license: other
+  missionStartDate: "2014-12-07T00:00:00Z"
+  title: Test Product 1
+
+TEST_PRODUCT_2:
+  abstract: |
+    This is the second test product.
+  instrument: I2
+  platform: Platform2
+  platformSerialIdentifier: P2
+  processingLevel: L2
+  keywords: TEST,PRODUCT2
+  sensorType: test
+  license: other
+  missionStartDate: "2014-12-07T00:00:00Z"
+  title: Test Product 2

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1936,16 +1936,10 @@ class TestCoreConfWithEnvVar(TestCoreBase):
     @classmethod
     def setUpClass(cls):
         super(TestCoreConfWithEnvVar, cls).setUpClass()
-        cls.dag = EODataAccessGateway()
-        # mock os.environ to empty env
-        cls.mock_os_environ = mock.patch.dict(os.environ, {}, clear=True)
-        cls.mock_os_environ.start()
 
     @classmethod
     def tearDownClass(cls):
         super(TestCoreConfWithEnvVar, cls).tearDownClass()
-        # stop os.environ
-        cls.mock_os_environ.stop()
 
     def test_core_object_prioritize_locations_file_in_envvar(self):
         """The core object must use the locations file pointed by the EODAG_LOCS_CFG_FILE env var"""

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1999,12 +1999,12 @@ class TestCoreConfWithEnvVar(TestCoreBase):
         providers_config[0].products["TEST_PRODUCT_1"] = {"productType": "TP1"}
         providers_config[0].products["TEST_PRODUCT_2"] = {"productType": "TP2"}
         with open(
-            os.path.join(TEST_RESOURCES_PATH, "file_providers_override2.yml"), "w"
+            os.path.join(self.tmp_home_dir.name, "file_providers_override2.yml"), "w"
         ) as f:
             f.write(yaml.dump(providers_config[0]))
         # set env variables
         os.environ["EODAG_PROVIDERS_CFG_FILE"] = os.path.join(
-            TEST_RESOURCES_PATH, "file_providers_override2.yml"
+            self.tmp_home_dir.name, "file_providers_override2.yml"
         )
         os.environ["EODAG_PRODUCT_TYPES_CFG_FILE"] = os.path.join(
             TEST_RESOURCES_PATH, "file_product_types_override.yml"
@@ -2015,8 +2015,7 @@ class TestCoreConfWithEnvVar(TestCoreBase):
         self.assertEqual(2, len(pt))
         self.assertEqual("TEST_PRODUCT_1", pt[0]["ID"])
         self.assertEqual("TEST_PRODUCT_2", pt[1]["ID"])
-        # remove temp file and env variables
-        os.remove(os.path.join(TEST_RESOURCES_PATH, "file_providers_override2.yml"))
+        # remove env variables
         os.environ.pop("EODAG_PROVIDERS_CFG_FILE", None)
         os.environ.pop("EODAG_PRODUCT_TYPES_CFG_FILE", None)
 


### PR DESCRIPTION
add `EODAG_PRODUCT_TYPES_CFG_FILE` environment variable to configure the path for the `product_types.yml` file