### PR TITLE
fix(providers): creodias and cop_dataspace products title mapping

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -974,7 +974,7 @@
         - null
         - '$.Attributes.processingLevel'
       # INSPIRE obligated OpenSearch Parameters for Collection Search (Table 4)
-      title: '$.Name'
+      title: '{$.Name#remove_extension}'
       resolution:
         - null
         - '$.Attributes.spatialResolution'
@@ -2604,7 +2604,7 @@
         - null
         - '$.Attributes.processingLevel'
       # INSPIRE obligated OpenSearch Parameters for Collection Search (Table 4)
-      title: '$.Name'
+      title: '{$.Name#remove_extension}'
       resolution:
         - null
         - '$.Attributes.spatialResolution'
@@ -4173,7 +4173,7 @@
         - null
         - '$.Attributes.processingLevel'
       # INSPIRE obligated OpenSearch Parameters for Collection Search (Table 4)
-      title: '$.Name'
+      title: '{$.Name#remove_extension}'
       resolution:
         - null
         - '$.Attributes.spatialResolution'


### PR DESCRIPTION
Fixes #1632 

Removes extension from `creodias` and `cop_dataspace` products `title` mapping, which caused already downloaded products not to be detected when the same download occurs again