### PR TITLE
refactor(plugins): move aws authentication methods to AwsAuth plugin

### DIFF
--- a/eodag/config.py
+++ b/eodag/config.py
@@ -542,8 +542,6 @@ class PluginConfig(yaml.YAMLObject):
     #: :class:`~eodag.plugins.download.s3rest.S3RestDownload`
     #: At which level of the path part of the url the bucket can be found
     bucket_path_level: int
-    #: :class:`~eodag.plugins.download.aws.AwsDownload` Whether download is done from a requester-pays bucket or not
-    requester_pays: bool
     #: :class:`~eodag.plugins.download.aws.AwsDownload` S3 endpoint
     s3_endpoint: str
 
@@ -570,6 +568,9 @@ class PluginConfig(yaml.YAMLObject):
     #: :class:`~eodag.plugins.authentication.base.Authentication` Part of the search or download plugin configuration
     #: that needs authentication
     matching_conf: dict[str, Any]
+    #: :class:`~eodag.plugins.authentication.aws_auth.AwsAuth`
+    #: Whether download is done from a requester-pays bucket or not
+    requester_pays: bool
     #: :class:`~eodag.plugins.authentication.openid_connect.OIDCRefreshTokenBase`
     #: How the token should be used in the request
     token_provision: str

--- a/eodag/plugins/apis/ecmwf.py
+++ b/eodag/plugins/apis/ecmwf.py
@@ -31,7 +31,6 @@ from eodag.plugins.apis.base import Api
 from eodag.plugins.search import PreparedSearch
 from eodag.plugins.search.base import Search
 from eodag.plugins.search.build_search_result import ECMWFSearch, ecmwf_mtd
-from eodag.types import S3AuthContextPool
 from eodag.utils import (
     DEFAULT_DOWNLOAD_TIMEOUT,
     DEFAULT_DOWNLOAD_WAIT,
@@ -47,6 +46,7 @@ from eodag.utils.logging import get_logging_verbose
 if TYPE_CHECKING:
     from typing import Any, Optional, Union
 
+    from mypy_boto3_s3 import S3ServiceResource
     from requests.auth import AuthBase
 
     from eodag.api.product import EOProduct
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from eodag.types import S3SessionKwargs
     from eodag.types.download_args import DownloadConf
     from eodag.utils import DownloadedCallback, ProgressCallback, Unpack
+
 
 logger = logging.getLogger("eodag.apis.ecmwf")
 
@@ -172,7 +173,7 @@ class EcmwfApi(Api, ECMWFSearch):
     def download(
         self,
         product: EOProduct,
-        auth: Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]] = None,
+        auth: Optional[Union[AuthBase, S3SessionKwargs, S3ServiceResource]] = None,
         progress_callback: Optional[ProgressCallback] = None,
         wait: float = DEFAULT_DOWNLOAD_WAIT,
         timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,

--- a/eodag/plugins/apis/ecmwf.py
+++ b/eodag/plugins/apis/ecmwf.py
@@ -31,6 +31,7 @@ from eodag.plugins.apis.base import Api
 from eodag.plugins.search import PreparedSearch
 from eodag.plugins.search.base import Search
 from eodag.plugins.search.build_search_result import ECMWFSearch, ecmwf_mtd
+from eodag.types import S3AuthContextPool
 from eodag.utils import (
     DEFAULT_DOWNLOAD_TIMEOUT,
     DEFAULT_DOWNLOAD_WAIT,
@@ -171,7 +172,7 @@ class EcmwfApi(Api, ECMWFSearch):
     def download(
         self,
         product: EOProduct,
-        auth: Optional[Union[AuthBase, S3SessionKwargs]] = None,
+        auth: Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]] = None,
         progress_callback: Optional[ProgressCallback] = None,
         wait: float = DEFAULT_DOWNLOAD_WAIT,
         timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,

--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -37,7 +37,6 @@ from eodag.api.product.metadata_mapping import (
 )
 from eodag.plugins.apis.base import Api
 from eodag.plugins.search import PreparedSearch
-from eodag.types import S3AuthContextPool
 from eodag.utils import (
     DEFAULT_DOWNLOAD_TIMEOUT,
     DEFAULT_DOWNLOAD_WAIT,
@@ -58,6 +57,7 @@ from eodag.utils.exceptions import (
 )
 
 if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3ServiceResource
     from requests.auth import AuthBase
 
     from eodag.api.search_result import SearchResult
@@ -297,7 +297,7 @@ class UsgsApi(Api):
     def download(
         self,
         product: EOProduct,
-        auth: Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]] = None,
+        auth: Optional[Union[AuthBase, S3SessionKwargs, S3ServiceResource]] = None,
         progress_callback: Optional[ProgressCallback] = None,
         wait: float = DEFAULT_DOWNLOAD_WAIT,
         timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,

--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -37,6 +37,7 @@ from eodag.api.product.metadata_mapping import (
 )
 from eodag.plugins.apis.base import Api
 from eodag.plugins.search import PreparedSearch
+from eodag.types import S3AuthContextPool
 from eodag.utils import (
     DEFAULT_DOWNLOAD_TIMEOUT,
     DEFAULT_DOWNLOAD_WAIT,
@@ -296,7 +297,7 @@ class UsgsApi(Api):
     def download(
         self,
         product: EOProduct,
-        auth: Optional[Union[AuthBase, S3SessionKwargs]] = None,
+        auth: Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]] = None,
         progress_callback: Optional[ProgressCallback] = None,
         wait: float = DEFAULT_DOWNLOAD_WAIT,
         timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,

--- a/eodag/plugins/authentication/aws_auth.py
+++ b/eodag/plugins/authentication/aws_auth.py
@@ -23,14 +23,13 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 import boto3
 from botocore.exceptions import ClientError, ProfileNotFound
 from botocore.handlers import disable_signing
-from mypy_boto3_s3 import S3Client
 
 from eodag.plugins.authentication.base import Authentication
 from eodag.types import S3SessionKwargs
 from eodag.utils.exceptions import AuthenticationError
 
 if TYPE_CHECKING:
-    from mypy_boto3_s3 import S3ServiceResource
+    from mypy_boto3_s3 import S3Client, S3ServiceResource
     from mypy_boto3_s3.service_resource import BucketObjectsCollection
 
     from eodag.config import PluginConfig

--- a/eodag/plugins/authentication/aws_auth.py
+++ b/eodag/plugins/authentication/aws_auth.py
@@ -17,15 +17,121 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, cast
+import logging
+from collections import UserList
+from typing import TYPE_CHECKING, Any, Optional
+
+import boto3
+from boto3.session import Session
+from botocore.exceptions import ClientError, ProfileNotFound
+from botocore.handlers import disable_signing
 
 from eodag.plugins.authentication.base import Authentication
 from eodag.types import S3SessionKwargs
+from eodag.utils.exceptions import AuthenticationError
 
 if TYPE_CHECKING:
-    from mypy_boto3_s3.client import S3Client
+    from mypy_boto3_s3 import S3ServiceResource
+    from mypy_boto3_s3.service_resource import BucketObjectsCollection
 
     from eodag.config import PluginConfig
+
+
+logger = logging.getLogger("eodag.download.aws_auth")
+
+AWS_AUTH_ERROR_MESSAGES = [
+    "AccessDenied",
+    "InvalidAccessKeyId",
+    "SignatureDoesNotMatch",
+    "InvalidRequest",
+]
+
+
+class S3AuthContext:
+
+    """Class defining an S3 authentication context (resource, session and authentication type used)"""
+
+    def __init__(
+        self, s3_resource: S3ServiceResource, auth_type: str, s3_session: Session
+    ):
+        self.s3_resource = s3_resource
+        self.auth_type = auth_type
+        self.s3_session = s3_session
+
+    @staticmethod
+    def create_auth_context_unsigned(endpoint_url: str):
+        """Auth strategy using no-sign-request"""
+        s3_resource = boto3.resource(service_name="s3", endpoint_url=endpoint_url)
+        s3_resource.meta.client.meta.events.register(
+            "choose-signer.s3.*", disable_signing
+        )
+        return S3AuthContext(
+            s3_resource=s3_resource, auth_type="unsigned", s3_session=Session()
+        )
+
+    @staticmethod
+    def create_auth_context_auth_profile(endpoint_url: str, profile_name: str):
+        """Auth strategy using ``aws_profile`` from provided credentials"""
+        s3_session = Session(profile_name=profile_name)
+        s3_resource = s3_session.resource(
+            service_name="s3",
+            endpoint_url=endpoint_url,
+        )
+        return S3AuthContext(
+            s3_resource=s3_resource, auth_type="auth_profile", s3_session=s3_session
+        )
+
+    @staticmethod
+    def create_auth_context_auth_keys(endpoint_url: str, credentials: dict[str, str]):
+        """Auth strategy using ``aws_access_key_id``/``aws_secret_access_key`` from provided credentials"""
+        s3_session_kwargs: S3SessionKwargs = {
+            "aws_access_key_id": credentials["aws_access_key_id"],
+            "aws_secret_access_key": credentials["aws_secret_access_key"],
+        }
+        if credentials.get("aws_session_token"):
+            s3_session_kwargs["aws_session_token"] = credentials["aws_session_token"]
+        s3_session = Session(**s3_session_kwargs)
+        s3_resource = s3_session.resource(
+            service_name="s3",
+            endpoint_url=endpoint_url,
+        )
+        return S3AuthContext(
+            s3_resource=s3_resource, auth_type="auth_keys", s3_session=s3_session
+        )
+
+    @staticmethod
+    def create_auth_context_env(endpoint_url: str):
+        """Auth strategy using current environment"""
+
+        s3_session = Session()
+        s3_resource = s3_session.resource(service_name="s3", endpoint_url=endpoint_url)
+        return S3AuthContext(
+            s3_resource=s3_resource, auth_type="env", s3_session=s3_session
+        )
+
+
+class S3AuthContextPool(UserList):
+
+    """Instances of S3AuthContextPool contain a list of possible authentication contexts
+    based on the given credentials"""
+
+    def __init__(self, endpoint_url, credentials: dict[str, str], *args: Any):
+        super(S3AuthContextPool, self).__init__(*args)
+        self.data.append(S3AuthContext.create_auth_context_unsigned(endpoint_url))
+        if "aws_profile" in credentials:
+            self.data.append(
+                S3AuthContext.create_auth_context_auth_profile(
+                    endpoint_url, credentials["aws_profile"]
+                )
+            )
+        if (
+            "aws_access_key_id" in credentials
+            and "aws_secret_access_key" in credentials
+        ):
+            self.data.append(
+                S3AuthContext.create_auth_context_auth_keys(endpoint_url, credentials)
+            )
+        self.data.append(S3AuthContext.create_auth_context_env(endpoint_url))
 
 
 class AwsAuth(Authentication):
