### PR TITLE
feat(plugins): auth token expiration margin

### DIFF
--- a/eodag/config.py
+++ b/eodag/config.py
@@ -628,12 +628,12 @@ class PluginConfig(yaml.YAMLObject):
     #: :class:`~eodag.plugins.authentication.token_exchange.OIDCTokenExchangeAuth`
     #: Identifies the issuer of the `subject_token`
     subject_issuer: str
-    #: :class:`~eodag.plugins.authentication.token_exchange.OIDCTokenExchangeAuth`
-    #: Audience that the token ID is intended for. :attr:`~eodag.config.PluginConfig.client_id` of the Relying Party
-    token_expiration_margin: int
     #: :class:`~eodag.plugins.authentication.openid_connect.OIDCAuthorizationCodeFlowAuth`
     #: :class:`~eodag.plugins.authentication.base.Authentication`
     #: Safety buffer to prevent token rejection from unexpected expiry between validity check and request.
+    token_expiration_margin: int
+    #: :class:`~eodag.plugins.authentication.token_exchange.OIDCTokenExchangeAuth`
+    #: Audience that the token ID is intended for. :attr:`~eodag.config.PluginConfig.client_id` of the Relying Party
     audience: str
     #: :class:`~eodag.plugins.authentication.generic.GenericAuth`
     #: which authentication method should be used

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -630,6 +630,10 @@ class PluginConfig(yaml.YAMLObject):
     subject_issuer: str
     #: :class:`~eodag.plugins.authentication.token_exchange.OIDCTokenExchangeAuth`
     #: Audience that the token ID is intended for. :attr:`~eodag.config.PluginConfig.client_id` of the Relying Party
+    token_expiration_margin: int
+    #: :class:`~eodag.plugins.authentication.openid_connect.OIDCAuthorizationCodeFlowAuth`
+    #: :class:`~eodag.plugins.authentication.base.Authentication`
+    #: Safety buffer to prevent token rejection from unexpected expiry between validity check and request.
     audience: str
     #: :class:`~eodag.plugins.authentication.generic.GenericAuth`
     #: which authentication method should be used

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -628,8 +628,8 @@ class PluginConfig(yaml.YAMLObject):
     #: :class:`~eodag.plugins.authentication.token_exchange.OIDCTokenExchangeAuth`
     #: Identifies the issuer of the `subject_token`
     subject_issuer: str
-    #: :class:`~eodag.plugins.authentication.openid_connect.OIDCAuthorizationCodeFlowAuth`
-    #: :class:`~eodag.plugins.authentication.base.Authentication`
+    #: :class:`~eodag.plugins.authentication.token.TokenAuth`
+    #: :class:`~eodag.plugins.authentication.openid_connect.OIDCRefreshTokenBase`
     #: Safety buffer to prevent token rejection from unexpected expiry between validity check and request.
     token_expiration_margin: int
     #: :class:`~eodag.plugins.authentication.token_exchange.OIDCTokenExchangeAuth`

--- a/eodag/plugins/authentication/keycloak.py
+++ b/eodag/plugins/authentication/keycloak.py
@@ -60,8 +60,10 @@ class KeycloakOIDCPasswordAuth(OIDCRefreshTokenBase):
           The allowed audiences that have to be present in the user token.
         * :attr:`~eodag.config.PluginConfig.auth_error_code` (``int``): which error code is
           returned in case of an authentication error
-        * :attr:`~eodag.config.PluginConfig.ssl_verify` (``bool``): if the ssl certificates
+        * :attr:`~eodag.config.PluginConfig.ssl_verify` (``bool``): If the SSL certificates
           should be verified in the token request; default: ``True``
+        * :attr:`~eodag.config.PluginConfig.token_expiration_margin` (``int``): The margin of time (in seconds)
+          before a token is considered expired. Default: 60 seconds
 
     Using :class:`~eodag.plugins.download.http.HTTPDownload` a download link
     ``http://example.com?foo=bar`` will become

--- a/eodag/plugins/authentication/openid_connect.py
+++ b/eodag/plugins/authentication/openid_connect.py
@@ -30,7 +30,14 @@ from lxml import etree
 from requests.auth import AuthBase
 
 from eodag.plugins.authentication import Authentication
