### PR TITLE
fix(plugins): openid_connect requests error handling (#1320)

### DIFF
--- a/eodag/plugins/authentication/openid_connect.py
+++ b/eodag/plugins/authentication/openid_connect.py
@@ -387,7 +387,6 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
                 timeout=HTTP_REQ_TIMEOUT,
                 verify=ssl_verify,
             )
-
         except requests.exceptions.Timeout as exc:
             raise TimeoutError(exc, "The authentication request timed out.") from exc
         except requests.RequestException as exc:
@@ -432,7 +431,6 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
             if not auth_uri:
                 raise MisconfiguredError("authentication_uri is missing")
         try:
-
             return self.session.post(
                 auth_uri,
                 data=login_data,
@@ -440,7 +438,6 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
                 timeout=HTTP_REQ_TIMEOUT,
                 verify=ssl_verify,
             )
-
         except requests.exceptions.Timeout as exc:
             raise TimeoutError(exc, "The authentication request timed out.") from exc
         except requests.RequestException as exc:

--- a/tests/units/test_auth_plugins.py
+++ b/tests/units/test_auth_plugins.py
@@ -1729,7 +1729,7 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         mock_request_new_token,
     ):
         """OIDCAuthorizationCodeFlowAuth.get_token_with_refresh_token must call `request_new_token()` if the POST
-        request raise an exception other than time out"""
+        request raises an exception other than time out"""
         auth_plugin = self.get_auth_plugin("provider_ok")
         auth_plugin.token_info = {"refresh_token": "old-refresh-token"}
         mock_requests_post.return_value = MockResponse({"err": "message"}, 500)


### PR DESCRIPTION
In this update, I introduced `try/except` blocks to some functions in the `openid_connect` file to enhance error handling and ensure the application handles exceptions better. 
I also added corresponding unit tests in the `test_auth_plugins` file to verify the new logic. 

Please note that the existing test: `test_all_requirements` is currently failing and will be addressed in a future update.