### PR TITLE
fix(core): always validate PluginConfig before loading

### DIFF
--- a/eodag/config.py
+++ b/eodag/config.py
@@ -194,7 +194,7 @@ class ProviderConfig(yaml.YAMLObject):
             },
         )
         for key in PLUGINS_TOPICS_KEYS:
-            current_value: Optional[dict[str, Any]] = getattr(self, key, None)
+            current_value: Optional[PluginConfig] = getattr(self, key, None)
             mapping_value = mapping.get(key, {})
             if current_value is not None:
                 current_value.update(mapping_value)
@@ -829,7 +829,9 @@ def provider_config_init(
         pass
 
 
-def override_config_from_file(config: dict[str, Any], file_path: str) -> None:
+def override_config_from_file(
+    config: dict[str, ProviderConfig], file_path: str
+) -> None:
     """Override a configuration with the values in a file
 
     :param config: An eodag providers configuration dictionary
@@ -848,7 +850,7 @@ def override_config_from_file(config: dict[str, Any], file_path: str) -> None:
     override_config_from_mapping(config, config_in_file)
 
 
-def override_config_from_env(config: dict[str, Any]) -> None:
+def override_config_from_env(config: dict[str, ProviderConfig]) -> None:
     """Override a configuration with environment variables values
 
     :param config: An eodag providers configuration dictionary
@@ -919,7 +921,7 @@ def override_config_from_env(config: dict[str, Any]) -> None:
 
 
 def override_config_from_mapping(
-    config: dict[str, Any], mapping: dict[str, Any]
+    config: dict[str, ProviderConfig], mapping: dict[str, Any]
 ) -> None:
     """Override a configuration with the values in a mapping.
 
@@ -966,7 +968,7 @@ def override_config_from_mapping(
                 )
 
         # try overriding conf
-        old_conf: Optional[dict[str, Any]] = config.get(provider)
+        old_conf: Optional[ProviderConfig] = config.get(provider)
         if old_conf is not None:
             old_conf.update(new_conf)
         else:

--- a/eodag/plugins/authentication/token_exchange.py
+++ b/eodag/plugins/authentication/token_exchange.py
@@ -79,6 +79,7 @@ class OIDCTokenExchangeAuth(Authentication):
             provider,
             PluginConfig.from_mapping(
                 {
+                    "type": "OIDCAuthorizationCodeFlowAuth",
                     "credentials": getattr(self.config, "credentials", {}),
                     **self.config.subject,
                 }

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -190,7 +190,7 @@ class PluginManager:
                 plugin = cast(Api, self._build_plugin(config.name, api, Api))
             else:
                 raise MisconfiguredError(
-                    f"No search plugin configureed for {config.name}."
+                    f"No search plugin configured for {config.name}."
                 )
             return plugin
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -309,6 +309,7 @@ class EODagTestCase(unittest.TestCase):
             output_dir = str(Path(self.tmp_download_dir.name).parent)
         dl_config = config.PluginConfig.from_mapping(
             {
+                "type": "HTTPDownload",
                 "base_uri": "fake_base_uri" if base_uri is None else base_uri,
                 "output_dir": output_dir,
                 "extract": True if extract is None else extract,

--- a/tests/integration/test_core_config.py
+++ b/tests/integration/test_core_config.py
@@ -146,6 +146,8 @@ class TestCoreProvidersConfig(TestCase):
                     type: StacSearch
                     api_endpoint: https://foo.bar/search
                     need_auth: True
+                auth:
+                    type: GenericAuth
                 products:
                     GENERIC_PRODUCT_TYPE:
                         productType: '{productType}'
@@ -178,6 +180,7 @@ class TestCoreProvidersConfig(TestCase):
             "a_provider_without_creds_matching_url",
             "https://foo.bar/search",
             auth={
+                "type": "GenericAuth",
                 "matching_url": "http://foo.bar",
             },
         )
@@ -185,6 +188,7 @@ class TestCoreProvidersConfig(TestCase):
             "a_provider_with_creds",
             "https://foo.bar/search",
             auth={
+                "type": "GenericAuth",
                 "matching_url": "http://foo.bar",
                 "credentials": {"username": "bar", "password": "foo"},
             },
@@ -199,6 +203,7 @@ class TestCoreProvidersConfig(TestCase):
                     GENERIC_PRODUCT_TYPE:
                         productType: '{productType}'
                 auth:
+                    type: GenericAuth
                     matching_conf:
                         something: special
                     credentials:
@@ -213,6 +218,7 @@ class TestCoreProvidersConfig(TestCase):
                     GENERIC_PRODUCT_TYPE:
                         productType: '{productType}'
                 auth:
+                    type: GenericAuth
                     matching_conf:
                         something: special
             """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -442,12 +442,12 @@ class TestConfigFunctions(unittest.TestCase):
         os.environ["EODAG__USGS__API__CREDENTIALS__USERNAME"] = "usr"
         os.environ["EODAG__USGS__API__CREDENTIALS__PASSWORD"] = "pwd"
         os.environ["EODAG__AWS_EOS__SEARCH__PRODUCT_LOCATION_SCHEME"] = "file"
-        os.environ["EODAG__AWS_EOS__AUTH__CREDENTIALS__APIKEY"] = "api-key"
+        os.environ["EODAG__AWS_EOS__SEARCH_AUTH__CREDENTIALS__APIKEY"] = "api-key"
         os.environ[
-            "EODAG__AWS_EOS__AUTH__CREDENTIALS__AWS_ACCESS_KEY_ID"
+            "EODAG__AWS_EOS__DOWNLOAD_AUTH__CREDENTIALS__AWS_ACCESS_KEY_ID"
         ] = "access-key-id"
         os.environ[
-            "EODAG__AWS_EOS__AUTH__CREDENTIALS__AWS_SECRET_ACCESS_KEY"
+            "EODAG__AWS_EOS__DOWNLOAD_AUTH__CREDENTIALS__AWS_SECRET_ACCESS_KEY"
         ] = "secret-access-key"
         os.environ["EODAG__PEPS__DOWNLOAD__OUTPUT_DIR"] = "/data"
         # check a parameter that has not been set yet
@@ -465,12 +465,13 @@ class TestConfigFunctions(unittest.TestCase):
 
         aws_conf = default_config["aws_eos"]
         self.assertEqual(aws_conf.search.product_location_scheme, "file")
-        self.assertEqual(aws_conf.auth.credentials["apikey"], "api-key")
+        self.assertEqual(aws_conf.search_auth.credentials["apikey"], "api-key")
         self.assertEqual(
-            aws_conf.auth.credentials["aws_access_key_id"], "access-key-id"
+            aws_conf.download_auth.credentials["aws_access_key_id"], "access-key-id"
         )
         self.assertEqual(
-            aws_conf.auth.credentials["aws_secret_access_key"], "secret-access-key"
+            aws_conf.download_auth.credentials["aws_secret_access_key"],
+            "secret-access-key",
         )
 
         peps_conf = default_config["peps"]

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -270,6 +270,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         )
         dl_config = config.PluginConfig.from_mapping(
             {
+                "type": "HTTPDownload",
                 "base_uri": "fake_base_uri",
                 "output_dir": self.output_dir,
                 "extract": False,

--- a/tests/units/test_utils_s3.py
+++ b/tests/units/test_utils_s3.py
@@ -90,10 +90,11 @@ class TestUtilsS3(TestCase):
             "dummy",
             PluginConfig.from_mapping(
                 {
+                    "type": "AwsAuth",
                     "credentials": dict(
                         aws_access_key_id="foo",
                         aws_secret_access_key="bar",
-                    )
+                    ),
                 }
             ),
         )
@@ -139,10 +140,11 @@ class TestUtilsS3(TestCase):
             "dummy",
             PluginConfig.from_mapping(
                 {
+                    "type": "AwsAuth",
                     "credentials": dict(
                         aws_access_key_id="foo",
                         aws_secret_access_key="bar",
-                    )
+                    ),
                 }
             ),
         )
@@ -184,7 +186,7 @@ class TestUtilsS3(TestCase):
     def test_utils_s3_update_assets_from_s3_credentials_nok(self):
         """update_assets_from_s3 must have required credentials"""
         prod = EOProduct("dummy", dict(geometry="POINT (0 0)", id="foo"))
-        auth_plugin = AwsAuth("dummy", PluginConfig.from_mapping({}))
+        auth_plugin = AwsAuth("dummy", PluginConfig())
         self.assertRaises(
             MisconfiguredError,
             update_assets_from_s3,


### PR DESCRIPTION
Always validate (check if `type` is in config) before creating a `PluginConfig` object (validation added when using `.from_mapping`).

Also adds a more explicit warning if a malformed plugin is attempted to be loaded from an old user config file that has incorrect plugin topic keys (e.g. `auth` instead of `search_auth`, etc)