### PR TITLE
feat: make count search param optional

### DIFF
--- a/docs/notebooks/api_user_guide/4_search.ipynb
+++ b/docs/notebooks/api_user_guide/4_search.ipynb
@@ -30,10 +30,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-02-06 17:50:59,590 eodag.config                     [INFO    ] Loading user configuration from: /home/anesson/.config/eodag/eodag.yml\n",
-      "2025-02-06 17:50:59,618 eodag.core                       [INFO    ] aws_eos: provider needing auth for search has been pruned because no credentials could be found\n",
-      "2025-02-06 17:50:59,619 eodag.core                       [INFO    ] geodes_s3: provider needing auth for search has been pruned because no credentials could be found\n",
-      "2025-02-06 17:50:59,633 eodag.core                       [INFO    ] Locations configuration loaded from /home/anesson/.config/eodag/locations.yml\n"
+      "2025-06-16 18:06:09,448 eodag.config                     [INFO    ] Loading user configuration from: /home/anesson/.config/eodag/eodag.yml\n",
+      "2025-06-16 18:06:09,480 eodag.core                       [INFO    ] geodes_s3: provider needing auth for search has been pruned because no credentials could be found\n",
+      "2025-06-16 18:06:10,121 eodag.core                       [INFO    ] Locations configuration loaded from /home/anesson/.config/eodag/locations.yml\n"
      ]
     }
    ],
@@ -55,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5296,21 +5295,21 @@
     "### Count\n",
     "\n",
     "The estimated total number of matching items can optionally be retrieved and stored in the [SearchResult.number_matched](../../api_reference/searchresult.rst#eodag.api.search_result.SearchResult) attribute.\n",