@@ -50,38 +156,129 @@ class AwsAuth(Authentication):
 
     """
 
-    s3_client: S3Client
-
     def __init__(self, provider: str, config: PluginConfig) -> None:
         super(AwsAuth, self).__init__(provider, config)
-        self.aws_access_key_id: Optional[str] = None
-        self.aws_secret_access_key: Optional[str] = None
-        self.aws_session_token: Optional[str] = None
-        self.profile_name: Optional[str] = None
+        endpoint_url = getattr(self.config, "s3_endpoint", None)
+        credentials = getattr(self.config, "credentials", {}) or {}
+        self.auth_context_pool = S3AuthContextPool(
+            endpoint_url=endpoint_url, credentials=credentials
+        )
+        self.s3_client = boto3.client(
+            service_name="s3",
+            endpoint_url=endpoint_url,
+            aws_access_key_id=credentials.get("aws_access_key_id"),
+            aws_secret_access_key=credentials.get("aws_secret_access_key"),
+            aws_session_token=credentials.get("aws_session_token"),
+        )
 
-    def authenticate(self) -> S3SessionKwargs:
+    def authenticate(self) -> S3AuthContextPool:
         """Authenticate
 
-        :returns: dict containing AWS/boto3 non-empty credentials
+        :returns: S3AuthContextPool with possible auth contexts
         """
-        credentials = getattr(self.config, "credentials", {}) or {}
-        self.aws_access_key_id = credentials.get(
-            "aws_access_key_id", self.aws_access_key_id
-        )
-        self.aws_secret_access_key = credentials.get(
-            "aws_secret_access_key", self.aws_secret_access_key
-        )
-        self.aws_session_token = credentials.get(
-            "aws_session_token", self.aws_session_token
-        )
-        self.profile_name = credentials.get("aws_profile", self.profile_name)
 
-        auth_dict = cast(
-            S3SessionKwargs,
-            {
-                k: getattr(self, k)
-                for k in S3SessionKwargs.__annotations__
-                if getattr(self, k, None)
-            },
+        return self.auth_context_pool
+
+    def _get_authenticated_objects(
+        self, bucket_name: str, prefix: str
+    ) -> BucketObjectsCollection:
+        """Get boto3 authenticated objects for the given bucket using
+        the most adapted auth strategy.
+
+        :param bucket_name: Bucket containg objects
+        :param prefix: Prefix used to filter objects on auth try
+                       (not used to filter returned objects)
+        :returns: The boto3 authenticated objects
+        """
+
+        for auth_context in self.auth_context_pool:
+            try:
+                if getattr(self.config, "requester_pays", False):
+                    objects = auth_context.s3_resource.Bucket(
+                        bucket_name
+                    ).objects.filter(RequestPayer="requester")
+                else:
+                    objects = auth_context.s3_resource.Bucket(bucket_name).objects
+                list(objects.filter(Prefix=prefix).limit(1))
+                if objects:
+                    logger.debug("Auth using %s succeeded", auth_context.auth_type)
+                    return objects
+            except ClientError as e:
+                if (
+                    e.response.get("Error", {}).get("Code", {})
+                    in AWS_AUTH_ERROR_MESSAGES
+                ):
+                    pass
+                else:
+                    raise e
+            except ProfileNotFound:
+                pass
+            logger.debug("Auth using %s failed", auth_context.auth_type)
+
+        raise AuthenticationError(
+            "Unable do authenticate on s3://%s using any available credendials configuration"
+            % bucket_name
         )
-        return auth_dict
+
+    def authenticate_objects(
+        self,
+        bucket_names_and_prefixes: list[tuple[str, Optional[str]]],
+    ) -> tuple[dict[str, Any], BucketObjectsCollection]:
+        """
+        Authenticates with s3 and retrieves the available objects
+
+        :param bucket_names_and_prefixes: list of bucket names and corresponding path prefixes
+        :raises AuthenticationError: authentication is not possible
+        :return: authenticated objects per bucket, list of available objects
+        """
+
+        authenticated_objects: dict[str, Any] = {}
+        auth_error_messages: set[str] = set()
+        for _, pack in enumerate(bucket_names_and_prefixes):
+            try:
+                bucket_name, prefix = pack
+                if not prefix:
+                    continue
+                if bucket_name not in authenticated_objects:
+                    # get Prefixes longest common base path
+                    common_prefix = ""
+                    prefix_split = prefix.split("/")
+                    prefixes_in_bucket = len(
+                        [p for b, p in bucket_names_and_prefixes if b == bucket_name]
+                    )
+                    for i in range(1, len(prefix_split)):
+                        common_prefix = "/".join(prefix_split[0:i])
+                        if (
+                            len(
+                                [
+                                    p
+                                    for b, p in bucket_names_and_prefixes
+                                    if p and b == bucket_name and common_prefix in p
+                                ]
+                            )
+                            < prefixes_in_bucket
+                        ):
+                            common_prefix = "/".join(prefix_split[0 : i - 1])
+                            break
+                    # connect to aws s3 and get bucket auhenticated objects
+                    s3_objects = self._get_authenticated_objects(
+                        bucket_name, common_prefix
+                    )
+                    authenticated_objects[bucket_name] = s3_objects
+                else:
+                    s3_objects = authenticated_objects[bucket_name]
+
+            except AuthenticationError as e:
+                logger.warning("Unexpected error: %s" % e)
+                logger.warning("Skipping %s/%s" % (bucket_name, prefix))
+                auth_error_messages.add(str(e))
+            except ClientError as e:
+                self._raise_if_auth_error(e)
+                logger.warning("Unexpected error: %s" % e)
+                logger.warning("Skipping %s/%s" % (bucket_name, prefix))
+                auth_error_messages.add(str(e))
+
+        # could not auth on any bucket
+        if not authenticated_objects:
+            raise AuthenticationError(", ".join(auth_error_messages))
+        return authenticated_objects, s3_objects

--- a/eodag/plugins/authentication/aws_auth.py
+++ b/eodag/plugins/authentication/aws_auth.py
@@ -184,13 +184,13 @@ class AwsAuth(Authentication):
     def authenticate_objects(
         self,
         bucket_names_and_prefixes: list[tuple[str, Optional[str]]],
-    ) -> tuple[dict[str, Any], BucketObjectsCollection]:
+    ) -> dict[str, Any]:
         """
         Authenticates with s3 and retrieves the available objects
 
         :param bucket_names_and_prefixes: list of bucket names and corresponding path prefixes
         :raises AuthenticationError: authentication is not possible
-        :return: authenticated objects per bucket, list of available objects
+        :return: authenticated objects per bucket
         """
 
         authenticated_objects: dict[str, Any] = {}
@@ -222,12 +222,9 @@ class AwsAuth(Authentication):
                             common_prefix = "/".join(prefix_split[0 : i - 1])
                             break
                     # connect to aws s3 and get bucket auhenticated objects
-                    s3_objects = self._get_authenticated_objects(
-                        bucket_name, common_prefix
-                    )
-                    authenticated_objects[bucket_name] = s3_objects
-                else:
-                    s3_objects = authenticated_objects[bucket_name]
+                    authenticated_objects[
+                        bucket_name
+                    ] = self._get_authenticated_objects(bucket_name, common_prefix)
 
             except AuthenticationError as e:
                 logger.warning("Unexpected error: %s" % e)
@@ -242,4 +239,4 @@ class AwsAuth(Authentication):
         # could not auth on any bucket
         if not authenticated_objects:
             raise AuthenticationError(", ".join(auth_error_messages))
-        return authenticated_objects, s3_objects
+        return authenticated_objects

--- a/eodag/plugins/authentication/aws_auth.py
+++ b/eodag/plugins/authentication/aws_auth.py
@@ -132,6 +132,7 @@ class S3AuthContextPool(UserList):
                 S3AuthContext.create_auth_context_auth_keys(endpoint_url, credentials)
             )
         self.data.append(S3AuthContext.create_auth_context_env(endpoint_url))
+        self.used_method = ""
 
 
 class AwsAuth(Authentication):
@@ -202,6 +203,7 @@ class AwsAuth(Authentication):
                 list(objects.filter(Prefix=prefix).limit(1))
                 if objects:
                     logger.debug("Auth using %s succeeded", auth_context.auth_type)
+                    self.auth_context_pool.used_method = auth_context.auth_type
                     return objects
             except ClientError as e:
                 if (

--- a/eodag/plugins/authentication/aws_auth.py
+++ b/eodag/plugins/authentication/aws_auth.py
@@ -67,7 +67,7 @@ def create_s3_session(**kwargs) -> boto3.Session:
 class AwsAuth(Authentication):
     """AWS authentication plugin
 
