### PR TITLE
fix(core): provider queryables metadata

### DIFF
--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -381,12 +381,12 @@ class Search(PluginTopic):
             for pt in available_product_types:
                 self.config.product_type_config = product_type_configs[pt]
                 pt_queryables = self._get_product_type_queryables(pt, None, filters)
-                # only use key and type because values and defaults will vary between product types
-                pt_queryables_neutral = {
-                    k: Annotated[v.__args__[0], Field(default=None)]
-                    for k, v in pt_queryables.items()
-                }
-                all_queryables.update(pt_queryables_neutral)
+                all_queryables.update(pt_queryables)
+            # reset defaults because they may vary between product types
+            for k, v in all_queryables.items():
+                v.__metadata__[0].default = getattr(
+                    Queryables.model_fields.get(k, Field(None)), "default", None
+                )
             return QueryablesDict(
                 additional_properties=True,
                 additional_information=additional_info,


### PR DESCRIPTION
Restore queryables metadata that was removed when only a `provider` (no product type) was passed as argument of [list_queryables](https://eodag.readthedocs.io/en/latest/api_reference/core.html#eodag.api.core.EODataAccessGateway.list_queryables)