### PR TITLE
fix(plugins): adapt queryables additional_properties to providers config

### DIFF
--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -370,8 +370,8 @@ class Search(PluginTopic):
             else ""
         )
         discover_metadata = getattr(self.config, "discover_metadata", {})
-
         auto_discovery = discover_metadata.get("auto_discovery", False)
+
         if product_type or getattr(self.config, "discover_queryables", {}).get(
             "fetch_url", ""
         ):
@@ -393,10 +393,8 @@ class Search(PluginTopic):
                 v.__metadata__[0].default = getattr(
                     Queryables.model_fields.get(k, Field(None)), "default", None
                 )
-            pt_queryables.additional_properties = auto_discovery
-
             return QueryablesDict(
-                additional_properties=pt_queryables.additional_properties,
+                additional_properties=auto_discovery,
                 additional_information=additional_info,
                 **all_queryables,
             )

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -389,8 +389,13 @@ class Search(PluginTopic):
                 v.__metadata__[0].default = getattr(
                     Queryables.model_fields.get(k, Field(None)), "default", None
                 )
+            discover_metadata = getattr(self.config, "discover_metadata", {})
+            auto_discovery = discover_metadata.get("auto_discovery", False)
+            if not auto_discovery:
+                pt_queryables.additional_properties = False
+
             return QueryablesDict(
-                additional_properties=True,
+                additional_properties=pt_queryables.additional_properties,
                 additional_information=additional_info,
                 **all_queryables,
             )

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -390,9 +390,9 @@ class Search(PluginTopic):
                     Queryables.model_fields.get(k, Field(None)), "default", None
                 )
             discover_metadata = getattr(self.config, "discover_metadata", {})
-            auto_discovery = discover_metadata.get("auto_discovery", False)
-            if not auto_discovery:
-                pt_queryables.additional_properties = False
+            pt_queryables.additional_properties = discover_metadata.get(
+                "auto_discovery", False
+            )
 
             return QueryablesDict(
                 additional_properties=pt_queryables.additional_properties,

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -369,6 +369,9 @@ class Search(PluginTopic):
             if not product_type
             else ""
         )
+        discover_metadata = getattr(self.config, "discover_metadata", {})
+
+        auto_discovery = discover_metadata.get("auto_discovery", False)
         if product_type or getattr(self.config, "discover_queryables", {}).get(
             "fetch_url", ""
         ):
@@ -376,6 +379,7 @@ class Search(PluginTopic):
                 self.config.product_type_config = product_type_configs[product_type]
             queryables = self._get_product_type_queryables(product_type, alias, filters)
             queryables.additional_information = additional_info
+            queryables.additional_properties = auto_discovery
 
             return queryables
         else:
@@ -389,10 +393,7 @@ class Search(PluginTopic):
                 v.__metadata__[0].default = getattr(
                     Queryables.model_fields.get(k, Field(None)), "default", None
                 )
