### PR TITLE
fix(core):  Ensure datetime format compliance with STAC specification

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -4435,7 +4435,7 @@
     metadata_mapping:
       startTimeFromAscendingNode: '{$.startTimeFromAscendingNode#to_iso_utc_datetime}'
       completionTimeFromAscendingNode:
-        - date={startTimeFromAscendingNode#to_iso_date}/{completionTimeFromAscendingNode#to_iso_date}
+        - '{{"date": "{startTimeFromAscendingNode#to_non_separated_date}/to/{completionTimeFromAscendingNode#to_non_separated_date}"}}'
         - '{$.completionTimeFromAscendingNode#to_iso_utc_datetime}'
       qs: $.qs
       orderLink: 'https://polytope.lumi.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{{"verb": "retrieve", "request": {qs#to_geojson} }}'

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1554,10 +1554,10 @@
     auth_endpoint: https://api.ecmwf.int/v1
     metadata_mapping:
       productType: $.productType
-      startTimeFromAscendingNode: '{$.startTimeFromAscendingNode#to_iso_date}'
+      startTimeFromAscendingNode: '{$.startTimeFromAscendingNode#to_iso_utc_datetime}'
       completionTimeFromAscendingNode:
         - 'date={startTimeFromAscendingNode#to_iso_date}/to/{completionTimeFromAscendingNode#to_iso_date(-1,)}'
-        - '{$.completionTimeFromAscendingNode#to_iso_date}'
+        - '{$.completionTimeFromAscendingNode#to_iso_utc_datetime}'
       # The geographic extent of the product
       geometry:
         - 'area={geometry#to_nwse_bounds_str(/)}'
@@ -1645,10 +1645,10 @@
       form_url: https://ads.atmosphere.copernicus.eu/api/catalogue/v1/collections/{dataset}/form.json
     metadata_mapping:
       productType: $.productType
-      startTimeFromAscendingNode: '{$.startTimeFromAscendingNode#to_iso_date}'
+      startTimeFromAscendingNode: '{$.startTimeFromAscendingNode#to_iso_utc_datetime}'
       completionTimeFromAscendingNode:
         - 'date={startTimeFromAscendingNode#to_iso_date}/{completionTimeFromAscendingNode#to_iso_date}'
-        - '{$.completionTimeFromAscendingNode#to_iso_date}'
+        - '{$.completionTimeFromAscendingNode#to_iso_utc_datetime}'
       # The geographic extent of the product
       geometry:
         - '{{"area": {geometry#to_nwse_bounds}}}'
@@ -4433,10 +4433,10 @@
       product_type_fetch_url: null
       constraints_url: "https://s3.central.data.destination-earth.eu/swift/v1/dedt-lumi-constraints/{dataset}.json"
     metadata_mapping:
-      startTimeFromAscendingNode: '{$.startTimeFromAscendingNode#to_iso_date}'
+      startTimeFromAscendingNode: '{$.startTimeFromAscendingNode#to_iso_utc_datetime}'
       completionTimeFromAscendingNode:
-        - '{{"date": "{startTimeFromAscendingNode#to_non_separated_date}/to/{completionTimeFromAscendingNode#to_non_separated_date}"}}'
-        - '{$.completionTimeFromAscendingNode#to_iso_date}'
+        - date={startTimeFromAscendingNode#to_iso_date}/{completionTimeFromAscendingNode#to_iso_date}
+        - '{$.completionTimeFromAscendingNode#to_iso_utc_datetime}'
       qs: $.qs
       orderLink: 'https://polytope.lumi.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{{"verb": "retrieve", "request": {qs#to_geojson} }}'
   products:

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -138,7 +138,7 @@ DEFAULT_ITEMS_PER_PAGE = 20
 DEFAULT_MAX_ITEMS_PER_PAGE = 50
 
 # default product-types start date
-DEFAULT_MISSION_START_DATE = "2015-01-01T00:00:00Z"
+DEFAULT_MISSION_START_DATE = "2015-01-01T00:00:00.000Z"
 
 # update missing mimetypes
 mimetypes.add_type("text/xml", ".xsd")

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -88,8 +88,8 @@ class TestApisPluginEcmwfApi(BaseApisPluginTest):
         self.provider = "ecmwf"
         self.api_plugin = self.get_search_plugin(provider=self.provider)
         self.query_dates = {
-            "startTimeFromAscendingNode": "2022-01-01",
-            "completionTimeFromAscendingNode": "2022-01-02",
+            "startTimeFromAscendingNode": "2022-01-01T00:00:00.000Z",
+            "completionTimeFromAscendingNode": "2022-01-02T00:00:00.000Z",
         }
         self.product_type = "TIGGE_CF_SFC"
         self.product_type_params = {
@@ -130,10 +130,12 @@ class TestApisPluginEcmwfApi(BaseApisPluginTest):
         )
         eoproduct = results[0]
         self.assertEqual(
-            eoproduct.properties["startTimeFromAscendingNode"], "2020-01-01"
+            eoproduct.properties["startTimeFromAscendingNode"],
+            "2020-01-01T00:00:00.000Z",
         )
         self.assertEqual(
-            eoproduct.properties["completionTimeFromAscendingNode"], "2020-01-02"
+            eoproduct.properties["completionTimeFromAscendingNode"],
+            "2020-01-02T00:00:00.000Z",
         )
 
         # missing start & stop
@@ -145,9 +147,15 @@ class TestApisPluginEcmwfApi(BaseApisPluginTest):
             eoproduct.properties["startTimeFromAscendingNode"],
             DEFAULT_MISSION_START_DATE,
         )
+        current_time = (
+            datetime.now(timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", ".000Z")
+        )
         self.assertIn(
             eoproduct.properties["completionTimeFromAscendingNode"],
-            datetime.now(timezone.utc).isoformat(),
+            current_time,
         )
 
         # missing start & stop and plugin.product_type_config set (set in core._prepare_search)
@@ -161,10 +169,12 @@ class TestApisPluginEcmwfApi(BaseApisPluginTest):
         )
         eoproduct = results[0]
         self.assertEqual(
-            eoproduct.properties["startTimeFromAscendingNode"], "1985-10-26"
+            eoproduct.properties["startTimeFromAscendingNode"],
+            "1985-10-26T00:00:00.000Z",
         )
         self.assertEqual(
-            eoproduct.properties["completionTimeFromAscendingNode"], "2015-10-21"
+            eoproduct.properties["completionTimeFromAscendingNode"],
+            "2015-10-21T00:00:00.000Z",
         )
 
     def test_plugins_apis_ecmwf_query_without_producttype(self):

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2205,10 +2205,12 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         )
         eoproduct = results[0]
         self.assertEqual(
-            "2020-01-01", eoproduct.properties["startTimeFromAscendingNode"]
+            "2020-01-01T00:00:00.000Z",
+            eoproduct.properties["startTimeFromAscendingNode"],
         )
         self.assertEqual(
-            "2020-01-02", eoproduct.properties["completionTimeFromAscendingNode"]
+            "2020-01-02T00:00:00.000Z",
+            eoproduct.properties["completionTimeFromAscendingNode"],
         )
         # start & stop as datetimes, not midnight -> keep and dates as it is
         results, _ = self.search_plugin.query(
@@ -2218,10 +2220,12 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         )
         eoproduct = results[0]
         self.assertEqual(
-            "2020-01-01", eoproduct.properties["startTimeFromAscendingNode"]
+            "2020-01-01T02:00:00.000Z",
+            eoproduct.properties["startTimeFromAscendingNode"],
         )
         self.assertEqual(
-            "2020-01-02", eoproduct.properties["completionTimeFromAscendingNode"]
+            "2020-01-02T03:00:00.000Z",
+            eoproduct.properties["completionTimeFromAscendingNode"],
         )
         # start & stop as datetimes, midnight -> exclude end date
         results, _ = self.search_plugin.query(
@@ -2231,10 +2235,12 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         )
         eoproduct = results[0]
         self.assertEqual(
-            "2020-01-01", eoproduct.properties["startTimeFromAscendingNode"]
+            "2020-01-01T00:00:00.000Z",
+            eoproduct.properties["startTimeFromAscendingNode"],
         )
         self.assertEqual(
-            "2020-01-01", eoproduct.properties["completionTimeFromAscendingNode"]
+            "2020-01-01T00:00:00.000Z",
+            eoproduct.properties["completionTimeFromAscendingNode"],
         )
         # start & stop same date -> keep end date
         results, _ = self.search_plugin.query(
@@ -2244,10 +2250,12 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         )
         eoproduct = results[0]
         self.assertEqual(
-            "2020-01-01", eoproduct.properties["startTimeFromAscendingNode"]
+            "2020-01-01T00:00:00.000Z",
+            eoproduct.properties["startTimeFromAscendingNode"],
         )
         self.assertEqual(
-            "2020-01-01", eoproduct.properties["completionTimeFromAscendingNode"]
+            "2020-01-01T00:00:00.000Z",
+            eoproduct.properties["completionTimeFromAscendingNode"],
         )
 
     def test_plugins_search_ecmwfsearch_dates_missing(self):
