### PR TITLE
fix(plugins): EcmwfSearch orderable products search

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -1222,6 +1222,9 @@ def _check_id(product: EOProduct) -> EOProduct:
     if not (product_id := product.search_kwargs.get("id")):
         return product
 
+    if "ORDERABLE" in product_id:
+        return product
+
     on_response_mm = getattr(product.downloader.config, "order_on_response", {}).get(
         "metadata_mapping", {}
     )

--- a/eodag/rest/core.py
+++ b/eodag/rest/core.py
@@ -247,8 +247,6 @@ def download_stac_item(
     :returns: a stream of the downloaded data (zip file)
     """
     product_type = collection_id
-    if "ORDERABLE" in item_id:
-        item_id = ""
 
     search_results = eodag_api.search(
         id=item_id, productType=product_type, provider=provider, **kwargs

--- a/eodag/rest/core.py
+++ b/eodag/rest/core.py
@@ -247,6 +247,8 @@ def download_stac_item(
     :returns: a stream of the downloaded data (zip file)
     """
     product_type = collection_id
+    if "ORDERABLE" in item_id:
+        item_id = None
 
     search_results = eodag_api.search(
         id=item_id, productType=product_type, provider=provider, **kwargs

--- a/eodag/rest/core.py
+++ b/eodag/rest/core.py
@@ -248,7 +248,7 @@ def download_stac_item(
     """
     product_type = collection_id
     if "ORDERABLE" in item_id:
-        item_id = None
+        item_id = ""
 
     search_results = eodag_api.search(
         id=item_id, productType=product_type, provider=provider, **kwargs

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -1194,13 +1194,13 @@ class RequestTestCase(unittest.TestCase):
         autospec=True,
     )
     @mock.patch("eodag.rest.core.eodag_api.search", autospec=True)
-    def test_download_item_not_available_yet(
+    def test_download_item_orderable(
         self,
         mock_search: Mock,
         mock_download: Mock,
         mock_auth: Mock,
     ):
-        """Download through eodag server catalog when ORDERABLE is in url"""
+        """Request orderable item through eodag server catalog should call search with id=''"""
         tmp_dl_dir = TemporaryDirectory()
         expected_file = f"{tmp_dl_dir.name}.tar"
         Path(expected_file).touch()
@@ -1217,7 +1217,7 @@ class RequestTestCase(unittest.TestCase):
             headers={},
         )
         mock_search.assert_called_once_with(
-            id=None, productType="ERA5_PL", provider="cop_cds"
+            id="", productType="ERA5_PL", provider="cop_cds"
         )
 
     @mock.patch(

--- a/tests/units/test_http_server.py
+++ b/tests/units/test_http_server.py
@@ -1190,6 +1190,41 @@ class RequestTestCase(unittest.TestCase):
         autospec=True,
     )
     @mock.patch(
+        "eodag.rest.core.eodag_api.download",
+        autospec=True,
+    )
+    @mock.patch("eodag.rest.core.eodag_api.search", autospec=True)
+    def test_download_item_not_available_yet(
+        self,
+        mock_search: Mock,
+        mock_download: Mock,
+        mock_auth: Mock,
+    ):
+        """Download through eodag server catalog when ORDERABLE is in url"""
+        tmp_dl_dir = TemporaryDirectory()
+        expected_file = f"{tmp_dl_dir.name}.tar"
+        Path(expected_file).touch()
+        mock_download.return_value = expected_file
+
+        tested_product_type = "ERA5_PL"
+
+        mock_search.return_value = self.mock_search_result()
+        self.app.request(
+            "GET",
+            f"collections/{tested_product_type}/items/foo_ORDERABLE/download?provider=cop_cds",
+            json=None,
+            follow_redirects=True,
+            headers={},
+        )
+        mock_search.assert_called_once_with(
+            id=None, productType="ERA5_PL", provider="cop_cds"
+        )
+
+    @mock.patch(
+        "eodag.plugins.authentication.base.Authentication.authenticate",
+        autospec=True,
+    )
+    @mock.patch(
         "eodag.plugins.download.base.Download._stream_download_dict",
         autospec=True,
     )


### PR DESCRIPTION
When we try to download an orderable item that isn't ready yet, we get an error. This PR fixes that. If "ORDERABLE" is in the link, we no longer search for the item—we directly order it.