-    The authentication method will be coses depending on which parameters are available in the configuration:
+    The authentication method will be chosen depending on which parameters are available in the configuration:
 
     * auth using ``profile_name`` (if credentials are given and contain ``aws_profile``)
     * auth using ``aws_access_key_id``, ``aws_secret_access_key`` and optionally ``aws_session_token``

--- a/eodag/plugins/authentication/aws_auth.py
+++ b/eodag/plugins/authentication/aws_auth.py
@@ -58,6 +58,7 @@ def raise_if_auth_error(exception: ClientError, provider: str) -> None:
 
 def create_s3_session(**kwargs) -> boto3.Session:
     """create s3 session based on available credentials
+
     :param kwargs: keyword arguments containing credentials
     :returns: boto3 Session
     """
@@ -89,6 +90,9 @@ class AwsAuth(Authentication):
         * :attr:`~eodag.config.PluginConfig.type` (``str``) (**mandatory**): AwsAuth
         * :attr:`~eodag.config.PluginConfig.auth_error_code` (``int``) (mandatory for ``creodias_s3``):
           which error code is returned in case of an authentication error
+        * :attr:`~eodag.config.PluginConfig.s3_endpoint` (``str``): s3 endpoint url
+        * :attr:`~eodag.config.PluginConfig.requester_pays` (``bool``): whether download is done
+          from a requester-pays bucket or not; default: ``False``
 
     """
 
@@ -96,6 +100,7 @@ class AwsAuth(Authentication):
         super(AwsAuth, self).__init__(provider, config)
         self.s3_session: Optional[boto3.Session] = None
         self.s3_resource: Optional[S3ServiceResource] = None
+        self.requester_pays = getattr(self.config, "requester_pays", False)
 
     def _create_s3_session_from_credentials(self) -> boto3.Session:
         credentials = getattr(self.config, "credentials", {}) or {}
@@ -145,7 +150,7 @@ class AwsAuth(Authentication):
     def authenticate(self) -> S3ServiceResource:
         """Authenticate
 
-        :returns: S3AuthContextPool with possible auth contexts
+        :returns: S3 Resource created based on an S3 session
         """
         self.s3_resource = self._create_s3_resource()
         return self.s3_resource

--- a/eodag/plugins/authentication/aws_auth.py
+++ b/eodag/plugins/authentication/aws_auth.py
@@ -100,7 +100,9 @@ class AwsAuth(Authentication):
         super(AwsAuth, self).__init__(provider, config)
         self.s3_session: Optional[boto3.Session] = None
         self.s3_resource: Optional[S3ServiceResource] = None
-        self.requester_pays = getattr(self.config, "requester_pays", False)
+        # set default for requester_pays if not given
+        if not getattr(self.config, "requester_pays", False):
+            setattr(self.config, "requester_pays", False)
 
     def _create_s3_session_from_credentials(self) -> boto3.Session:
         credentials = getattr(self.config, "credentials", {}) or {}
@@ -167,7 +169,7 @@ class AwsAuth(Authentication):
         if not self.s3_resource:
             self.s3_resource = self._create_s3_resource()
         try:
-            if getattr(self.config, "requester_pays", False):
+            if self.config.requester_pays:
                 objects = self.s3_resource.Bucket(bucket_name).objects.filter(
                     RequestPayer="requester"
                 )

--- a/eodag/plugins/authentication/aws_auth.py
+++ b/eodag/plugins/authentication/aws_auth.py
@@ -101,8 +101,7 @@ class AwsAuth(Authentication):
         self.s3_session: Optional[boto3.Session] = None
         self.s3_resource: Optional[S3ServiceResource] = None
         # set default for requester_pays if not given
-        if not getattr(self.config, "requester_pays", False):
-            setattr(self.config, "requester_pays", False)
+        self.config.__dict__.setdefault("requester_pays", False)
 
     def _create_s3_session_from_credentials(self) -> boto3.Session:
         credentials = getattr(self.config, "credentials", {}) or {}

--- a/eodag/plugins/authentication/aws_auth.py
+++ b/eodag/plugins/authentication/aws_auth.py
@@ -72,8 +72,10 @@ class AwsAuth(Authentication):
     * auth using ``profile_name`` (if credentials are given and contain ``aws_profile``)
     * auth using ``aws_access_key_id``, ``aws_secret_access_key`` and optionally ``aws_session_token``
       (if credentials are given but no ``aws_profile``)
-    * auth using current environment - AWS environment variables and/or ``~/aws/*``
+    * auth using current environment - AWS environment variables and/or ``~/.aws/*``
       (if no credentials are given in config)
+    * auth anonymously using no-sign-request if no credentials are given in config and
+      auth using current environment failed
 
     :param provider: provider name
     :param config: Authentication plugin configuration:

--- a/eodag/plugins/authentication/aws_auth.py
+++ b/eodag/plugins/authentication/aws_auth.py
@@ -201,7 +201,7 @@ class AwsAuth(Authentication):
                 logger.warning("Skipping %s/%s" % (bucket_name, prefix))
                 auth_error_messages.add(str(e))
             except ClientError as e:
-                self._raise_if_auth_error(e)
+                raise_if_auth_error(e, self.provider)
                 logger.warning("Unexpected error: %s" % e)
                 logger.warning("Skipping %s/%s" % (bucket_name, prefix))
                 auth_error_messages.add(str(e))

--- a/eodag/plugins/authentication/base.py
+++ b/eodag/plugins/authentication/base.py
@@ -20,10 +20,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from eodag.plugins.base import PluginTopic
-from eodag.types import S3AuthContextPool
 from eodag.utils.exceptions import MisconfiguredError
 
 if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3ServiceResource
     from mypy_boto3_s3.service_resource import BucketObjectsCollection
     from requests.auth import AuthBase
 
@@ -42,7 +42,7 @@ class Authentication(PluginTopic):
           configuration that needs authentication and helps identifying it
     """
 
-    def authenticate(self) -> Union[AuthBase, S3SessionKwargs, S3AuthContextPool]:
+    def authenticate(self) -> Union[AuthBase, S3SessionKwargs, S3ServiceResource]:
         """Authenticate"""
         raise NotImplementedError
 

--- a/eodag/plugins/authentication/base.py
+++ b/eodag/plugins/authentication/base.py
@@ -24,7 +24,6 @@ from eodag.utils.exceptions import MisconfiguredError
 
 if TYPE_CHECKING:
     from mypy_boto3_s3 import S3ServiceResource
-    from mypy_boto3_s3.service_resource import BucketObjectsCollection
     from requests.auth import AuthBase
 
     from eodag.types import S3SessionKwargs
@@ -76,7 +75,7 @@ class Authentication(PluginTopic):
     def authenticate_objects(
         self,
         bucket_names_and_prefixes: list[tuple[str, Optional[str]]],
-    ) -> tuple[dict[str, Any], BucketObjectsCollection]:
+    ) -> dict[str, Any]:
         """
         Authenticates with s3 and retrieves the available objects
         """

--- a/eodag/plugins/authentication/base.py
+++ b/eodag/plugins/authentication/base.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+from collections import UserList
 from typing import TYPE_CHECKING, Union
 
 from eodag.plugins.base import PluginTopic
@@ -40,7 +41,7 @@ class Authentication(PluginTopic):
           configuration that needs authentication and helps identifying it
     """
 
-    def authenticate(self) -> Union[AuthBase, S3SessionKwargs]:
+    def authenticate(self) -> Union[AuthBase, UserList, S3SessionKwargs]:
         """Authenticate"""
         raise NotImplementedError
 

--- a/eodag/plugins/authentication/base.py
+++ b/eodag/plugins/authentication/base.py
@@ -17,13 +17,14 @@
 # limitations under the License.
 from __future__ import annotations
 
-from collections import UserList
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from eodag.plugins.base import PluginTopic
+from eodag.types import S3AuthContextPool
 from eodag.utils.exceptions import MisconfiguredError
 
 if TYPE_CHECKING:
+    from mypy_boto3_s3.service_resource import BucketObjectsCollection
     from requests.auth import AuthBase
 
     from eodag.types import S3SessionKwargs
@@ -41,7 +42,7 @@ class Authentication(PluginTopic):
           configuration that needs authentication and helps identifying it
     """
 
-    def authenticate(self) -> Union[AuthBase, UserList, S3SessionKwargs]:
+    def authenticate(self) -> Union[AuthBase, S3SessionKwargs, S3AuthContextPool]:
         """Authenticate"""
         raise NotImplementedError
 
@@ -71,3 +72,12 @@ class Authentication(PluginTopic):
                     self.provider, ", ".join(missing_credentials)
                 )
             )
+
+    def authenticate_objects(
+        self,
+        bucket_names_and_prefixes: list[tuple[str, Optional[str]]],
+    ) -> tuple[dict[str, Any], BucketObjectsCollection]:
+        """
+        Authenticates with s3 and retrieves the available objects
+        """
+        raise NotImplementedError

--- a/eodag/plugins/base.py
+++ b/eodag/plugins/base.py
@@ -65,9 +65,10 @@ class PluginTopic(metaclass=EODAGPluginMount):
         self.provider = provider
 
     def __repr__(self) -> str:
+        config = getattr(self, "config", None)
         return "{}(provider={}, priority={}, topic={})".format(
             self.__class__.__name__,
-            self.provider,
-            self.config.priority,
+            getattr(self, "provider", ""),
+            config.priority if config else "",
             self.__class__.mro()[-3].__name__,
         )

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -199,8 +199,6 @@ class AwsDownload(Download):
 
         * :attr:`~eodag.config.PluginConfig.type` (``str``) (**mandatory**): AwsDownload
         * :attr:`~eodag.config.PluginConfig.s3_endpoint` (``str``): s3 endpoint url
-        * :attr:`~eodag.config.PluginConfig.requester_pays` (``bool``): whether download is done
-          from a requester-pays bucket or not; default: ``False``
         * :attr:`~eodag.config.PluginConfig.flatten_top_dirs` (``bool``): if the directory structure
           should be flattened; default: ``True``
         * :attr:`~eodag.config.PluginConfig.ignore_assets` (``bool``): ignore assets and download
@@ -223,7 +221,6 @@ class AwsDownload(Download):
 
     def __init__(self, provider: str, config: PluginConfig) -> None:
         super(AwsDownload, self).__init__(provider, config)
-        self.requester_pays = getattr(self.config, "requester_pays", False)
 
     def download(
         self,
@@ -813,7 +810,7 @@ class AwsDownload(Download):
 
         s3_session = auth_plugin.s3_session
 
-        if self.requester_pays:
+        if auth_plugin.requester_pays:
             rio_env_kwargs["requester_pays"] = True
         return {
             "session": s3_session,

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -230,7 +230,7 @@ class AwsDownload(Download):
     def download(
         self,
         product: EOProduct,
-        auth: Optional[S3ServiceResource] = None,
+        auth: Optional[Union[AuthBase, S3SessionKwargs, S3ServiceResource]] = None,
         progress_callback: Optional[ProgressCallback] = None,
         wait: float = DEFAULT_DOWNLOAD_WAIT,
         timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,
@@ -623,7 +623,7 @@ class AwsDownload(Download):
     def _stream_download_dict(
         self,
         product: EOProduct,
-        auth: Optional[S3ServiceResource] = None,
+        auth: Optional[Union[AuthBase, S3SessionKwargs, S3ServiceResource]] = None,
         byte_range: tuple[Optional[int], Optional[int]] = (None, None),
         compress: Literal["zip", "raw", "auto"] = "auto",
         wait: float = DEFAULT_DOWNLOAD_WAIT,
@@ -713,7 +713,7 @@ class AwsDownload(Download):
             ignore_assets,
             product,
         )
-        if auth:
+        if auth and isinstance(auth, boto3.resources.base.ServiceResource):
             self.s3_resource = auth
         else:
             self.s3_resource = boto3.resource(
@@ -805,7 +805,7 @@ class AwsDownload(Download):
             rio_env_kwargs["endpoint_url"] = endpoint_url.split("://")[-1]
         rio_env_kwargs |= {}
 
-        s3_session = auth_plugin.s3_session(bucket_name, prefix)
+        s3_session = auth_plugin.s3_session
 
         if self.requester_pays:
             rio_env_kwargs["requester_pays"] = True

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -810,7 +810,7 @@ class AwsDownload(Download):
 
         s3_session = auth_plugin.s3_session
 
-        if auth_plugin.requester_pays:
+        if auth_plugin.config.requester_pays:
             rio_env_kwargs["requester_pays"] = True
         return {
             "session": s3_session,

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -299,10 +299,9 @@ class AwsDownload(Download):
 
         # authenticate
         if product.downloader_auth:
-            (
-                authenticated_objects,
-                s3_objects,
-            ) = product.downloader_auth.authenticate_objects(bucket_names_and_prefixes)
+            authenticated_objects = product.downloader_auth.authenticate_objects(
+                bucket_names_and_prefixes
+            )
         else:
             raise MisconfiguredError(
                 "Authentication plugin (AwsAuth) has to be configured if AwsDownload is used"
@@ -351,11 +350,17 @@ class AwsDownload(Download):
                 if not os.path.isdir(chunk_abs_path_dir):
                     os.makedirs(chunk_abs_path_dir)
 
+                bucket_objects = authenticated_objects.get(product_chunk.bucket_name)
+                extra_args = (
+                    getattr(bucket_objects, "_params", {}).copy()
+                    if bucket_objects
+                    else {}
+                )
                 if not os.path.isfile(chunk_abs_path):
                     product_chunk.Bucket().download_file(
                         product_chunk.key,
                         chunk_abs_path,
-                        ExtraArgs=getattr(s3_objects, "_params", {}),
+                        ExtraArgs=extra_args,
                         Callback=progress_callback,
                     )
 
@@ -698,7 +703,7 @@ class AwsDownload(Download):
 
         # authenticate
         if product.downloader_auth:
-            authenticated_objects, _ = product.downloader_auth.authenticate_objects(
+            authenticated_objects = product.downloader_auth.authenticate_objects(
                 bucket_names_and_prefixes
             )
         else:

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -403,7 +403,7 @@ class AwsDownload(Download):
             logger.debug("Cannot check files in s3 zip without s3 resource")
             return bucket_names_and_prefixes
 
-        s3_client = product.downloader_auth.s3_client
+        s3_client = product.downloader_auth.get_s3_client()
 
         downloaded = []
         for i, pack in enumerate(bucket_names_and_prefixes):

--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -30,6 +30,7 @@ from time import sleep
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, TypeVar, Union
 
 from eodag.api.product.metadata_mapping import ONLINE_STATUS
+from eodag.plugins.authentication.aws_auth import S3AuthContextPool
 from eodag.plugins.base import PluginTopic
 from eodag.utils import (
     DEFAULT_DOWNLOAD_TIMEOUT,
@@ -103,7 +104,7 @@ class Download(PluginTopic):
     def download(
         self,
         product: EOProduct,
-        auth: Optional[Union[AuthBase, S3SessionKwargs]] = None,
+        auth: Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]] = None,
         progress_callback: Optional[ProgressCallback] = None,
         wait: float = DEFAULT_DOWNLOAD_WAIT,
         timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,
@@ -133,7 +134,7 @@ class Download(PluginTopic):
     def _stream_download_dict(
         self,
         product: EOProduct,
-        auth: Optional[Union[AuthBase, S3SessionKwargs]] = None,
+        auth: Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]] = None,
         byte_range: tuple[Optional[int], Optional[int]] = (None, None),
         compress: Literal["zip", "raw", "auto"] = "auto",
         wait: float = DEFAULT_DOWNLOAD_WAIT,

--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -30,7 +30,6 @@ from time import sleep
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, TypeVar, Union
 
 from eodag.api.product.metadata_mapping import ONLINE_STATUS
-from eodag.plugins.authentication.aws_auth import S3AuthContextPool
 from eodag.plugins.base import PluginTopic
 from eodag.utils import (
     DEFAULT_DOWNLOAD_TIMEOUT,
@@ -48,6 +47,7 @@ from eodag.utils.exceptions import (
 from eodag.utils.notebook import NotebookWidgets
 
 if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3ServiceResource
     from requests.auth import AuthBase
 
     from eodag.api.product import EOProduct
@@ -104,7 +104,7 @@ class Download(PluginTopic):
     def download(
         self,
         product: EOProduct,
-        auth: Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]] = None,
+        auth: Optional[Union[AuthBase, S3SessionKwargs, S3ServiceResource]] = None,
         progress_callback: Optional[ProgressCallback] = None,
         wait: float = DEFAULT_DOWNLOAD_WAIT,
         timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,
@@ -134,7 +134,7 @@ class Download(PluginTopic):
     def _stream_download_dict(
         self,
         product: EOProduct,
-        auth: Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]] = None,
+        auth: Optional[Union[AuthBase, S3SessionKwargs, S3ServiceResource]] = None,
         byte_range: tuple[Optional[int], Optional[int]] = (None, None),
         compress: Literal["zip", "raw", "auto"] = "auto",
         wait: float = DEFAULT_DOWNLOAD_WAIT,

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -58,6 +58,7 @@ from eodag.api.product.metadata_mapping import (
     properties_from_xml,
 )
 from eodag.plugins.download.base import Download
+from eodag.types import S3AuthContextPool
 from eodag.utils import (
     DEFAULT_DOWNLOAD_TIMEOUT,
     DEFAULT_DOWNLOAD_WAIT,
@@ -589,7 +590,7 @@ class HTTPDownload(Download):
     def download(
         self,
         product: EOProduct,
-        auth: Optional[Union[AuthBase, S3SessionKwargs]] = None,
+        auth: Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]] = None,
         progress_callback: Optional[ProgressCallback] = None,
         wait: float = DEFAULT_DOWNLOAD_WAIT,
         timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -754,7 +754,7 @@ class HTTPDownload(Download):
     def _stream_download_dict(
         self,
         product: EOProduct,
-        auth: Optional[Union[AuthBase, S3SessionKwargs]] = None,
+        auth: Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]] = None,
         byte_range: tuple[Optional[int], Optional[int]] = (None, None),
         compress: Literal["zip", "raw", "auto"] = "auto",
         wait: float = DEFAULT_DOWNLOAD_WAIT,

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -58,7 +58,6 @@ from eodag.api.product.metadata_mapping import (
     properties_from_xml,
 )
 from eodag.plugins.download.base import Download
-from eodag.types import S3AuthContextPool
 from eodag.utils import (
     DEFAULT_DOWNLOAD_TIMEOUT,
     DEFAULT_DOWNLOAD_WAIT,
@@ -88,6 +87,7 @@ from eodag.utils.exceptions import (
 
 if TYPE_CHECKING:
     from jsonpath_ng import JSONPath
+    from mypy_boto3_s3 import S3ServiceResource
     from requests import Response
 
     from eodag.api.product import Asset, EOProduct  # type: ignore
@@ -590,7 +590,7 @@ class HTTPDownload(Download):
     def download(
         self,
         product: EOProduct,
-        auth: Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]] = None,
+        auth: Optional[Union[AuthBase, S3SessionKwargs, S3ServiceResource]] = None,
         progress_callback: Optional[ProgressCallback] = None,
         wait: float = DEFAULT_DOWNLOAD_WAIT,
         timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,
@@ -754,7 +754,7 @@ class HTTPDownload(Download):
     def _stream_download_dict(
         self,
         product: EOProduct,
-        auth: Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]] = None,
+        auth: Optional[Union[AuthBase, S3SessionKwargs, S3ServiceResource]] = None,
         byte_range: tuple[Optional[int], Optional[int]] = (None, None),
         compress: Literal["zip", "raw", "auto"] = "auto",
         wait: float = DEFAULT_DOWNLOAD_WAIT,

--- a/eodag/plugins/download/s3rest.py
+++ b/eodag/plugins/download/s3rest.py
@@ -31,6 +31,7 @@ from requests.auth import AuthBase
 from eodag.api.product.metadata_mapping import OFFLINE_STATUS, ONLINE_STATUS
 from eodag.plugins.download.base import Download
 from eodag.plugins.download.http import HTTPDownload
+from eodag.types import S3AuthContextPool
 from eodag.utils import (
     DEFAULT_DOWNLOAD_TIMEOUT,
     DEFAULT_DOWNLOAD_WAIT,
@@ -94,7 +95,7 @@ class S3RestDownload(Download):
     def download(
         self,
         product: EOProduct,
-        auth: Optional[Union[AuthBase, S3SessionKwargs]] = None,
+        auth: Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]] = None,
         progress_callback: Optional[ProgressCallback] = None,
         wait: float = DEFAULT_DOWNLOAD_WAIT,
         timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,

--- a/eodag/plugins/download/s3rest.py
+++ b/eodag/plugins/download/s3rest.py
@@ -31,7 +31,6 @@ from requests.auth import AuthBase
 from eodag.api.product.metadata_mapping import OFFLINE_STATUS, ONLINE_STATUS
 from eodag.plugins.download.base import Download
 from eodag.plugins.download.http import HTTPDownload
-from eodag.types import S3AuthContextPool
 from eodag.utils import (
     DEFAULT_DOWNLOAD_TIMEOUT,
     DEFAULT_DOWNLOAD_WAIT,
@@ -53,6 +52,8 @@ from eodag.utils.exceptions import (
 )
 
 if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3ServiceResource
+
     from eodag.api.product import EOProduct
     from eodag.config import PluginConfig
     from eodag.types import S3SessionKwargs
@@ -95,7 +96,7 @@ class S3RestDownload(Download):
     def download(
         self,
         product: EOProduct,
-        auth: Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]] = None,
+        auth: Optional[Union[AuthBase, S3SessionKwargs, S3ServiceResource]] = None,
         progress_callback: Optional[ProgressCallback] = None,
         wait: float = DEFAULT_DOWNLOAD_WAIT,
         timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -36,6 +36,7 @@ from eodag.plugins.base import EODAGPluginMount
 from eodag.plugins.crunch.base import Crunch
 from eodag.plugins.download.base import Download
 from eodag.plugins.search.base import Search
+from eodag.types import S3AuthContextPool
 from eodag.utils import GENERIC_PRODUCT_TYPE, deepcopy, dict_md5sum
 from eodag.utils.exceptions import (
     AuthenticationError,
@@ -361,7 +362,7 @@ class PluginManager:
         provider: str,
         matching_url: Optional[str] = None,
         matching_conf: Optional[PluginConfig] = None,
-    ) -> Optional[Union[AuthBase, S3SessionKwargs]]:
+    ) -> Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]]:
         """Authenticate and return the authenticated object for the first matching
         authentication plugin
 

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -36,7 +36,6 @@ from eodag.plugins.base import EODAGPluginMount
 from eodag.plugins.crunch.base import Crunch
 from eodag.plugins.download.base import Download
 from eodag.plugins.search.base import Search
-from eodag.types import S3AuthContextPool
 from eodag.utils import GENERIC_PRODUCT_TYPE, deepcopy, dict_md5sum
 from eodag.utils.exceptions import (
     AuthenticationError,
@@ -45,6 +44,7 @@ from eodag.utils.exceptions import (
 )
 
 if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3ServiceResource
     from requests.auth import AuthBase
 
     from eodag.api.product import EOProduct
@@ -362,7 +362,7 @@ class PluginManager:
         provider: str,
         matching_url: Optional[str] = None,
         matching_conf: Optional[PluginConfig] = None,
-    ) -> Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]]:
+    ) -> Optional[Union[AuthBase, S3SessionKwargs, S3ServiceResource]]:
         """Authenticate and return the authenticated object for the first matching
         authentication plugin
 

--- a/eodag/plugins/search/__init__.py
+++ b/eodag/plugins/search/__init__.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from eodag.types import S3AuthContextPool
 from eodag.utils import DEFAULT_ITEMS_PER_PAGE, DEFAULT_PAGE
 
 if TYPE_CHECKING:
@@ -39,7 +40,7 @@ class PreparedSearch:
     product_type: Optional[str] = None
     page: Optional[int] = DEFAULT_PAGE
     items_per_page: Optional[int] = DEFAULT_ITEMS_PER_PAGE
-    auth: Optional[Union[AuthBase, S3SessionKwargs]] = None
+    auth: Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]] = None
     auth_plugin: Optional[Authentication] = None
     count: bool = True
     url: Optional[str] = None