-    "This is done by setting the search parameter `count=True`. If not set, *count* will be disabled (parameter default value is `False`) as this operation can cost extra time on some providers:"
+    "This is done by setting the search parameter `count=True`. If not set, *count* will be activated or not according to the search plugin configuration of the provider used for the search. *count* default value in the provider configuration is `True` as it does not have a big impact on searches with most of providers but you may take into consideration this operation can cost extra time on some providers where `count=False` in their configuration:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-11-22 17:32:51,361 eodag.core                       [INFO    ] Searching on provider peps\n",
-      "2024-11-22 17:32:51,364 eodag.search.qssearch            [INFO    ] Sending search request: https://peps.cnes.fr/resto/api/collections/S2ST/search.json?startDate=2021-03-01&completionDate=2021-03-31&geometry=POLYGON ((1.0000 43.0000, 1.0000 44.0000, 2.0000 44.0000, 2.0000 43.0000, 1.0000 43.0000))&productType=S2MSI1C&maxRecords=20&page=1\n",
-      "2024-11-22 17:32:53,303 eodag.core                       [INFO    ] Found 48 result(s) on provider 'peps'\n"
+      "2025-06-16 18:09:38,951 eodag.core                       [INFO    ] Searching on provider peps\n",
+      "2025-06-16 18:09:38,992 eodag.search.qssearch            [INFO    ] Sending search request: https://peps.cnes.fr/resto/api/collections/S2ST/search.json?startDate=2021-03-01&completionDate=2021-03-31&geometry=POLYGON ((1.0000 43.0000, 1.0000 44.0000, 2.0000 44.0000, 2.0000 43.0000, 1.0000 43.0000))&productType=S2MSI1C&maxRecords=20&page=1\n",
+      "2025-06-16 18:09:46,041 eodag.core                       [INFO    ] Found 48 result(s) on provider 'peps'\n"
      ]
     },
     {
@@ -5322,21 +5321,21 @@
     }
    ],
    "source": [
-    "results_with_count = dag.search(count=True, **default_search_criteria)\n",
-    "print(f\"number_matched: {results_with_count.number_matched}\")"
+    "nb_matched_results_without_count = dag.search(**default_search_criteria)\n",
+    "print(f\"number_matched: {nb_matched_results_without_count.number_matched}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-11-22 17:32:53,315 eodag.core                       [INFO    ] Searching on provider peps\n",
-      "2024-11-22 17:32:53,319 eodag.search.qssearch            [INFO    ] Sending search request: https://peps.cnes.fr/resto/api/collections/S2ST/search.json?startDate=2021-03-01&completionDate=2021-03-31&geometry=POLYGON ((1.0000 43.0000, 1.0000 44.0000, 2.0000 44.0000, 2.0000 43.0000, 1.0000 43.0000))&productType=S2MSI1C&maxRecords=20&page=1\n"
+      "2025-06-16 18:09:48,251 eodag.core                       [INFO    ] Searching on provider peps\n",
+      "2025-06-16 18:09:48,288 eodag.search.qssearch            [INFO    ] Sending search request: https://peps.cnes.fr/resto/api/collections/S2ST/search.json?startDate=2021-03-01&completionDate=2021-03-31&geometry=POLYGON ((1.0000 43.0000, 1.0000 44.0000, 2.0000 44.0000, 2.0000 43.0000, 1.0000 43.0000))&productType=S2MSI1C&maxRecords=20&page=1\n"
      ]
     },
     {
@@ -5348,8 +5347,35 @@
     }
    ],
    "source": [
-    "results_with_count = dag.search(count=False, **default_search_criteria)\n",
-    "print(f\"number_matched: {results_with_count.number_matched}\")"
+    "no_nb_matched_results_with_count = dag.search(count=False, **default_search_criteria)\n",
+    "print(f\"number_matched: {no_nb_matched_results_with_count.number_matched}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-06-16 18:09:17,357 eodag.core                       [INFO    ] Searching on provider cop_dataspace\n",
+      "2025-06-16 18:09:17,358 eodag.search.base                [INFO    ] cop_dataspace is configured with default sorting by 'startTimeFromAscendingNode' in ascending order\n",
+      "2025-06-16 18:09:17,393 eodag.search.qssearch            [INFO    ] Sending search request: https://catalogue.dataspace.copernicus.eu/odata/v1/Products?$filter=Collection/Name%20eq%20%27SENTINEL-2%27%20and%20OData.CSC.Intersects%28area=geography%27SRID=4326%3BPOLYGON%20%28%281.0000%2043.0000%2C%201.0000%2044.0000%2C%202.0000%2044.0000%2C%202.0000%2043.0000%2C%201.0000%2043.0000%29%29%27%29%20and%20Attributes/OData.CSC.StringAttribute/any%28att:att/Name%20eq%20%27productType%27%20and%20att/OData.CSC.StringAttribute/Value%20eq%20%27S2MSI1C%27%29%20and%20ContentDate/Start%20lt%202021-03-31T00:00:00.000Z%20and%20ContentDate/End%20gt%202021-03-01T00:00:00.000Z&$orderby=ContentDate/Start%20asc&$top=20&$skip=0&$expand=Attributes&$expand=Assets\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "number_matched: None\n"
+     ]
+    }
+   ],
+   "source": [
+    "no_nb_matched_results_without_count = dag.search(provider=\"cop_dataspace\", **default_search_criteria)\n",
+    "print(f\"number_matched: {no_nb_matched_results_without_count.number_matched}\")"
    ]
   },
   {
@@ -5532,7 +5558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -6270,7 +6296,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "tmp-16655007909baa5",
+   "display_name": "eodag_dev",
    "language": "python",
    "name": "python3"
   },

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -1127,7 +1127,7 @@ class EODataAccessGateway:
         geom: Optional[Union[str, dict[str, float], BaseGeometry]] = None,
         locations: Optional[dict[str, str]] = None,
         provider: Optional[str] = None,
