### PR TITLE
refactor: get_rio_env to AwsAuth

### DIFF
--- a/eodag/plugins/authentication/aws_auth.py
+++ b/eodag/plugins/authentication/aws_auth.py
@@ -256,3 +256,25 @@ class AwsAuth(Authentication):
         if not authenticated_objects:
             raise AuthenticationError(", ".join(auth_error_messages))
         return authenticated_objects
+
+    def get_rio_env(self) -> dict[str, Any]:
+        """Get rasterio environment variables needed for data access authentication.
+
+        :returns: The rasterio environement variables
+        """
+        rio_env_kwargs = {}
+        if endpoint_url := getattr(self.config, "s3_endpoint", None):
+            rio_env_kwargs["endpoint_url"] = endpoint_url.split("://")[-1]
+        rio_env_kwargs |= {}
+
+        if self.s3_session is None:
+            self.authenticate()
+
+        s3_session = self.s3_session
+
+        if self.config.requester_pays:
+            rio_env_kwargs["requester_pays"] = True
+        return {
+            "session": s3_session,
+            **rio_env_kwargs,
+        }

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -34,7 +34,7 @@ from eodag.api.product.metadata_mapping import (
     properties_from_json,
     properties_from_xml,
 )
-from eodag.plugins.authentication.aws_auth import AwsAuth, raise_if_auth_error
+from eodag.plugins.authentication.aws_auth import raise_if_auth_error
 from eodag.plugins.download.base import Download
 from eodag.utils import (
     DEFAULT_DOWNLOAD_TIMEOUT,
@@ -792,30 +792,6 @@ class AwsDownload(Download):
                 self.get_chunk_dest_path(product, product_chunk, build_safe=build_safe)
             )
         return os.path.commonpath(chunk_paths)
-
-    def get_rio_env(
-        self, bucket_name: str, prefix: str, auth_plugin: AwsAuth
-    ) -> dict[str, Any]:
-        """Get rasterio environment variables needed for data access authentication.
-
-        :param bucket_name: Bucket containg objects
-        :param prefix: Prefix used to try auth
-        :param auth_dict: Dictionary containing authentication keys
-        :returns: The rasterio environement variables
-        """
-        rio_env_kwargs = {}
-        if endpoint_url := getattr(self.config, "s3_endpoint", None):
-            rio_env_kwargs["endpoint_url"] = endpoint_url.split("://")[-1]
-        rio_env_kwargs |= {}
-
-        s3_session = auth_plugin.s3_session
-
-        if auth_plugin.config.requester_pays:
-            rio_env_kwargs["requester_pays"] = True
-        return {
-            "session": s3_session,
-            **rio_env_kwargs,
-        }
 
     def get_product_bucket_name_and_prefix(
         self, product: EOProduct, url: Optional[str] = None

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -2303,15 +2303,15 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
         auth_plugin.authenticate()
 
         # nothing needed
-        rio_env_dict = plugin.get_rio_env("some-bucket", "some/prefix", auth_plugin)
+        rio_env_dict = auth_plugin.get_rio_env()
         self.assertIn("session", rio_env_dict)
         self.assertIn("requester_pays", rio_env_dict)
         self.assertTrue(rio_env_dict["requester_pays"])
 
         # with endpoint url
-        plugin.config.s3_endpoint = "some.endpoint"
+        auth_plugin.config.s3_endpoint = "some.endpoint"
         self.assertEqual(auth_plugin.config.requester_pays, True)
-        rio_env_dict = plugin.get_rio_env("some-bucket", "some/prefix", auth_plugin)
+        rio_env_dict = auth_plugin.get_rio_env()
         self.assertIsNotNone(rio_env_dict.pop("session", None))
         self.assertDictEqual(
             rio_env_dict,


### PR DESCRIPTION
Following https://github.com/CS-SI/eodag/pull/1769, move `get_rio_env` to `AwsAuth` to make it work with `eodag-cube`