--- a/eodag/plugins/search/__init__.py
+++ b/eodag/plugins/search/__init__.py
@@ -21,12 +21,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from eodag.types import S3AuthContextPool
 from eodag.utils import DEFAULT_ITEMS_PER_PAGE, DEFAULT_PAGE
 
 if TYPE_CHECKING:
     from typing import Any, Optional, Union
 
+    from mypy_boto3_s3 import S3ServiceResource
     from requests.auth import AuthBase
 
     from eodag.plugins.authentication.base import Authentication
@@ -40,7 +40,7 @@ class PreparedSearch:
     product_type: Optional[str] = None
     page: Optional[int] = DEFAULT_PAGE
     items_per_page: Optional[int] = DEFAULT_ITEMS_PER_PAGE
-    auth: Optional[Union[AuthBase, S3SessionKwargs, S3AuthContextPool]] = None
+    auth: Optional[Union[AuthBase, S3SessionKwargs, S3ServiceResource]] = None
     auth_plugin: Optional[Authentication] = None
     count: bool = True
     url: Optional[str] = None

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -31,7 +31,7 @@ from eodag.api.product.metadata_mapping import (
 )
 from eodag.plugins.base import PluginTopic
 from eodag.plugins.search import PreparedSearch
-from eodag.types import S3AuthContextPool, model_fields_to_annotated
+from eodag.types import model_fields_to_annotated
 from eodag.types.queryables import Queryables, QueryablesDict
 from eodag.types.search_args import SortByList
 from eodag.utils import (
@@ -47,6 +47,7 @@ from eodag.utils.exceptions import ValidationError
 if TYPE_CHECKING:
     from typing import Any, Optional, Union
 
+    from mypy_boto3_s3 import S3ServiceResource
     from requests.auth import AuthBase
 
     from eodag.api.product import EOProduct
@@ -63,7 +64,7 @@ class Search(PluginTopic):
     :param config: An EODAG plugin configuration
     """
 
-    auth: Union[AuthBase, S3SessionKwargs, S3AuthContextPool]
+    auth: Union[AuthBase, S3SessionKwargs, S3ServiceResource]
     next_page_url: Optional[str]
     next_page_query_obj: Optional[dict[str, Any]]
     total_items_nb: int

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -31,7 +31,7 @@ from eodag.api.product.metadata_mapping import (
 )
 from eodag.plugins.base import PluginTopic
 from eodag.plugins.search import PreparedSearch
-from eodag.types import model_fields_to_annotated
+from eodag.types import S3AuthContextPool, model_fields_to_annotated
 from eodag.types.queryables import Queryables, QueryablesDict
 from eodag.types.search_args import SortByList
 from eodag.utils import (
@@ -63,7 +63,7 @@ class Search(PluginTopic):
     :param config: An EODAG plugin configuration
     """
 
-    auth: Union[AuthBase, S3SessionKwargs]
+    auth: Union[AuthBase, S3SessionKwargs, S3AuthContextPool]
     next_page_url: Optional[str]
     next_page_query_obj: Optional[dict[str, Any]]
     total_items_nb: int

--- a/eodag/plugins/search/creodias_s3.py
+++ b/eodag/plugins/search/creodias_s3.py
@@ -42,13 +42,11 @@ def patched_register_downloader(self, downloader, authenticator):
     """
     # verify credentials
     required_creds = ["aws_access_key_id", "aws_secret_access_key"]
-    if not all(
-        x in authenticator.credentials and authenticator.credentials[x]
-        for x in required_creds
-    ):
+    credentials = getattr(authenticator.config, "credentials", {}) or {}
+    if not all(x in credentials and credentials[x] for x in required_creds):
         raise MisconfiguredError(
             f"Incomplete credentials for {self.provider}, missing "
-            f"{[x for x in required_creds if x not in authenticator.credentials or not authenticator.credentials[x]]}"
+            f"{[x for x in required_creds if x not in credentials or not credentials[x]]}"
         )
     # register downloader
     self.register_downloader_only(downloader, authenticator)

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1358,6 +1358,7 @@
   auth: !plugin
     type: AwsAuth
     matching_url: s3://
+    s3_endpoint: https://storage.googleapis.com
     matching_conf:
       s3_endpoint: https://storage.googleapis.com
 ---
@@ -3943,6 +3944,7 @@
   auth: !plugin
     type: AwsAuth
     auth_error_code: 403
+    s3_endpoint: 'https://eodata.cloudferro.com'
     matching_conf:
       s3_endpoint: 'https://eodata.cloudferro.com'
   products:
@@ -5421,6 +5423,7 @@
   auth: !plugin
     type: AwsAuth
     matching_url: s3://
+    s3_endpoint: https://s3.waw3-1.cloudferro.com
     matching_conf:
       s3_endpoint: https://s3.waw3-1.cloudferro.com
 
@@ -5670,6 +5673,7 @@
   auth: !plugin
     type: AwsAuth
     auth_error_code: 403
+    s3_endpoint: https://s3.datalake.cnes.fr
     matching_conf:
       s3_endpoint: https://s3.datalake.cnes.fr
 

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -492,7 +492,6 @@
 
   download: !plugin
     type: AwsDownload
-    requester_pays: True
     ssl_verify: true
     products:
       CBERS4_MUX_L2:
@@ -531,6 +530,7 @@
   download_auth: !plugin
     type: AwsAuth
     matching_url: s3://
+    requester_pays: True
   search_auth: !plugin
     type: HttpQueryStringAuth
     matching_url: https://gate.eos.com
@@ -1124,11 +1124,11 @@
       productType: '{productType}'
   download: !plugin
     type: AwsDownload
-    requester_pays: True
     ssl_verify: true
   auth: !plugin
     type: AwsAuth
     matching_url: s3://
+    requester_pays: True
 
 ---
 !provider # MARK: earth_search
@@ -1223,7 +1223,6 @@
       productType: '{productType}'
   download: !plugin
     type: AwsDownload
-    requester_pays: True
     ssl_verify: true
     products:
       S2_MSI_L1C:
@@ -1235,6 +1234,7 @@
   auth: !plugin
     type: AwsAuth
     matching_url: s3://
+    requester_pays: True
 
 ---
 !provider # MARK: earth_search_cog

--- a/eodag/types/__init__.py
+++ b/eodag/types/__init__.py
@@ -19,9 +19,7 @@
 
 from __future__ import annotations
 
-from collections import UserList
 from typing import (
-    TYPE_CHECKING,
     Annotated,
     Any,
     Literal,
@@ -33,10 +31,7 @@ from typing import (
     get_origin,
 )
 
-import boto3
 from annotated_types import Gt, Lt
-from boto3 import Session
-from botocore.handlers import disable_signing
 from pydantic import BaseModel, ConfigDict, Field, create_model
 from pydantic.annotated_handlers import GetJsonSchemaHandler
 from pydantic.fields import FieldInfo
@@ -45,9 +40,6 @@ from pydantic_core import CoreSchema, PydanticUndefined
 
 from eodag.utils import copy_deepcopy
 from eodag.utils.exceptions import ValidationError
-
-if TYPE_CHECKING:
-    from mypy_boto3_s3 import S3ServiceResource
 
 # Types mapping from JSON Schema and OpenAPI 3.1.0 specifications to Python
 # See https://spec.openapis.org/oas/v3.1.0#data-types
@@ -455,91 +447,3 @@ class S3SessionKwargs(TypedDict, total=False):
     aws_secret_access_key: Optional[str]
     aws_session_token: Optional[str]
     profile_name: Optional[str]
-
-
-class S3AuthContext:
-
-    """Class defining an S3 authentication context (resource, session and authentication type used)"""
-
-    def __init__(
-        self, s3_resource: S3ServiceResource, auth_type: str, s3_session: Session
-    ):
-        self.s3_resource: S3ServiceResource = s3_resource
-        self.auth_type: str = auth_type
-        self.s3_session: Session = s3_session
-
-    @staticmethod
-    def create_auth_context_unsigned(endpoint_url: str):
-        """Auth strategy using no-sign-request"""
-        s3_resource = boto3.resource(service_name="s3", endpoint_url=endpoint_url)
-        s3_resource.meta.client.meta.events.register(
-            "choose-signer.s3.*", disable_signing
-        )
-        return S3AuthContext(
-            s3_resource=s3_resource, auth_type="unsigned", s3_session=Session()
-        )
-
-    @staticmethod
-    def create_auth_context_auth_profile(endpoint_url: str, profile_name: str):
-        """Auth strategy using ``aws_profile`` from provided credentials"""
-        s3_session = Session(profile_name=profile_name)
-        s3_resource = s3_session.resource(
-            service_name="s3",
-            endpoint_url=endpoint_url,
-        )
-        return S3AuthContext(
-            s3_resource=s3_resource, auth_type="auth_profile", s3_session=s3_session
-        )
-
-    @staticmethod
-    def create_auth_context_auth_keys(endpoint_url: str, credentials: dict[str, str]):
-        """Auth strategy using ``aws_access_key_id``/``aws_secret_access_key`` from provided credentials"""
-        s3_session_kwargs: S3SessionKwargs = {
-            "aws_access_key_id": credentials["aws_access_key_id"],
-            "aws_secret_access_key": credentials["aws_secret_access_key"],
-        }
-        if credentials.get("aws_session_token"):
-            s3_session_kwargs["aws_session_token"] = credentials["aws_session_token"]
-        s3_session = Session(**s3_session_kwargs)
-        s3_resource = s3_session.resource(
-            service_name="s3",
-            endpoint_url=endpoint_url,
-        )
-        return S3AuthContext(
-            s3_resource=s3_resource, auth_type="auth_keys", s3_session=s3_session
-        )
-
-    @staticmethod
-    def create_auth_context_env(endpoint_url: str):
-        """Auth strategy using current environment"""
-
-        s3_session = Session()
-        s3_resource = s3_session.resource(service_name="s3", endpoint_url=endpoint_url)
-        return S3AuthContext(
-            s3_resource=s3_resource, auth_type="env", s3_session=s3_session
-        )
-
-
-class S3AuthContextPool(UserList):
-
-    """Instances of S3AuthContextPool contain a list of possible authentication contexts
-    based on the given credentials"""
-
-    def __init__(self, endpoint_url, credentials: dict[str, str], *args: Any):
-        super(S3AuthContextPool, self).__init__(*args)
-        self.data.append(S3AuthContext.create_auth_context_unsigned(endpoint_url))
-        if "aws_profile" in credentials:
-            self.data.append(
-                S3AuthContext.create_auth_context_auth_profile(
-                    endpoint_url, credentials["aws_profile"]
-                )
-            )
-        if (
-            "aws_access_key_id" in credentials
-            and "aws_secret_access_key" in credentials
-        ):
-            self.data.append(
-                S3AuthContext.create_auth_context_auth_keys(endpoint_url, credentials)
-            )
-        self.data.append(S3AuthContext.create_auth_context_env(endpoint_url))
-        self.used_method = ""

--- a/eodag/utils/s3.py
+++ b/eodag/utils/s3.py
@@ -502,10 +502,7 @@ def update_assets_from_s3(
     try:
 
         logger.debug("Listing assets in %s", prefix)
-        if auth.s3_client:
-            s3_client = auth.s3_client
-        else:
-            s3_client = auth.get_s3_client()
+        s3_client = auth.get_s3_client()
 
         if prefix.endswith(".zip"):
             # List prefix zip content

--- a/eodag/utils/s3.py
+++ b/eodag/utils/s3.py
@@ -27,7 +27,6 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 from zipfile import ZIP_STORED, ZipFile
 
-import boto3
 import botocore
 import botocore.exceptions
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
@@ -45,7 +44,6 @@ from eodag.utils.exceptions import (
     AuthenticationError,
     DownloadError,
     InvalidDataError,
-    MisconfiguredError,
     NotAvailableError,
 )
 
@@ -491,7 +489,6 @@ def update_assets_from_s3(
     :param content_url: s3 URL pointing to the content that must be listed (defaults to
                         ``product.remote_location`` if empty)
     """
-    required_creds = ["aws_access_key_id", "aws_secret_access_key"]
 
     if content_url is None:
         content_url = product.remote_location
@@ -503,21 +500,6 @@ def update_assets_from_s3(
         return None
 
     try:
-        auth_dict = auth.authenticate()
-
-        if not all(x in auth_dict for x in required_creds):
-            raise MisconfiguredError(
-                f"Incomplete credentials for {product.provider}, missing "
-                f"{[x for x in required_creds if x not in auth_dict]}"
-            )
-        if not getattr(auth, "s3_client", None):
-            auth.s3_client = boto3.client(
-                service_name="s3",
-                endpoint_url=s3_endpoint,
-                aws_access_key_id=auth_dict.get("aws_access_key_id"),
-                aws_secret_access_key=auth_dict.get("aws_secret_access_key"),
-                aws_session_token=auth_dict.get("aws_session_token"),
-            )
 
         logger.debug("Listing assets in %s", prefix)
 

--- a/eodag/utils/s3.py
+++ b/eodag/utils/s3.py
@@ -502,18 +502,22 @@ def update_assets_from_s3(
     try:
 
         logger.debug("Listing assets in %s", prefix)
+        if auth.s3_client:
+            s3_client = auth.s3_client
+        else:
+            s3_client = auth.get_s3_client()
 
         if prefix.endswith(".zip"):
             # List prefix zip content
             assets_urls = [
                 f"zip+s3://{bucket}/{prefix}!{f.filename}"
-                for f in list_files_in_s3_zipped_object(bucket, prefix, auth.s3_client)
+                for f in list_files_in_s3_zipped_object(bucket, prefix, s3_client)
             ]
         else:
             # List files in prefix
             assets_urls = [
                 f"s3://{bucket}/{obj['Key']}"
-                for obj in auth.s3_client.list_objects(
+                for obj in s3_client.list_objects(
                     Bucket=bucket, Prefix=prefix, MaxKeys=300
                 ).get("Contents", [])
             ]

--- a/tests/integration/test_core_search_results.py
+++ b/tests/integration/test_core_search_results.py
@@ -466,16 +466,12 @@ class TestCoreSearchResults(EODagTestCase):
         )
         self.assertIsInstance(results[1].downloader, Download)
 
-    @mock.patch(
-        "eodag.plugins.authentication.aws_auth.AwsAuth.__init__",
-        autospec=True,
-    )
     @mock.patch("eodag.api.core.fetch_stac_items", autospec=True)
     def test_core_import_stac_items_from_known_provider(
-        self, mock_fetch_stac_items, mock_aws_auth_init
+        self,
+        mock_fetch_stac_items,
     ):
         """The core api must import STAC items from a knwown provider"""
-        mock_aws_auth_init.return_value = None
         earth_search_resp_search_file = os.path.join(
             TEST_RESOURCES_PATH, "provider_responses", "earth_search_search.json"
         )

--- a/tests/integration/test_core_search_results.py
+++ b/tests/integration/test_core_search_results.py
@@ -466,9 +466,16 @@ class TestCoreSearchResults(EODagTestCase):
         )
         self.assertIsInstance(results[1].downloader, Download)
 
+    @mock.patch(
+        "eodag.plugins.authentication.aws_auth.AwsAuth.__init__",
+        autospec=True,
+    )
     @mock.patch("eodag.api.core.fetch_stac_items", autospec=True)
-    def test_core_import_stac_items_from_known_provider(self, mock_fetch_stac_items):
+    def test_core_import_stac_items_from_known_provider(
+        self, mock_fetch_stac_items, mock_aws_auth_init
+    ):
         """The core api must import STAC items from a knwown provider"""
+        mock_aws_auth_init.return_value = None
         earth_search_resp_search_file = os.path.join(
             TEST_RESOURCES_PATH, "provider_responses", "earth_search_search.json"
         )

--- a/tests/units/test_auth_plugins.py
+++ b/tests/units/test_auth_plugins.py
@@ -674,7 +674,7 @@ class TestAuthPluginAwsAuth(BaseAuthPluginTest):
             None, self.profile_name
         )
 
-    @mock.patch("eodag.plugins.authentication.aws_auth.S3AuthContext", autospec=True)
+    @mock.patch("eodag.types.S3AuthContext", autospec=True)
     @mock.patch(
         "eodag.plugins.authentication.aws_auth.AwsAuth.create_s3_client", autospec=True
     )

--- a/tests/units/test_auth_plugins.py
+++ b/tests/units/test_auth_plugins.py
@@ -616,7 +616,7 @@ class TestAuthPluginAwsAuth(BaseAuthPluginTest):
         "eodag.plugins.authentication.aws_auth.create_s3_session", autospec=True
     )
     @mock.patch(
-        "eodag.plugins.authentication.aws_auth.AwsAuth.create_s3_client", autospec=True
+        "eodag.plugins.authentication.aws_auth.AwsAuth.get_s3_client", autospec=True
     )
     def test_plugins_auth_aws_authenticate(self, mock_s3_client, mock_create_session):
         """AwsAuth.authenticate must return an S3AuthContextPool containing available auth contexts"""
