### PR TITLE
fix(plugins): AwsDownload with asset and ignore_assets

### DIFF
--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -292,10 +292,10 @@ class AwsDownload(Download):
         asset_filter = kwargs.get("asset", None)
         if asset_filter:
             build_safe = False
+            ignore_assets = False
         else:
             build_safe = product_conf.get("build_safe", False)
-
-        ignore_assets = getattr(self.config, "ignore_assets", False)
+            ignore_assets = getattr(self.config, "ignore_assets", False)
 
         # product conf overrides provider conf for "flatten_top_dirs"
         flatten_top_dirs = product_conf.get(

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -5938,6 +5938,7 @@
   download: !plugin
     type: AwsDownload
     s3_endpoint: https://s3.datalake.cnes.fr
+    ignore_assets: True
   auth: !plugin
     type: AwsAuth
     auth_error_code: 403


### PR DESCRIPTION
If `ignore_assets` is set in `AwsDownload` configuration in order to download whole product using `downloadLink` instead of assets, allow single asset download if wanted.

Set `ignore_assets = True` in `geodes_s3` settings.