-        count: bool = False,
+        count: Optional[bool] = None,
         **kwargs: Any,
     ) -> SearchResult:
         """Look for products matching criteria on known providers.
@@ -1803,7 +1803,7 @@ class EODataAccessGateway:
     def _do_search(
         self,
         search_plugin: Union[Search, Api],
-        count: bool = False,
+        count: Optional[bool] = None,
         raise_errors: bool = False,
         **kwargs: Any,
     ) -> SearchResult:
@@ -1833,6 +1833,12 @@ class EODataAccessGateway:
                 kwargs["items_per_page"],
                 max_items_per_page,
             )
+
+        count = (
+            search_plugin.config.pagination.get("count", True)
+            if count is None
+            else count
+        )
 
         results: list[EOProduct] = []
         total_results: Optional[int] = 0 if count else None

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -224,6 +224,8 @@ class PluginConfig(yaml.YAMLObject):
         #: Template to add to :attr:`~eodag.config.PluginConfig.Pagination.next_page_url_tpl` to enable count in
         #: search request
         count_tpl: str
+        # Whether count is enabled by default in search request on the provider or not
+        count: bool
         #: The f-string template for pagination requests.
         next_page_url_tpl: str
         #: The query-object for POST pagination requests.

--- a/eodag/plugins/search/__init__.py
+++ b/eodag/plugins/search/__init__.py
@@ -41,7 +41,7 @@ class PreparedSearch:
     items_per_page: Optional[int] = DEFAULT_ITEMS_PER_PAGE
     auth: Optional[Union[AuthBase, S3SessionKwargs]] = None
     auth_plugin: Optional[Authentication] = None
-    count: bool = True
+    count: bool = False
     url: Optional[str] = None
     info_message: Optional[str] = None
     exception_message: Optional[str] = None

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -304,10 +304,11 @@ class CopMarineSearch(StaticStacSearch):
         """
         page = prep.page
         items_per_page = prep.items_per_page
+        count = prep.count
 
         # only return 1 page if pagination is disabled
         if page is None or items_per_page is None or page > 1 and items_per_page <= 0:
-            return ([], 0) if prep.count else ([], None)
+            return ([], 0) if count else ([], None)
 
         product_type = kwargs.get("productType", prep.product_type)
         if not product_type:
@@ -395,7 +396,7 @@ class CopMarineSearch(StaticStacSearch):
                     )
                 if "Contents" not in s3_objects:
                     if len(products) == 0 and i == len(datasets_items_list) - 1:
-                        return ([], 0) if prep.count else ([], None)
+                        return ([], 0) if count else ([], None)
                     else:
                         break
 

--- a/eodag/plugins/search/csw.py
+++ b/eodag/plugins/search/csw.py
@@ -110,8 +110,9 @@ class CSWSearch(Search):
     ) -> tuple[list[EOProduct], Optional[int]]:
         """Perform a search on a OGC/CSW-like interface"""
         product_type = kwargs.get("productType")
+        count = prep.count
         if product_type is None:
-            return ([], 0) if prep.count else ([], None)
+            return ([], 0) if count else ([], None)
         auth = kwargs.get("auth")
         if auth:
             self.__init_catalog(**getattr(auth.config, "credentials", {}))
@@ -156,7 +157,7 @@ class CSWSearch(Search):
                 )
                 results.extend(partial_results)
         logger.info("Found %s overall results", len(results))
