### PR TITLE
refactor: directly import urllib.parse methods 

### DIFF
--- a/eodag/cli.py
+++ b/eodag/cli.py
@@ -49,11 +49,12 @@ import sys
 import textwrap
 from importlib.metadata import metadata
 from typing import TYPE_CHECKING, Any, Mapping
+from urllib.parse import parse_qs
 
 import click
 
 from eodag.api.core import EODataAccessGateway, SearchResult
-from eodag.utils import DEFAULT_ITEMS_PER_PAGE, DEFAULT_PAGE, parse_qs
+from eodag.utils import DEFAULT_ITEMS_PER_PAGE, DEFAULT_PAGE
 from eodag.utils.exceptions import NoMatchingProductType, UnsupportedProvider
 from eodag.utils.logging import setup_logging
 

--- a/eodag/plugins/authentication/openid_connect.py
+++ b/eodag/plugins/authentication/openid_connect.py
@@ -23,6 +23,7 @@ import string
 from datetime import datetime, timedelta, timezone
 from random import SystemRandom
 from typing import TYPE_CHECKING, Any, Optional
+from urllib.parse import parse_qs, urlparse
 
 import jwt
 import requests
@@ -34,9 +35,7 @@ from eodag.utils import (
     DEFAULT_TOKEN_EXPIRATION_MARGIN,
     HTTP_REQ_TIMEOUT,
     USER_AGENT,
-    parse_qs,
     repeatfunc,
-    urlparse,
 )
 from eodag.utils.exceptions import (
     AuthenticationError,

--- a/eodag/plugins/download/s3rest.py
+++ b/eodag/plugins/download/s3rest.py
@@ -21,6 +21,7 @@ import logging
 import os
 import os.path
 from typing import TYPE_CHECKING, Optional, Union
+from urllib.parse import unquote, urljoin
 from xml.dom import minidom
 from xml.parsers.expat import ExpatError
 
@@ -40,8 +41,6 @@ from eodag.utils import (
     ProgressCallback,
     get_bucket_name_and_prefix,
     path_to_uri,
-    unquote,
-    urljoin,
 )
 from eodag.utils.exceptions import (
     AuthenticationError,

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -35,9 +35,11 @@ from typing import (
 from urllib.error import URLError
 from urllib.parse import (
     parse_qsl,
+    quote,
     quote_plus,
     unquote,
     unquote_plus,
+    urlencode,
     urlparse,
     urlunparse,
 )
@@ -86,10 +88,8 @@ from eodag.utils import (
     dict_items_recursive_apply,
     format_dict_items,
     get_ssl_context,
-    quote,
     string_to_jsonpath,
     update_nested_dict,
-    urlencode,
 )
 from eodag.utils.exceptions import (
     AuthenticationError,

--- a/eodag/rest/core.py
+++ b/eodag/rest/core.py
@@ -23,6 +23,7 @@ import os
 import re
 from typing import TYPE_CHECKING, cast
 from unittest.mock import Mock
+from urllib.parse import urlencode
 
 import dateutil
 from cachetools.func import lru_cache
@@ -68,7 +69,6 @@ from eodag.utils import (
     dict_items_recursive_apply,
     format_dict_items,
     obj_md5sum,
-    urlencode,
 )
 from eodag.utils.exceptions import (
     MisconfiguredError,

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -375,27 +375,29 @@ def merge_mappings(mapping1: dict[Any, Any], mapping2: dict[Any, Any]) -> None:
             # `m1_keys_lowercase.get(key, key)`
             current_value = mapping1.get(m1_keys_lowercase.get(key, key))
             if current_value is not None:
-                current_value_type = type(current_value)
-                new_value_type = type(value)
                 try:
                     # If current or new value is a list (search queryable parameter), simply replace current with new
                     if (
-                        new_value_type == list
-                        and current_value_type != list
-                        or new_value_type != list
-                        and current_value_type == list
+                        isinstance(value, list)
+                        and not isinstance(current_value, list)
+                        or not isinstance(value, list)
+                        and isinstance(current_value, list)
                     ):
                         mapping1[m1_keys_lowercase.get(key, key)] = value
                     else:
                         mapping1[m1_keys_lowercase.get(key, key)] = cast_scalar_value(
-                            value, current_value_type
+                            value, type(current_value)
                         )
                 except (TypeError, ValueError):
                     # Ignore any override value that does not have the same type
                     # as the default value
                     logger.debug(
-                        f"Ignored '{key}' setting override from '{current_value}' to '{value}', "
-                        f"(could not cast {new_value_type} to {current_value_type})"
+                        "Ignored '%s' setting override from '%s' to '%s', (could not cast %s to %s)",
+                        key,
+                        current_value,
+                        value,
+                        type(value),
+                        type(current_value),
                     )
                     pass
             else:

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -62,25 +62,13 @@ from typing import (
     Union,
     cast,
 )
-
-# All modules using these should import them from utils package
-from urllib.parse import (  # noqa; noqa
-    parse_qs,
-    parse_qsl,
-    quote,
-    unquote,
-    urlencode,
-    urljoin,
-    urlparse,
-    urlsplit,
-)
+from urllib.parse import urlparse, urlsplit
 from urllib.request import url2pathname
 
 if sys.version_info >= (3, 12):
     from typing import Unpack  # type: ignore # noqa
 else:
     from typing_extensions import Unpack  # noqa
-
 
 import click
 import orjson

--- a/tests/context.py
+++ b/tests/context.py
@@ -92,7 +92,6 @@ from eodag.utils import (
     ProgressCallback,
     DownloadedCallback,
     uri_to_path,
-    parse_qsl,
     urlsplit,
     GENERIC_PRODUCT_TYPE,
     GENERIC_STAC_PROVIDER,


### PR DESCRIPTION
Directly import `urllib.parse` methods instead of importing from utils.
`eodag.utils.merge_mapping` also lightly refactored.