### PR TITLE
fix: default values for some ECMWF collections

### DIFF
--- a/eodag/resources/product_types.yml
+++ b/eodag/resources/product_types.yml
@@ -3503,7 +3503,7 @@ SATELLITE_CARBON_DIOXIDE:
   sensorType: ATMOSPHERIC
   license: other
   title: Carbon dioxide data from 2002 to present derived from satellite observations
-  missionStartDate: "2003-01-10T00:00:00Z"
+  missionStartDate: "2002-10-01T00:00:00Z"
   missionEndDate: "2022-12-31T23:59:59"
 
 SATELLITE_FIRE_BURNED_AREA:
@@ -3575,7 +3575,7 @@ SATELLITE_METHANE:
   sensorType: ATMOSPHERIC
   license: other
   title: Methane data from 2003 to present derived from satellite observations
-  missionStartDate: "2003-01-06T00:00:00Z"
+  missionStartDate: "2002-10-01T00:00:00Z"
 
 SATELLITE_SEA_ICE_EDGE_TYPE:
   abstract: |

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1969,8 +1969,8 @@
       dataset: satellite-carbon-dioxide
       processing_level: level_2
       variable: xco2
-      sensor_and_algorithm: merged_emma
-      version: '4_5'
+      sensor_and_algorithm: sciamachy_wfmd
+      version: '4_0'
       metadata_mapping:
         <<: *day_month_year
     SATELLITE_FIRE_BURNED_AREA:
@@ -1986,8 +1986,8 @@
       dataset: satellite-methane
       processing_level: level_2
       variable: xch4
-      sensor_and_algorithm: merged_emma
-      version: '4_5'
+      sensor_and_algorithm: sciamachy_wfmd
+      version: '4_0'
       metadata_mapping:
         <<: *day_month_year
     SATELLITE_SEA_ICE_EDGE_TYPE:
@@ -3543,9 +3543,9 @@
     SATELLITE_CARBON_DIOXIDE:
       dataset: EO:ECMWF:DAT:SATELLITE_CARBON_DIOXIDE
       processing_level: level_2
-      version: '4_5'
+      version: '4_0'
       variable: xco2
-      sensor_and_algorithm: merged_emma
+      sensor_and_algorithm: sciamachy_wfmd
       metadata_mapping:
         <<: *day_month_year
     SATELLITE_FIRE_BURNED_AREA:


### PR DESCRIPTION
Update default values for SATELLITE_METHANE and SATELLITE_CARBON_DIOXIDE datasets.