### PR TITLE
refactor(core): Use importlib.metadata instead of the deprecated pkg_resources

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     botocore
     click
     geojson
+    importlib_metadata >= 5.0
     jsonpath-ng
     lxml
     orjson
@@ -55,7 +56,6 @@ install_requires =
     python-dateutil
     PyYAML
     requests
-    setuptools
     shapely >= 2.0.6
     stream-zip
     tqdm

--- a/tests/resources/fake_ext_plugin/eodag_fakeplugin.egg-info_/PKG-INFO
+++ b/tests/resources/fake_ext_plugin/eodag_fakeplugin.egg-info_/PKG-INFO
@@ -1,0 +1,3 @@
+Metadata-Version: 2.4
+Name: eodag_fakeplugin
+Version: 1.0

--- a/tests/resources/fake_ext_plugin/eodag_fakeplugin.egg-info_/SOURCES.txt
+++ b/tests/resources/fake_ext_plugin/eodag_fakeplugin.egg-info_/SOURCES.txt
@@ -1,0 +1,7 @@
+pyproject.toml
+eodag_fakeplugin/__init__.py
+eodag_fakeplugin.egg-info/PKG-INFO
+eodag_fakeplugin.egg-info/SOURCES.txt
+eodag_fakeplugin.egg-info/dependency_links.txt
+eodag_fakeplugin.egg-info/entry_points.txt
+eodag_fakeplugin.egg-info/top_level.txt

--- a/tests/resources/fake_ext_plugin/eodag_fakeplugin.egg-info_/entry_points.txt
+++ b/tests/resources/fake_ext_plugin/eodag_fakeplugin.egg-info_/entry_points.txt
@@ -1,0 +1,2 @@
+[eodag.plugins.api]
+FakePluginAPI = eodag_fakeplugin:FakePluginAPI

--- a/tests/resources/fake_ext_plugin/eodag_fakeplugin.egg-info_/top_level.txt
+++ b/tests/resources/fake_ext_plugin/eodag_fakeplugin.egg-info_/top_level.txt
@@ -1,0 +1,1 @@
+eodag_fakeplugin

--- a/tests/resources/fake_ext_plugin/pyproject.toml
+++ b/tests/resources/fake_ext_plugin/pyproject.toml
@@ -11,3 +11,6 @@ FakePluginAPI = "eodag_fakeplugin:FakePluginAPI"
 
 [tool.setuptools]
 packages = ["eodag_fakeplugin"]
+
+[tool.setuptools.package-data]
+eodag_fakeplugin = ["providers.yml"]

--- a/tests/resources/fake_ext_plugin/pyproject.toml
+++ b/tests/resources/fake_ext_plugin/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "eodag_fakeplugin"
+version = "1.0"
+
+[project.entry-points."eodag.plugins.api"]
+FakePluginAPI = "eodag_fakeplugin:FakePluginAPI"
+
+[tool.setuptools]
+packages = ["eodag_fakeplugin"]

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -31,7 +31,6 @@ from tempfile import TemporaryDirectory
 
 import yaml
 from lxml import html
-from pkg_resources import DistributionNotFound
 from pydantic import ValidationError
 from shapely import wkt
 from shapely.geometry import LineString, MultiPolygon, Polygon
@@ -1253,18 +1252,18 @@ class TestCore(TestCoreBase):
             os.environ.pop("EODAG__PEPS__SEARCH__NEED_AUTH", None)
             os.environ.pop("EODAG__PEPS__AUTH__CREDENTIALS__USERNAME", None)
 
-    @mock.patch("eodag.plugins.manager.pkg_resources.iter_entry_points", autospec=True)
+    @mock.patch("eodag.plugins.manager.importlib_metadata.entry_points", autospec=True)
     def test_prune_providers_list_skipped_plugin(self, mock_iter_ep):
         """Providers needing skipped plugin must be pruned on init"""
         empty_conf_file = str(
             res_files("eodag") / "resources" / "user_conf_template.yml"
         )
 
-        def skip_qssearch(topic):
+        def skip_qssearch(group):
             ep = mock.MagicMock()
-            if topic == "eodag.plugins.search":
+            if group == "eodag.plugins.search":
                 ep.name = "QueryStringSearch"
-                ep.load = mock.MagicMock(side_effect=DistributionNotFound())
+                ep.load = mock.MagicMock(side_effect=ModuleNotFoundError())
             return [ep]
 
         mock_iter_ep.side_effect = skip_qssearch


### PR DESCRIPTION
### Description
This PR replaces the use deprecated `pkg_resources` with `importilib.metadata`.
It fixes #1623 and resolve almost completely the issues reported in #1624.
Closes: #1623 

### Further comments
The solution uses the compatibility module `importlib_metadata` to support Python v3.9.
When you will decide to drop support for Python v3.9, that you should also be able to use the `importlib.metadata` directly from the standard library and remove the dependency from the external `importlib_metadata` package.

Thank you!
