### PR TITLE
perf(plugins): optimize AwsDownload streaming

### DIFF
--- a/eodag/cli.py
+++ b/eodag/cli.py
@@ -109,8 +109,9 @@ class MutuallyExclusiveOption(click.Option):
         """Raise error or use parent handle_parse_result()"""
         if self.mutually_exclusive.intersection(opts) and self.name in opts:
             raise click.UsageError(
-                "Illegal usage: `{}` is mutually exclusive with "
-                "arguments `{}`.".format(self.name, ", ".join(self.mutually_exclusive))
+                "Illegal usage: `{}` is mutually exclusive with arguments `{}`.".format(
+                    self.name, ", ".join(self.mutually_exclusive)
+                )
             )
 
         return super(MutuallyExclusiveOption, self).handle_parse_result(ctx, opts, args)
@@ -687,6 +688,7 @@ def serve_rest(
     setup_logging(verbose=ctx.obj["verbosity"])
     try:
         import uvicorn
+        import uvicorn.config
     except ImportError:
         raise ImportError(
             "Feature not available, please install eodag[server] or eodag[all]"

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -58,7 +58,7 @@ from eodag.utils.exceptions import (
     NotAvailableError,
     TimeOutError,
 )
-from eodag.utils.s3 import FileInfo, open_s3_zipped_object, stream_download_from_s3
+from eodag.utils.s3 import S3FileInfo, open_s3_zipped_object, stream_download_from_s3
 
 if TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client
@@ -831,7 +831,7 @@ class AwsDownload(Download):
                     "type"
                 )
 
-                file_info = FileInfo(
+                file_info = S3FileInfo(
                     key=obj.key,
                     size=obj.size,
                     bucket_name=obj.bucket_name,

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -798,6 +798,8 @@ class AwsDownload(Download):
             if flatten_top_dirs
             else ""
         )
+        if len(product_objects) == 1:
+            common_path = os.path.dirname(common_path)
 
         assets_by_path = {
             a.get("href", "").split("s3://")[-1]: a

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -714,10 +714,10 @@ class AwsDownload(Download):
         compress: Literal["zip", "raw", "auto"] = "auto",
         wait: float = DEFAULT_DOWNLOAD_WAIT,
         timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,
-        **kwargs: Any,
+        **kwargs: Unpack[DownloadConf],
     ) -> StreamResponse:
         """
-        Stream EO product data as a FastAPI `StreamResponse`, with support for partial downloads,
+        Stream EO product data as a FastAPI-compatible `StreamResponse`, with support for partial downloads,
         asset filtering, and on-the-fly compression.
 
         This method streams data from one or more S3 objects that belong to a given EO product.
@@ -956,6 +956,7 @@ class AwsDownload(Download):
         )
         objects = s3_resource.Bucket(bucket_name).objects
         list(objects.filter(Prefix=prefix).limit(1))
+        self.s3_resource = s3_resource
         return objects
 
     def _get_authenticated_objects_from_auth_profile(

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -808,6 +808,7 @@ class AwsDownload(Download):
         )
 
         assets_values = product.assets.get_values(asset_filter=asset_regex or "")
+        assets_by_key = {a.get("key"): a for a in assets_values}
 
         zip_filename = (
             sanitize(product.properties["title"])
@@ -822,17 +823,14 @@ class AwsDownload(Download):
                 size=obj.size,
                 bucket_name=obj.bucket_name,
                 rel_path=objects_rel_path[i],
-                zip_filename=zip_filename,
             )
-            if data_type := assets_values[i].get(obj.key, None):
+            if data_type := assets_by_key.get(obj.key, {}).get("type"):
                 info.data_type = data_type
 
             list_info.append(info)
 
         return stream_download_from_s3(
-            self.s3_resource.meta.client,
-            list_info,
-            byte_range,
+            self.s3_resource.meta.client, list_info, byte_range, compress, zip_filename
         )
 
     def _validate_product_objects(

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -45,7 +45,6 @@ from eodag.utils import (
     StreamResponse,
     flatten_top_directories,
     get_bucket_name_and_prefix,
-    guess_file_type,
     path_to_uri,
     rename_subfolder,
     sanitize,
@@ -819,7 +818,7 @@ class AwsDownload(Download):
 
                 data_type = assets_by_path.get(f"{obj.bucket_name}/{obj.key}", {}).get(
                     "type"
-                ) or guess_file_type(obj.key)
+                )
 
                 file_info = FileInfo(
                     key=obj.key,

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -712,6 +712,7 @@ class AwsDownload(Download):
         auth: Optional[Union[AuthBase, S3SessionKwargs]] = None,
         byte_range: tuple[Optional[int], Optional[int]] = (None, None),
         compress: Literal["zip", "raw", "auto"] = "auto",
+        **kwargs: Any,
     ) -> StreamResponse:
         """
         Stream EO product data as a FastAPI `StreamResponse`, with support for partial downloads,

--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -27,7 +27,7 @@ import zipfile
 from datetime import datetime, timedelta
 from pathlib import Path
 from time import sleep
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, TypeVar, Union
 
 from eodag.api.product.metadata_mapping import ONLINE_STATUS
 from eodag.plugins.base import PluginTopic
@@ -134,7 +134,8 @@ class Download(PluginTopic):
         self,
         product: EOProduct,
         auth: Optional[Union[AuthBase, S3SessionKwargs]] = None,
-        progress_callback: Optional[ProgressCallback] = None,
+        byte_range: tuple[Optional[int], Optional[int]] = (None, None),
+        compress: Literal["zip", "raw", "auto"] = "auto",
         wait: float = DEFAULT_DOWNLOAD_WAIT,
         timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,
         **kwargs: Unpack[DownloadConf],

--- a/eodag/plugins/download/creodias_s3.py
+++ b/eodag/plugins/download/creodias_s3.py
@@ -15,7 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import boto3
 from botocore.exceptions import ClientError
@@ -25,8 +25,6 @@ from eodag.plugins.download.aws import AwsDownload
 from eodag.utils.exceptions import MisconfiguredError
 
 if TYPE_CHECKING:
-    from typing import Optional
-
     from mypy_boto3_s3.service_resource import S3ServiceResource
 
 

--- a/eodag/plugins/download/creodias_s3.py
+++ b/eodag/plugins/download/creodias_s3.py
@@ -72,8 +72,9 @@ class CreodiasS3Download(AwsDownload):
     def _get_bucket_names_and_prefixes(
         self,
         product: EOProduct,
-        asset_filter: Optional[str] = None,
-        ignore_assets: Optional[bool] = False,
+        asset_filter: Optional[str],
+        ignore_assets: bool,
+        complementary_url_keys: list[str],
     ) -> list[tuple[str, Optional[str]]]:
         """
         Retrieves the bucket names and path prefixes for the assets
@@ -86,7 +87,7 @@ class CreodiasS3Download(AwsDownload):
         # if assets are defined, use them instead of scanning product.location
         if len(product.assets) > 0 and not ignore_assets:
             bucket_names_and_prefixes = super()._get_bucket_names_and_prefixes(
-                product, asset_filter, ignore_assets
+                product, asset_filter, ignore_assets, complementary_url_keys
             )
         else:
             # if no assets are given, use productIdentifier to get S3 path for download

--- a/eodag/plugins/download/creodias_s3.py
+++ b/eodag/plugins/download/creodias_s3.py
@@ -19,6 +19,7 @@ from typing import Optional
 
 import boto3
 from botocore.exceptions import ClientError
+from mypy_boto3_s3.service_resource import S3ServiceResource
 
 from eodag import EOProduct
 from eodag.plugins.download.aws import AwsDownload
@@ -60,10 +61,10 @@ class CreodiasS3Download(AwsDownload):
             )
 
         s3_session = boto3.session.Session(**auth_dict)
-        s3_resource = s3_session.resource(
+        self.s3_resource: S3ServiceResource = s3_session.resource(
             "s3", endpoint_url=getattr(self.config, "s3_endpoint", None)
         )
-        objects = s3_resource.Bucket(bucket_name).objects.filter()
+        objects = self.s3_resource.Bucket(bucket_name).objects.filter()
         list(objects.filter(Prefix=prefix).limit(1))
         self.s3_session = s3_session
         return objects

--- a/eodag/plugins/download/creodias_s3.py
+++ b/eodag/plugins/download/creodias_s3.py
@@ -15,15 +15,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
+from typing import TYPE_CHECKING
 
 import boto3
 from botocore.exceptions import ClientError
-from mypy_boto3_s3.service_resource import S3ServiceResource
 
 from eodag import EOProduct
 from eodag.plugins.download.aws import AwsDownload
 from eodag.utils.exceptions import MisconfiguredError
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from mypy_boto3_s3.service_resource import S3ServiceResource
 
 
 class CreodiasS3Download(AwsDownload):

--- a/eodag/plugins/download/creodias_s3.py
+++ b/eodag/plugins/download/creodias_s3.py
@@ -69,6 +69,7 @@ class CreodiasS3Download(AwsDownload):
         objects = s3_resource.Bucket(bucket_name).objects.filter()
         list(objects.filter(Prefix=prefix).limit(1))
         self.s3_session = s3_session
+        self.s3_resource = s3_resource
         return objects
 
     def _get_bucket_names_and_prefixes(

--- a/eodag/plugins/download/creodias_s3.py
+++ b/eodag/plugins/download/creodias_s3.py
@@ -61,10 +61,10 @@ class CreodiasS3Download(AwsDownload):
             )
 
         s3_session = boto3.session.Session(**auth_dict)
-        self.s3_resource: S3ServiceResource = s3_session.resource(
+        s3_resource: S3ServiceResource = s3_session.resource(
             "s3", endpoint_url=getattr(self.config, "s3_endpoint", None)
         )
-        objects = self.s3_resource.Bucket(bucket_name).objects.filter()
+        objects = s3_resource.Bucket(bucket_name).objects.filter()
         list(objects.filter(Prefix=prefix).limit(1))
         self.s3_session = s3_session
         return objects

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -28,7 +28,16 @@ from email.message import Message
 from itertools import chain
 from json import JSONDecodeError
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterator, Optional, TypedDict, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Iterator,
+    Literal,
+    Optional,
+    TypedDict,
+    Union,
+    cast,
+)
 from urllib.parse import parse_qs, urlparse
 
 import geojson
@@ -745,7 +754,8 @@ class HTTPDownload(Download):
         self,
         product: EOProduct,
         auth: Optional[Union[AuthBase, S3SessionKwargs]] = None,
-        progress_callback: Optional[ProgressCallback] = None,
+        byte_range: tuple[Optional[int], Optional[int]] = (None, None),
+        compress: Literal["zip", "raw", "auto"] = "auto",
         wait: float = DEFAULT_DOWNLOAD_WAIT,
         timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,
         **kwargs: Unpack[DownloadConf],
@@ -779,7 +789,7 @@ class HTTPDownload(Download):
                 chunks_tuples = self._stream_download_assets(
                     product,
                     auth,
-                    progress_callback,
+                    None,
                     assets_values=assets_values,
                     **kwargs,
                 )
@@ -825,9 +835,7 @@ class HTTPDownload(Download):
                 else:
                     pass
 
-        chunk_iterator = self._stream_download(
-            product, auth, progress_callback, **kwargs
-        )
+        chunk_iterator = self._stream_download(product, auth, None, **kwargs)
 
         # start reading chunks to set product.headers
         try:

--- a/eodag/rest/core.py
+++ b/eodag/rest/core.py
@@ -28,7 +28,6 @@ import dateutil
 from cachetools.func import lru_cache
 from fastapi.responses import ORJSONResponse, StreamingResponse
 from pydantic import ValidationError as pydanticValidationError
-from pyinstrument import Profiler
 from requests.models import Response as RequestsResponse
 
 import eodag
@@ -96,19 +95,6 @@ crunchers = {
     "filterLatestByName": Cruncher(FilterLatestByName, ["name_pattern"]),
     "filterOverlap": Cruncher(FilterOverlap, ["minimum_overlap"]),
 }
-
-
-def profile_generator(gen, profile_file="stream_profile.html"):
-    """Wrap generator with PyInstrument profiler"""
-    profiler = Profiler()
-    profiler.start()
-
-    for chunk in gen:
-        yield chunk
-
-    profiler.stop()
-    with open(profile_file, "w", encoding="utf-8") as f:
-        f.write(profiler.output_html())
 
 
 @_deprecated(reason="No more needed with STAC API + Swagger", version="2.6.1")

--- a/eodag/rest/core.py
+++ b/eodag/rest/core.py
@@ -279,7 +279,9 @@ def download_stac_item(
         if product.properties.get("orderLink"):
             _order_and_update(product, auth, kwargs)
 
-        download_stream = product.downloader.stream_download(product, asset, auth)
+        download_stream = product.downloader._stream_download_dict(
+            product, auth=auth, asset=asset
+        )
     except NotImplementedError:
         logger.warning(
             "Download streaming not supported for %s: downloading locally then delete",
@@ -309,7 +311,7 @@ def download_stac_item(
             raise
 
     return StreamingResponse(
-        content=profile_generator(download_stream.content),
+        content=download_stream.content,
         headers=download_stream.headers,
         media_type=download_stream.media_type,
     )

--- a/eodag/rest/core.py
+++ b/eodag/rest/core.py
@@ -266,7 +266,7 @@ def download_stac_item(
             _order_and_update(product, auth, kwargs)
 
         download_stream = product.downloader._stream_download_dict(
-            product, auth=auth, asset=asset
+            product, auth=auth, asset=asset, wait=-1, timeout=-1
         )
     except NotImplementedError:
         logger.warning(

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -1574,10 +1574,24 @@ def remove_str_array_quotes(input_str: str) -> str:
 
 
 def parse_le_uint32(data: bytes) -> int:
-    """Parse little-endian unsigned 4-byte integer."""
+    """
+    Parse little-endian unsigned 4-byte integer.
+
+    >>> parse_le_uint32(b'\\x01\\x00\\x00\\x00')
+    1
+    >>> parse_le_uint32(b'\\xff\\xff\\xff\\xff')
+    4294967295
+    """
     return struct.unpack("<I", data)[0]
 
 
 def parse_le_uint16(data: bytes) -> int:
-    """Parse little-endian unsigned 2-byte integer."""
+    """
+    Parse little-endian unsigned 2-byte integer.
+
+    >>> parse_le_uint16(b'\\x01\\x00')
+    1
+    >>> parse_le_uint16(b'\\xff\\xff')
+    65535
+    """
     return struct.unpack("<H", data)[0]

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -36,6 +36,7 @@ import re
 import shutil
 import ssl
 import string
+import struct
 import sys
 import types
 import unicodedata
@@ -224,14 +225,13 @@ class FloatRange(click.types.FloatParamType):
         ):
             if self.min is None:
                 self.fail(
-                    "%s is bigger than the maximum valid value " "%s." % (rv, self.max),
+                    "%s is bigger than the maximum valid value %s." % (rv, self.max),
                     param,
                     ctx,
                 )
             elif self.max is None:
                 self.fail(
-                    "%s is smaller than the minimum valid value "
-                    "%s." % (rv, self.min),
+                    "%s is smaller than the minimum valid value %s." % (rv, self.min),
                     param,
                     ctx,
                 )
@@ -1451,8 +1451,7 @@ def cast_scalar_value(value: Any, new_type: Any) -> Any:
         # case
         if value.capitalize() not in ("True", "False"):
             raise ValueError(
-                "Only true or false strings (case insensitive) are "
-                "allowed for booleans"
+                "Only true or false strings (case insensitive) are allowed for booleans"
             )
         # Get the real Python value of the boolean. e.g: value='tRuE'
         # => eval(value.capitalize())=True.
@@ -1572,3 +1571,13 @@ def remove_str_array_quotes(input_str: str) -> str:
             continue
         output_str += input_str[i]
     return output_str
+
+
+def parse_le_uint32(data: bytes) -> int:
+    """Parse little-endian unsigned 4-byte integer."""
+    return struct.unpack("<I", data)[0]
+
+
+def parse_le_uint16(data: bytes) -> int:
+    """Parse little-endian unsigned 2-byte integer."""
+    return struct.unpack("<H", data)[0]

--- a/eodag/utils/exceptions.py
+++ b/eodag/utils/exceptions.py
@@ -79,6 +79,10 @@ class STACOpenerError(EodagError):
     """An error indicating that a STAC file could not be opened"""
 
 
+class InvalidDataError(EodagError):
+    """Raised when data is invalid, malformed, or corrupt and cannot be processed as expected."""
+
+
 class RequestError(EodagError):
     """An error indicating that a request has failed. Usually eodag functions
     and methods should catch and skip this"""

--- a/eodag/utils/s3.py
+++ b/eodag/utils/s3.py
@@ -251,7 +251,7 @@ def _chunks_from_s3_objects(
                 while next_start in current_info.buffers:
                     chunk = current_info.buffers.pop(next_start)
                     if not isinstance(chunk, bytes):
-                        raise TypeError(
+                        raise InvalidDataError(
                             f"Expected bytes, got {type(chunk).__name__} in stream chunks: {chunk}"
                         )
                     yield chunk

--- a/eodag/utils/s3.py
+++ b/eodag/utils/s3.py
@@ -21,14 +21,22 @@ import io
 import logging
 import os
 import zipfile
-from typing import TYPE_CHECKING, List, Optional
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
+from zipfile import ZipFile
 
 import boto3
 import botocore
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 
 from eodag.plugins.authentication.aws_auth import AwsAuth
-from eodag.utils import get_bucket_name_and_prefix, guess_file_type
+from eodag.utils import (
+    get_bucket_name_and_prefix,
+    guess_file_type,
+    parse_le_uint16,
+    parse_le_uint32,
+)
 from eodag.utils.exceptions import (
     AuthenticationError,
     MisconfiguredError,
@@ -36,102 +44,246 @@ from eodag.utils.exceptions import (
 )
 
 if TYPE_CHECKING:
-    from zipfile import ZipFile, ZipInfo
+    from typing import Iterator, Optional
+    from zipfile import ZipInfo
 
     from mypy_boto3_s3.client import S3Client
+    from mypy_boto3_s3.service_resource import ObjectSummary
 
     from eodag.api.product import EOProduct  # type: ignore
 
 logger = logging.getLogger("eodag.utils.s3")
 
 
-def fetch(
-    bucket_name: str, key_name: str, start: int, len: int, client_s3: S3Client
+def fetch_range(
+    bucket_name: str, key_name: str, start: int, end: int, client_s3: S3Client
 ) -> bytes:
     """
     Range-fetches a S3 key.
 
     :param bucket_name: Bucket name of the object to fetch
     :param key_name: Key name of the object to fetch
-    :param start: Bucket name to fetch
-    :param len: Bucket name to fetch
+    :param start: Start byte position to fetch
+    :param end: End byte position to fetch
     :param client_s3: s3 client used to fetch the object
     :returns: Object bytes
     """
-    end = start + len - 1
-    s3_object = client_s3.get_object(
+    response = client_s3.get_object(
         Bucket=bucket_name, Key=key_name, Range="bytes=%d-%d" % (start, end)
     )
-    return s3_object["Body"].read()
+    return response["Body"].read()
 
 
-def parse_int(bytes: bytes) -> int:
+@dataclass
+class _FileInfo:
     """
-    Parses 2 or 4 little-endian bits into their corresponding integer value.
-
-    :param bytes: bytes to parse
-    :returns: parsed int
+    Describe a S3 object with basic info and its download state.
     """
-    val = (bytes[0]) + ((bytes[1]) << 8)
-    if len(bytes) > 3:
-        val += ((bytes[2]) << 16) + ((bytes[3]) << 24)
-    return val
+
+    size: int
+    key: str
+    bucket_name: str
+    zip_filename: Optional[str] = None
+    data_start_offset: int = 0
+
+    # These fields hold the state for downloading
+    file_start_offset: int = 0
+    futures: dict = field(
+        default_factory=dict
+    )  # Mapping of futures for each range (start -> future)
+    buffers: dict[int, bytes] = field(
+        default_factory=dict
+    )  # Map of start byte to data chunks
+    next_yield: int = 0  # The next offset to yield in the file
 
 
-def open_s3_zipped_object(
-    bucket_name: str, key_name: str, client_s3: S3Client, partial: bool = True
-) -> ZipFile:
-    """
-    Open s3 zipped object, without downloading it.
+def _prepare_file_in_zip(info: _FileInfo, s3_client: S3Client) -> _FileInfo:
+    """Update file information with the offset and size of the file inside the zip archive"""
 
-    See https://stackoverflow.com/questions/41789176/how-to-count-files-inside-zip-in-aws-s3-without-downloading-it;
-    Based on https://stackoverflow.com/questions/51351000/read-zip-files-from-s3-without-downloading-the-entire-file
+    splitted_path = info.key.split(".zip!")
+    info.key = f"{splitted_path[0]}.zip"
+    info.zip_filename = splitted_path[-1]  # file path inside the ZIP archive
 
-    :param bucket_name: Bucket name of the object to fetch
-    :param key_name: Key name of the object to fetch
-    :param client_s3: s3 client used to fetch the object
-    :param partial: fetch partial data if only content info is needed
-    :returns: List of files in zip
-    """
-    response = client_s3.head_object(Bucket=bucket_name, Key=key_name)
-    size = response["ContentLength"]
-
-    # End Of Central Directory bytes
-    eocd = fetch(bucket_name, key_name, size - 22, 22, client_s3)
-
-    # start offset and size of the central directory
-    cd_start = parse_int(eocd[16:20])
-    cd_size = parse_int(eocd[12:16])
-
-    # fetch central directory, append EOCD, and open as zipfile
-    cd = fetch(bucket_name, key_name, cd_start, cd_size, client_s3)
-
-    zip_data = (
-        cd + eocd if partial else fetch(bucket_name, key_name, 0, size, client_s3)
+    info.data_start_offset, info.size = file_position_from_s3_zip(
+        info.bucket_name,
+        info.key,
+        s3_client,
+        info.zip_filename,
     )
 
-    zip = zipfile.ZipFile(io.BytesIO(zip_data))
 
-    return zip
-
-
-def list_files_in_s3_zipped_object(
-    bucket_name: str, key_name: str, client_s3: S3Client
-) -> List[ZipInfo]:
+def _compute_file_ranges(
+    file_info: _FileInfo,
+    byte_range: tuple[Optional[int], Optional[int]],
+    range_size: int,
+) -> Optional[list[tuple[int, int]]]:
     """
-    List files in s3 zipped object, without downloading it.
+    Compute the byte ranges to download for a single file, considering the overall requested range.
 
-    See https://stackoverflow.com/questions/41789176/how-to-count-files-inside-zip-in-aws-s3-without-downloading-it;
-    Based on https://stackoverflow.com/questions/51351000/read-zip-files-from-s3-without-downloading-the-entire-file
+    This function calculates which byte ranges within the given file should be downloaded,
+    based on the global requested byte range (`byte_range`) and the size of each chunk (`range_size`).
+    It accounts for possible offsets if the file is part of a ZIP archive or not aligned at offset zero.
 
-    :param bucket_name: Bucket name of the object to fetch
-    :param key_name: Key name of the object to fetch
-    :param client_s3: s3 client used to fetch the object
-    :returns: List of files in zip
+    :param file_info: The _FileInfo object containing file metadata, including size, data offset,
+                      and its starting offset in the full logical file stream.
+    :param byte_range: A tuple (start, end) specifying the requested global byte range, where either
+                       value may be None to indicate an open-ended range.
+    :param range_size: The size of each download chunk in bytes.
+    :returns: A list of (start, end) tuples indicating byte ranges to download within this file,
+              or None if the file lies completely outside the requested range.
     """
-    with open_s3_zipped_object(bucket_name, key_name, client_s3) as zip_file:
-        logger.debug("Found %s files in %s" % (len(zip_file.filelist), key_name))
-        return zip_file.filelist
+    file_size = file_info.size
+    file_start_offset = file_info.file_start_offset
+    file_end_offset = file_start_offset + file_size - 1
+
+    range_start, range_end = byte_range
+
+    # Check if the file overlaps with the requested range
+    if range_end is not None and range_start is not None:
+        if file_end_offset < range_start or file_start_offset > range_end:
+            return None  # No overlap, skip this file
+
+    start = 0
+    end = file_size - 1
+
+    # Adjust start and end based on the requested range
+    if range_start is not None:
+        start = max(0, range_start - file_start_offset)
+    if range_end is not None:
+        end = min(file_size - 1, range_end - file_start_offset)
+
+    start += file_info.data_start_offset
+    end += file_info.data_start_offset
+
+    # Compute the ranges in chunks
+    ranges = []
+    for chunk_start in range(start, end + 1, range_size):
+        chunk_end = min(chunk_start + range_size - 1, end)
+        ranges.append((chunk_start, chunk_end))
+
+    return ranges
+
+
+def stream_download_from_s3(
+    s3_client: "S3Client",
+    object_summaries: list[ObjectSummary],
+    byte_range: tuple[Optional[int], Optional[int]] = (None, None),
+    range_size: int = 1024**2 * 8,
+    max_workers: int = 8,
+) -> Iterator[tuple[int, bytes]]:
+    """
+    Stream data from one or more S3 objects in chunks, with support for global byte ranges
+    and partial file extraction from ZIP archives.
+
+    This method downloads product data from S3 using concurrent range requests across one or
+    multiple files. It divides the requested data into chunks (default: 8 MiB) and issues
+    parallel HTTP range requests to optimize download throughput. This is particularly useful
+    for large files or datasets stored across multiple S3 objects.
+
+    If the S3 key refers to a path inside a `.zip` file (denoted by `.zip!<internal_path>`),
+    the function extracts the specified file from the archive **only if it is stored uncompressed**
+    (i.e., ZIP method = STORE). Compressed formats (like DEFLATE) are not supported for partial ZIP extraction.
+
+    The function supports global byte range filtering via the `byte_range` parameter, which allows
+    requesting only a specific portion of the logical file stream across all provided objects.
+
+    Downloads are performed concurrently using a thread pool and HTTP range requests. Each chunk is downloaded
+    as a separate HTTP request and yielded in file order.
+
+    :param s3_client: A configured S3 client capable of making range requests.
+    :param object_summaries: A list of S3 object metadata representing the files to download.
+    :param byte_range: A tuple of (start, end) defining the inclusive global byte range to download
+                       across all objects. Either value can be None to indicate open-ended range.
+    :param range_size: The size in bytes of each download chunk. Defaults to 8 MiB.
+    :param max_workers: The maximum number of concurrent download tasks. Controls the size of the thread pool.
+    :returns: An iterator yielding (file_index, data_chunk) tuples, where:
+              - file_index is the index of the file in the input object list
+              - data_chunk is a `bytes` object containing the downloaded chunk
+    :rtype: Iterator[tuple[int, bytes]]
+    """
+    list_info: list[_FileInfo] = []
+    offset = 0
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        # Compute start offset of each file within the aggregated stream
+        for obj_summary in object_summaries:
+            info = _FileInfo(
+                size=obj_summary.size,
+                key=obj_summary.key,
+                bucket_name=obj_summary.bucket_name,
+            )
+
+            list_info.append(info)
+
+            # Check if file is inside a ZIP
+            if ".zip!" in info.key:
+                future = executor.submit(_prepare_file_in_zip, info)
+                info.futures[future] = 0  # track this future for download state
+
+        # Wait for ZIP file preparation
+        for info in list_info:
+            for future in info.futures:
+                future.result()
+            info.file_start_offset = offset
+            offset += info.size
+
+        # Submit download tasks per file
+        for info in list_info:
+            ranges = _compute_file_ranges(info, byte_range, range_size)
+
+            if not ranges:
+                # File lies outside requested range; skip it
+                continue
+
+            futures = {}
+            for start, length in ranges:
+                future = executor.submit(
+                    fetch_range,
+                    info.bucket_name,
+                    info.key,
+                    start,
+                    length,
+                    s3_client,
+                )
+                futures[future] = start
+
+            info.futures = futures
+
+        # Combine all futures to wait on globally
+        all_futures = {
+            fut: (info, start)
+            for info in list_info
+            for fut, start in info.futures.items()
+        }
+
+        current_file_index = 0
+
+        # Yield chunks in order, honoring file ordering
+        while current_file_index < len(list_info):
+            if not all_futures:
+                break  # No more data to process
+
+            done, _ = wait(all_futures.keys(), return_when=FIRST_COMPLETED)
+            for fut in done:
+                info, start = all_futures.pop(fut)
+                data = fut.result()
+                info.buffers[start] = data
+
+            # Try to yield available chunks from current file in order
+            buffer = list_info[current_file_index].buffers
+            next_start = list_info[current_file_index].next_yield
+
+            while next_start in buffer:
+                yield current_file_index, buffer.pop(next_start)
+                next_start += range_size
+                list_info[current_file_index].next_yield = next_start
+
+            # Check if current file is fully downloaded
+            file_size = list_info[current_file_index].size
+            last_chunk_start = (file_size - 1) // range_size * range_size
+
+            if next_start > last_chunk_start:
+                current_file_index += 1
 
 
 def update_assets_from_s3(
@@ -229,3 +381,188 @@ def update_assets_from_s3(
         raise NotAvailableError(
             f"assets for product {prefix} could not be found"
         ) from e
+
+
+# ----- ZIP section -----
+
+
+def open_s3_zipped_object(
+    bucket_name: str,
+    key_name: str,
+    s3_client,
+    zip_size: Optional[int] = None,
+    partial: bool = True,
+) -> tuple[ZipFile, bytes]:
+    """
+    Fetch central directory + EOCD from S3 and open ZipFile in memory.
+    Returns (ZipFile, central_directory_bytes)
+    """
+    # EOCD is at least 22 bytes, but can be longer if ZIP comment exists.
+    # For simplicity, we fetch last 64KB max (max EOCD + comment length allowed by ZIP spec)
+    if zip_size is None:
+        response = s3_client.head_object(Bucket=bucket_name, Key=key_name)
+        zip_size = response["ContentLength"]
+
+    fetch_size = min(65536, zip_size)
+    eocd_search = fetch_range(
+        bucket_name, key_name, zip_size - fetch_size, zip_size - 1, s3_client
+    )
+
+    # Find EOCD signature from end: 0x06054b50 (little endian)
+    eocd_signature = b"\x50\x4b\x05\x06"
+    eocd_offset = eocd_search.rfind(eocd_signature)
+    if eocd_offset == -1:
+        raise RuntimeError("EOCD signature not found in last 64KB of the file.")
+
+    eocd = eocd_search[eocd_offset : eocd_offset + 22]
+
+    cd_size = parse_le_uint32(eocd[12:16])
+    cd_start = parse_le_uint32(eocd[16:20])
+
+    # Fetch central directory
+    cd_data = fetch_range(
+        bucket_name, key_name, cd_start, cd_start + cd_size - 1, s3_client
+    )
+
+    zip_data = (
+        cd_data + eocd
+        if partial
+        else fetch_range(bucket_name, key_name, 0, zip_size - 1, s3_client)
+    )
+    zipf = ZipFile(io.BytesIO(zip_data))
+    return zipf, cd_data
+
+
+def _parse_central_directory_entry(cd_data: bytes, offset: int) -> dict[str, int]:
+    """
+    Parse one central directory file header entry starting at offset.
+    Returns dict with relative local header offset and sizes.
+    """
+    signature = cd_data[offset : offset + 4]
+    if signature != b"PK\x01\x02":
+        raise RuntimeError("Bad central directory file header signature")
+
+    filename_len = parse_le_uint16(cd_data[offset + 28 : offset + 30])
+    extra_len = parse_le_uint16(cd_data[offset + 30 : offset + 32])
+    comment_len = parse_le_uint16(cd_data[offset + 32 : offset + 34])
+
+    relative_offset = parse_le_uint32(cd_data[offset + 42 : offset + 46])
+
+    header_size = 46 + filename_len + extra_len + comment_len
+
+    return {
+        "relative_offset": relative_offset,
+        "header_size": header_size,
+        "filename_len": filename_len,
+        "extra_len": extra_len,
+        "comment_len": comment_len,
+        "total_size": header_size,
+    }
+
+
+def _parse_local_file_header(local_header_bytes: bytes) -> int:
+    """
+    Parse local file header to find total header size:
+    fixed 30 bytes + filename length + extra field length
+    """
+    if local_header_bytes[0:4] != b"PK\x03\x04":
+        raise RuntimeError("Bad local file header signature")
+
+    filename_len = parse_le_uint16(local_header_bytes[26:28])
+    extra_len = parse_le_uint16(local_header_bytes[28:30])
+    total_size = 30 + filename_len + extra_len
+    return total_size
+
+
+def file_position_from_s3_zip(
+    s3_bucket: str,
+    object_key: str,
+    s3_client,
+    target_filename: str,
+) -> tuple[int, int]:
+    """
+    Get the start position and size of a specific file inside a ZIP archive stored in S3.
+    This function assumes the file is uncompressed (ZIP_STORED).
+
+    :param s3_bucket: The S3 bucket name.
+    :param object_key: The S3 object key for the ZIP file.
+    :param s3_client: The Boto3 S3 client.
+    :param target_filename: The filename inside the ZIP archive to locate.
+    :return: A tuple (file_data_start, file_size) where:
+             - file_data_start is the byte offset where the file data starts in the ZIP archive.
+             - file_size is the size of the file in bytes.
+    :raises FileNotFoundError: If the target file is not found in the ZIP archive.
+    :raises NotImplementedError: If the file is not uncompressed (ZIP_STORED)
+    """
+    zipf, cd_data = open_s3_zipped_object(s3_bucket, object_key, s3_client)
+
+    # Find file in zipf.filelist to get its index and info
+    target_info = None
+    cd_offset = 0
+    for fi in zipf.filelist:
+        if fi.filename == target_filename:
+            target_info = fi
+            break
+        cd_entry_len = (
+            46 + len(fi.filename.encode("utf-8")) + len(fi.extra) + len(fi.comment)
+        )
+        cd_offset += cd_entry_len
+
+    zipf.close()
+
+    if target_info is None:
+        raise FileNotFoundError(f"File {target_filename} not found in ZIP archive")
+
+    if target_info.compress_type != zipfile.ZIP_STORED:
+        raise NotImplementedError("Only uncompressed files (ZIP_STORED) are supported.")
+
+    # Parse central directory entry to get relative local header offset
+    cd_entry = cd_data[
+        cd_offset : cd_offset
+        + (
+            46
+            + len(target_info.filename.encode("utf-8"))
+            + len(target_info.extra)
+            + len(target_info.comment)
+        )
+    ]
+    cd_entry_info = _parse_central_directory_entry(cd_entry, 0)
+
+    local_header_offset = cd_entry_info["relative_offset"]
+
+    # Fetch local file header from S3 (at least 30 bytes + filename + extra field)
+    # We'll fetch 4 KB max to cover large filenames/extra fields safely
+    local_header_fetch_size = 4096
+    local_header_bytes = fetch_range(
+        s3_bucket,
+        object_key,
+        local_header_offset,
+        local_header_offset + local_header_fetch_size - 1,
+        s3_client,
+    )
+
+    local_header_size = _parse_local_file_header(local_header_bytes)
+
+    # Calculate file data start and end offsets
+    file_data_start = local_header_offset + local_header_size
+
+    return file_data_start, target_info.file_size
+
+
+def list_files_in_s3_zipped_object(
+    bucket_name: str, key_name: str, s3_client: S3Client
+) -> list[ZipInfo]:
+    """
+    List files in s3 zipped object, without downloading it.
+
+    See https://stackoverflow.com/questions/41789176/how-to-count-files-inside-zip-in-aws-s3-without-downloading-it;
+    Based on https://stackoverflow.com/questions/51351000/read-zip-files-from-s3-without-downloading-the-entire-file
+
+    :param bucket_name: Bucket name of the object to fetch
+    :param key_name: Key name of the object to fetch
+    :param s3_resource: s3 resource used to fetch the object
+    :returns: List of files in zip
+    """
+    with open_s3_zipped_object(bucket_name, key_name, s3_client) as (zip_file, _):
+        logger.debug("Found %s files in %s" % (len(zip_file.filelist), key_name))
+        return zip_file.filelist

--- a/tests/context.py
+++ b/tests/context.py
@@ -136,6 +136,7 @@ from eodag.utils.exceptions import (
     UnsupportedProductType,
     UnsupportedProvider,
     ValidationError,
+    InvalidDataError,
 )
 from eodag.utils.stac_reader import fetch_stac_items, _TextOpener
 from tests import TEST_RESOURCES_PATH

--- a/tests/context.py
+++ b/tests/context.py
@@ -111,7 +111,7 @@ from eodag.utils.s3 import (
     list_files_in_s3_zipped_object,
     update_assets_from_s3,
     open_s3_zipped_object,
-    FileInfo,
+    S3FileInfo,
     file_position_from_s3_zip,
     _chunks_from_s3_objects,
     _prepare_file_in_zip,

--- a/tests/context.py
+++ b/tests/context.py
@@ -17,8 +17,9 @@
 # limitations under the License.
 """Explicitly import here everything you want to use from the eodag package
 
-    isort:skip_file
+isort:skip_file
 """
+
 # ruff: noqa
 import os
 import sys
@@ -102,6 +103,7 @@ from eodag.utils import (
     parse_header,
     get_ssl_context,
     cached_yaml_load_all,
+    StreamResponse,
 )
 from eodag.utils.env import is_env_var_true
 from eodag.utils.requests import fetch_json
@@ -109,7 +111,16 @@ from eodag.utils.s3 import (
     list_files_in_s3_zipped_object,
     update_assets_from_s3,
     open_s3_zipped_object,
+    FileInfo,
+    file_position_from_s3_zip,
+    _chunks_from_s3_objects,
+    _prepare_file_in_zip,
+    _compute_file_ranges,
+    stream_download_from_s3,
+    _build_stream_response,
 )
+
+
 from eodag.utils.exceptions import (
     AddressNotFound,
     AuthenticationError,

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -1818,13 +1818,16 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
         """AwsDownload.download() must handle files in zip"""
 
         def _open_zip(*args, **kwargs):
-            return zipfile.ZipFile(
-                os.path.join(
-                    TEST_RESOURCES_PATH,
-                    "products",
-                    "as_archive",
-                    "S2A_MSIL1C_20180101T105441_N0206_R051_T31TDH_20180101T124911.zip",
-                )
+            return (
+                zipfile.ZipFile(
+                    os.path.join(
+                        TEST_RESOURCES_PATH,
+                        "products",
+                        "as_archive",
+                        "S2A_MSIL1C_20180101T105441_N0206_R051_T31TDH_20180101T124911.zip",
+                    )
+                ),
+                b"",
             )
 
         mock_open_s3_zipped_object.side_effect = _open_zip

--- a/tests/units/test_utils_s3.py
+++ b/tests/units/test_utils_s3.py
@@ -13,9 +13,9 @@ from tests import TEST_RESOURCES_PATH
 from tests.context import (
     AwsAuth,
     EOProduct,
-    FileInfo,
     MisconfiguredError,
     PluginConfig,
+    S3FileInfo,
     StreamResponse,
     _build_stream_response,
     _chunks_from_s3_objects,
@@ -56,7 +56,7 @@ def make_mock_fileinfo(
     file_start_offset=0,
     data_type="application/octet-stream",
 ):
-    fi = FileInfo(key=key, size=size, data_type=data_type, bucket_name="mybucket")
+    fi = S3FileInfo(key=key, size=size, data_type=data_type, bucket_name="mybucket")
     fi.rel_path = key
     fi.futures = {}
     fi.file_start_offset = file_start_offset

--- a/tests/units/test_utils_s3.py
+++ b/tests/units/test_utils_s3.py
@@ -13,6 +13,7 @@ from tests import TEST_RESOURCES_PATH
 from tests.context import (
     AwsAuth,
     EOProduct,
+    InvalidDataError,
     MisconfiguredError,
     PluginConfig,
     S3FileInfo,
@@ -335,7 +336,7 @@ class TestUtilsS3(TestCase):
         )
         from tests.context import open_s3_zipped_object
 
-        with self.assertRaises(RuntimeError) as e:
+        with self.assertRaises(InvalidDataError) as e:
             open_s3_zipped_object("mybucket", "bad.zip", self.s3_client)
         self.assertIn("EOCD signature not found", str(e.exception))
 

--- a/tests/units/test_utils_s3.py
+++ b/tests/units/test_utils_s3.py
@@ -1,26 +1,73 @@
+import io
 import os
+import re
 import zipfile
 from unittest import TestCase
+from unittest.mock import call, patch
 
 import boto3
+from concurrent.futures import ThreadPoolExecutor
 from moto import mock_aws
 
 from tests import TEST_RESOURCES_PATH
 from tests.context import (
     AwsAuth,
     EOProduct,
+    FileInfo,
     MisconfiguredError,
     PluginConfig,
+    StreamResponse,
+    _build_stream_response,
+    _chunks_from_s3_objects,
+    _compute_file_ranges,
+    _prepare_file_in_zip,
+    file_position_from_s3_zip,
     list_files_in_s3_zipped_object,
     open_s3_zipped_object,
+    stream_download_from_s3,
     update_assets_from_s3,
 )
+
+
+def fake_get_object(files):
+    """Help function to mock S3 get_object calls."""
+
+    def _get_object(Bucket, Key, Range=None):
+        full_data = files.get(Key)
+        if full_data is None:
+            raise KeyError(f"No such key: {Key}")
+        if Range:
+            _, byte_range = Range.split("=")
+            start_str, end_str = byte_range.split("-")
+            start = int(start_str) if start_str else 0
+            end = int(end_str) if end_str else len(full_data) - 1
+            chunk = full_data[start : end + 1]
+        else:
+            chunk = full_data
+        return {"Body": io.BytesIO(chunk)}
+
+    return _get_object
+
+
+def make_mock_fileinfo(
+    key,
+    size=10,
+    data_start_offset=0,
+    file_start_offset=0,
+    data_type="application/octet-stream",
+):
+    fi = FileInfo(key=key, size=size, data_type=data_type, bucket_name="mybucket")
+    fi.rel_path = key
+    fi.futures = {}
+    fi.file_start_offset = file_start_offset
+    fi.data_start_offset = data_start_offset
+    return fi
 
 
 class TestUtilsS3(TestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestUtilsS3, cls).setUpClass()
+        super().setUpClass()
         cls.mock_aws = mock_aws()
         cls.mock_aws.start()
 
@@ -58,6 +105,48 @@ class TestUtilsS3(TestCase):
     def tearDownClass(cls):
         cls.mock_aws.stop()
 
+    def setUp(self):
+        self.prod = EOProduct("dummy", dict(geometry="POINT (0 0)", id="foo"))
+        self.auth_plugin = AwsAuth(
+            "dummy",
+            PluginConfig.from_mapping(
+                {
+                    "type": "AwsAuth",
+                    "credentials": dict(
+                        aws_access_key_id="foo",
+                        aws_secret_access_key="bar",
+                    ),
+                }
+            ),
+        )
+
+    def assert_stream_response(
+        self,
+        response,
+        expected_media_type,
+        expected_filename_ext=None,
+        expected_filename=None,
+    ):
+        self.assertIsInstance(response, StreamResponse)
+        if expected_media_type == "multipart/mixed":
+            self.assertTrue(response.media_type.startswith("multipart/mixed"))
+        else:
+            self.assertEqual(response.media_type, expected_media_type)
+        if expected_filename_ext:
+            self.assertIn("content-disposition", response.headers)
+            match = re.search(
+                r'filename="([^"]+)"',
+                response.headers["content-disposition"],
+            )
+            self.assertIsNotNone(match)
+            filename = match.group(1)  # type: ignore
+            self.assertTrue(filename.endswith(expected_filename_ext))
+        elif expected_filename:
+            self.assertIn("content-disposition", response.headers)
+            self.assertIn(expected_filename, response.headers["content-disposition"])
+        else:
+            self.assertNotIn("content-disposition", response.headers)
+
     def test_utils_s3_list_files_in_s3_zipped_object(self):
         """list_files_in_s3_zipped_object must list the files in a zipped object stored in S3"""
         zip_infos = list_files_in_s3_zipped_object(
@@ -77,52 +166,33 @@ class TestUtilsS3(TestCase):
 
     def test_utils_s3_open_s3_zipped_object(self):
         """list_files_in_s3_zipped_object must list the files in a zipped object stored in S3"""
-        zip_file = open_s3_zipped_object(
+        zip_file, cd_data = open_s3_zipped_object(
             "mybucket", "path/to/product.zip", self.s3_client
         )
         self.assertIsInstance(zip_file, zipfile.ZipFile)
+        self.assertIsInstance(cd_data, bytes)
         self.assertEqual(len(zip_file.filelist), 6)
 
     def test_utils_s3_update_assets_from_s3_zip(self):
         """update_assets_from_s3 must update the assets of a product from a zipped object stored in S3"""
-        prod = EOProduct("dummy", dict(geometry="POINT (0 0)", id="foo"))
-        auth_plugin = AwsAuth(
-            "dummy",
-            PluginConfig.from_mapping(
-                {
-                    "type": "AwsAuth",
-                    "credentials": dict(
-                        aws_access_key_id="foo",
-                        aws_secret_access_key="bar",
-                    ),
-                }
-            ),
-        )
         update_assets_from_s3(
-            prod, auth_plugin, content_url="s3://mybucket/path/to/product.zip"
+            self.prod, self.auth_plugin, content_url="s3://mybucket/path/to/product.zip"
         )
-        self.assertEqual(len(prod.assets), 3)
-        self.assertDictEqual(
-            prod.assets["MTD_MSIL1C.xml"].data,
-            {
+        self.assertEqual(len(self.prod.assets), 3)
+        expected_assets = {
+            "MTD_MSIL1C.xml": {
                 "title": "MTD_MSIL1C.xml",
                 "roles": ["metadata"],
                 "href": "zip+s3://mybucket/path/to/product.zip!MTD_MSIL1C.xml",
                 "type": "application/xml",
             },
-        )
-        self.assertDictEqual(
-            prod.assets["MTD_TL.xml"].data,
-            {
+            "MTD_TL.xml": {
                 "title": "MTD_TL.xml",
                 "roles": ["metadata"],
                 "href": "zip+s3://mybucket/path/to/product.zip!GRANULE/L1C_T31TDH_A013204_20180101T105435/MTD_TL.xml",
                 "type": "application/xml",
             },
-        )
-        self.assertDictEqual(
-            prod.assets["T31TDH_20180101T105441_B01.jp2"].data,
-            {
+            "T31TDH_20180101T105441_B01.jp2": {
                 "title": "T31TDH_20180101T105441_B01.jp2",
                 "roles": ["data"],
                 "href": (
@@ -131,48 +201,31 @@ class TestUtilsS3(TestCase):
                 ),
                 "type": "image/jp2",
             },
-        )
+        }
+        for asset_name, expected in expected_assets.items():
+            with self.subTest(asset=asset_name):
+                self.assertDictEqual(self.prod.assets[asset_name].data, expected)
 
     def test_utils_s3_update_assets_from_s3(self):
         """update_assets_from_s3 must update the assets of a product from a folder stored in S3"""
-        prod = EOProduct("dummy", dict(geometry="POINT (0 0)", id="foo"))
-        auth_plugin = AwsAuth(
-            "dummy",
-            PluginConfig.from_mapping(
-                {
-                    "type": "AwsAuth",
-                    "credentials": dict(
-                        aws_access_key_id="foo",
-                        aws_secret_access_key="bar",
-                    ),
-                }
-            ),
-        )
         update_assets_from_s3(
-            prod, auth_plugin, content_url="s3://mybucket/path/to/unzipped"
+            self.prod, self.auth_plugin, content_url="s3://mybucket/path/to/unzipped"
         )
-        self.assertEqual(len(prod.assets), 3)
-        self.assertDictEqual(
-            prod.assets["MTD_MSIL1C.xml"].data,
-            {
+        self.assertEqual(len(self.prod.assets), 3)
+        expected_assets = {
+            "MTD_MSIL1C.xml": {
                 "title": "MTD_MSIL1C.xml",
                 "roles": ["metadata"],
                 "href": "s3://mybucket/path/to/unzipped/MTD_MSIL1C.xml",
                 "type": "application/xml",
             },
-        )
-        self.assertDictEqual(
-            prod.assets["MTD_TL.xml"].data,
-            {
+            "MTD_TL.xml": {
                 "title": "MTD_TL.xml",
                 "roles": ["metadata"],
                 "href": "s3://mybucket/path/to/unzipped/GRANULE/L1C_T31TDH_A013204_20180101T105435/MTD_TL.xml",
                 "type": "application/xml",
             },
-        )
-        self.assertDictEqual(
-            prod.assets["T31TDH_20180101T105441_B01.jp2"].data,
-            {
+            "T31TDH_20180101T105441_B01.jp2": {
                 "title": "T31TDH_20180101T105441_B01.jp2",
                 "roles": ["data"],
                 "href": (
@@ -181,7 +234,10 @@ class TestUtilsS3(TestCase):
                 ),
                 "type": "image/jp2",
             },
-        )
+        }
+        for asset_name, expected in expected_assets.items():
+            with self.subTest(asset=asset_name):
+                self.assertDictEqual(self.prod.assets[asset_name].data, expected)
 
     def test_utils_s3_update_assets_from_s3_credentials_nok(self):
         """update_assets_from_s3 must have required credentials"""
@@ -194,3 +250,380 @@ class TestUtilsS3(TestCase):
             auth_plugin,
             content_url="s3://mybucket/path/to/unzipped",
         )
+
+    def test_utils_s3_file_position_from_s3_zip(self):
+        # Prepare a zip with both uncompressed and compressed files
+        zip_bytes = io.BytesIO()
+        with zipfile.ZipFile(zip_bytes, "w", compression=zipfile.ZIP_STORED) as zf:
+            zf.writestr("intro.txt", "Intro file content.")
+            zf.writestr("folder/data.txt", "This is a test.")
+        zip_bytes.seek(0)
+        self.s3_client.put_object(
+            Bucket="mybucket", Key="test_uncompressed.zip", Body=zip_bytes.read()
+        )
+
+        # Prepare a zip with a compressed file
+        zip_bytes2 = io.BytesIO()
+        with zipfile.ZipFile(zip_bytes2, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("compressed.txt", "compressed content")
+        zip_bytes2.seek(0)
+        self.s3_client.put_object(
+            Bucket="mybucket", Key="test_compressed.zip", Body=zip_bytes2.read()
+        )
+
+        test_cases = [
+            {
+                "desc": "uncompressed file found",
+                "bucket": "mybucket",
+                "key": "test_uncompressed.zip",
+                "filename": "folder/data.txt",
+                "expected_start": 103,
+                "expected_size": 15,
+                "expect_exception": None,
+            },
+            {
+                "desc": "file not found",
+                "bucket": "mybucket",
+                "key": "test_uncompressed.zip",
+                "filename": "does/not/exist.txt",
+                "expected_start": None,
+                "expected_size": None,
+                "expect_exception": FileNotFoundError,
+            },
+            {
+                "desc": "compressed file",
+                "bucket": "mybucket",
+                "key": "test_compressed.zip",
+                "filename": "compressed.txt",
+                "expected_start": None,
+                "expected_size": None,
+                "expect_exception": NotImplementedError,
+            },
+        ]
+
+        for case in test_cases:
+            with self.subTest(msg=case["desc"]):
+                if case["expect_exception"]:
+                    with self.assertRaises(case["expect_exception"]) as ctx:
+                        file_position_from_s3_zip(
+                            case["bucket"],
+                            case["key"],
+                            self.s3_client,
+                            case["filename"],
+                        )
+                    if case["expect_exception"] is NotImplementedError:
+                        self.assertIn(
+                            "Only uncompressed files (ZIP_STORED) are supported.",
+                            str(ctx.exception),
+                        )
+                else:
+                    start, size = file_position_from_s3_zip(
+                        case["bucket"], case["key"], self.s3_client, case["filename"]
+                    )
+                    self.assertIsInstance(start, int)
+                    self.assertIsInstance(size, int)
+                    self.assertEqual(start, case["expected_start"])
+                    self.assertEqual(size, case["expected_size"])
+
+    def test_utils_s3_open_s3_zipped_object_invalid(self):
+        """Test a corrupted ZIP file to ensure you raise properly on bad EOCD."""
+        self.s3_client.put_object(
+            Bucket="mybucket", Key="bad.zip", Body=b"This is not a zip"
+        )
+        from tests.context import open_s3_zipped_object
+
+        with self.assertRaises(RuntimeError) as e:
+            open_s3_zipped_object("mybucket", "bad.zip", self.s3_client)
+        self.assertIn("EOCD signature not found", str(e.exception))
+
+    def test_utils_s3_empty_zip(self):
+        """Test an empty ZIP file to ensure it returns an empty list."""
+        empty_zip = io.BytesIO()
+        with zipfile.ZipFile(empty_zip, "w"):
+            pass
+        empty_zip.seek(0)
+        self.s3_client.put_object(
+            Bucket="mybucket", Key="empty.zip", Body=empty_zip.read()
+        )
+
+        files = list_files_in_s3_zipped_object("mybucket", "empty.zip", self.s3_client)
+        self.assertEqual(files, [])
+
+    def test_chunks_from_s3_objects(self):
+        """Test _chunks_from_s3_objects to ensure it correctly retrieves data from S3 objects."""
+
+        data = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        self.s3_client.put_object(Bucket="mybucket", Key="alpha", Body=data)
+
+        fi = make_mock_fileinfo("alpha", len(data))
+        fi.data_start_offset = 0
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            it = _chunks_from_s3_objects(
+                self.s3_client, [fi], (None, None), range_size=10, executor=executor
+            )
+            idx, gen = next(it)
+            chunks = b"".join(gen)
+            self.assertEqual(idx, 0)
+            self.assertEqual(chunks, data)
+
+    def test_chunks_from_s3_objects_chunk_count_and_worker_usage(self):
+        """Test that correct number of chunks are requested and workers are used efficiently."""
+
+        data_map = {
+            "file1": b"A" * 25,  # 3 chunks (10 + 10 + 5)
+            "file2": b"B" * 30,  # 3 chunks (10 + 10 + 10)
+        }
+        range_size = 10
+
+        file_infos = []
+        for key, body in data_map.items():
+            self.s3_client.put_object(Bucket="mybucket", Key=key, Body=body)
+            fi = make_mock_fileinfo(key, len(body))
+            fi.data_start_offset = 0
+            file_infos.append(fi)
+
+        with patch(
+            "eodag.utils.s3.fetch_range", return_value=b"X" * range_size
+        ) as mock_fetch:
+            with ThreadPoolExecutor(max_workers=4) as executor:
+                result = _chunks_from_s3_objects(
+                    self.s3_client,
+                    file_infos,
+                    byte_range=(None, None),
+                    range_size=range_size,
+                    executor=executor,
+                )
+
+                for _ in result:
+                    pass
+
+            # Each 10-byte chunk corresponds to one fetch_range call
+            expected_calls = [
+                call("mybucket", "file1", 0, 9, self.s3_client),
+                call("mybucket", "file1", 10, 19, self.s3_client),
+                call("mybucket", "file1", 20, 24, self.s3_client),
+                call("mybucket", "file2", 0, 9, self.s3_client),
+                call("mybucket", "file2", 10, 19, self.s3_client),
+                call("mybucket", "file2", 20, 29, self.s3_client),
+            ]
+
+            self.assertEqual(mock_fetch.call_count, 6)
+            mock_fetch.assert_has_calls(expected_calls, any_order=True)
+
+    def test_prepare_file_in_zip(self):
+        """Test _prepare_file_in_zip to ensure it sets the correct attributes for retrieving a file inside a ZIP."""
+
+        zip_bytes = io.BytesIO()
+        with zipfile.ZipFile(zip_bytes, "w", compression=zipfile.ZIP_STORED) as zf:
+            zf.writestr("foo.txt", "hello")
+        zip_bytes.seek(0)
+        self.s3_client.put_object(
+            Bucket="mybucket", Key="test.zip", Body=zip_bytes.read()
+        )
+
+        fi = make_mock_fileinfo("test.zip!foo.txt", 0)
+        _prepare_file_in_zip(fi, self.s3_client)
+
+        self.assertEqual(fi.key, "test.zip")
+        self.assertEqual(fi.zip_filepath, "foo.txt")
+        self.assertGreater(fi.data_start_offset, 0)
+        self.assertEqual(fi.size, len("hello"))
+
+    def test_compute_file_ranges(self):
+        """Test _compute_file_ranges to ensure it calculates correct byte ranges for files to download."""
+
+        range_size = 10
+
+        test_cases = [
+            {
+                "desc": "Full file, no byte_range limits (start=None, end=None)",
+                "file_info": make_mock_fileinfo("a", 50),
+                "byte_range": (None, None),
+                "expected": [
+                    (i, min(i + range_size - 1, 49)) for i in range(0, 50, range_size)
+                ],
+            },
+            {
+                "desc": "Partial overlap at start: range starts inside the file",
+                "file_info": make_mock_fileinfo("a", 50, 5, 100),
+                "byte_range": (110, 149),
+                "expected": [(15, 24), (25, 34), (35, 44), (45, 54)],
+            },
+            {
+                "desc": "Partial overlap at end: range ends inside the file",
+                "file_info": make_mock_fileinfo("a", 50, 0, 100),
+                "byte_range": (90, 120),
+                "expected": [(0, 9), (10, 19), (20, 20)],
+            },
+            {
+                "desc": "Range fully inside file",
+                "file_info": make_mock_fileinfo("a", 50, 0, 0),
+                "byte_range": (10, 29),
+                "expected": [(10, 19), (20, 29)],
+            },
+            {
+                "desc": "Range fully outside before file - should return None",
+                "file_info": make_mock_fileinfo("a", 50, 0, 100),
+                "byte_range": (0, 50),
+                "expected": None,
+            },
+            {
+                "desc": "Range fully outside after file - should return None",
+                "file_info": make_mock_fileinfo("a", 50, 0, 100),
+                "byte_range": (151, 200),
+                "expected": None,
+            },
+            {
+                "desc": "Open ended start range (None as start)",
+                "file_info": make_mock_fileinfo("a", 50, 2, 100),
+                "byte_range": (None, 105),
+                "expected": [(2, 7)],
+            },
+            {
+                "desc": "Open ended end range (None as end)",
+                "file_info": make_mock_fileinfo("a", 50, 2, 100),
+                "byte_range": (102, None),
+                "expected": [(4, 13), (14, 23), (24, 33), (34, 43), (44, 51)],
+            },
+        ]
+
+        for case in test_cases:
+            with self.subTest(msg=case["desc"]):
+                result = _compute_file_ranges(
+                    case["file_info"], case["byte_range"], range_size
+                )
+                self.assertEqual(result, case["expected"])
+
+    def test_build_stream_response(self):
+        test_cases = [
+            {
+                "desc": "single file, raw",
+                "zip_filename": "file.txt",
+                "files_info": [
+                    make_mock_fileinfo("file.txt", size=11, data_type="text/plain")
+                ],
+                "files_iterator": iter([(0, iter([b"hello world"]))]),
+                "compress": "raw",
+                "expected_media_type": "text/plain",
+                "expected_filename": "file.txt",
+            },
+            {
+                "desc": "multiple files, zip",
+                "zip_filename": "archive.zip",
+                "files_info": [
+                    make_mock_fileinfo("file1.txt", size=5),
+                    make_mock_fileinfo("file2.txt", size=6),
+                ],
+                "files_iterator": iter(
+                    [
+                        (0, iter([b"abcde"])),
+                        (1, iter([b"123456"])),
+                    ]
+                ),
+                "compress": "zip",
+                "expected_media_type": "application/zip",
+                "expected_filename": "archive.zip",
+            },
+            {
+                "desc": "multiple files, multipart",
+                "zip_filename": "archive",
+                "files_info": [
+                    make_mock_fileinfo("file1.txt", size=5, data_type="text/plain"),
+                    make_mock_fileinfo("file2.txt", size=6, data_type="text/plain"),
+                ],
+                "files_iterator": iter(
+                    [
+                        (0, iter([b"abcde"])),
+                        (1, iter([b"123456"])),
+                    ]
+                ),
+                "compress": "raw",
+                "expected_media_type": "multipart/mixed",  # boundary will be appended
+                "expected_filename": None,
+            },
+            {
+                "desc": "single file, zipped",
+                "zip_filename": "singlefile",
+                "files_info": [
+                    make_mock_fileinfo("file.txt", size=11, data_type="text/plain")
+                ],
+                "files_iterator": iter([(0, iter([b"hello world"]))]),
+                "compress": "zip",
+                "expected_media_type": "application/zip",
+                "expected_filename": "singlefile.zip",
+            },
+        ]
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            for case in test_cases:
+                with self.subTest(msg=case["desc"]):
+                    response = _build_stream_response(
+                        zip_filename=case["zip_filename"],
+                        files_info=case["files_info"],
+                        files_iterator=case["files_iterator"],
+                        compress=case["compress"],
+                        executor=executor,
+                    )
+                    self.assert_stream_response(
+                        response,
+                        case["expected_media_type"],
+                        expected_filename=case.get("expected_filename"),
+                    )
+
+    def test_stream_download_from_s3(self):
+        test_cases = [
+            {
+                "desc": "single file, raw",
+                "files_info": [
+                    make_mock_fileinfo(
+                        "path/to/unzipped/file1.txt", size=6, data_type="text/plain"
+                    )
+                ],
+                "data_map": {
+                    "path/to/unzipped/file1.txt": b"ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+                },
+                "compress": "raw",
+                "zip_filename": "archive",
+                "expected_media_type": "text/plain",
+                "expected_filename_ext": None,
+                "expected_filename": "file1.txt",
+            },
+            {
+                "desc": "multiple files, zip",
+                "files_info": [
+                    make_mock_fileinfo("path/to/unzipped/file1.txt", size=6),
+                    make_mock_fileinfo("path/to/unzipped/file2.txt", size=6),
+                ],
+                "data_map": {
+                    "path/to/unzipped/file1.txt": b"abcdef",
+                    "path/to/unzipped/file2.txt": b"ghijkl",
+                },
+                "compress": "zip",
+                "zip_filename": "myarchive",
+                "expected_media_type": "application/zip",
+                "expected_filename_ext": ".zip",
+            },
+        ]
+
+        for case in test_cases:
+            with self.subTest(msg=case["desc"]):
+                with patch.object(
+                    self.s3_client,
+                    "get_object",
+                    side_effect=fake_get_object(case["data_map"]),
+                ):
+                    response = stream_download_from_s3(
+                        s3_client=self.s3_client,
+                        files_info=case["files_info"],
+                        compress=case["compress"],
+                        zip_filename=case["zip_filename"],
+                        max_workers=2,
+                    )
+
+                self.assert_stream_response(
+                    response,
+                    case["expected_media_type"],
+                    expected_filename_ext=case.get("expected_filename_ext"),
+                    expected_filename=case.get("expected_filename"),
+                )


### PR DESCRIPTION
Optimize stream download for AWS plugin (used in server-mode)

- zip but do not compress
- multiple parallel download
- direct stream response to keep light memory pressure
- support multipart and zipped responses when downloading multiple files
- raw or zipped responses for single files
- support global range requests
- support download single files from remote zip archive

Download rate comparison when downloading a `S2_MSI_L1C` product on `creodias_s3`:
- before: 6,78 MB/s
- after: 19,3 MB/s (+184%)