### PR TITLE
refactor(plugins): dedt_lumi not-available data error message

### DIFF
--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -334,18 +334,6 @@ class HTTPDownload(Download):
                     f"Order download status request responded with {response.status_code}"
                 )
 
-                # [CFDEDL-6623]: dedt_lumi currently responds with a 400 when no data is available.
-                # This often happens when Region of Interest polygon is not available.
-                # This is ad-hoc error handling for that case.
-                if (
-                    product.provider == "dedt_lumi"
-                    and "ecmwf:feature" in product.properties
-                    and response.status_code == 400
-                ):
-                    raise DownloadError(
-                        "No data was returned by the provider. Region of Interest may not be available."
-                    )
-
                 response.raise_for_status()  # Raise an exception if status code indicates an error
 
                 # Handle redirection (if needed)

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -155,6 +155,7 @@ class HTTPDownload(Download):
         auth: Optional[AuthBase] = None,
         **kwargs: Unpack[DownloadConf],
     ) -> Optional[dict[str, Any]]:
+
         """Send product order request.
 
         It will be executed once before the download retry loop, if the product is OFFLINE
@@ -332,6 +333,19 @@ class HTTPDownload(Download):
                 logger.debug(
                     f"Order download status request responded with {response.status_code}"
                 )
+
+                # [CFDEDL-6623]: dedt_lumi currently responds with a 400 when no data is available.
+                # This often happens when Region of Interest polygon is not available.
+                # This is ad-hoc error handling for that case.
+                if (
+                    product.provider == "dedt_lumi"
+                    and "ecmwf:feature" in product.properties
+                    and response.status_code == 400
+                ):
+                    raise DownloadError(
+                        "No data was returned by the provider. Region of Interest may not be available."
+                    )
+
                 response.raise_for_status()  # Raise an exception if status code indicates an error
 
                 # Handle redirection (if needed)

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -1269,7 +1269,7 @@ def _check_id(product: EOProduct) -> EOProduct:
             isinstance(e, DownloadError) or isinstance(e, ValidationError)
         ) and "order status could not be checked" in e.args[0]:
             raise ValidationError(
-                f"Item {product_id} does not exist with {product.provider}."
+                f"Requested data is not available on {product.provider} ({product_id})."
             ) from e
         raise ValidationError(e.args[0]) from e
 


### PR DESCRIPTION
dedt_lumi respond with 400 when downloading an order that returns no data.
This PR improves the reported message to the user in such instance.
