### PR TITLE
fix(plugins): add alias to properties in cop_marine and EcmwfSearch plugins

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -1176,6 +1176,7 @@ class ECMWFSearch(PostJsonSearch):
                 + "_ORDERABLE_"
                 + query_hash
             )
+            # use product_type_config as default properties
             product_type_config = getattr(self.config, "product_type_config", {})
             properties = dict(product_type_config, **properties)
 
@@ -1441,6 +1442,7 @@ class MeteoblueSearch(ECMWFSearch):
             productType=product_type,
             properties=properties,
         )
+        # use product_type_config as default properties
         product_type_config = getattr(self.config, "product_type_config", {})
         product.properties = dict(product_type_config, **product.properties)
 

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -1176,6 +1176,9 @@ class ECMWFSearch(PostJsonSearch):
                 + "_ORDERABLE_"
                 + query_hash
             )
+            product_type_config = getattr(self.config, "product_type_config", {})
+            if "alias" in product_type_config:
+                properties["alias"] = product_type_config["alias"]
 
         qs = geojson.dumps(sorted_unpaginated_qp)
 

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -1177,8 +1177,7 @@ class ECMWFSearch(PostJsonSearch):
                 + query_hash
             )
             product_type_config = getattr(self.config, "product_type_config", {})
-            if "alias" in product_type_config:
-                properties["alias"] = product_type_config["alias"]
+            properties = dict(product_type_config, **properties)
 
         qs = geojson.dumps(sorted_unpaginated_qp)
 
@@ -1442,6 +1441,8 @@ class MeteoblueSearch(ECMWFSearch):
             productType=product_type,
             properties=properties,
         )
+        product_type_config = getattr(self.config, "product_type_config", {})
+        product.properties = dict(product_type_config, **product.properties)
 
         return [
             product,

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -285,6 +285,9 @@ class CopMarineSearch(StaticStacSearch):
             }
         }
         product = EOProduct(self.provider, properties, productType=product_type)
+        product_type_config = getattr(self.config, "product_type_config", {})
+        if "alias" in product_type_config:
+            product.properties["alias"] = product_type_config["alias"]
         product.assets = AssetsDict(product, assets)
         return product
 

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -286,8 +286,7 @@ class CopMarineSearch(StaticStacSearch):
         }
         product = EOProduct(self.provider, properties, productType=product_type)
         product_type_config = getattr(self.config, "product_type_config", {})
-        if "alias" in product_type_config:
-            product.properties["alias"] = product_type_config["alias"]
+        product.properties = dict(product_type_config, **product.properties)
         product.assets = AssetsDict(product, assets)
         return product
 

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -285,6 +285,7 @@ class CopMarineSearch(StaticStacSearch):
             }
         }
         product = EOProduct(self.provider, properties, productType=product_type)
+        # use product_type_config as default properties
         product_type_config = getattr(self.config, "product_type_config", {})
         product.properties = dict(product_type_config, **product.properties)
         product.assets = AssetsDict(product, assets)

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -1825,6 +1825,8 @@ class TestSearchPluginMeteoblueSearch(BaseSearchPluginTest):
 
         # custom query for meteoblue
         custom_query = {"queries": {"foo": "bar"}}
+        product_type_config = {"platform": "NEMSGLOBAL", "alias": "THE.ALIAS"}
+        setattr(self.search_plugin.config, "product_type_config", product_type_config)
         products, estimate = self.search_plugin.query(
             prep=PreparedSearch(auth_plugin=self.auth_plugin, auth=self.auth),
             **custom_query,
@@ -1864,6 +1866,8 @@ class TestSearchPluginMeteoblueSearch(BaseSearchPluginTest):
                 }
             ),
         )
+        self.assertEqual(products[0].properties["platform"], "NEMSGLOBAL")
+        self.assertEqual(products[0].properties["alias"], "THE.ALIAS")
 
 
 class MockResponse:
@@ -2343,9 +2347,10 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
             "productType": self.product_type,
             "missionStartDate": "1985-10-26",
             "missionEndDate": "2015-10-21",
+            "alias": "THE.ALIAS",
         }
         results, _ = self.search_plugin.query(
-            productType=self.product_type,
+            productType="THE.ALIAS",
         )
         eoproduct = results[0]
         self.assertEqual(
@@ -2356,6 +2361,7 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
             eoproduct.properties["completionTimeFromAscendingNode"],
             "1985-10-26T00:00:00.000Z",
         )
+        self.assertEqual("THE.ALIAS", eoproduct.properties["alias"])
 
     def test_plugins_search_ecmwfsearch_without_producttype(self):
         """
@@ -3000,6 +3006,8 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
         ]
 
         search_plugin = self.get_search_plugin("PRODUCT_A", self.provider)
+        product_type_config = {"platform": "P1"}
+        setattr(search_plugin.config, "product_type_config", product_type_config)
 
         with mock.patch("eodag.plugins.search.cop_marine._get_s3_client") as s3_stub:
             s3_stub.return_value = self.s3
@@ -3057,6 +3065,7 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
                 "2020-01-03T00:00:00Z",
                 products_dataset2[0].properties["completionTimeFromAscendingNode"],
             )
+            self.assertEqual("P1", products_dataset2[0].properties["platform"])
 
     @mock.patch("eodag.plugins.search.cop_marine.requests.get")
     def test_plugins_search_cop_marine_query_no_dates_in_id(self, mock_requests_get):


### PR DESCRIPTION
adds the product type alias to the product properties in the `ECMWFSearch` and `CopMarineSearch` plugin; This is required to use the alias for the download metrics of `opentelemetry-instrumentation-eodag`.
