### PR TITLE
feat(cli): download output directory

### DIFF
--- a/eodag/cli.py
+++ b/eodag/cli.py
@@ -563,6 +563,11 @@ Examples:
     show_default=False,
     help="Download only quicklooks of products instead full set of files",
 )
+@click.option(
+    "--output-dir",
+    type=click.Path(dir_okay=True, file_okay=False),
+    help="Products or quicklooks download directory (Default: local temporary directory)",
+)
 @click.pass_context
 def download(ctx: Context, **kwargs: Any) -> None:
     """Download a bunch of products from a serialized search result"""
@@ -587,7 +592,9 @@ def download(ctx: Context, **kwargs: Any) -> None:
     if stac_items:
         search_results.extend(satim_api.import_stac_items(list(stac_items)))
 
+    output_dir = kwargs.pop("output_dir")
     get_quicklooks = kwargs.pop("quicklooks")
+
     if get_quicklooks:
         # Download only quicklooks
         click.echo(
@@ -595,7 +602,7 @@ def download(ctx: Context, **kwargs: Any) -> None:
         )
 
         for idx, product in enumerate(search_results):
-            downloaded_file = product.get_quicklook()
+            downloaded_file = product.get_quicklook(output_dir=output_dir)
             if not downloaded_file:
                 click.echo(
                     "A quicklook may have been downloaded but we cannot locate it. "
@@ -606,7 +613,7 @@ def download(ctx: Context, **kwargs: Any) -> None:
 
     else:
         # Download products
-        downloaded_files = satim_api.download_all(search_results)
+        downloaded_files = satim_api.download_all(search_results, output_dir=output_dir)
         if downloaded_files and len(downloaded_files) > 0:
             for downloaded_file in downloaded_files:
                 if downloaded_file is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -411,7 +411,9 @@ class TestEodagCli(unittest.TestCase):
             api_obj.search.assert_called_once_with(
                 count=False, items_per_page=DEFAULT_ITEMS_PER_PAGE, page=1, **criteria
             )
-            api_obj.download_all.assert_called_once_with(search_results)
+            api_obj.download_all.assert_called_once_with(
+                search_results, output_dir=None
+            )
 
     @mock.patch("eodag.cli.EODataAccessGateway", autospec=True)
     def test_eodag_search_all(self, dag):
@@ -888,7 +890,9 @@ class TestEodagCli(unittest.TestCase):
             dag.return_value.import_stac_items.assert_called_once_with(
                 ["foo", "bar"],
             )
-            dag.return_value.download_all.assert_called_once_with(fake_result)
+            dag.return_value.download_all.assert_called_once_with(
+                fake_result, output_dir=None
+            )
 
     def test_eodag_download_missingcredentials(self):
         """Calling eodag download with missing credentials must raise MisconfiguredError"""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -945,6 +945,23 @@ class TestEodagCli(unittest.TestCase):
         self.assertEqual(mock_get_quicklook.call_count, 2)
         self.assertIn("Downloaded /fake_path\n", result.output)
 
+        # change output dir
+        output_dir = os.path.join(self.tmp_home_dir.name, "quicklooks")
+        result = self.runner.invoke(
+            eodag,
+            [
+                "download",
+                "--search-results",
+                search_results_path,
+                "-f",
+                config_path,
+                "--quicklooks",
+                "--output-dir",
+                output_dir,
+            ],
+        )
+        mock_get_quicklook.assert_called_with(mock.ANY, output_dir=output_dir)
+
         # Testing the case when no quicklook path is returned
         mock_get_quicklook.return_value = None
         result = self.runner.invoke(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -832,6 +832,24 @@ class TestEodagCli(unittest.TestCase):
             "A file may have been downloaded but we cannot locate it\n", result.output
         )
 
+        # Testing output directory
+        output_dir = os.path.join(self.tmp_home_dir.name, "downloads")
+        result = self.runner.invoke(
+            eodag,
+            [
+                "download",
+                "--search-results",
+                search_results_path,
+                "-f",
+                config_path,
+                "--output-dir",
+                output_dir,
+            ],
+        )
+        dag.return_value.download_all.assert_called_with(
+            mock.ANY, output_dir=output_dir
+        )
+
     @mock.patch("eodag.cli.EODataAccessGateway", autospec=True)
     def test_eodag_download_ko(self, dag):
         """Calling eodag download with all args well formed fails"""


### PR DESCRIPTION
Allows user to specify download directory using `--output-dir` option:

```sh
eodag download results.geojson --output-dir /path/to/downloads
```

See [CLI User Guide / Download](https://eodag.readthedocs.io/en/latest/cli_user_guide.html)