### PR TITLE
fix(plugins): StaticStacSearch text opener

### DIFF
--- a/docs/notebooks/tutos/tuto_stac_client.ipynb
+++ b/docs/notebooks/tutos/tuto_stac_client.ipynb
@@ -22981,7 +22981,7 @@
    "id": "seasonal-internet",
    "metadata": {},
    "source": [
-    "EODAG can search for items over a STAC static catalog using [StaticStacSearch](https://eodag.readthedocs.io/en/latest/plugins_reference/generated/eodag.plugins.search.static_stac_search.StaticStacSearch.html) plugin. Path to the catalog must be set as `search.api_endpoint` and the download plugin can also be set ([HTTPDownload](https://eodag.readthedocs.io/en/latest/plugins_reference/generated/eodag.plugins.download.http.HTTPDownload.html) by default) depending on the provider.\n",
+    "EODAG can search for items over a STAC static catalog using [StaticStacSearch](https://eodag.readthedocs.io/en/latest/plugins_reference/generated/eodag.plugins.search.static_stac_search.StaticStacSearch.html) plugin. Path to the catalog (or item) must be set as `search.api_endpoint` and the download plugin can also be set ([HTTPDownload](https://eodag.readthedocs.io/en/latest/plugins_reference/generated/eodag.plugins.download.http.HTTPDownload.html) by default) depending on the provider.\n",
     "\n",
     "Here is an example with a catalog from https://stacindex.org/catalogs/spot-orthoimages-canada-2005, which will use \n",
     " `HTTPDownload` as download plugin, without credentials as no authentication is needed for download.\n",

--- a/eodag/plugins/search/static_stac_search.py
+++ b/eodag/plugins/search/static_stac_search.py
@@ -46,7 +46,7 @@ logger = logging.getLogger("eodag.search.static_stac_search")
 class StaticStacSearch(StacSearch):
     """Static STAC Catalog search plugin
 
-    This plugin first loads all STAC items found in the catalog, and converts them to
+    This plugin first loads all STAC items found in the catalog (or item), and converts them to
     EOProducts using :class:`~eodag.plugins.search.qssearch.StacSearch`.
     Then it uses crunchers to only keep products matching query parameters.
 
@@ -56,7 +56,7 @@ class StaticStacSearch(StacSearch):
     :param provider: provider name
     :param config: Search plugin configuration:
 
-        * :attr:`~eodag.config.PluginConfig.api_endpoint` (``str``) (**mandatory**): path to the catalog;
+        * :attr:`~eodag.config.PluginConfig.api_endpoint` (``str``) (**mandatory**): path to the catalog or item;
           in contrast to the api_endpoint for other plugin types this can be a url or local system path.
         * :attr:`~eodag.config.PluginConfig.max_connections` (``int``): Maximum number of concurrent
           connections for HTTP requests; default: ``100``

--- a/eodag/utils/stac_reader.py
+++ b/eodag/utils/stac_reader.py
@@ -122,12 +122,13 @@ def fetch_stac_items(
     # URI opener used by PySTAC internally, instantiated here
     # to retrieve the timeout.
     _text_opener = _TextOpener(timeout, ssl_verify)
-    pystac.StacIO.read_text = _text_opener  # type: ignore[assignment]
+    stac_io = pystac.StacIO.default()
+    stac_io.read_text = _text_opener  # type: ignore[assignment]
 
-    stac_obj = pystac.read_file(stac_path)
+    stac_obj = pystac.read_file(stac_path, stac_io=stac_io)
     # Single STAC item
     if isinstance(stac_obj, pystac.Item):
-        return [stac_obj.to_dict()]
+        return [stac_obj.to_dict(transform_hrefs=False)]
     # STAC catalog
     elif isinstance(stac_obj, pystac.Catalog):
         return _fetch_stac_items_from_catalog(
@@ -152,7 +153,9 @@ def _fetch_stac_items_from_catalog(
     if extensions:
         extensions = extensions if isinstance(extensions, list) else [extensions]
         if "single-file-stac" in extensions:
-            items = [feature for feature in cat.to_dict()["features"]]
+            items = [
+                feature for feature in cat.to_dict(transform_hrefs=False)["features"]
+            ]
             return items
 
     # Making the links absolutes allow for both relative and absolute links to be handled.
@@ -201,9 +204,10 @@ def fetch_stac_collections(
 
     # URI opener used by PySTAC internally, instantiated here to retrieve the timeout.
     _text_opener = _TextOpener(timeout, ssl_verify)
-    pystac.StacIO.read_text = _text_opener  # type: ignore[assignment]
+    stac_io = pystac.StacIO.default()
+    stac_io.read_text = _text_opener  # type: ignore[assignment]
 
-    stac_obj = pystac.read_file(stac_path)
+    stac_obj = pystac.read_file(stac_path, stac_io=stac_io)
     if isinstance(stac_obj, pystac.Catalog):
         return _fetch_stac_collections_from_catalog(
             stac_obj, collection, max_connections, _text_opener


### PR DESCRIPTION
Restores custom text opener passed to `pystac` from `StaticStacSearch` that was not used any more.

Also updates documentation to mention that a STAC item can directly be a possible source for `StaticStacSearch` plugin.