### PR TITLE
fix(logging): logs handling through tqdm

### DIFF
--- a/eodag/utils/logging.py
+++ b/eodag/utils/logging.py
@@ -18,9 +18,29 @@
 from __future__ import annotations
 
 import logging.config
-from typing import Optional
+from typing import Any, Optional
 
 disable_tqdm = False
+
+
+class TqdmLoggingHandler(logging.StreamHandler):
+    """Logging handler writing through :func:`tqdm.write` to avoid breaking progress bars"""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Emit a record using ``tqdm.write()`` if progress bars are enabled
+
+        :param record: The log record to emit
+        """
+        if disable_tqdm:
+            super().emit(record)
+            return
+        try:
+            from tqdm.auto import tqdm
+
+            tqdm.write(self.format(record), file=self.stream, end=self.terminator)
+            self.flush()
+        except Exception:
+            self.handleError(record)
 
 
 def setup_logging(verbose: int, no_progress_bar: bool = False) -> None:
@@ -45,10 +65,10 @@ def setup_logging(verbose: int, no_progress_bar: bool = False) -> None:
 
     level = "DEBUG" if verbose == 3 else "INFO"
 
-    handlers = {
+    handlers: dict[str, dict[str, Any]] = {
         "console": {
             "level": level,
-            "class": "logging.StreamHandler",
+            "class": "eodag.utils.logging.TqdmLoggingHandler",
             "formatter": "standard",
         },
         "null": {"level": level, "class": "logging.NullHandler"},

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -34,6 +34,7 @@ from requests.exceptions import RequestException
 from shapely.geometry import Point, Polygon
 
 from eodag.utils import get_geometry_from_ecmwf_area, get_geometry_from_ecmwf_feature
+from eodag.utils.logging import TqdmLoggingHandler
 from tests.context import (
     HTTP_REQ_TIMEOUT,
     USER_AGENT,
@@ -202,6 +203,56 @@ class TestUtils(unittest.TestCase):
             with ProgressCallback(total=2, file=tqdm_out, disable=True) as bar:
                 bar(1)
             self.assertEqual(tqdm_out.getvalue(), "")
+
+    @mock.patch("tqdm.auto.tqdm.write")
+    def test_tqdm_logging_handler_uses_tqdm_write(self, tqdm_write):
+        """Test logging through tqdm preserves the progress bar output."""
+        handler = TqdmLoggingHandler(stream=StringIO())
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        record = logging.LogRecord(
+            name="eodag",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="log message",
+            args=(),
+            exc_info=None,
+        )
+
+        handler.emit(record)
+
+        tqdm_write.assert_called_once_with(
+            "log message", file=handler.stream, end=handler.terminator
+        )
+
+    @mock.patch("tqdm.auto.tqdm.write")
+    def test_tqdm_logging_handler_falls_back_to_stream(self, tqdm_write):
+        """Test disabled progress bars use the regular stream handler."""
+        setup_logging(verbose=2, no_progress_bar=True)
+        output = StringIO()
+        handler = TqdmLoggingHandler(stream=output)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        record = logging.LogRecord(
+            name="eodag",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="log message",
+            args=(),
+            exc_info=None,
+        )
+
+        handler.emit(record)
+
+        self.assertEqual(output.getvalue(), "log message\n")
+        tqdm_write.assert_not_called()
+
+    def test_setup_logging_installs_tqdm_handler(self):
+        """Test console logging uses the handler that cooperates with tqdm."""
+        setup_logging(verbose=2)
+
+        logger = logging.getLogger("eodag")
+        self.assertIsInstance(logger.handlers[0], TqdmLoggingHandler)
 
     def test_merge_mappings(self):
         """Test merge_mappings merges configuration mappings correctly."""


### PR DESCRIPTION
Fixes logging formatting issue that occurred during downloads:
```py
>>> prods[0].download()
                                                                                 2025-04-28 10:25:19,545 eodag.download.base              [INFO    ] Download url: https://catalogue.dataspace.copernicus.eu/odata/v1/Products(0030d7fd-0e02-42d8-a1a4-41d85631f5fc)/$value510_R130_T50CMT_20240101T010416: 0.00B [00:00, ?B/s]
```
This happened because `tqdm` writes progress bar to stdout.
Current fix uses a custom logging handler derived from [tqdm.contrib.logging._TqdmLoggingHandler](https://github.com/tqdm/tqdm/blob/v4.70.0/tqdm/contrib/logging.py#L16) and uses [tqdm.write](https://tqdm.github.io/docs/tqdm/#write)