### PR TITLE
build: do not install usgs from git repo

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,11 +60,12 @@ Plugins new features and fixes
 Miscellaneous
 """""""""""""
 
-* **[build]** remove dependencies max versions (:pull:`1519`), ``usgs`` latest version from git repo (:pull:`1552`)
+* **[build]** remove dependencies max versions (:pull:`1519`)
 * **[docs]** ``eodag-cube`` `Python API documentation
   <https://eodag.readthedocs.io/en/latest/notebooks/api_user_guide/9_post_process.html#Data-access-with-eodag-cube>`_
   (:pull:`1511`), ``usgs`` registration update (:pull:`1551`)
-* Various minor fixes and improvements (:pull:`1502`)(:pull:`1540`)(:pull:`1541`)(:pull:`1547`)(:pull:`1566`)
+* Various minor fixes and improvements (:pull:`1502`)(:pull:`1540`)(:pull:`1541`)(:pull:`1547`)(:pull:`1552`)
+  (:pull:`1566`)(:pull:`1568`)
 * External product types reference updates (:pull:`1510`)(:pull:`1525`)(:pull:`1539`)(:pull:`1548`)(:pull:`1553`)
   (:pull:`1557`)(:pull:`1565`)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ csw =
 ecmwf =
     ecmwf-api-client
 usgs =
-    usgs @ git+https://github.com/kapadia/usgs@master
+    usgs >= 0.3.1
 server =
     fastapi >= 0.93.0
     pygeofilter
@@ -85,7 +85,7 @@ server =
 notebook = tqdm[notebook]
 tutorials =
     eodag[ecmwf,notebook]
-    eodag-cube @ git+https://github.com/CS-SI/eodag-cube@develop
+    eodag-cube >= 0.6.0b2
     jupyter
     ipyleaflet >= 0.10.0
     ipywidgets


### PR DESCRIPTION
Do not install `usgs` from its github repository. 

Same thing for `eodag-cube` in tutorials.