### PR TITLE
refactor: use zipstream-ng instead of stream-zip

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -95,3 +95,13 @@ See project link for details.
 
 https://github.com/matplotlib
 https://github.com/python/typing_extensions
+
+
+================================================================
+The LGPL-3.0 License
+================================================================
+
+The following components are provided under the LGPL-3.0 License (https://opensource.org/license/lgpl-3-0).
+See project link for details.
+
+https://github.com/pR0Ps/zipstream-ng

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -808,7 +808,12 @@ class HTTPDownload(Download):
                         else sanitize(product.properties.get("id", "download"))
                     )
 
-                    zip_stream = ZipStream(sized=True)
+                    # do not use global size if one of the assets has no size
+                    missing_length = any(not (asset.size) for asset in assets_values)
+
+                    zip_stream = (
+                        ZipStream(sized=True) if not missing_length else ZipStream()
+                    )
                     for asset_stream in assets_stream_list:
                         zip_stream.add(
                             asset_stream.content,
@@ -816,8 +821,6 @@ class HTTPDownload(Download):
                             size=asset_stream.size,
                         )
 
-                    # do not use global size if one of the assets has no size
-                    missing_length = any(not (asset.size) for asset in assets_values)
                     zip_length = len(zip_stream) if not missing_length else None
 
                     return StreamResponse(

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -1181,6 +1181,11 @@ class HTTPDownload(Download):
 
         # Process each asset
         for asset in assets_values:
+            if not asset["href"] or asset["href"].startswith("file:"):
+                logger.info(
+                    f"Local asset detected. Download skipped for {asset['href']}"
+                )
+                continue
             asset_chunks = get_chunks_generator(asset)
             try:
                 # start reading chunks to set assets attributes
@@ -1193,9 +1198,9 @@ class HTTPDownload(Download):
             assets_stream_list.append(
                 StreamResponse(
                     content=asset_chunks,
-                    filename=asset.filename,
-                    arcname=asset.rel_path,
-                    size=asset.size or None,
+                    filename=getattr(asset, "filename", None),
+                    arcname=getattr(asset, "rel_path", None),
+                    size=getattr(asset, "size", 0) or None,
                 )
             )
 

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -845,6 +845,8 @@ class HTTPDownload(Download):
         return StreamResponse(
             content=chain(iter([first_chunk]), chunk_iterator),
             headers=product.headers,
+            filename=getattr(product, "filename", None),
+            size=getattr(product, "size", None),
         )
 
     def _check_auth_exception(self, e: Optional[RequestException]) -> None:
@@ -1039,7 +1041,6 @@ class HTTPDownload(Download):
 
             product.headers = self.stream.headers
             filename = self._check_product_filename(product)
-            product.headers["content-disposition"] = f"attachment; filename={filename}"
             content_type = product.headers.get("Content-Type")
             guessed_content_type = (
                 guess_file_type(filename) if filename and not content_type else None
@@ -1048,6 +1049,7 @@ class HTTPDownload(Download):
                 product.headers["Content-Type"] = guessed_content_type
 
             progress_callback.reset(total=stream_size)
+            product.size = stream_size
 
             product.filename = filename
             return self.stream.iter_content(chunk_size=64 * 1024)

--- a/eodag/rest/utils/__init__.py
+++ b/eodag/rest/utils/__init__.py
@@ -203,7 +203,5 @@ def file_to_stream(
     filename = os.path.basename(filepath_to_stream)
     return StreamResponse(
         content=read_file_chunks_and_delete(open(filepath_to_stream, "rb")),
-        headers={
-            "content-disposition": f"attachment; filename={filename}",
-        },
+        filename=filename,
     )

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -1462,6 +1462,7 @@ class StreamResponse:
     headers: dict[str, str] = field(default_factory=dict)
     media_type: Optional[str] = None
     status_code: Optional[int] = None
+    arcname: Optional[str] = None
 
     def __init__(
         self,
@@ -1471,11 +1472,13 @@ class StreamResponse:
         headers: Optional[Mapping[str, str]] = None,
         media_type: Optional[str] = None,
         status_code: Optional[int] = None,
+        arcname: Optional[str] = None,
     ):
         self.content = content
         self.headers = dict(headers) if headers else {}
         self.media_type = media_type
         self.status_code = status_code
+        self.arcname = arcname
         # use property setters to update headers
         self.filename = filename
         self.size = size

--- a/eodag/utils/s3.py
+++ b/eodag/utils/s3.py
@@ -448,21 +448,6 @@ def stream_download_from_s3(
     :raises NotAvailableError: If S3 objects cannot be accessed
     :raises AuthenticationError: If S3 credentials are invalid
     :raises NotImplementedError: If compressed files within ZIP archives are encountered
-
-    Example:
-        >>> files = [S3FileInfo(bucket_name="bucket", key="file.txt", size=1024)]
-        >>> response = stream_download_from_s3(s3_client, files)
-        >>> for chunk in response.content:
-        ...     # Process streaming data
-        ...     pass
-
-    Example with ZIP archive file:
-        >>> files = [S3FileInfo(
-        ...     bucket_name="bucket",
-        ...     key="archive.zip!internal.txt",
-        ...     size=512
-        ... )]
-        >>> response = stream_download_from_s3(s3_client, files)
     """
 
     executor = ThreadPoolExecutor(max_workers=max_workers)

--- a/eodag/utils/s3.py
+++ b/eodag/utils/s3.py
@@ -317,11 +317,15 @@ def _build_stream_response(
         content_gen: Iterable[bytes],
         media_type: str,
         extra_headers: dict[str, str] = {},
+        filename: Optional[str] = None,
+        size: Optional[int] = None,
     ) -> StreamResponse:
         return StreamResponse(
             content=_wrap_generator_with_cleanup(content_gen, executor),
             media_type=media_type,
             headers={**headers, **extra_headers},
+            filename=filename,
+            size=size,
         )
 
     zip_response = (len(files_info) > 1 and compress == "auto") or compress == "zip"
@@ -367,9 +371,7 @@ def _build_stream_response(
         return _build_response(
             content_gen=zip_generator(),
             media_type="application/zip",
-            extra_headers={
-                "content-disposition": f'attachment; filename="{zip_filename}.zip"'
-            },
+            filename=f"{zip_filename}.zip",
         )
 
     elif len(files_info) > 1:
@@ -408,7 +410,7 @@ def _build_stream_response(
         return _build_response(
             content_gen=single_file_stream(),
             media_type=files_info[index].data_type,
-            extra_headers={"content-disposition": f'attachment; filename="{filename}"'},
+            filename=filename,
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,9 @@ module = [
     "shapely.*",
     "stream_zip",
     "usgs",
-    "usgs.*"
+    "usgs.*",
+    "zipstream",
+    "zipstream.*",
 ]
 ignore_missing_imports = true
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,10 +57,10 @@ install_requires =
     PyYAML
     requests
     shapely >= 2.0.6
-    stream-zip
     tqdm
     typing_extensions >= 4.8.0
     urllib3
+    zipstream-ng
 
 [options.extras_require]
 all =

--- a/tests/context.py
+++ b/tests/context.py
@@ -116,7 +116,6 @@ from eodag.utils.s3 import (
     _prepare_file_in_zip,
     _compute_file_ranges,
     stream_download_from_s3,
-    _build_stream_response,
 )
 
 

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -710,8 +710,8 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         self.product.properties["id"] = "someproduct"
         self.product.assets.clear()
         self.product.assets.update({"foo": {"href": "http://somewhere/something"}})
-        mock_requests_get.return_value.__enter__.return_value.iter_content.return_value = io.BytesIO(
-            b"some content"
+        mock_requests_get.return_value.__enter__.return_value.iter_content.return_value = iter(
+            [b"some ", b"content"]
         )
         mock_requests_get.return_value.__enter__.return_value.headers = {
             "content-disposition": '; filename = "somethingelse"'


### PR DESCRIPTION
Following https://github.com/CS-SI/eodag/discussions/1798,

[stream-zip](https://pypi.org/project/stream-zip) source code is no more available: https://github.com/uktrade/stream-zip

The author answer is:
> We're unable to provide more information due to Section 24 of FOIA.
> You can read more about Section 24 here: https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-24-safeguarding-national-security

This PR removes `stream-zip` dependency ant replaces it with [zipstream-ng](https://github.com/pR0Ps/zipstream-ng).
