### PR TITLE
fix(server): empty instruments mapping

### DIFF
--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -219,7 +219,7 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
                 elif value is not None:
                     converted = self.custom_converter(value)
                 else:
-                    converted = ""
+                    converted = None
                 # Clear this state variable in case the same converter is used to
                 # resolve other named arguments
                 self.custom_converter = None

--- a/eodag/resources/stac.yml
+++ b/eodag/resources/stac.yml
@@ -195,8 +195,7 @@ item:
     license: '{catalog[license]}'
     constellation: '$.product.properties.platform'
     platform: '$.product.properties.platformSerialIdentifier'
-    instruments:
-      - '$.product.properties.instrument'
+    instruments: '{$.product.properties.instrument#replace_str(r"^(.*)$",r"""["\1"]""")}'
     gsd: '$.product.properties.resolution'
     published: '$.product.properties.publicationDate'
     eo:cloud_cover: '$.product.properties.cloudCover'

--- a/tests/units/test_metadata_mapping.py
+++ b/tests/units/test_metadata_mapping.py
@@ -306,6 +306,10 @@ class TestMetadataFormatter(unittest.TestCase):
         to_format = r"{fieldname#to_upper}"
         self.assertEqual(format_metadata(to_format, fieldname="FoO.bAr"), "FOO.BAR")
 
+    def test_convert_to_upper_empty(self):
+        to_format = r"{fieldname#to_upper}"
+        self.assertEqual(format_metadata(to_format, fieldname=None), "None")
+
     def test_convert_fake_l2a_title_from_l1c(self):
         to_format = "{fieldname#fake_l2a_title_from_l1c}"
         self.assertEqual(


### PR DESCRIPTION
Fixes #1604 

Fixes empty `instruments` mapping in server mode