### PR TITLE
fix(server): remove duplicate host

### DIFF
--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -790,10 +790,6 @@ class StacCollection(StacCommon):
                 f"Product type keywords: {str(product_type_collection['keywords'])}",
             )
 
-        # merge providers
-        if "providers" in ext_stac_collection:
-            ext_stac_collection["providers"] += product_type_collection["providers"]
-
         product_type_collection.update(ext_stac_collection)
 
         # parse f-strings


### PR DESCRIPTION
We added the host field directly in the retrieved STAC collection.
Because of that, we no longer need to add it manually, which previously caused a duplicate with the wrong value.