### PR TITLE
feat(plugins): do not guess keys from href when inappropriate

### DIFF
--- a/eodag/config.py
+++ b/eodag/config.py
@@ -443,6 +443,9 @@ class PluginConfig(yaml.YAMLObject):
     literal_search_params: dict[str, str]
     #: :class:`~eodag.plugins.search.qssearch.QueryStringSearch` Characters that should not be quoted in the url params
     dont_quote: list[str]
+    #: :class:`~eodag.plugins.search.qssearch.QueryStringSearch` Guess assets keys using their ``href``.
+    #: Use their original key if ``False``
+    asset_key_from_href: bool
     #: :class:`~eodag.plugins.search.qssearch.ODataV4Search` Dict describing free text search request build
     free_text_search_operations: dict[str, Any]
     #: :class:`~eodag.plugins.search.qssearch.ODataV4Search` Set to ``True`` if the metadata is not given in the search

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -123,6 +123,8 @@ class QueryStringSearch(Search):
           authentication error; only used if ``need_auth=true``
         * :attr:`~eodag.config.PluginConfig.ssl_verify` (``bool``): if the ssl certificates should be verified in
           requests; default: ``True``
+        * :attr:`~eodag.config.PluginConfig.asset_key_from_href` (``bool``): guess assets keys using their ``href``. Use
+          their original key if ``False``; default: ``True``
         * :attr:`~eodag.config.PluginConfig.dont_quote` (``list[str]``): characters that should not be quoted in the
           url params
         * :attr:`~eodag.config.PluginConfig.timeout` (``int``): time to wait until request timeout in seconds;
@@ -1072,6 +1074,7 @@ class QueryStringSearch(Search):
             % normalize_remaining_count
         )
         products: list[EOProduct] = []
+        asset_key_from_href = getattr(self.config, "asset_key_from_href", True)
         for result in results:
             product = EOProduct(
                 self.provider,
@@ -1089,7 +1092,8 @@ class QueryStringSearch(Search):
             # move assets from properties to product's attr, normalize keys & roles
             for key, asset in product.properties.pop("assets", {}).items():
                 norm_key, asset["roles"] = product.driver.guess_asset_key_and_roles(
-                    asset.get("href", ""), product
+                    asset.get("href", "") if asset_key_from_href else key,
+                    product,
                 )
                 if norm_key:
                     product.assets[norm_key] = asset

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -2936,6 +2936,7 @@
     need_auth: true
     auth_error_code: 401
     ssl_verify: true
+    asset_key_from_href: false
     discover_queryables:
       fetch_url: null
       product_type_fetch_url: null
@@ -4527,6 +4528,7 @@
     api_endpoint: https://hda.data.destination-earth.eu/stac/search
     need_auth: true
     timeout: 60
+    asset_key_from_href: false
     metadata_mapping:
       defaultGeometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
       quicklook: '{thumbnail}'
@@ -5071,6 +5073,7 @@
     dont_quote:
       - '='
       - '&'
+    asset_key_from_href: false
     pagination:
       next_page_url_tpl: '{url}?{search}&c={items_per_page}&pw={page}'
       start_page: 0
@@ -5515,6 +5518,7 @@
     api_endpoint: 'https://stac.marine.copernicus.eu/metadata/{collection}/product.stac.json'
     need_auth: false
     ssl_verify: true
+    asset_key_from_href: false
     timeout: 20
     results_entry: links
     discover_product_types:
@@ -5683,6 +5687,7 @@
     api_endpoint: https://geodes-portal.cnes.fr/api/stac/search
     need_auth: false
     ssl_verify: false
+    asset_key_from_href: false
     discover_queryables:
       fetch_url: null
       product_type_fetch_url: null
@@ -5798,6 +5803,7 @@
     s3_endpoint: https://s3.datalake.cnes.fr
     need_auth: true
     ssl_verify: false
+    asset_key_from_href: false
     discover_queryables:
       fetch_url: null
       product_type_fetch_url: null

--- a/tests/context.py
+++ b/tests/context.py
@@ -71,6 +71,7 @@ from eodag.plugins.download.http import HTTPDownload
 from eodag.plugins.manager import PluginManager
 from eodag.plugins.search import PreparedSearch
 from eodag.plugins.search.base import Search
+from eodag.plugins.search.qssearch import QueryStringSearch
 from eodag.types import model_fields_to_annotated
 from eodag.types.queryables import CommonQueryables, Queryables
 from eodag.utils import (


### PR DESCRIPTION
Do not guess assets keys from from their URL/href when inappropriate.
Set search plugin `asset_key_from_href` configuration parameter to `False` to bypass the guess.