@@ -688,7 +688,7 @@ class TestAuthPluginAwsAuth(BaseAuthPluginTest):
         "eodag.plugins.authentication.aws_auth.create_s3_session", autospec=True
     )
     @mock.patch(
-        "eodag.plugins.authentication.aws_auth.AwsAuth.create_s3_client", autospec=True
+        "eodag.plugins.authentication.aws_auth.AwsAuth.get_s3_client", autospec=True
     )
     @mock.patch(
         "eodag.plugins.authentication.aws_auth.AwsAuth._get_authenticated_objects",

--- a/tests/units/test_auth_plugins.py
+++ b/tests/units/test_auth_plugins.py
@@ -654,7 +654,7 @@ class TestAuthPluginAwsAuth(BaseAuthPluginTest):
             "aws_access_key_id": self.aws_access_key_id,
             "aws_secret_access_key": self.aws_secret_access_key,
         }
-        self.assertDictEqual(keys_dict, plugin_auth_keys.credentials)
+        self.assertDictEqual(keys_dict, plugin_auth_keys.config.credentials)
         mock_create_session.reset_mock()
 
         mock_create_session.return_value = MockSession(
@@ -677,7 +677,7 @@ class TestAuthPluginAwsAuth(BaseAuthPluginTest):
             "aws_secret_access_key": self.aws_secret_access_key,
             "aws_session_token": self.aws_session_token,
         }
