### PR TITLE
perf(s3): reduce stream memory footprint and add backpressure limit

### DIFF
--- a/eodag/utils/s3.py
+++ b/eodag/utils/s3.py
@@ -216,15 +216,15 @@ def _chunks_from_s3_objects(
     # Combine all futures to wait on globally (initially empty)
     all_futures = {}
 
-    # Track outstanding chunks and next file index
-    total_outstanding_chunks = 0
+    # Track pending chunks and next file index
+    total_pending_chunks = 0
     next_file_index = 0  # Track which file to submit from next
 
     def submit_tasks_to_limit() -> bool:
         """Submit S3 chunk download tasks up to the global backpressure limit, prioritizing files sequentially."""
-        nonlocal total_outstanding_chunks, next_file_index
+        nonlocal total_pending_chunks, next_file_index
 
-        while total_outstanding_chunks < BACKPRESSURE_DOWNLOAD_CHUNKS:
+        while total_pending_chunks < BACKPRESSURE_DOWNLOAD_CHUNKS:
             if next_file_index >= len(files_info):
                 break  # No more files with pending ranges
 
@@ -240,7 +240,7 @@ def _chunks_from_s3_objects(
                     s3_client,
                 )
                 all_futures[future] = (f_info, start, end)
-                total_outstanding_chunks += 1
+                total_pending_chunks += 1
 
                 if not f_info.pending_ranges:
                     next_file_index += 1  # Move to next file when current is exhausted
@@ -253,7 +253,7 @@ def _chunks_from_s3_objects(
     def make_chunks_generator(target_info: S3FileInfo) -> Iterator[bytes]:
         """Create a generator bound to a specific file info (no late-binding bug)."""
         info = target_info  # bind
-        nonlocal total_outstanding_chunks, pending_chunks_count
+        nonlocal total_pending_chunks, pending_chunks_count
         while info.next_yield < info.size:
             # First, try to flush anything already buffered for this file
             next_start = info.next_yield
@@ -270,7 +270,7 @@ def _chunks_from_s3_objects(
                 next_start += chunk_len
                 info.next_yield = next_start
                 flushed = True
-                total_outstanding_chunks -= 1
+                total_pending_chunks -= 1
                 pending_chunks_count -= 1
 
             if info.next_yield >= info.size:

--- a/eodag/utils/s3.py
+++ b/eodag/utils/s3.py
@@ -56,8 +56,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("eodag.utils.s3")
 
-MIME_OCTET_STREAM = "application/octet-stream"
-
 # Backpressure configuration
 BACKPRESSURE_DOWNLOAD_CHUNKS = 10  # Total chunks (downloading + buffered) per file
 

--- a/eodag/utils/s3.py
+++ b/eodag/utils/s3.py
@@ -56,6 +56,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("eodag.utils.s3")
 
+MIME_OCTET_STREAM = "application/octet-stream"
+
+# Backpressure configuration
+BACKPRESSURE_DOWNLOAD_CHUNKS = 10  # Total chunks (downloading + buffered) per file
+
 
 def fetch_range(
     bucket_name: str, key_name: str, start: int, end: int, client_s3: S3Client
@@ -98,11 +103,6 @@ class S3FileInfo:
     # These fields hold the state for downloading
     #: Offset in the logical (global) file stream where this file starts.
     file_start_offset: int = 0
-    #: Mapping of futures to their start byte offsets, used to track download progress.
-    #: Each future corresponds to a chunk of data being downloaded.
-    #: The key is the future object, and the value is the start byte offset of that
-    #: chunk in the logical file stream.
-    futures: dict = field(default_factory=dict)
     #: Buffers for downloaded data chunks, mapping start byte offsets to the actual data.
     #: This allows for partial downloads and efficient memory usage.
     #: The key is the start byte offset, and the value is the bytes data for that
@@ -114,6 +114,8 @@ class S3FileInfo:
     #: This allows the streaming process to continue from where it left off,
     #: ensuring that all data is eventually yielded without duplication.
     next_yield: int = 0
+    #: Queue of pending ranges that haven't been submitted yet
+    pending_ranges: list[tuple[int, int]] = field(default_factory=list)
 
 
 def _prepare_file_in_zip(f_info: S3FileInfo, s3_client: S3Client):
@@ -192,48 +194,66 @@ def _chunks_from_s3_objects(
 ) -> Iterator[tuple[int, Iterator[bytes]]]:
     """Download chunks from S3 objects in parallel, respecting byte ranges and file order."""
     # Prepare ranges and futures per file
+    pending_chunks_count = 0
     for f_info in files_info:
         ranges = _compute_file_ranges(f_info, byte_range, range_size)
-
-        if not ranges:
-            # Mark as inactive (no futures)
-            f_info.futures = {}
-            f_info.buffers = {}
-            f_info.next_yield = 0
-            continue
 
         f_info.buffers = {}
         f_info.next_yield = 0
 
-        futures = {}
-        # start,end are absolute offsets in the S3 object (data_start_offset already applied)
-        for start, end in ranges:
-            future = executor.submit(
-                fetch_range,
-                f_info.bucket_name,
-                f_info.key,
-                start,
-                end,
-                s3_client,
-            )
-            # Track both start and end so we can compute the yielded length precisely
-            futures[future] = (start, end)
+        if not ranges:
+            # Mark as inactive
+            f_info.pending_ranges = []
+            continue
 
-        f_info.futures = futures
+        f_info.pending_ranges = ranges
+
+        pending_chunks_count += len(ranges)
 
     # Keep only files that actually have something to download
-    active_indices = [i for i, fi in enumerate(files_info) if fi.futures]
+    active_indices = [i for i, fi in enumerate(files_info) if fi.pending_ranges]
 
-    # Combine all futures to wait on globally
-    all_futures = {
-        fut: (f_info, start, end)
-        for f_info in (files_info[i] for i in active_indices)
-        for fut, (start, end) in f_info.futures.items()
-    }
+    # Combine all futures to wait on globally (initially empty)
+    all_futures = {}
+
+    # Track outstanding chunks and next file index
+    total_outstanding_chunks = 0
+    next_file_index = 0  # Track which file to submit from next
+
+    def submit_tasks_to_limit() -> bool:
+        """Submit S3 chunk download tasks up to the global backpressure limit, prioritizing files sequentially."""
+        nonlocal total_outstanding_chunks, next_file_index
+
+        while total_outstanding_chunks < BACKPRESSURE_DOWNLOAD_CHUNKS:
+            if next_file_index >= len(files_info):
+                break  # No more files with pending ranges
+
+            f_info = files_info[next_file_index]
+            if f_info.pending_ranges:
+                start, end = f_info.pending_ranges.pop(0)
+                future = executor.submit(
+                    fetch_range,
+                    f_info.bucket_name,
+                    f_info.key,
+                    start,
+                    end,
+                    s3_client,
+                )
+                all_futures[future] = (f_info, start, end)
+                total_outstanding_chunks += 1
+
+                if not f_info.pending_ranges:
+                    next_file_index += 1  # Move to next file when current is exhausted
+            else:
+                next_file_index += 1  # Skip completed files
+                # If we reach here, no files have pending ranges
+
+        return False
 
     def make_chunks_generator(target_info: S3FileInfo) -> Iterator[bytes]:
         """Create a generator bound to a specific file info (no late-binding bug)."""
         info = target_info  # bind
+        nonlocal total_outstanding_chunks, pending_chunks_count
         while info.next_yield < info.size:
             # First, try to flush anything already buffered for this file
             next_start = info.next_yield
@@ -244,10 +264,14 @@ def _chunks_from_s3_objects(
                     raise InvalidDataError(
                         f"Expected bytes, got {type(chunk).__name__} in stream chunks: {chunk}"
                     )
+                chunk_len = len(chunk)
+
                 yield chunk
-                next_start += len(chunk)
+                next_start += chunk_len
                 info.next_yield = next_start
                 flushed = True
+                total_outstanding_chunks -= 1
+                pending_chunks_count -= 1
 
             if info.next_yield >= info.size:
                 break
@@ -257,7 +281,7 @@ def _chunks_from_s3_objects(
                 continue
 
             # Nothing to flush for this file: wait for more futures to complete globally
-            if not all_futures:
+            if not pending_chunks_count:
                 # No more incoming data anywhere; stop to avoid waiting on an empty set
                 break
 
@@ -268,6 +292,10 @@ def _chunks_from_s3_objects(
                 # Store buffer with a key relative to the start of the file data
                 rel_start = start - f_info.data_start_offset
                 f_info.buffers[rel_start] = data
+
+            submit_tasks_to_limit()
+
+    submit_tasks_to_limit()
 
     # Yield per-file generators with their original indices
     for idx in active_indices:
@@ -307,14 +335,6 @@ def _build_stream_response(
     :return: Streaming HTTP response with appropriate content, headers, and media type.
     """
 
-    def _wrap_generator_with_cleanup(
-        generator: Iterable[bytes], executor: ThreadPoolExecutor
-    ) -> Iterator[bytes]:
-        try:
-            yield from generator
-        finally:
-            executor.shutdown(wait=True)
-
     def _build_response(
         content_gen: Iterable[bytes],
         media_type: str,
@@ -322,7 +342,7 @@ def _build_stream_response(
         size: Optional[int] = None,
     ) -> StreamResponse:
         return StreamResponse(
-            content=_wrap_generator_with_cleanup(content_gen, executor),
+            content=content_gen,
             media_type=media_type,
             headers={"Accept-Ranges": "bytes"},
             filename=filename,

--- a/tests/units/test_utils_s3.py
+++ b/tests/units/test_utils_s3.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 from unittest.mock import call, patch
 
 import boto3
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from moto import mock_aws
 
 from tests import TEST_RESOURCES_PATH
@@ -425,6 +425,44 @@ class TestUtilsS3(TestCase):
 
             self.assertEqual(mock_fetch.call_count, 6)
             mock_fetch.assert_has_calls(expected_calls, any_order=True)
+
+    def test_chunks_from_s3_objects_respects_backpressure_download_chunks(self):
+        """Test that chunk submissions are capped by BACKPRESSURE_DOWNLOAD_CHUNKS."""
+
+        range_size = 10
+
+        # Use file metadata only: fetch_range is mocked, so S3 object content is irrelevant.
+        fi = make_mock_fileinfo("file1", 50)
+        fi.data_start_offset = 0
+
+        class ImmediateExecutor:
+            def submit(self, fn, *args, **kwargs):
+                fut = Future()
+                fut.set_result(fn(*args, **kwargs))
+                return fut
+
+        with patch("eodag.utils.s3.BACKPRESSURE_DOWNLOAD_CHUNKS", 2):
+            with patch(
+                "eodag.utils.s3.fetch_range", return_value=b"X" * range_size
+            ) as mock_fetch:
+                executor = ImmediateExecutor()
+                result = _chunks_from_s3_objects(
+                    self.s3_client,
+                    [fi],
+                    byte_range=(None, None),
+                    range_size=range_size,
+                    executor=executor,
+                )
+
+                # First iteration triggers initial submissions, capped by backpressure.
+                _, gen = next(result)
+                self.assertEqual(mock_fetch.call_count, 2)
+
+                # Consuming the stream releases slots and allows remaining chunk submissions.
+                chunks = b"".join(gen)
+                self.assertEqual(chunks, b"X" * fi.size)
+
+            self.assertEqual(mock_fetch.call_count, 5)
 
     def test_prepare_file_in_zip(self):
         """Test _prepare_file_in_zip to ensure it sets the correct attributes for retrieving a file inside a ZIP."""


### PR DESCRIPTION
Files were fully loaded into memory when using `AwsDownload` [stream_download()](https://eodag.readthedocs.io/en/latest/api_reference/eoproduct.html#eodag.api.product._product.EOProduct.stream_download).

The back-pressure limit prevents the explosion of the buffer size when waiting on long pending requests.

