### PR TITLE
fix(core): remove quotes around arrays in query param

### DIFF
--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -49,6 +49,7 @@ from eodag.utils import (
     get_timestamp,
     items_recursive_apply,
     nested_pairs2dict,
+    remove_str_array_quotes,
     sanitize,
     string_to_jsonpath,
     update_nested_dict,
@@ -1284,23 +1285,6 @@ def mtd_cfg_as_conversion_and_querypath(
     return dest_dict
 
 
-def _remove_array_quotes(input_str: str) -> str:
-    """Remove quotes around arrays to avoid json parsing errors
-    >>> _remove_array_quotes('"a":"["a", "b"]"')
-    '"a":["a", "b"]'
-    >>> _remove_array_quotes('{"a":"["a", "b"]", "b": ["c", "d"]}')
-    '{"a":["a", "b"], "b": ["c", "d"]}'
-    """
-    output_str = ""
-    for i in range(0, len(input_str)):
-        if i < len(input_str) - 1 and input_str[i] == '"' and input_str[i + 1] == "[":
-            continue
-        if input_str[i] == '"' and input_str[i - 1] == "]":
-            continue
-        output_str += input_str[i]
-    return output_str
-
-
 def format_query_params(
     product_type: str, config: PluginConfig, query_dict: dict[str, Any]
 ) -> dict[str, Any]:
@@ -1335,7 +1319,9 @@ def format_query_params(
                     if "}[" in formatted_query_param:
                         formatted_query_param = _resolve_hashes(formatted_query_param)
                     # remove quotes around arrays
-                    formatted_query_param = _remove_array_quotes(formatted_query_param)
+                    formatted_query_param = remove_str_array_quotes(
+                        formatted_query_param
+                    )
                     # json query string (for POST request)
                     update_nested_dict(
                         query_params,

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -1284,6 +1284,23 @@ def mtd_cfg_as_conversion_and_querypath(
     return dest_dict
 
 
+def _remove_array_quotes(input_str: str) -> str:
+    """Remove quotes around arrays to avoid json parsing errors
+    >>> _remove_array_quotes('"a":"["a", "b"]"')
+    '"a":["a", "b"]'
+    >>> _remove_array_quotes('{"a":"["a", "b"]", "b": ["c", "d"]}')
+    '{"a":["a", "b"], "b": ["c", "d"]}'
+    """
+    output_str = ""
+    for i in range(0, len(input_str)):
+        if i < len(input_str) - 1 and input_str[i] == '"' and input_str[i + 1] == "[":
+            continue
+        if input_str[i] == '"' and input_str[i - 1] == "]":
+            continue
+        output_str += input_str[i]
+    return output_str
+
+
 def format_query_params(
     product_type: str, config: PluginConfig, query_dict: dict[str, Any]
 ) -> dict[str, Any]:
@@ -1317,6 +1334,8 @@ def format_query_params(
                     # retrieve values from hashes where keys are given in the param
                     if "}[" in formatted_query_param:
                         formatted_query_param = _resolve_hashes(formatted_query_param)
+                    # remove quotes around arrays
+                    formatted_query_param = _remove_array_quotes(formatted_query_param)
                     # json query string (for POST request)
                     update_nested_dict(
                         query_params,

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -1545,6 +1545,10 @@ def dict_md5sum(input_dict: dict[str, Any]) -> str:
 
 def remove_str_array_quotes(input_str: str) -> str:
     """Remove quotes around arrays to avoid json parsing errors
+
+    :param input_str: string to format
+    :returns: string without quotes surrounding array brackets
+
     >>> remove_str_array_quotes('"a":"["a", "b"]"')
     '"a":["a", "b"]'
     >>> remove_str_array_quotes('{"a":"["a", "b"]", "b": ["c", "d"]}')

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -1541,3 +1541,20 @@ def dict_md5sum(input_dict: dict[str, Any]) -> str:
     >>> assert(dict_md5sum({"a": 4, "b": {"b": 3, "c": 1, "a": 2}}) == hd)
     """
     return obj_md5sum(sort_dict(input_dict))
+
+
+def remove_str_array_quotes(input_str: str) -> str:
+    """Remove quotes around arrays to avoid json parsing errors
+    >>> remove_str_array_quotes('"a":"["a", "b"]"')
+    '"a":["a", "b"]'
+    >>> remove_str_array_quotes('{"a":"["a", "b"]", "b": ["c", "d"]}')
+    '{"a":["a", "b"], "b": ["c", "d"]}'
+    """
+    output_str = ""
+    for i in range(0, len(input_str)):
+        if i < len(input_str) - 1 and input_str[i] == '"' and input_str[i + 1] == "[":
+            continue
+        if input_str[i] == '"' and input_str[i - 1] == "]":
+            continue
+        output_str += input_str[i]
+    return output_str


### PR DESCRIPTION
If a search on a provider using `StacSearch` (e.g. `dedl`) was done using an array in the input for one or several of the query parameters (e.g. ` {"provider": "dedl", "productType": "SIS_HYDRO_MET_PROJ", "ecmwf:time_aggregation": ["annual_mean", "monthly_mean"]`), the search was failing due to a json parsing error. This has now been fixed by removing the quotes around arrays in the query string.