### PR TITLE
fix(core): missing queryables from metadata-mapping

### DIFF
--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -337,7 +337,9 @@ class Search(PluginTopic):
         try:
             filters["productType"] = product_type
             queryables = self.discover_queryables(**{**default_values, **filters}) or {}
-        except NotImplementedError:
+        except NotImplementedError as e:
+            if str(e):
+                logger.debug(str(e))
             queryables = self.queryables_from_metadata_mapping(product_type, alias)
 
         return QueryablesDict(**queryables)

--- a/eodag/rest/errors.py
+++ b/eodag/rest/errors.py
@@ -31,6 +31,7 @@ from eodag.utils.exceptions import (
     MisconfiguredError,
     NoMatchingProductType,
     NotAvailableError,
+    PluginImplementationError,
     RequestError,
     TimeOutError,
     UnsupportedProductType,
@@ -42,6 +43,7 @@ EODAG_DEFAULT_STATUS_CODES = {
     AuthenticationError: status.HTTP_500_INTERNAL_SERVER_ERROR,
     DownloadError: status.HTTP_500_INTERNAL_SERVER_ERROR,
     MisconfiguredError: status.HTTP_500_INTERNAL_SERVER_ERROR,
+    PluginImplementationError: status.HTTP_500_INTERNAL_SERVER_ERROR,
     NotAvailableError: status.HTTP_404_NOT_FOUND,
     NoMatchingProductType: status.HTTP_404_NOT_FOUND,
     TimeOutError: status.HTTP_504_GATEWAY_TIMEOUT,
@@ -80,7 +82,11 @@ class ResponseSearchError(Exception):
                 type(exception), getattr(exception, "status_code", 500)
             )
 
-            if type(exception) in (MisconfiguredError, AuthenticationError):
+            if type(exception) in (
+                MisconfiguredError,
+                AuthenticationError,
+                PluginImplementationError,
+            ):
                 logger.error("%s: %s", type(exception).__name__, str(exception))
                 error_dict[
                     "message"
@@ -132,10 +138,19 @@ async def eodag_errors_handler(request: Request, exc: Exception) -> ORJSONRespon
 
     detail = f"{type(exc).__name__}: {str(exc)}"
 
-    if type(exc) in (MisconfiguredError, AuthenticationError, TimeOutError):
+    if type(exc) in (
+        MisconfiguredError,
+        AuthenticationError,
+        TimeOutError,
+        PluginImplementationError,
+    ):
         logger.error("%s: %s", type(exc).__name__, str(exc))
 
-    if type(exc) in (MisconfiguredError, AuthenticationError):
+    if type(exc) in (
+        MisconfiguredError,
+        AuthenticationError,
+        PluginImplementationError,
+    ):
         detail = "Internal server error: please contact the administrator"
 
     if type(exc) is ValidationError:

--- a/eodag/types/queryables.py
+++ b/eodag/types/queryables.py
@@ -146,6 +146,9 @@ class Queryables(CommonQueryables):
     maximumIncidenceAngle: Annotated[float, Field(None)]
     dopplerFrequency: Annotated[float, Field(None)]
     incidenceAngleVariation: Annotated[float, Field(None)]
+    # Custom parameters (not defined in the base document referenced above)
+    id: Annotated[str, Field(None)]
+    tileIdentifier: Annotated[str, Field(None, pattern=r"[0-9]{2}[A-Z]{3}")]
 
 
 class QueryablesDict(UserDict[str, Any]):

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -1362,12 +1362,13 @@ class RequestTestCase(unittest.TestCase):
             wekeo_main_constraints = {"constraints": constraints}
 
             planetary_computer_queryables_url = (
-                "https://planetarycomputer.microsoft.com/api/stac/v1/search/../collections/"
+                "https://planetarycomputer.microsoft.com/api/stac/v1/collections/"
                 "sentinel-1-grd/queryables"
             )
-            norm_planetary_computer_queryables_url = os.path.normpath(
-                planetary_computer_queryables_url
-            ).replace("https:/", "https://")
+            dedl_queryables_url = (
+                "https://hda.data.destination-earth.eu/stac/collections/"
+                "EO.ESA.DAT.SENTINEL-1.L1_GRD/queryables"
+            )
             wekeo_main_constraints_url = (
                 "https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/queryable/"
                 "EO:ESA:DAT:SENTINEL-1"
@@ -1385,6 +1386,12 @@ class RequestTestCase(unittest.TestCase):
                 status=200,
                 json=wekeo_main_constraints,
             )
+            responses.add(
+                responses.GET,
+                dedl_queryables_url,
+                status=200,
+                json=provider_queryables,
+            )
 
             # no provider is specified with the product type (3 providers get a queryables or constraints file
             # among available providers for S1_SAR_GRD for the moment): queryables intersection returned
@@ -1396,7 +1403,7 @@ class RequestTestCase(unittest.TestCase):
 
             # check the mock call on planetary_computer
             self.assertEqual(
-                norm_planetary_computer_queryables_url, responses.calls[0].request.url
+                planetary_computer_queryables_url, responses.calls[0].request.url
             )
             self.assertIn(
                 ("timeout", DEFAULT_SEARCH_TIMEOUT),

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -48,6 +48,7 @@ from tests.context import (
     ONLINE_STATUS,
     TEST_RESOURCES_PATH,
     AuthenticationError,
+    PluginImplementationError,
     SearchResult,
 )
 
@@ -566,6 +567,7 @@ class RequestTestCase(unittest.TestCase):
             response_content = json.loads(response.content.decode("utf-8"))
 
             self.assertIn("description", response_content)
+            self.assertIn("Internal server error", response_content["description"])
             self.assertIn("AuthenticationError", str(cm_logs.output))
             self.assertIn("you are not authorized", str(cm_logs.output))
 
@@ -577,7 +579,7 @@ class RequestTestCase(unittest.TestCase):
         side_effect=TimeOutError("too long"),
     )
     def test_timeout_error(self, mock_search: Mock):
-        """A request to eodag server raising a Authentication error must return a 500 HTTP error code"""
+        """A request to eodag server raising a timeout error must return a 504 HTTP error code"""
         with self.assertLogs(level="ERROR") as cm_logs:
             response = self.app.get(
                 f"search?collections={self.tested_product_type}", follow_redirects=True
@@ -585,10 +587,32 @@ class RequestTestCase(unittest.TestCase):
             response_content = json.loads(response.content.decode("utf-8"))
 
             self.assertIn("description", response_content)
+            self.assertIn("TimeOutError", response_content["description"])
+            self.assertIn("too long", response_content["description"])
             self.assertIn("TimeOutError", str(cm_logs.output))
             self.assertIn("too long", str(cm_logs.output))
 
         self.assertEqual(504, response.status_code)
+
+    @mock.patch(
+        "eodag.rest.core.eodag_api.search",
+        autospec=True,
+        side_effect=PluginImplementationError("some error"),
+    )
+    def test_plugin_implementation_error(self, mock_search: Mock):
+        """A request to eodag server raising a plugin implementation error must return a 500 HTTP error code"""
+        with self.assertLogs(level="ERROR") as cm_logs:
+            response = self.app.get(
+                f"search?collections={self.tested_product_type}", follow_redirects=True
+            )
+            response_content = json.loads(response.content.decode("utf-8"))
+
+            self.assertIn("description", response_content)
+            self.assertIn("Internal server error", response_content["description"])
+            self.assertIn("PluginImplementationError", str(cm_logs.output))
+            self.assertIn("some error", str(cm_logs.output))
+
+        self.assertEqual(500, response.status_code)
 
     def test_filter(self):
         """latestIntersect filter should only keep the latest products once search area is fully covered"""


### PR DESCRIPTION
- Fixes empty queryables returned instead of guessing from metadata mapping
- Adds default queryables for `id` and `tileIdentifier`  