### PR TITLE
fix(plugins): check expiration time in token auth

### DIFF
--- a/eodag/config.py
+++ b/eodag/config.py
@@ -615,6 +615,9 @@ class PluginConfig(yaml.YAMLObject):
     #: :class:`~eodag.plugins.authentication.token.TokenAuth`
     #: type of the token
     token_type: str
+    #: :class:`~eodag.plugins.authentication.token.TokenAuth`
+    #: key to get the expiration time of the token
+    token_expiration_key: str
     #: :class:`~eodag.plugins.authentication.token_exchange.OIDCTokenExchangeAuth`
     #: The full :class:`~eodag.plugins.authentication.openid_connect.OIDCAuthorizationCodeFlowAuth` plugin configuration
     #: used to retrieve subject token

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3442,6 +3442,7 @@
     token_type: json
     token_key: access_token
     refresh_token_key: refresh_token
+    token_expiration_key: expires_in
   download: !plugin
     type: HTTPDownload
     base_uri: https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess
@@ -3913,6 +3914,7 @@
     token_type: json
     token_key: access_token
     refresh_token_key: refresh_token
+    token_expiration_key: expires_in
   download: !plugin
     type: HTTPDownload
     auth_error_code: 401
@@ -5503,6 +5505,7 @@
       grant_type: client_credentials
     token_type: json
     token_key: access_token
+    token_expiration_key: expires_in
     ssl_verify: true
 
 ---


### PR DESCRIPTION
So far the expiration time of an access token was not stored and checked in the `TokenAuth` plugin. This is now done, so that no token request is sent if there is already an existing, valid token. 

The corresponding configuration has to be set using the new parameter `token_expiration_key`, see [TokenAuth configuration](https://eodag.readthedocs.io/en/latest/plugins_reference/generated/eodag.plugins.authentication.token.TokenAuth.html). It has been added for the providers `wekeo_main`, `wekeo_ecmwf` and `eumetsat_ds`.