-            discover_metadata = getattr(self.config, "discover_metadata", {})
-            pt_queryables.additional_properties = discover_metadata.get(
-                "auto_discovery", False
-            )
+            pt_queryables.additional_properties = auto_discovery
 
             return QueryablesDict(
                 additional_properties=pt_queryables.additional_properties,

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -470,7 +470,7 @@ class ECMWFSearch(PostJsonSearch):
         self.config.__dict__.setdefault(
             "discover_metadata",
             {
-                "auto_discovery": True,
+                "auto_discovery": False,
                 "search_param": "{metadata}",
                 "metadata_pattern": "^[a-zA-Z0-9][a-zA-Z0-9_]*$",
             },

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1521,6 +1521,30 @@ class TestCore(TestCoreBase):
         "eodag.plugins.search.build_search_result.ECMWFSearch.discover_queryables",
         autospec=True,
     )
+    def test_additional_properties_in_list_queryables(
+        self, mock_discover_queryables: mock.Mock
+    ):
+
+        cop_marine_queryables = self.dag.list_queryables(provider="cop_marine")
+        self.assertFalse(cop_marine_queryables.additional_properties)
+
+        item_cop_marine_queryables = self.dag.list_queryables(
+            productType="MO_INSITU_GLO_PHY_TS_OA_NRT_013_002", provider="cop_marine"
+        )
+        self.assertFalse(item_cop_marine_queryables.additional_properties)
+
+        peps_queryables = self.dag.list_queryables(provider="peps")
+        self.assertTrue(peps_queryables.additional_properties)
+
+        item_peps_queryables = self.dag.list_queryables(
+            productType="S2_MSI_L1C", provider="peps"
+        )
+        self.assertTrue(item_peps_queryables.additional_properties)
+
+    @mock.patch(
+        "eodag.plugins.search.build_search_result.ECMWFSearch.discover_queryables",
+        autospec=True,
+    )
     def test_list_queryables_with_constraints(
         self, mock_discover_queryables: mock.Mock
     ):

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1524,7 +1524,9 @@ class TestCore(TestCoreBase):
     def test_additional_properties_in_list_queryables(
         self, mock_discover_queryables: mock.Mock
     ):
-
+        """additional_properties in queryables must be adapted to provider's configuration"""
+        # discover_metadata.auto_discovery == False
+        self.assertFalse(self.dag.providers_config["cop_marine"].search.discover_metadata["auto_discovery"])
         cop_marine_queryables = self.dag.list_queryables(provider="cop_marine")
         self.assertFalse(cop_marine_queryables.additional_properties)
 
@@ -1533,6 +1535,8 @@ class TestCore(TestCoreBase):
         )
         self.assertFalse(item_cop_marine_queryables.additional_properties)
 
+        # discover_metadata.auto_discovery == True
+        self.assertTrue(self.dag.providers_config["peps"].search.discover_metadata["auto_discovery"])
         peps_queryables = self.dag.list_queryables(provider="peps")
         self.assertTrue(peps_queryables.additional_properties)
 
@@ -1540,6 +1544,10 @@ class TestCore(TestCoreBase):
             productType="S2_MSI_L1C", provider="peps"
         )
         self.assertTrue(item_peps_queryables.additional_properties)
+
+        # additional_properties set to False for EcmwfSearch plugin
+        cop_cds_queryables = self.dag.list_queryables(provider="cop_cds")
+        self.assertFalse(cop_cds_queryables.additional_properties)
 
     @mock.patch(
         "eodag.plugins.search.build_search_result.ECMWFSearch.discover_queryables",

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1525,8 +1525,12 @@ class TestCore(TestCoreBase):
         self, mock_discover_queryables: mock.Mock
     ):
         """additional_properties in queryables must be adapted to provider's configuration"""
-        # discover_metadata.auto_discovery == False
-        self.assertFalse(self.dag.providers_config["cop_marine"].search.discover_metadata["auto_discovery"])
+        # Check if discover_metadata.auto_discovery is False
+        self.assertFalse(
+            self.dag.providers_config["cop_marine"].search.discover_metadata[
+                "auto_discovery"
+            ]
+        )
         cop_marine_queryables = self.dag.list_queryables(provider="cop_marine")
         self.assertFalse(cop_marine_queryables.additional_properties)
 
@@ -1535,8 +1539,10 @@ class TestCore(TestCoreBase):
         )
         self.assertFalse(item_cop_marine_queryables.additional_properties)
 
-        # discover_metadata.auto_discovery == True
-        self.assertTrue(self.dag.providers_config["peps"].search.discover_metadata["auto_discovery"])
+        # Check if discover_metadata.auto_discovery is True
+        self.assertTrue(
+            self.dag.providers_config["peps"].search.discover_metadata["auto_discovery"]
+        )
         peps_queryables = self.dag.list_queryables(provider="peps")
         self.assertTrue(peps_queryables.additional_properties)
 


### PR DESCRIPTION
No longer force `additional_properties` to `True`.  Use `discover_metadata.auto_discovery` value from `providers.yml` instead. 

ref https://github.com/CS-SI/eodag/issues/1642