### PR TITLE
fix(providers): CLMS_CORINE metadata mapping for wekeo

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3264,9 +3264,6 @@
         id:
           - '{{"format": "{id#get_group_name((?P<GeoPackage>geoPackage)|(?P<ESRI fgdb>fgdb)|(?P<GeoTiff100mt>raster100m))}"}}'
           - '$.id'
-        providerProductType:
-          - '{{"product_type": "{providerProductType}"}}'
-          - '$.null'
         startTimeFromAscendingNode: '$.properties.startdate'
         completionTimeFromAscendingNode: '$.properties.enddate'
         format:


### PR DESCRIPTION
The mapping for `providerProductType` for `CLMS_CORINE` has changed on wekeo side, it is now the same as for the other collections.