-        total_results = len(results) if prep.count else None
+        total_results = len(results) if count else None
         return results, total_results
 
     def __init_catalog(

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -159,6 +159,8 @@ class QueryStringSearch(Search):
             returns a json or xml document
           * :attr:`~eodag.config.PluginConfig.Pagination.count_endpoint` (``str``): The endpoint for counting the number
             of items satisfying a request
+          * :attr:`~eodag.config.PluginConfig.Pagination.count` (``bool``): Whether the provider default search counts
+            items or not
           * :attr:`~eodag.config.PluginConfig.Pagination.count_tpl` (``str``): template for the count parameter that
             should be added to the search request
           * :attr:`~eodag.config.PluginConfig.Pagination.next_page_url_key_path` (``str``): A JsonPath expression used

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -734,7 +734,7 @@ class QueryStringSearch(Search):
             logger.warning(
                 "GENERIC_PRODUCT_TYPE is not a real product_type and should only be used internally as a template"
             )
-            return ([], 0) if prep.count else ([], None)
+            return ([], 0) if count else ([], None)
 
         sort_by_arg: Optional[SortByList] = self.get_sort_by_arg(kwargs)
         prep.sort_by_qs, _ = (
@@ -1549,7 +1549,7 @@ class PostJsonSearch(QueryStringSearch):
             for k in keywords.keys()
             if isinstance(product_type_metadata_mapping.get(k, []), list)
         ):
-            return ([], 0) if prep.count else ([], None)
+            return ([], 0) if count else ([], None)
         prep.query_params = dict(qp, **sort_by_qp)
         prep.search_urls, total_items = self.collect_search_urls(prep, **kwargs)
         if not count and getattr(prep, "need_count", False):

--- a/eodag/plugins/search/static_stac_search.py
+++ b/eodag/plugins/search/static_stac_search.py
@@ -159,6 +159,7 @@ class StaticStacSearch(StacSearch):
         **kwargs: Any,
     ) -> tuple[list[EOProduct], Optional[int]]:
         """Perform a search on a static STAC Catalog"""
+        count = prep.count
 
         # only return 1 page if pagination is disabled
         if (
@@ -167,7 +168,7 @@ class StaticStacSearch(StacSearch):
             and prep.items_per_page is not None
             and prep.items_per_page <= 0
         ):
-            return ([], 0) if prep.count else ([], None)
+            return ([], 0) if count else ([], None)
 
         product_type = kwargs.get("productType", prep.product_type)
         # provider product type specific conf
@@ -247,6 +248,6 @@ class StaticStacSearch(StacSearch):
 
         return (
             (search_result.data, len(search_result))
-            if prep.count
+            if count
             else (search_result.data, None)
         )

--- a/eodag/plugins/search/static_stac_search.py
+++ b/eodag/plugins/search/static_stac_search.py
@@ -202,7 +202,7 @@ class StaticStacSearch(StacSearch):
             return_value=MockResponse(feature_collection, 200),
         ):
             eo_products, _ = super(StaticStacSearch, self).query(
-                PreparedSearch(items_per_page=nb_features, page=1, count=True), **kwargs
+                PreparedSearch(items_per_page=nb_features, page=1), **kwargs
             )
         # filter using query params
         search_result = SearchResult(eo_products)

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -896,6 +896,7 @@
     pagination:
       next_page_url_tpl: '{url}?{search}&$top={items_per_page}&$skip={skip}&$expand=Attributes&$expand=Assets'
       count_tpl: '&$count=True'
+      count: false
       total_items_nb_key_path: '$."@odata.count"'
       max_items_per_page: 1_000
     sort:
@@ -2523,6 +2524,7 @@
     pagination:
       next_page_url_tpl: '{url}?{search}&$top={items_per_page}&$skip={skip}&$expand=Attributes&$expand=Assets'
       count_tpl: '&$count=True'
+      count: false
       total_items_nb_key_path: '$."@odata.count"'
       max_items_per_page: 1_000
     sort:
@@ -4096,6 +4098,7 @@
     pagination:
       next_page_url_tpl: '{url}?{search}&$top={items_per_page}&$skip={skip}&$expand=Attributes&$expand=Assets'
       count_tpl: '&$count=True'
+      count: false
       total_items_nb_key_path: '$."@odata.count"'
       max_items_per_page: 1_000
     sort:

--- a/tests/integration/test_core_config.py
+++ b/tests/integration/test_core_config.py
@@ -336,7 +336,7 @@ class TestCoreProvidersConfig(TestCase):
             search={
                 "type": "QueryStringSearch",
                 "api_endpoint": "https://foo.bar/search",
-                "pagination": {"next_page_url_tpl": ""},
+                "pagination": {"next_page_url_tpl": "", "count": False},
                 "metadata_mapping": {"bar": "$.properties.bar"},
             },
         )