-        self.assertDictEqual(keys_dict, plugin_auth_keys_session.credentials)
+        self.assertDictEqual(keys_dict, plugin_auth_keys_session.config.credentials)
         mock_create_session.reset_mock()
 
         mock_create_session.return_value = MockSession(profile_name=self.profile_name)
@@ -686,7 +686,7 @@ class TestAuthPluginAwsAuth(BaseAuthPluginTest):
         mock_create_session.assert_called_once_with(profile_name=self.profile_name)
 
         keys_dict = {"aws_profile": self.profile_name}
-        self.assertDictEqual(keys_dict, plugin_auth_profile.credentials)
+        self.assertDictEqual(keys_dict, plugin_auth_profile.config.credentials)
 
     @mock.patch(
         "eodag.plugins.authentication.aws_auth.create_s3_session", autospec=True

--- a/tests/units/test_auth_plugins.py
+++ b/tests/units/test_auth_plugins.py
@@ -28,8 +28,8 @@ from requests.auth import AuthBase
 from requests.exceptions import RequestException
 
 from eodag.config import override_config_from_mapping
-from eodag.plugins.authentication.aws_auth import S3AuthContext
 from eodag.plugins.authentication.openid_connect import CodeAuthorizedAuth
+from eodag.types import S3AuthContext
 from eodag.utils import MockResponse
 from eodag.utils.exceptions import RequestError
 from tests.context import (
@@ -613,7 +613,7 @@ class TestAuthPluginAwsAuth(BaseAuthPluginTest):
         )
         cls.plugins_manager = PluginManager(cls.providers_config)
 
-    @mock.patch("eodag.plugins.authentication.aws_auth.S3AuthContext", autospec=True)
+    @mock.patch("eodag.types.S3AuthContext", autospec=True)
     @mock.patch(
         "eodag.plugins.authentication.aws_auth.AwsAuth.create_s3_client", autospec=True
     )

--- a/tests/units/test_auth_plugins.py
+++ b/tests/units/test_auth_plugins.py
@@ -714,16 +714,14 @@ class TestAuthPluginAwsAuth(BaseAuthPluginTest):
             ["c/y.json"],
         ]
         auth_objects = plugin.authenticate_objects(buckets_prefixes)
-        self.assertEqual(({"b": ["c/y.json"]}, ["c/y.json"]), auth_objects)
+        self.assertDictEqual({"b": ["c/y.json"]}, auth_objects)
 
         # both buckets authenticated
         plugin = self.get_auth_plugin("provider_with_auth_profile")
         buckets_prefixes = [("a", "b/c/x.png"), ("b", "b/c/y.json")]
         mock_get_authenticated_objects.side_effect = [["b/c/x.json"], ["c/y.json"]]
         auth_objects = plugin.authenticate_objects(buckets_prefixes)
-        self.assertEqual(
-            ({"a": ["b/c/x.json"], "b": ["c/y.json"]}, ["c/y.json"]), auth_objects
-        )
+        self.assertDictEqual({"a": ["b/c/x.json"], "b": ["c/y.json"]}, auth_objects)
 
 
 class TestAuthPluginHTTPHeaderAuth(BaseAuthPluginTest):

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -1886,8 +1886,9 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
         # no SAFE build and flatten_top_dirs
         plugin.config.products[self.product.product_type]["build_safe"] = False
         plugin.config.flatten_top_dirs = True
+        auth = auth_plugin.authenticate()
 
