### PR TITLE
fix(core): Queryables mismatch when list of possible values contains a single value

### DIFF
--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -29,7 +29,6 @@ from typing import (
     Optional,
     Sequence,
     TypedDict,
-    Union,
     cast,
     get_args,
 )
@@ -51,12 +50,11 @@ import requests
 import yaml
 from jsonpath_ng import JSONPath
 from lxml import etree
-from pydantic import Field, create_model
+from pydantic import create_model
 from pydantic.fields import FieldInfo
 from requests import Response
 from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase
-from shapely.geometry.base import BaseGeometry
 from urllib3 import Retry
 
 from eodag.api.product import EOProduct
@@ -1928,17 +1926,9 @@ class StacSearch(PostJsonSearch):
             python_queryables = create_model("m", **field_definitions).model_fields
             geom_queryable = python_queryables.pop("geometry", None)
             if geom_queryable:
-                python_queryables["geom"] = geom_queryable
+                python_queryables["geom"] = Queryables.model_fields["geom"]
 
             queryables_dict = model_fields_to_annotated(python_queryables)
-            if "geom" in queryables_dict:
-                queryables_dict["geom"] = Annotated[
-                    Union[str, dict[str, float], BaseGeometry],
-                    Field(
-                        None,
-                        description="Read EODAG documentation for all supported geometry format.",
-                    ),
-                ]
             # append "datetime" as "start" & "end" if needed
             if "datetime" in json_queryables:
                 eodag_queryables = copy_deepcopy(

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -29,6 +29,7 @@ from typing import (
     Optional,
     Sequence,
     TypedDict,
+    Union,
     cast,
     get_args,
 )
@@ -50,11 +51,12 @@ import requests
 import yaml
 from jsonpath_ng import JSONPath
 from lxml import etree
-from pydantic import create_model
+from pydantic import Field, create_model
 from pydantic.fields import FieldInfo
 from requests import Response
 from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase
+from shapely.geometry.base import BaseGeometry
 from urllib3 import Retry
 
 from eodag.api.product import EOProduct
@@ -1929,7 +1931,14 @@ class StacSearch(PostJsonSearch):
                 python_queryables["geom"] = geom_queryable
 
             queryables_dict = model_fields_to_annotated(python_queryables)
-
+            if "geom" in queryables_dict:
+                queryables_dict["geom"] = Annotated[
+                    Union[str, dict[str, float], BaseGeometry],
+                    Field(
+                        None,
+                        description="Read EODAG documentation for all supported geometry format.",
+                    ),
+                ]
             # append "datetime" as "start" & "end" if needed
             if "datetime" in json_queryables:
                 eodag_queryables = copy_deepcopy(

--- a/eodag/types/__init__.py
+++ b/eodag/types/__init__.py
@@ -236,7 +236,7 @@ def json_field_definition_to_python(
         python_type = list[literal] if python_type in (list, set) else literal  # type: ignore
     elif anyOf:
         union_types = [resolve_type(sub) for sub in anyOf]
-        python_type = Union[tuple(union_types)]
+        python_type = Union[tuple(union_types)]  # type: ignore
 
     if "$ref" in json_field_definition:
         field_type_kwargs["json_schema_extra"] = {"$ref": json_field_definition["$ref"]}

--- a/eodag/types/__init__.py
+++ b/eodag/types/__init__.py
@@ -19,7 +19,6 @@
 
 from __future__ import annotations
 
-import datetime
 from typing import (
     Annotated,
     Any,
@@ -150,32 +149,6 @@ def python_type_to_json(
         return None
 
 
-def resolve_type(schema: dict):
-    """
-    Resolves a Python type based on a JSON Schema definition.
-
-    This function takes a dictionary representing a JSON Schema snippet and
-    maps its "type" and optional "format" to the corresponding Python type.
-    It's typically used to convert schema definitions for dynamic typing,
-    including in contexts such as processing `anyOf` unions.
-
-    Currently, only "string" types are supported, with optional "format"
-    handling for "date" and "date-time".
-
-    :param schema: A dictionary representing a JSON Schema snippet.
-    :return: The corresponding Python type, or None if the schema is not supported.
-    """
-    type = schema.get("type")
-    fmt = schema.get("format")
-
-    if type == "string":
-        if fmt == "date":
-            return datetime.date
-        elif fmt == "date-time":
-            return datetime.datetime
-        return str
-
-
 def json_field_definition_to_python(
     json_field_definition: dict[str, Any],
     default_value: Optional[Any] = None,
@@ -235,8 +208,7 @@ def json_field_definition_to_python(
         literal = Literal[const]
         python_type = list[literal] if python_type in (list, set) else literal  # type: ignore
     elif anyOf:
-        union_types = [resolve_type(sub) for sub in anyOf]
-        python_type = Union[tuple(union_types)]  # type: ignore
+        python_type = str
 
     if "$ref" in json_field_definition:
         field_type_kwargs["json_schema_extra"] = {"$ref": json_field_definition["$ref"]}

--- a/eodag/types/queryables.py
+++ b/eodag/types/queryables.py
@@ -18,14 +18,14 @@
 from __future__ import annotations
 
 from collections import UserDict
-from datetime import date, datetime
 from typing import Annotated, Any, Optional, Union
 
 from annotated_types import Lt
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic.fields import FieldInfo
 from pydantic.types import PositiveInt
 from pydantic_core import PydanticUndefined
+from shapely.geometry.base import BaseGeometry
 
 from eodag.types import annotated_dict_to_model, model_fields_to_annotated
 from eodag.utils.repr import remove_class_repr, shorter_type_repr
@@ -72,12 +72,28 @@ class Queryables(CommonQueryables):
     """
 
     start: Annotated[
-        Union[datetime, date], Field(None, alias="startTimeFromAscendingNode")
+        str,
+        Field(
+            None,
+            alias="startTimeFromAscendingNode",
+            description="Date/time as string in ISO 8601 format (e.g. '2024-06-10T12:00:00Z')",
+        ),
     ]
     end: Annotated[
-        Union[datetime, date], Field(None, alias="completionTimeFromAscendingNode")
+        str,
+        Field(
+            None,
+            alias="completionTimeFromAscendingNode",
+            description="Date/time as string in ISO 8601 format (e.g. '2024-06-10T12:00:00Z')",
+        ),
     ]
-    geom: Annotated[str, Field(None, alias="geometry")]
+    geom: Annotated[
+        Union[str, dict[str, float], BaseGeometry],
+        Field(
+            None,
+            description="Read EODAG documentation for all supported geometry format.",
+        ),
+    ]
     uid: Annotated[str, Field(None)]
     # OpenSearch Parameters for Collection Search (Table 3)
     doi: Annotated[str, Field(None)]
@@ -149,6 +165,8 @@ class Queryables(CommonQueryables):
     # Custom parameters (not defined in the base document referenced above)
     id: Annotated[str, Field(None)]
     tileIdentifier: Annotated[str, Field(None, pattern=r"[0-9]{2}[A-Z]{3}")]
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class QueryablesDict(UserDict[str, Any]):

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -1809,6 +1809,19 @@ class TestSearchPluginStacSearch(BaseSearchPluginTest):
         "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
     )
     def test_plugins_search_dedl_discover_queryables(self, mock_request):
+        """
+        Test the discovery and parsing of queryables from the DEDL provider.
+
+        This test verifies that:
+        - The "ecmwf:time" field is correctly interpreted as an annotated list with a
+        single literal value "00:00".
+        - The "start" field is interpreted as an annotated union of datetime and date types.
+        - The "geom" field is interpreted as an annotated union that includes a string,
+        a dictionary with string keys and float values, and subclasses of BaseGeometry.
+
+        The test mocks the _request method of the plugin to simulate a response with
+        predefined queryables, then verifies the correctness of the resulting type annotations.
+        """
         provider_queryables = {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
             "type": "object",

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -21,7 +21,7 @@ import os
 import re
 import ssl
 import unittest
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Literal, Union, get_origin
 from unittest import mock
@@ -1909,15 +1909,11 @@ class TestSearchPluginStacSearch(BaseSearchPluginTest):
         literal_args = get_args(base_type)
         self.assertEqual(literal_args, (Literal["00:00"],))
 
-        # Check that "start" has type typing.Annotated[typing.Union[datetime.datetime, datetime.date], ...]
+        # Check that "start" has type Annotated[str, ...]
         self.assertIn("start", queryables_dedl)
         annotated_type = queryables_dedl["start"]
         args = get_args(annotated_type)
-        base_type = args[0]
-        self.assertEqual(get_origin(base_type), Union)
-        union_args = get_args(base_type)
-        self.assertIn(datetime, union_args)
-        self.assertIn(date, union_args)
+        self.assertEqual(args[0], str)
 
         # Check that "geom" has type Annotated[Union[str, dict[str, float], BaseGeometry], ...]
         self.assertIn("geom", queryables_dedl)

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -21,8 +21,9 @@ import os
 import re
 import ssl
 import unittest
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
+from typing import Literal, Union, get_origin
 from unittest import mock
 from unittest.mock import call
 
@@ -35,6 +36,7 @@ import yaml
 from botocore.stub import Stubber
 from pydantic_core import PydanticUndefined
 from requests import RequestException
+from shapely.geometry.base import BaseGeometry
 from typing_extensions import get_args
 
 from eodag.api.product import AssetsDict
@@ -1802,6 +1804,124 @@ class TestSearchPluginStacSearch(BaseSearchPluginTest):
         self.assertIn("geom", queryables)
         self.assertIn("start", queryables)
         self.assertIn("end", queryables)
+
+    @mock.patch(
+        "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
+    )
+    def test_plugins_search_dedl_discover_queryables(self, mock_request):
+        provider_queryables = {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "title": "Queryables for EODAG STAC API",
+            "description": "Queryable names for the EODAG STAC API Item Search filter. ",
+            "properties": {
+                "ecmwf:variable": {
+                    "default": "10m_u_component_of_wind",
+                    "items": {
+                        "enum": [
+                            "10m_u_component_of_wind",
+                            "10m_v_component_of_wind",
+                            "2m_dewpoint_temperature",
+                            "2m_temperature",
+                        ],
+                        "type": "string",
+                    },
+                    "title": "variable",
+                    "type": "array",
+                },
+                "ecmwf:pressure_level": {
+                    "items": {},
+                    "title": "pressure_level",
+                    "type": "array",
+                },
+                "ecmwf:time": {
+                    "default": "00:00",
+                    "description": "Model base time as HH:MM (UTC)",
+                    "items": {"const": "00:00", "type": "string"},
+                    "title": "time",
+                    "type": "array",
+                },
+                "start_datetime": {
+                    "anyOf": [
+                        {"format": "date-time", "type": "string"},
+                        {"format": "date", "type": "string"},
+                    ],
+                    "default": "2015-01-01T00:00:00Z",
+                    "title": "start_datetime",
+                },
+                "end_datetime": {
+                    "anyOf": [
+                        {"format": "date-time", "type": "string"},
+                        {"format": "date", "type": "string"},
+                    ],
+                    "default": "2015-01-01T00:00:00Z",
+                    "title": "end_datetime",
+                },
+                "geometry": {
+                    "description": "Geometry",
+                    "ref": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/geometry",
+                },
+                "bbox": {
+                    "description": "BBox",
+                    "type": "array",
+                    "oneOf": [
+                        {"minItems": 4, "maxItems": 4},
+                        {"minItems": 6, "maxItems": 6},
+                    ],
+                    "items": {"type": "number"},
+                },
+            },
+            "required": [
+                "ecmwf:variable",
+                "ecmwf:time",
+                "start_datetime",
+                "geometry",
+                "bbox",
+            ],
+            "additionalProperties": False,
+        }
+        mock_request.return_value = mock.Mock()
+        mock_request.return_value.json.side_effect = [provider_queryables]
+        plugin = self.get_search_plugin(provider="dedl")
+        queryables_dedl = plugin.discover_queryables(
+            productType="CAMS_GAC_FORECAST", provider="dedl"
+        )
+
+        # Check that "ecmwf:time" has type Annotated[list[Literal['00:00']], ...]
+        self.assertIn("ecmwf:time", queryables_dedl)
+        annotated_type = queryables_dedl["ecmwf:time"]
+        args = get_args(annotated_type)
+        base_type = args[0]
+        self.assertEqual(get_origin(base_type), list)
+        literal_args = get_args(base_type)
+        self.assertEqual(literal_args, (Literal["00:00"],))
+
+        # Check that "start" has type typing.Annotated[typing.Union[datetime.datetime, datetime.date], ...]
+        self.assertIn("start", queryables_dedl)
+        annotated_type = queryables_dedl["start"]
+        args = get_args(annotated_type)
+        base_type = args[0]
+        self.assertEqual(get_origin(base_type), Union)
+        union_args = get_args(base_type)
+        self.assertIn(datetime, union_args)
+        self.assertIn(date, union_args)
+
+        # Check that "geom" has type Annotated[Union[str, dict[str, float], BaseGeometry], ...]
+        self.assertIn("geom", queryables_dedl)
+        annotated_type = queryables_dedl["geom"]
+        args = get_args(annotated_type)
+        base_type = args[0]
+        self.assertEqual(get_origin(base_type), Union)
+        union_args = get_args(base_type)
+        self.assertIn(str, union_args)
+        self.assertTrue(any(get_origin(arg) is dict for arg in union_args))
+        self.assertTrue(
+            any(
+                issubclass(arg, BaseGeometry)
+                for arg in union_args
+                if isinstance(arg, type)
+            )
+        )
 
 
 class TestSearchPluginMeteoblueSearch(BaseSearchPluginTest):


### PR DESCRIPTION
This pull request fixes an issue where queryables were not matching correctly.
When the list of possible values contained only a single value, the dedl provider was returning an empty list instead of the expected single-item list.