@@ -358,7 +358,7 @@ class TestCoreProvidersConfig(TestCase):
             search={
                 "type": "QueryStringSearch",
                 "api_endpoint": "https://foo.bar/search",
-                "pagination": {"next_page_url_tpl": ""},
+                "pagination": {"next_page_url_tpl": "", "count": False},
                 "metadata_mapping": {"bar": "$.properties.baz"},
             },
         )

--- a/tests/integration/test_search_stac_static.py
+++ b/tests/integration/test_search_stac_static.py
@@ -156,7 +156,7 @@ class TestSearchStacStatic(unittest.TestCase):
         """Use StaticStacSearch plugin to search all items"""
         # mock on fetch_product_types_list not needed with provider specified,
         #    as product types discovery must be disabled by default for stac static
-        search_result = self.dag.search(provider=self.static_stac_provider, count=True)
+        search_result = self.dag.search(provider=self.static_stac_provider)
         self.assertEqual(len(search_result), self.root_cat_len)
         self.assertEqual(search_result.number_matched, self.root_cat_len)
         for item in search_result:
@@ -286,7 +286,7 @@ class TestSearchStacStatic(unittest.TestCase):
         self, mock_fetch_product_types_list, mock_auth_session_request
     ):
         """Use StaticStacSearch plugin to search by date"""
-        filtered_sr = self.dag.search(start="2018-01-01", end="2019-01-01", count=True)
+        filtered_sr = self.dag.search(start="2018-01-01", end="2019-01-01")
         self.assertEqual(len(filtered_sr), self.child_cat_len)
         self.assertEqual(filtered_sr.number_matched, self.child_cat_len)
         for item in filtered_sr:
@@ -363,7 +363,7 @@ class TestSearchStacStatic(unittest.TestCase):
         self, mock_fetch_product_types_list, mock_auth_session_request
     ):
         """Use StaticStacSearch plugin to search by geometry"""
-        search_result = self.dag.search(geom=self.extent_big, count=True)
+        search_result = self.dag.search(geom=self.extent_big)
         self.assertEqual(len(search_result), 3)
         self.assertEqual(search_result.number_matched, 3)
 
@@ -410,7 +410,7 @@ class TestSearchStacStatic(unittest.TestCase):
         self, mock_fetch_product_types_list, mock_auth_session_request
     ):
         """Use StaticStacSearch plugin to search by property"""
-        search_result = self.dag.search(orbitNumber=110, count=True)
+        search_result = self.dag.search(orbitNumber=110)
         self.assertEqual(len(search_result), 3)
         self.assertEqual(search_result.number_matched, 3)
 
@@ -425,7 +425,7 @@ class TestSearchStacStatic(unittest.TestCase):
         self, mock_fetch_product_types_list, mock_auth_session_request
     ):
         """Use StaticStacSearch plugin to search by cloud cover"""