@@ -2260,10 +2268,12 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         )
         eoproduct = results[0]
         self.assertEqual(
-            eoproduct.properties["startTimeFromAscendingNode"], "2020-01-01"
+            eoproduct.properties["startTimeFromAscendingNode"],
+            "2020-01-01T00:00:00.000Z",
         )
         self.assertEqual(
-            eoproduct.properties["completionTimeFromAscendingNode"], "2020-01-02"
+            eoproduct.properties["completionTimeFromAscendingNode"],
+            "2020-01-02T00:00:00.000Z",
         )
 
         # missing start & stop
@@ -2276,11 +2286,11 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
             DEFAULT_MISSION_START_DATE,
         )
         exp_end_date = datetime.strptime(
-            DEFAULT_MISSION_START_DATE, "%Y-%m-%dT%H:%M:%SZ"
+            DEFAULT_MISSION_START_DATE, "%Y-%m-%dT%H:%M:%S.%fZ"
         )
         self.assertIn(
             eoproduct.properties["completionTimeFromAscendingNode"],
-            exp_end_date.strftime("%Y-%m-%d"),
+            exp_end_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-4] + "Z",
         )
 
         # missing start & stop and plugin.product_type_config set (set in core._prepare_search)
@@ -2294,10 +2304,12 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         )
         eoproduct = results[0]
         self.assertEqual(
-            eoproduct.properties["startTimeFromAscendingNode"], "1985-10-26"
+            eoproduct.properties["startTimeFromAscendingNode"],
+            "1985-10-26T00:00:00.000Z",
         )
         self.assertEqual(
-            eoproduct.properties["completionTimeFromAscendingNode"], "1985-10-26"
+            eoproduct.properties["completionTimeFromAscendingNode"],
+            "1985-10-26T00:00:00.000Z",
         )
 
     def test_plugins_search_ecmwfsearch_without_producttype(self):
@@ -2316,8 +2328,14 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         assert count == 1
         eoproduct = results[0]
         assert eoproduct.geometry.bounds == (-180.0, -90.0, 180.0, 90.0)
-        assert eoproduct.properties["startTimeFromAscendingNode"] == "2020-01-01"
-        assert eoproduct.properties["completionTimeFromAscendingNode"] == "2020-01-02"
+        assert (
+            eoproduct.properties["startTimeFromAscendingNode"]
+            == "2020-01-01T00:00:00.000Z"
+        )
+        assert (
+            eoproduct.properties["completionTimeFromAscendingNode"]
+            == "2020-01-02T00:00:00.000Z"
+        )
         assert eoproduct.properties["title"] == eoproduct.properties["id"]
         assert eoproduct.properties["title"].startswith(
             f"{self.product_dataset.upper()}"


### PR DESCRIPTION
According to the STAC specification, a full datetime value is expected instead of just a date. This fix ensures compliance by correctly handling datetime values.