### PR TITLE
docs: import_stac_items documentation update

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -2483,7 +2483,7 @@ class EODataAccessGateway:
 
         - Origin provider and download links will be set if item comes from an EODAG
           server.
-        - If item comes from a knwon EODAG provider, result will be registered to it,
+        - If item comes from a known EODAG provider, result will be registered to it,
           ready to download and its metadata normalized.
         - If item comes from an unknown provider, a generic STAC provider will be used.
 


### PR DESCRIPTION
Following https://github.com/CS-SI/eodag/pull/1705, update [import_stac_items](https://eodag.readthedocs.io/en/latest/api_reference/core.html#eodag.api.core.EODataAccessGateway.import_stac_items) documentation