-        path = plugin.download(self.product, output_dir=self.output_dir)
+        path = plugin.download(self.product, output_dir=self.output_dir, auth=auth)
 
         self.assertEqual(mock_open_s3_zipped_object.call_count, 2)
         mock_open_s3_zipped_object.assert_called_with(
@@ -2129,6 +2130,7 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
 
         plugin = self.get_download_plugin(self.product)
         auth_plugin = self.get_auth_plugin(plugin, self.product)
+        auth_plugin.authenticate()
 
         # nothing needed
         rio_env_dict = plugin.get_rio_env("some-bucket", "some/prefix", auth_plugin)

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -2140,7 +2140,7 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
 
         # with endpoint url
         plugin.config.s3_endpoint = "some.endpoint"
-        self.assertEqual(plugin.config.requester_pays, True)
+        self.assertEqual(auth_plugin.config.requester_pays, True)
         rio_env_dict = plugin.get_rio_env("some-bucket", "some/prefix", auth_plugin)
         self.assertIsNotNone(rio_env_dict.pop("session", None))
         self.assertDictEqual(

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -1892,7 +1892,7 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
 
         self.assertEqual(mock_open_s3_zipped_object.call_count, 2)
         mock_open_s3_zipped_object.assert_called_with(
-            "example", "path/to/foo.zip", auth_plugin.s3_client, partial=False
+            "example", "path/to/foo.zip", auth_plugin.get_s3_client(), partial=False
         )
         self.assertTrue(
             os.path.isfile(

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -2098,7 +2098,7 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
             plugin.download(self.product, outputs_prefix=self.output_dir)
 
     @mock.patch(
-        "eodag.plugins.authentication.aws_auth.AwsAuth.create_s3_client",
+        "eodag.plugins.authentication.aws_auth.AwsAuth.get_s3_client",
         autospec=True,
     )
     @mock.patch(

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2387,7 +2387,7 @@ class TestSearchPluginCreodiasS3Search(BaseSearchPluginTest):
         "eodag.plugins.authentication.aws_auth.create_s3_session", autospec=True
     )
     @mock.patch(
-        "eodag.plugins.authentication.aws_auth.AwsAuth.create_s3_client", autospec=True
+        "eodag.plugins.authentication.aws_auth.AwsAuth.get_s3_client", autospec=True
     )
     @mock.patch(
         "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2320,12 +2320,16 @@ class TestSearchPluginCreodiasS3Search(BaseSearchPluginTest):
         self.provider = "creodias_s3"
 
     @mock.patch(
+        "eodag.plugins.authentication.aws_auth.AwsAuth.get_s3_client", autospec=True
+    )
+    @mock.patch(
         "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
     )
-    def test_plugins_search_creodias_s3_links(self, mock_request):
+    def test_plugins_search_creodias_s3_links(self, mock_request, mock_s3_client):
         # s3 links should be added to products with register_downloader
         search_plugin = self.get_search_plugin("S1_SAR_GRD", self.provider)
         client = boto3.client("s3", aws_access_key_id="a", aws_secret_access_key="b")
+        mock_s3_client.return_value = client
         stubber = Stubber(client)
         s3_response_file = (
             Path(TEST_RESOURCES_PATH) / "provider_responses/creodias_s3_objects.json"
@@ -2345,9 +2349,8 @@ class TestSearchPluginCreodiasS3Search(BaseSearchPluginTest):
             auth_plugin = self.plugins_manager.get_auth_plugin(download_plugin, product)
             stubber.add_response("list_objects", list_objects_response)
             stubber.activate()
-            setattr(auth_plugin, "s3_client", client)
             # fails if credentials are missing
-            auth_plugin.credentials = {
+            auth_plugin.config.credentials = {
                 "aws_access_key_id": "",
                 "aws_secret_access_key": "",
             }
@@ -2356,7 +2359,7 @@ class TestSearchPluginCreodiasS3Search(BaseSearchPluginTest):
                 r"^Incomplete credentials .* \['aws_access_key_id', 'aws_secret_access_key'\]$",
             ):
                 product.register_downloader(download_plugin, auth_plugin)
-            auth_plugin.credentials = {
+            auth_plugin.config.credentials = {
                 "aws_access_key_id": "foo",
                 "aws_secret_access_key": "bar",
             }
@@ -2379,12 +2382,18 @@ class TestSearchPluginCreodiasS3Search(BaseSearchPluginTest):
         self.assertEqual(0, len(res[0][0].assets))
 
     @mock.patch(
+        "eodag.plugins.authentication.aws_auth.AwsAuth.get_s3_client", autospec=True
+    )
+    @mock.patch(
         "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
     )
-    def test_plugins_search_creodias_s3_client_error(self, mock_request):
+    def test_plugins_search_creodias_s3_client_error(
+        self, mock_request, mock_s3_client
+    ):
         # request error should be raised when there is an error when fetching data from the s3
         search_plugin = self.get_search_plugin("S1_SAR_GRD", self.provider)
         client = boto3.client("s3", aws_access_key_id="a", aws_secret_access_key="b")
+        mock_s3_client.return_value = client
         stubber = Stubber(client)
 
         creodias_search_result_file = (
@@ -2401,13 +2410,12 @@ class TestSearchPluginCreodiasS3Search(BaseSearchPluginTest):
                 auth_plugin = self.plugins_manager.get_auth_plugin(
                     download_plugin, product
                 )
-                auth_plugin.credentials = {
+                auth_plugin.config.credentials = {
                     "aws_access_key_id": "foo",
                     "aws_secret_access_key": "bar",
                 }
                 stubber.add_client_error("list_objects")
                 stubber.activate()
-                setattr(auth_plugin, "s3_client", client)
                 product.register_downloader(download_plugin, auth_plugin)
 
 

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2320,15 +2320,10 @@ class TestSearchPluginCreodiasS3Search(BaseSearchPluginTest):
         self.provider = "creodias_s3"
 
     @mock.patch(
-        "eodag.plugins.authentication.aws_auth.AwsAuth.__init__",
-        autospec=True,
-    )
-    @mock.patch(
         "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
     )
-    def test_plugins_search_creodias_s3_links(self, mock_request, mock_aws_auth_init):
+    def test_plugins_search_creodias_s3_links(self, mock_request):
         # s3 links should be added to products with register_downloader
-        mock_aws_auth_init.return_value = None
         search_plugin = self.get_search_plugin("S1_SAR_GRD", self.provider)
         client = boto3.client("s3", aws_access_key_id="a", aws_secret_access_key="b")
         stubber = Stubber(client)
@@ -2384,17 +2379,9 @@ class TestSearchPluginCreodiasS3Search(BaseSearchPluginTest):
         self.assertEqual(0, len(res[0][0].assets))
 
     @mock.patch(
-        "eodag.plugins.authentication.aws_auth.create_s3_session", autospec=True
-    )
-    @mock.patch(
-        "eodag.plugins.authentication.aws_auth.AwsAuth.get_s3_client", autospec=True
-    )
-    @mock.patch(
         "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
     )
-    def test_plugins_search_creodias_s3_client_error(
-        self, mock_request, mock_s3_client, mock_session
-    ):
+    def test_plugins_search_creodias_s3_client_error(self, mock_request):
         # request error should be raised when there is an error when fetching data from the s3
         search_plugin = self.get_search_plugin("S1_SAR_GRD", self.provider)
         client = boto3.client("s3", aws_access_key_id="a", aws_secret_access_key="b")

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -42,7 +42,6 @@ from typing_extensions import get_args
 
 from eodag.api.product import AssetsDict
 from eodag.api.product.metadata_mapping import get_queryable_from_provider
-from eodag.types import S3AuthContext
 from eodag.utils import deepcopy
 from eodag.utils.exceptions import UnsupportedProductType, ValidationError
 from tests.context import (
@@ -2384,7 +2383,9 @@ class TestSearchPluginCreodiasS3Search(BaseSearchPluginTest):
         self.assertIsNotNone(res[0][0].driver)
         self.assertEqual(0, len(res[0][0].assets))
 
-    @mock.patch("eodag.types.S3AuthContext", autospec=True)
+    @mock.patch(
+        "eodag.plugins.authentication.aws_auth.create_s3_session", autospec=True
+    )
     @mock.patch(
         "eodag.plugins.authentication.aws_auth.AwsAuth.create_s3_client", autospec=True
     )
@@ -2392,21 +2393,9 @@ class TestSearchPluginCreodiasS3Search(BaseSearchPluginTest):
         "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
     )
     def test_plugins_search_creodias_s3_client_error(
-        self, mock_request, mock_s3_client, mock_auth_context
+        self, mock_request, mock_s3_client, mock_session
     ):
         # request error should be raised when there is an error when fetching data from the s3
-        mock_auth_context.create_auth_context_unsigned.return_value = S3AuthContext(
-            None, "unsigned", None
-        )
-        mock_auth_context.create_auth_context_auth_profile.return_value = S3AuthContext(
-            None, "auth_profile", None
-        )
-        mock_auth_context.create_auth_context_auth_keys.return_value = S3AuthContext(
-            None, "auth_keys", None
-        )
-        mock_auth_context.create_auth_context_env.return_value = S3AuthContext(
-            None, "env", None
-        )
         search_plugin = self.get_search_plugin("S1_SAR_GRD", self.provider)
         client = boto3.client("s3", aws_access_key_id="a", aws_secret_access_key="b")
         stubber = Stubber(client)

--- a/tests/units/test_utils_s3.py
+++ b/tests/units/test_utils_s3.py
@@ -14,7 +14,6 @@ from tests.context import (
     AwsAuth,
     EOProduct,
     InvalidDataError,
-    MisconfiguredError,
     PluginConfig,
     S3FileInfo,
     StreamResponse,
@@ -242,18 +241,6 @@ class TestUtilsS3(TestCase):
         for asset_name, expected in expected_assets.items():
             with self.subTest(asset=asset_name):
                 self.assertDictEqual(self.prod.assets[asset_name].data, expected)
-
-    def test_utils_s3_update_assets_from_s3_credentials_nok(self):
-        """update_assets_from_s3 must have required credentials"""
-        prod = EOProduct("dummy", dict(geometry="POINT (0 0)", id="foo"))
-        auth_plugin = AwsAuth("dummy", PluginConfig())
-        self.assertRaises(
-            MisconfiguredError,
-            update_assets_from_s3,
-            prod,
-            auth_plugin,
-            content_url="s3://mybucket/path/to/unzipped",
-        )
 
     def test_utils_s3_file_position_from_s3_zip(self):
         # Prepare a zip with both uncompressed and compressed files


### PR DESCRIPTION
The `AwsAuth` plugin is refactored to actually perform the authentication on S3 and fetch the available objects:

- The `AwsAuth` plugin initializes the `s3_session` and `s3_resource` based on the available credentials.
- The method `do_authentication` has been renamed to `authenticate_objects` and moved to the `AwsAuth` plugin. Its sub-methods have also been moved or deleted because they were not necessary anymore due to simplification of the code.
- The s3 endpoint has been added to the config of the auth plugin.
