### PR TITLE
docs: configuration environment variables defaults

### DIFF
--- a/docs/getting_started_guide/configure.rst
+++ b/docs/getting_started_guide/configure.rst
@@ -142,16 +142,21 @@ Core configuration using environment variables
 
 Some EODAG core settings can be overriden using environment variables:
 
-* ``EODAG_CFG_DIR`` customized configuration directory in place of ``~/.config/eodag``
+* ``EODAG_CFG_DIR`` customized configuration directory in place of `~/.config/eodag`.
 * ``EODAG_CFG_FILE`` for defining the desired path to the `user configuration file\
   <https://eodag.readthedocs.io/en/stable/getting_started_guide/configure.html#yaml-user-configuration-file>`_
+  in place of `~/.config/eodag/eodag.yml`.
 * ``EODAG_LOCS_CFG_FILE`` for defining the desired path to the
   `locations <https://eodag.readthedocs.io/en/stable/notebooks/api_user_guide/4_search.html#Locations-search>`_
-  configuration file
-* ``EODAG_PROVIDERS_CFG_FILE`` for defining the desired path to the providers configuration file
-* ``EODAG_PRODUCT_TYPES_CFG_FILE`` for defining the desired path to the product types configuration file
+  configuration file in place of `~/.config/eodag/locations.yml`.
+* ``EODAG_PROVIDERS_CFG_FILE`` for defining the desired path to the providers configuration file in place of
+  `<python-site-packages>/eodag/resources/providers.yml`.
+* ``EODAG_PRODUCT_TYPES_CFG_FILE`` for defining the desired path to the product types configuration file in place of
+  `<python-site-packages>/eodag/resources/product_types.yml`.
 * ``EODAG_EXT_PRODUCT_TYPES_CFG_FILE`` for defining the desired path to the `external product types configuration file\
   <https://eodag.readthedocs.io/en/stable/notebooks/api_user_guide/2_providers_products_available.html#Product-types-discovery>`_
+  in place of https://cs-si.github.io/eodag/eodag/resources/ext_product_types.json.
+  If the file is not readable, only user-modified providers will be fetched.
 
 CLI configuration
 ^^^^^^^^^^^^^^^^^

--- a/docs/notebooks/api_user_guide/2_providers_products_available.ipynb
+++ b/docs/notebooks/api_user_guide/2_providers_products_available.ipynb
@@ -702,7 +702,7 @@
     "\n",
     "In EODAG, the discovered *EODAG external product types configuration file* can be set to:\n",
     "\n",
-    "* a file automatically built from github actions and stored in [eodag/resources/ext_product_types.json](https://raw.githubusercontent.com/CS-SI/eodag/develop/eodag/resources/ext_product_types.json) (default settings)\n",
+    "* a file automatically built from github actions and stored in [eodag/resources/ext_product_types.json](https://cs-si.github.io/eodag/eodag/resources/ext_product_types.json) (default settings)\n",
     "* a custom remote or local file by setting its path in `EODAG_EXT_PRODUCT_TYPES_CFG_FILE` environment variable (if the file is not readable, only user-modified providers will be fetched).\n",
     "\n",
     "Then, when listing product types using [list_product_types(fetch_providers=True)](../../api_reference/core.rst#eodag.api.core.EODataAccessGateway.list_product_types), EODAG will first read the content of the *EODAG external product types configuration file* using [fetch_product_types_list()](../../api_reference/core.rst#eodag.api.core.EODataAccessGateway.fetch_product_types_list) \n",


### PR DESCRIPTION
Describes [configuration environment variables](https://eodag.readthedocs.io/en/latest/getting_started_guide/configure.html#core-configuration-using-environment-variables) default values