### PR TITLE
fix(providers): sanitize eumetsat_ds titles

### DIFF
--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -49,6 +49,7 @@ from eodag.utils import (
     get_timestamp,
     items_recursive_apply,
     nested_pairs2dict,
+    sanitize,
     string_to_jsonpath,
     update_nested_dict,
 )
@@ -176,6 +177,7 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
         - ``split_corine_id``: get the product type by splitting the product id
         - ``to_datetime_dict``: convert a datetime string to a dictionary where values are either a string or a list
         - ``get_ecmwf_time``: get the time of a datetime string in the ECMWF format
+        - ``sanitize``: sanitize string
 
     :param search_param: The string to be formatted
     :param args: (optional) Additional arguments to use in the formatting process
@@ -822,6 +824,11 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
                 str(MetadataFormatter.convert_to_datetime_dict(date, "str")["hour"])
                 + ":00"
             ]
+
+        @staticmethod
+        def convert_sanitize(text: str) -> str:
+            """Sanitize string"""
+            return sanitize(text)
 
         @staticmethod
         def convert_get_dates_from_string(text: str, split_param="-"):

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -5123,7 +5123,7 @@
       platform: '$.properties.acquisitionInformation[0].platform.platformShortName'
       instrument: '$.properties.acquisitionInformation[0].instrument.instrumentShortName'
       # INSPIRE obligated OpenSearch Parameters for Collection Search (Table 4)
-      title: '{$.properties.title#remove_extension}'
+      title: '{$.properties.title#sanitize}'
       # OpenSearch Parameters for Product Search (Table 5)
       parentIdentifier:
         - pi

--- a/tests/units/test_metadata_mapping.py
+++ b/tests/units/test_metadata_mapping.py
@@ -677,3 +677,13 @@ class TestMetadataMappingFunctions(unittest.TestCase):
             "variable", provider_queryables, metadata_mapping
         )
         self.assertEqual("variable", provider_key)
+
+    def test_convert_sanitize(self):
+        to_format = "{path#sanitize}"
+        self.assertEqual(
+            format_metadata(
+                to_format,
+                path="replaçe,  pônctuation:;sïgns!?byunderscorekeeping-hyphen.dot_and_underscore",
+            ),
+            "replace_ponctuation_signs_byunderscorekeeping-hyphen.dot_and_underscore",
+        )


### PR DESCRIPTION
Sanitize products `title` from `eumetsat_ds` provider to avoid special characters in strings like `"W_XX-EUMETSAT-Darmstadt,IMG+SAT,MTI1+FCI-2-OCA--FD--x-x---x_C_EUMT_20250127140934_L2PF_OPE_20250127135000_20250127140000_N__C_0084_0000"`