### PR TITLE
build: pin pydantic < 2.12.0 to prevent sphinx failures

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -258,6 +258,7 @@ intersphinx_mapping = {
     "rasterio": ("https://rasterio.readthedocs.io/en/stable/", None),
     "rioxarray": ("https://corteva.github.io/rioxarray/stable/", None),
     "fsspec": ("https://filesystem-spec.readthedocs.io/en/stable/", None),
+    "pydantic": ("https://docs.pydantic.dev/latest", None),
 }
 
 suppress_warnings = ["misc.copy_overwrite"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     jsonpath-ng
     lxml
     orjson
-    pydantic >= 2.1.0, != 2.10.0
+    pydantic >= 2.1.0, != 2.10.0, < 2.12.0
     pydantic_core
     PyJWT[crypto] >= 2.5.0
     pyproj >= 2.1.0


### PR DESCRIPTION
Until we find how to fix/bypass these issues, pin `pydantic < 2.12.0` to prevent `sphinx` failures while building documentation:
```
WARNING: Failed guarded type import with TypeError("unsupported operand type(s) for |: 'types.GenericAlias' and 'types.GenericAlias'")
WARNING: Failed guarded type import with ImportError("cannot import name 'AbstractSetIntStr' from 'pydantic._internal._utils' (/home/runner/work/eodag/eodag/.tox/docs/lib/python3.9/site-packages/pydantic/_internal/_utils.py)")
```