### PR TITLE
docs: fix binder tutos links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ nbsphinx_prolog = """
    You can run this notebook in a live session with |Binder|.
 
 .. |Binder| image:: https://static.mybinder.org/badge.svg
-   :target: https://mybinder.org/v2/gh/CS-SI/eodag/master?urlpath=lab/tree/docs/api_user_guide/{{ docname }}
+   :target: https://mybinder.org/v2/gh/CS-SI/eodag/master?urlpath=lab/tree/docs/notebooks/tutos/{{ docname }}
 """
 
 # sphinx-copybutton configurations


### PR DESCRIPTION
Replaced the outdated binder tutos link in conf.py, going from "api_user_guide" to "notebooks/tutos". This should ensure that users can access the tutorials without any issues.