-        search_result = self.dag.search(cloudCover=10, count=True)
+        search_result = self.dag.search(cloudCover=10)
         self.assertEqual(len(search_result), 1)
         self.assertEqual(search_result.number_matched, 1)
 

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -180,7 +180,9 @@ class TestApisPluginEcmwfApi(BaseApisPluginTest):
         EcmwfApi.query must build a EOProduct from input parameters without product type.
         For test only, result cannot be downloaded.
         """
-        results, count = self.api_plugin.query(**self.query_dates)
+        results, count = self.api_plugin.query(
+            PreparedSearch(count=True), **self.query_dates
+        )
         assert count == 1
         eoproduct = results[0]
         assert eoproduct.geometry.bounds == (-180.0, -90.0, 180.0, 90.0)

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -127,6 +127,7 @@ class TestSearchPluginQueryStringSearchXml(BaseSearchPluginTest):
 
         products, estimate = self.mundi_search_plugin.query(
             prep=PreparedSearch(
+                count=True,
                 page=1,
                 items_per_page=2,
                 auth_plugin=self.mundi_auth_plugin,
@@ -255,6 +256,7 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
         ]
         products, estimate = self.peps_search_plugin.query(
             prep=PreparedSearch(
+                count=True,
                 page=1,
                 items_per_page=2,
                 auth_plugin=self.peps_auth_plugin,
@@ -294,7 +296,6 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
         mock__request.return_value.json.return_value = peps_resp_search
         products, estimate = self.peps_search_plugin.query(
             prep=PreparedSearch(
-                count=False,
                 page=1,
                 items_per_page=2,
                 auth_plugin=self.peps_auth_plugin,
@@ -696,6 +697,7 @@ class TestSearchPluginPostJsonSearch(BaseSearchPluginTest):
         ]
         products, estimate = self.awseos_search_plugin.query(
             prep=PreparedSearch(
+                count=True,
                 page=1,
                 items_per_page=2,
                 auth_plugin=self.awseos_auth_plugin,
@@ -1181,6 +1183,7 @@ class TestSearchPluginODataV4Search(BaseSearchPluginTest):
         )
         products, estimate = self.onda_search_plugin.query(
             prep=PreparedSearch(
+                count=True,
                 page=1,
                 items_per_page=2,
                 auth=self.onda_auth_plugin,
@@ -1226,7 +1229,7 @@ class TestSearchPluginODataV4Search(BaseSearchPluginTest):
     def test_plugins_search_odatav4search_with_ssl_context(
         self, mock_cast, mock_urlopen, mock_request, mock_get_ssl_context
     ):
-        """A query with a ODataV4Search (here onda) must return tuple with a list of EOProduct and a number of available products"""  # noqa
+        """A query with a ODataV4Search (here onda) must work in a ssl context"""  # noqa
         self.onda_search_plugin.config.ssl_verify = False
         mock_cast.return_value.json.return_value = 2
 
@@ -1245,15 +1248,12 @@ class TestSearchPluginODataV4Search(BaseSearchPluginTest):
                 items_per_page=2,
                 auth=self.onda_auth_plugin,
             ),
-            # custom query argument that must be mapped using discovery_metata.search_param
-            foo="bar",
-            **self.search_criteria_s2_msi_l1c,
         )
 
         mock_get_ssl_context.assert_called_with(False)
 
         # # Asserting that get_ssl_context has been called
-        self.assertEqual(mock_get_ssl_context.call_count, 2)
+        self.assertEqual(mock_get_ssl_context.call_count, 1)
 
         # Asserting that urlopen has been called with the correct arguments
         mock_urlopen.assert_called_with(
@@ -1293,6 +1293,7 @@ class TestSearchPluginODataV4Search(BaseSearchPluginTest):
         )
         products, estimate = self.onda_search_plugin.query(
             prep=PreparedSearch(
+                count=True,
                 page=1,
                 items_per_page=2,
                 auth=self.onda_auth_plugin,
@@ -1373,8 +1374,9 @@ class TestSearchPluginODataV4Search(BaseSearchPluginTest):
         mock_requests_get.side_effect = RequestException()
 
         with self.assertLogs(level="ERROR") as cm:
-            products, estimate = self.onda_search_plugin.query(
+            _, _ = self.onda_search_plugin.query(
                 prep=PreparedSearch(
+                    count=True,
                     page=1,
                     items_per_page=2,
                     auth=self.onda_auth_plugin,


### PR DESCRIPTION
Fixes #1644 

`count` mechanism has changed:

- `count` in search parameters is optional
- if `count` is not set in search parameters, its value is taken from `count` config parameter located in `pagination` config. For now, it is set only for `creodias`, `creodias_s3` and `cop_dataspace` where counting make the search much more slower than for a search without counting.
- if `count` is not set in search parameters and in `pagination` config, its value is `True` by default.