-from eodag.utils import HTTP_REQ_TIMEOUT, USER_AGENT, parse_qs, repeatfunc, urlparse
+from eodag.utils import (
+    DEFAULT_TOKEN_EXPIRATION_MARGIN,
+    HTTP_REQ_TIMEOUT,
+    USER_AGENT,
+    parse_qs,
+    repeatfunc,
+    urlparse,
+)
 from eodag.utils.exceptions import (
     AuthenticationError,
     MisconfiguredError,
@@ -118,7 +125,9 @@ class OIDCRefreshTokenBase(Authentication):
     def _get_access_token(self) -> str:
         now = datetime.now(timezone.utc)
         expiration_margin = timedelta(
-            seconds=getattr(self.config, "token_expiration_margin", 60)
+            seconds=getattr(
+                self.config, "token_expiration_margin", DEFAULT_TOKEN_EXPIRATION_MARGIN
+            )
         )
 
         if self.access_token and self.access_token_expiration - now > expiration_margin:
@@ -275,6 +284,8 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
           Refers to the name of the query param to be used in the query request
         * :attr:`~eodag.config.PluginConfig.refresh_token_key` (``str``): The key pointing to
           the refresh_token in the json response to the POST request to the token server
+        * :attr:`~eodag.config.PluginConfig.token_expiration_margin` (``int``): The margin of time (in seconds)
+           before a token is considered expired. Default: 60 seconds.
 
     """
 

--- a/eodag/plugins/authentication/openid_connect.py
+++ b/eodag/plugins/authentication/openid_connect.py
@@ -117,8 +117,8 @@ class OIDCRefreshTokenBase(Authentication):
 
     def _get_access_token(self) -> str:
         now = datetime.now(timezone.utc)
-        expiration_margin = getattr(
-            self.config, "token_expiration_margin", timedelta(seconds=60)
+        expiration_margin = timedelta(
+            seconds=getattr(self.config, "token_expiration_margin", 60)
         )
 
         if self.access_token and self.access_token_expiration - now > expiration_margin:

--- a/eodag/plugins/authentication/openid_connect.py
+++ b/eodag/plugins/authentication/openid_connect.py
@@ -285,7 +285,7 @@ class OIDCAuthorizationCodeFlowAuth(OIDCRefreshTokenBase):
         * :attr:`~eodag.config.PluginConfig.refresh_token_key` (``str``): The key pointing to
           the refresh_token in the json response to the POST request to the token server
         * :attr:`~eodag.config.PluginConfig.token_expiration_margin` (``int``): The margin of time (in seconds)
-           before a token is considered expired. Default: 60 seconds.
+          before a token is considered expired. Default: 60 seconds.
 
     """
 

--- a/eodag/plugins/authentication/token.py
+++ b/eodag/plugins/authentication/token.py
@@ -152,9 +152,14 @@ class TokenAuth(Authentication):
 
         # Use a thread lock to avoid several threads requesting the token at the same time
         with self.auth_lock:
-
+            expiration_margin = getattr(
+                self.config, "token_expiration_margin", timedelta(seconds=60)
+            )
             self.validate_config_credentials()
-            if self.token and self.token_expiration > datetime.now():
+            if (
+                self.token
+                and self.token_expiration - datetime.now() > expiration_margin
+            ):
                 logger.debug("using existing access token")
                 return RequestsTokenAuth(
                     self.token, "header", headers=getattr(self.config, "headers", {})

--- a/eodag/plugins/authentication/token.py
+++ b/eodag/plugins/authentication/token.py
@@ -152,8 +152,8 @@ class TokenAuth(Authentication):
 
         # Use a thread lock to avoid several threads requesting the token at the same time
         with self.auth_lock:
-            expiration_margin = getattr(
-                self.config, "token_expiration_margin", timedelta(seconds=60)
+            expiration_margin = timedelta(
+                seconds=getattr(self.config, "token_expiration_margin", 60)
             )
             self.validate_config_credentials()
             if (

--- a/eodag/plugins/authentication/token.py
+++ b/eodag/plugins/authentication/token.py
@@ -31,6 +31,7 @@ from urllib3 import Retry
 
 from eodag.plugins.authentication.base import Authentication
 from eodag.utils import (
+    DEFAULT_TOKEN_EXPIRATION_MARGIN,
     HTTP_REQ_TIMEOUT,
     REQ_RETRY_BACKOFF_FACTOR,
     REQ_RETRY_STATUS_FORCELIST,
@@ -90,6 +91,8 @@ class TokenAuth(Authentication):
         * :attr:`~eodag.config.PluginConfig.retry_status_forcelist` (``list[int]``): :class:`urllib3.util.Retry`
           ``status_forcelist`` parameter, list of integer HTTP status codes that we should force a retry on; default:
           ``[401, 429, 500, 502, 503, 504]``
+        * :attr:`~eodag.config.PluginConfig.token_expiration_margin` (``int``): The margin of time (in seconds) before
+          a token is considered expired. Default: 60 seconds.
     """
 
     def __init__(self, provider: str, config: PluginConfig) -> None:
@@ -153,7 +156,11 @@ class TokenAuth(Authentication):
         # Use a thread lock to avoid several threads requesting the token at the same time
         with self.auth_lock:
             expiration_margin = timedelta(
-                seconds=getattr(self.config, "token_expiration_margin", 60)
+                seconds=getattr(
+                    self.config,
+                    "token_expiration_margin",
+                    DEFAULT_TOKEN_EXPIRATION_MARGIN,
+                )
             )
             self.validate_config_credentials()
             if (

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -140,6 +140,9 @@ DEFAULT_MAX_ITEMS_PER_PAGE = 50
 # default product-types start date
 DEFAULT_MISSION_START_DATE = "2015-01-01T00:00:00.000Z"
 
+# default token expiration margin in seconds
+DEFAULT_TOKEN_EXPIRATION_MARGIN = 60
+
 # update missing mimetypes
 mimetypes.add_type("text/xml", ".xsd")
 mimetypes.add_type("application/x-grib", ".grib")


### PR DESCRIPTION
A new configuration parameter, `token_expiration_margin` (default: 60 seconds), has been added to introduce a safety buffer that prevents authentication tokens from being rejected due to expiration occurring between the token's validity check and the actual request. 
This parameter was added to `config.py` and integrated into the `authentication` logic in both `eodag/plugins/authentication/token.py` and `eodag/plugins/authentication/openid_connect.py`, ensuring that token validity checks now consider this margin. 
Unit tests were also added to verify the correct behavior of this new logic. 

Fixes #1598