### PR TITLE
fix(providers): harmonize polarizationChannels property

### DIFF
--- a/docs/_static/params_mapping_extra.csv
+++ b/docs/_static/params_mapping_extra.csv
@@ -13,8 +13,8 @@ latitudeBand,,,,:green:`queryable metadata`,,,,,,,,,,
 links,,,,,,,,,,,metadata only,,,
 modifiedAfter,:green:`queryable metadata`,,,,,,,,,,,,,
 modifiedBefore,:green:`queryable metadata`,,,,,,,,,,,,,
-polarizationChannels,:green:`queryable metadata`,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,,,:green:`queryable metadata`,:green:`queryable metadata`,,:green:`queryable metadata`,,:green:`queryable metadata`
-polarizationMode,,,,,metadata only,,,,,,:green:`queryable metadata`,,:green:`queryable metadata`,
+polarizationChannels,:green:`queryable metadata`,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`
+polarizationMode,,,,,metadata only,,,,,,,,,
 productIdentifier,metadata only,,metadata only,,,,,,,,,,,
 productInformation,,,,,,,,metadata only,,,,,,
 providerProductType,,,,,,,,,,:green:`queryable metadata`,,,,

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -531,6 +531,35 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             return re.sub(old, new, value)
 
         @staticmethod
+        def convert_replace_str_tuple(value: Any, args: str) -> str:
+            """
+            Apply multiple replacements on a string.
+            args should be a string representing a list/tuple of (old, new) pairs.
+            Example: '(("old1", "new1"), ("old2", "new2"))'
+            """
+            if isinstance(value, dict):
+                value = MetadataFormatter.convert_to_geojson(value)
+            elif not isinstance(value, str):
+                raise TypeError(
+                    f"convert_replace_str_tuple expects a string or a dict (apply to_geojson). "
+                    f"Got {type(value)}: {value}"
+                )
+
+            # args sera une chaîne représentant une liste/tuple de tuples
+            replacements = ast.literal_eval(args)
+
+            if not isinstance(replacements, (list, tuple)):
+                raise TypeError(
+                    f"convert_replace_str_tuple expects a list/tuple of (old,new) pairs. "
+                    f"Got {type(replacements)}: {replacements}"
+                )
+
+            for old, new in replacements:
+                value = re.sub(old, new, value)
+
+            return value
+
+        @staticmethod
         def convert_ceda_collection_name(value: str) -> str:
             data_regex = re.compile(r"/data/(?P<name>.+?)/?$")
             match = data_regex.search(value)

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -171,7 +171,6 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
         - ``replace_str``: execute "string".replace(old, new)
         - ``recursive_sub_str``: recursively substitue in the structure (e.g. dict)
           values matching a regex
-        - ``normalize_polarization``: normalize the polarization channels and mode
         - ``slice_str``: slice a string (equivalent to s[start, end, step])
         - ``to_lower``: Convert a string to lowercase
         - ``to_upper``: Convert a string to uppercase
@@ -549,22 +548,6 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
                 lambda k, v, x, y: re.sub(x, y, v) if isinstance(v, str) else v,
                 **{"x": old, "y": new},
             )
-
-        @staticmethod
-        def convert_normalize_polarization(s: str) -> str:
-            """
-            Normalize polarization channels and mode
-            Examples:
-            'VV VH' -> 'VV+VH'
-            """
-            if not s or s == NOT_AVAILABLE:
-                return s
-            # split on any non word character
-            parts = re.split(r"\W+", s.strip())
-            # remove empty parts
-            parts = [p for p in parts if p]
-            # return parts joined by +
-            return "+".join(parts)
 
         @staticmethod
         def convert_dict_update(

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -557,7 +557,7 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             Examples:
             'VV VH' -> 'VV+VH'
             """
-            if not s:
+            if not s or s == NOT_AVAILABLE:
                 return s
             # split on any non word character
             parts = re.split(r"\W+", s.strip())

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -171,6 +171,7 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
         - ``replace_str``: execute "string".replace(old, new)
         - ``recursive_sub_str``: recursively substitue in the structure (e.g. dict)
           values matching a regex
+        - ``normalize_polarization``: normalize the polarization channels and mode
         - ``slice_str``: slice a string (equivalent to s[start, end, step])
         - ``to_lower``: Convert a string to lowercase
         - ``to_upper``: Convert a string to uppercase
@@ -548,6 +549,22 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
                 lambda k, v, x, y: re.sub(x, y, v) if isinstance(v, str) else v,
                 **{"x": old, "y": new},
             )
+
+        @staticmethod
+        def convert_normalize_polarization(s: str) -> str:
+            """
+            Normalize polarization channels and mode
+            Examples:
+            'VV VH' -> 'VV+VH'
+            """
+            if not s:
+                return s
+            # split on any non word character
+            parts = re.split(r"\W+", s.strip())
+            # remove empty parts
+            parts = [p for p in parts if p]
+            # return parts joined by +
+            return "+".join(parts)
 
         @staticmethod
         def convert_dict_update(

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3979,10 +3979,10 @@
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'orbitDirection' and att/OData.CSC.StringAttribute/Value eq '{orbitDirection#to_upper}')"
             - "Attributes/OData.CSC.DoubleAttribute/any(att:att/Name eq 'cloudCover' and att/OData.CSC.DoubleAttribute/Value le {cloudCover})"
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'operationalMode' and att/OData.CSC.StringAttribute/Value eq '{sensorMode}')"
-            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'polarisationChannels' and att/OData.CSC.StringAttribute/Value eq '{polarizationChannels#replace_str('\\+','%26')}')"
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'tileId' and att/OData.CSC.StringAttribute/Value eq '{tileIdentifier}')"
             - "ContentDate/Start lt {completionTimeFromAscendingNode#to_iso_utc_datetime}"
             - "ContentDate/End gt {startTimeFromAscendingNode#to_iso_utc_datetime}"
+            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'polarisationChannels' and att/OData.CSC.StringAttribute/Value eq '{polarizationChannels#replace_str('\\+','%26')}')"
             - contains(Name,'{id}')
     discover_metadata:
       auto_discovery: true

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -360,7 +360,7 @@
         completionTimeFromAscendingNode:
           - '{{"search":{{"date":{{"to":"{completionTimeFromAscendingNode}"}} }} }}'
           - '$.date'
-        polarizationMode:
+        polarizationChannels:
           - '{{"search":{{"polarization":"{polarizationMode}" }} }}'
           - '{$.polarization#normalize_polarization}'
         # Custom parameters (not defined in the base document referenced above)
@@ -630,7 +630,7 @@
       completionTimeFromAscendingNode:
         - completionDate
         - '$.properties.completionDate'
-      polarizationMode:
+      polarizationChannels:
         - 'polarisation'
         - '{$.properties.polarisation#normalize_polarization}'
 
@@ -2105,7 +2105,7 @@
       completionTimeFromAscendingNode:
         - completionDate
         - '$.properties.completionDate'
-      polarizationMode:
+      polarizationChannels:
         - 'polarisation'
         - '{$.properties.polarisation#normalize_polarization}'
       # Custom parameters (not defined in the base document referenced above)

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -362,7 +362,7 @@
           - '$.date'
         polarizationMode:
           - '{{"search":{{"polarization":"{polarizationMode}" }} }}'
-          - '$.polarization'
+          - '{$.polarization#normalize_polarization}'
         # Custom parameters (not defined in the base document referenced above)
         awsPath:
           - '{{"search":{{"awsPath":"{awsPath}" }} }}'
@@ -632,7 +632,7 @@
         - '$.properties.completionDate'
       polarizationMode:
         - 'polarisation'
-        - '$.properties.polarisation'
+        - '{$.properties.polarisation#normalize_polarization}'
 
       # Custom parameters (not defined in the base document referenced above)
       id:
@@ -824,7 +824,7 @@
         - '$.ContentDate.End'
       polarizationChannels:
         - null
-        - '$.Attributes.polarisationChannels'
+        - '{$.Attributes.polarisationChannels#normalize_polarization}'
       # Custom parameters (not defined in the base document referenced above)
       id:
         - null
@@ -2107,7 +2107,7 @@
         - '$.properties.completionDate'
       polarizationMode:
         - 'polarisation'
-        - '$.properties.polarisation'
+        - '{$.properties.polarisation#normalize_polarization}'
       # Custom parameters (not defined in the base document referenced above)
       id:
         - 'productIdentifier={id#remove_extension}'
@@ -2534,7 +2534,7 @@
         - '$.ContentDate.End'
       polarizationChannels:
         - null
-        - '$.Attributes.polarisationChannels'
+        - '{$.Attributes.polarisationChannels#normalize_polarization}'
       # Custom parameters (not defined in the base document referenced above)
       id:
         - null
@@ -4046,7 +4046,7 @@
         - '$.ContentDate.End'
       polarizationChannels:
         - null
-        - '$.Attributes.polarisationChannels'
+        - '{$.Attributes.polarisationChannels#normalize_polarization}'
       # Custom parameters (not defined in the base document referenced above)
       id:
         - null

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -362,7 +362,7 @@
           - '$.date'
         polarizationChannels:
           - '{{"search":{{"polarization":"{polarizationMode}" }} }}'
-          - '{$.polarization#normalize_polarization}'
+          - '$.polarization'
         # Custom parameters (not defined in the base document referenced above)
         awsPath:
           - '{{"search":{{"awsPath":"{awsPath}" }} }}'
@@ -632,7 +632,7 @@
         - '$.properties.completionDate'
       polarizationChannels:
         - 'polarisation'
-        - '{$.properties.polarisation#normalize_polarization}'
+        - '{$.properties.polarisation#replace_str(" ","+")}'
 
       # Custom parameters (not defined in the base document referenced above)
       id:
@@ -824,7 +824,7 @@
         - '$.ContentDate.End'
       polarizationChannels:
         - null
-        - '{$.Attributes.polarisationChannels#normalize_polarization}'
+        - '{$.Attributes.polarisationChannels#replace_str("&","+")}'
       # Custom parameters (not defined in the base document referenced above)
       id:
         - null
@@ -2107,7 +2107,7 @@
         - '$.properties.completionDate'
       polarizationChannels:
         - 'polarisation'
-        - '{$.properties.polarisation#normalize_polarization}'
+        - '{$.properties.polarisation#replace_str(",","+")}'
       # Custom parameters (not defined in the base document referenced above)
       id:
         - 'productIdentifier={id#remove_extension}'
@@ -2534,7 +2534,7 @@
         - '$.ContentDate.End'
       polarizationChannels:
         - null
-        - '{$.Attributes.polarisationChannels#normalize_polarization}'
+        - '{$.Attributes.polarisationChannels#replace_str("&","+")}'
       # Custom parameters (not defined in the base document referenced above)
       id:
         - null
@@ -4046,7 +4046,7 @@
         - '$.ContentDate.End'
       polarizationChannels:
         - null
-        - '{$.Attributes.polarisationChannels#normalize_polarization}'
+        - '{$.Attributes.polarisationChannels#replace_str("&","+")}'
       # Custom parameters (not defined in the base document referenced above)
       id:
         - null

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -749,10 +749,10 @@
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'orbitDirection' and att/OData.CSC.StringAttribute/Value eq '{orbitDirection#to_upper}')"
             - "Attributes/OData.CSC.DoubleAttribute/any(att:att/Name eq 'cloudCover' and att/OData.CSC.DoubleAttribute/Value le {cloudCover})"
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'operationalMode' and att/OData.CSC.StringAttribute/Value eq '{sensorMode}')"
-            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'polarisationChannels' and att/OData.CSC.StringAttribute/Value eq '{polarizationChannels#replace_str('\\+','%26')}')"
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'tileId' and att/OData.CSC.StringAttribute/Value eq '{tileIdentifier}')"
             - "ContentDate/Start lt {completionTimeFromAscendingNode#to_iso_utc_datetime}"
             - "ContentDate/End gt {startTimeFromAscendingNode#to_iso_utc_datetime}"
+            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'polarisationChannels' and att/OData.CSC.StringAttribute/Value eq '{polarizationChannels#replace_str('\\+','%26')}')"
             - contains(Name,'{id}')
     discover_metadata:
       auto_discovery: true

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -361,8 +361,8 @@
           - '{{"search":{{"date":{{"to":"{completionTimeFromAscendingNode}"}} }} }}'
           - '$.date'
         polarizationChannels:
-          - '{{"search":{{"polarization":"{polarizationChannels}" }} }}'
-          - '$.polarization'
+          - '{{"search":{{"polarization":"{polarizationChannels#replace_str_tuple((("HH","SH"),("VV","SV"),("HH+HV", "DH"),("VV+VH","DV")))}" }} }}'
+          - '{$.polarization#replace_str_tuple((("SH","HH"),("SV","VV"),("DH","HH+HV"),("DV","VV+VH")))}'
         # Custom parameters (not defined in the base document referenced above)
         awsPath:
           - '{{"search":{{"awsPath":"{awsPath}" }} }}'
@@ -712,6 +712,7 @@
       - '='
       - '&'
       - ':'
+      - '%'
     pagination:
       next_page_url_tpl: '{url}?{search}&$top={items_per_page}&$skip={skip}&$expand=Attributes&$expand=Assets'
       count_tpl: '&$count=True'
@@ -748,7 +749,7 @@
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'orbitDirection' and att/OData.CSC.StringAttribute/Value eq '{orbitDirection#to_upper}')"
             - "Attributes/OData.CSC.DoubleAttribute/any(att:att/Name eq 'cloudCover' and att/OData.CSC.DoubleAttribute/Value le {cloudCover})"
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'operationalMode' and att/OData.CSC.StringAttribute/Value eq '{sensorMode}')"
-            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'polarisationChannels' and att/OData.CSC.StringAttribute/Value eq '{polarizationChannels}')"
+            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'polarisationChannels' and att/OData.CSC.StringAttribute/Value eq '{polarizationChannels#replace_str('\\+','%26')}')"
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'tileId' and att/OData.CSC.StringAttribute/Value eq '{tileIdentifier}')"
             - "ContentDate/Start lt {completionTimeFromAscendingNode#to_iso_utc_datetime}"
             - "ContentDate/End gt {startTimeFromAscendingNode#to_iso_utc_datetime}"

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -361,7 +361,7 @@
           - '{{"search":{{"date":{{"to":"{completionTimeFromAscendingNode}"}} }} }}'
           - '$.date'
         polarizationChannels:
-          - '{{"search":{{"polarization":"{polarizationMode}" }} }}'
+          - '{{"search":{{"polarization":"{polarizationChannels}" }} }}'
           - '$.polarization'
         # Custom parameters (not defined in the base document referenced above)
         awsPath:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -2033,6 +2033,12 @@
         operations:
           and:
             - '{orbitDirection#to_title}'
+      polarisation:
+        union: '&'
+        wrapper: '{}'
+        operations:
+          and:
+            - '{polarizationChannels#replace_str("\\+",",")}'
     discover_metadata:
       auto_discovery: true
       metadata_pattern: '^(?!collection)[a-zA-Z0-9_]+$'
@@ -2106,7 +2112,7 @@
         - completionDate
         - '$.properties.completionDate'
       polarizationChannels:
-        - 'polarisation'
+        - null
         - '{$.properties.polarisation#replace_str(",","+")}'
       # Custom parameters (not defined in the base document referenced above)
       id:
@@ -2402,6 +2408,7 @@
       - '='
       - '&'
       - ':'
+      - '%'
     pagination:
       next_page_url_tpl: '{url}?{search}&$top={items_per_page}&$skip={skip}&$expand=Attributes&$expand=Assets'
       count_tpl: '&$count=True'
@@ -2439,7 +2446,7 @@
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'orbitDirection' and att/OData.CSC.StringAttribute/Value eq '{orbitDirection#to_upper}')"
             - "Attributes/OData.CSC.DoubleAttribute/any(att:att/Name eq 'cloudCover' and att/OData.CSC.DoubleAttribute/Value le {cloudCover})"
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'operationalMode' and att/OData.CSC.StringAttribute/Value eq '{sensorMode}')"
-            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'polarisationChannels' and att/OData.CSC.StringAttribute/Value eq '{polarizationChannels}')"
+            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'polarisationChannels' and att/OData.CSC.StringAttribute/Value eq '{polarizationChannels#replace_str('\\+','%26')}')"
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'tileId' and att/OData.CSC.StringAttribute/Value eq '{tileIdentifier}')"
             - "ModificationDate gt {modifiedAfter#to_iso_utc_datetime}"
             - "ModificationDate lt {modifiedBefore#to_iso_utc_datetime}"
@@ -3934,6 +3941,7 @@
       - '='
       - '&'
       - ':'
+      - '%'
     pagination:
       next_page_url_tpl: '{url}?{search}&$top={items_per_page}&$skip={skip}&$expand=Attributes&$expand=Assets'
       count_tpl: '&$count=True'
@@ -3970,7 +3978,7 @@
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'orbitDirection' and att/OData.CSC.StringAttribute/Value eq '{orbitDirection#to_upper}')"
             - "Attributes/OData.CSC.DoubleAttribute/any(att:att/Name eq 'cloudCover' and att/OData.CSC.DoubleAttribute/Value le {cloudCover})"
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'operationalMode' and att/OData.CSC.StringAttribute/Value eq '{sensorMode}')"
-            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'polarisationChannels' and att/OData.CSC.StringAttribute/Value eq '{polarizationChannels}')"
+            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'polarisationChannels' and att/OData.CSC.StringAttribute/Value eq '{polarizationChannels#replace_str('\\+','%26')}')"
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'tileId' and att/OData.CSC.StringAttribute/Value eq '{tileIdentifier}')"
             - "ContentDate/Start lt {completionTimeFromAscendingNode#to_iso_utc_datetime}"
             - "ContentDate/End gt {startTimeFromAscendingNode#to_iso_utc_datetime}"

--- a/eodag/resources/stac_provider.yml
+++ b/eodag/resources/stac_provider.yml
@@ -140,7 +140,7 @@ search:
       - '$.properties."view:sun_elevation"'
     polarizationChannels:
       - '{{"query":{{"sar:polarizations":{{"eq":"{polarizationChannels}"}}}}}}'
-      - '$.properties."sar:polarizations"'
+      - '{$.properties."sar:polarizations"#normalize_polarization}'
     dopplerFrequency:
       - '{{"query":{{"sar:frequency_band":{{"eq":"{dopplerFrequency}"}}}}}}'
       - '$.properties."sar:frequency_band"'

--- a/eodag/resources/stac_provider.yml
+++ b/eodag/resources/stac_provider.yml
@@ -140,7 +140,7 @@ search:
       - '$.properties."view:sun_elevation"'
     polarizationChannels:
       - '{{"query":{{"sar:polarizations":{{"eq":"{polarizationChannels}"}}}}}}'
-      - '{$.properties."sar:polarizations"#normalize_polarization}'
+      - '{$.properties."sar:polarizations"#replace_str(" ","+")}'
     dopplerFrequency:
       - '{{"query":{{"sar:frequency_band":{{"eq":"{dopplerFrequency}"}}}}}}'
       - '$.properties."sar:frequency_band"'

--- a/tests/units/test_metadata_mapping.py
+++ b/tests/units/test_metadata_mapping.py
@@ -347,25 +347,6 @@ class TestMetadataFormatter(unittest.TestCase):
             "[{'a': 'this was foo...', 'b': [{'c': 'that was bar...'}]}]",
         )
 
-    def test_convert_normalize_polarization(self):
-        to_format = r"{fieldname#normalize_polarization}"
-        self.assertEqual(
-            format_metadata(to_format, fieldname="VV VH"),
-            "VV+VH",
-        )
-        self.assertEqual(
-            format_metadata(to_format, fieldname="VV&VH"),
-            "VV+VH",
-        )
-        self.assertEqual(
-            format_metadata(to_format, fieldname="VV/VH"),
-            "VV+VH",
-        )
-        self.assertEqual(
-            format_metadata(to_format, fieldname="VV"),
-            "VV",
-        )
-
     def test_convert_dict_update(self):
         to_format = '{fieldname#dict_update([["b",[["href","bar"],["title","baz"]]]])}'
         self.assertEqual(

--- a/tests/units/test_metadata_mapping.py
+++ b/tests/units/test_metadata_mapping.py
@@ -327,6 +327,29 @@ class TestMetadataFormatter(unittest.TestCase):
         with self.assertRaises(TypeError):
             format_metadata(to_format, fieldname=123)
 
+    def test_convert_replace_str_tuple(self):
+        to_format = r"{fieldname#replace_str_tuple((('foo','bar'),('this','that')))}"
+
+        # Test with a string
+        self.assertEqual(
+            format_metadata(to_format, fieldname="this is foo"),
+            "that is bar",
+        )
+
+        # Test with a dictionary
+        self.assertEqual(
+            format_metadata(to_format, fieldname={"key": "this is foo"}),
+            '{"key": "that is bar"}',
+        )
+
+        # Test with a list (should fail)
+        with self.assertRaises(TypeError):
+            format_metadata(to_format, fieldname=["this is foo"])
+
+        # Test with an integer (should fail)
+        with self.assertRaises(TypeError):
+            format_metadata(to_format, fieldname=123)
+
     def test_convert_ceda_collection_name(self):
         to_format = r"{fieldname#ceda_collection_name}"
         self.assertEqual(

--- a/tests/units/test_metadata_mapping.py
+++ b/tests/units/test_metadata_mapping.py
@@ -347,6 +347,25 @@ class TestMetadataFormatter(unittest.TestCase):
             "[{'a': 'this was foo...', 'b': [{'c': 'that was bar...'}]}]",
         )
 
+    def test_convert_normalize_polarization(self):
+        to_format = r"{fieldname#normalize_polarization}"
+        self.assertEqual(
+            format_metadata(to_format, fieldname="VV VH"),
+            "VV+VH",
+        )
+        self.assertEqual(
+            format_metadata(to_format, fieldname="VV&VH"),
+            "VV+VH",
+        )
+        self.assertEqual(
+            format_metadata(to_format, fieldname="VV/VH"),
+            "VV+VH",
+        )
+        self.assertEqual(
+            format_metadata(to_format, fieldname="VV"),
+            "VV",
+        )
+
     def test_convert_dict_update(self):
         to_format = '{fieldname#dict_update([["b",[["href","bar"],["title","baz"]]]])}'
         self.assertEqual(


### PR DESCRIPTION
Fixes #1824 
In  order to align with [SAR STAC extension](https://github.com/stac-extensions/sar?tab=readme-ov-file#sarpolarizations), harmonize `polarizationChannels` values: 
- `SH` to `HH`
- `SV` to `VV`
- `DH` to `HH+HV`
- `DV` to `VV+VH`
- `VV VH` to `VV+VH`
- `VV&VH` to `VV+VH`
- `VV/VH` to `VV+VH`
- ... 

Unappropriate `polarizationMode` was also renamed to `polarizationChannels` for providers `aws_eos`, `peps`, and `sara`.