### PR TITLE
chore(cli/docs): deprecate STAC REST API server

### DIFF
--- a/docs/stac_rest.rst
+++ b/docs/stac_rest.rst
@@ -3,6 +3,12 @@
 STAC REST API Server
 ====================
 
+.. warning::
+
+   DEPRECATED since v3.9.0: Running the STAC REST API server from the CLI is deprecated
+   and will be removed in a future version. This functionality has moved to its own repository:
+   https://github.com/CS-SI/stac-fastapi-eodag
+
 .. image:: _static/eodag_stac_server.png
    :width: 800
    :alt: EODAG as STAC server

--- a/eodag/rest/core.py
+++ b/eodag/rest/core.py
@@ -21,6 +21,7 @@ import datetime
 import logging
 import os
 import re
+import warnings
 from typing import TYPE_CHECKING, cast
 from unittest.mock import Mock
 from urllib.parse import urlencode
@@ -82,6 +83,13 @@ if TYPE_CHECKING:
     from requests.auth import AuthBase
     from starlette.responses import Response
 
+
+warnings.warn(
+    "The module `eodag.rest.core` is deprecated since v3.9.0 and will be removed in a future version. "
+    "The STAC server has moved to https://github.com/CS-SI/stac-fastapi-eodag",
+    category=DeprecationWarning,
+    stacklevel=2,
+)
 
 eodag_api = eodag.EODataAccessGateway()
 

--- a/eodag/rest/errors.py
+++ b/eodag/rest/errors.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 import logging
 import re
+import warnings
 from typing import Union
 
 from fastapi import FastAPI, Request
@@ -52,6 +53,14 @@ EODAG_DEFAULT_STATUS_CODES = {
     UnsupportedProvider: status.HTTP_404_NOT_FOUND,
     ValidationError: status.HTTP_400_BAD_REQUEST,
 }
+
+warnings.warn(
+    "The module `eodag.rest.errors` is deprecated since v3.9.0 and will be removed in a future version. "
+    "The STAC server has moved to https://github.com/CS-SI/stac-fastapi-eodag",
+    category=DeprecationWarning,
+    stacklevel=2,
+)
+
 
 logger = logging.getLogger("eodag.rest.server")
 

--- a/eodag/rest/server.py
+++ b/eodag/rest/server.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import warnings
 from contextlib import asynccontextmanager
 from importlib.metadata import version
 from json import JSONDecodeError
@@ -66,6 +67,13 @@ if TYPE_CHECKING:
     from requests import Response
 
 from starlette.responses import Response as StarletteResponse
+
+warnings.warn(
+    "The module `eodag.rest.server` is deprecated since v3.9.0 and will be removed in a future version. "
+    "The STAC server has moved to https://github.com/CS-SI/stac-fastapi-eodag",
+    category=DeprecationWarning,
+    stacklevel=2,
+)
 
 logger = logging.getLogger("eodag.rest.server")
 

--- a/eodag/rest/stac.py
+++ b/eodag/rest/stac.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 import os
+import warnings
 from collections import defaultdict
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional
@@ -67,6 +68,13 @@ if TYPE_CHECKING:
     from eodag.api.product import EOProduct
     from eodag.api.search_result import SearchResult
 
+
+warnings.warn(
+    "The module `eodag.rest.stac` is deprecated since v3.9.0 and will be removed in a future version. "
+    "The STAC server has moved to https://github.com/CS-SI/stac-fastapi-eodag",
+    category=DeprecationWarning,
+    stacklevel=2,
+)
 
 logger = logging.getLogger("eodag.rest.stac")
 


### PR DESCRIPTION
deprecate the server mode in EODAG library and CLI in favor of https://github.com/CS-SI/stac-fastapi-eodag

updates https://github.com/CS-SI/eodag/issues/1647