### PR TITLE
fix: pagination for Fresh Data Pool

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -1299,6 +1299,12 @@ class EODataAccessGateway:
                     search_results.next_page_token_key = (
                         search_plugin.next_page_token_key
                     )
+                else:
+                    if token is None:
+                        token = "1"
+                    if token.isdigit():
+                        token = str(int(token) + 1)
+                    search_results.next_page_token_key = f"page:{token}"
                 return search_results
 
         if i > 1:

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -67,7 +67,6 @@ from eodag.utils import (
     DEFAULT_DOWNLOAD_WAIT,
     DEFAULT_ITEMS_PER_PAGE,
     DEFAULT_MAX_ITEMS_PER_PAGE,
-    DEFAULT_PAGE,
     GENERIC_PRODUCT_TYPE,
     GENERIC_STAC_PROVIDER,
     HTTP_REQ_TIMEOUT,
@@ -1193,7 +1192,7 @@ class EODataAccessGateway:
 
     def search(
         self,
-        page: int = DEFAULT_PAGE,
+        token: Optional[str] = None,
         items_per_page: int = DEFAULT_ITEMS_PER_PAGE,
         raise_errors: bool = False,
         start: Optional[str] = None,
@@ -1274,7 +1273,7 @@ class EODataAccessGateway:
         search_kwargs.pop("_dc_qs", None)
 
         search_kwargs.update(
-            page=page,
+            token=token,
             items_per_page=items_per_page,
         )
 
@@ -1296,6 +1295,10 @@ class EODataAccessGateway:
                 )
             elif len(search_results) > 0:
                 search_results.errors = errors
+                if search_plugin.next_page_token_key is not None:
+                    search_results.next_page_token_key = (
+                        search_plugin.next_page_token_key
+                    )
                 return search_results
 
         if i > 1:
@@ -1937,7 +1940,7 @@ class EODataAccessGateway:
                 ):
                     prep.auth = auth
 
-            prep.page = kwargs.pop("page", None)
+            prep.token = kwargs.pop("token", None)
             prep.items_per_page = kwargs.pop("items_per_page", None)
 
             res, nb_res = search_plugin.query(prep, **kwargs)

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -234,6 +234,8 @@ class PluginConfig(yaml.YAMLObject):
         next_page_query_obj_key_path: Union[str, JSONPath]
         # TODO: change this typing to bool and adapt code to it
         next_page_merge_key_path: Union[str, JSONPath]
+        #: Token for the next page
+        next_page_token: Union[str, JSONPath]
         #: Template to add to :attr:`~eodag.config.PluginConfig.Pagination.next_page_url_tpl` to enable count in
         #: search request
         count_tpl: str

--- a/eodag/plugins/search/__init__.py
+++ b/eodag/plugins/search/__init__.py
@@ -53,3 +53,4 @@ class PreparedSearch:
     product_type_def_params: dict[str, Any] = field(init=False, repr=False)
     total_items_nb: int = field(init=False, repr=False)
     sort_by_qs: str = field(init=False, repr=False)
+    token: Optional[str] = field(init=False, repr=False)

--- a/eodag/rest/types/stac_search.py
+++ b/eodag/rest/types/stac_search.py
@@ -107,6 +107,10 @@ class SearchPostRequest(BaseModel):
     page: Optional[PositiveInt] = Field(  # type: ignore
         default=None, description="Page number, must be a positive integer."
     )
+    next_page_token: Optional[str] = Field(
+        default=None,
+        description="Token for pagination, used to retrieve the next page of results.",
+    )
     query: Optional[dict[str, Any]] = None
     filter: Optional[dict[str, Any]] = None
     filter_lang: Optional[str] = Field(


### PR DESCRIPTION
This PR fixes the pagination mechanism for fetching items from the Fresh Data Pool API.
Previously, passing a page parameter had no effect, as the API uses token-based pagination instead of numeric indexing. This update now follows the next token provided in the links field of each response to reach the desired page.

Changes:
- Implemented a loop to follow next tokens returned in the response, up to the requested page.
- Updated the request logic to inject the correct token in each iteration.

