### PR TITLE
refactor(core): remove deprecatred legacy driver and get_data doc

### DIFF
--- a/docs/_static/params_mapping_extra.csv
+++ b/docs/_static/params_mapping_extra.csv
@@ -55,7 +55,7 @@ sar:instrument_mode,:green:`queryable metadata`,,:green:`queryable metadata`,,,,
 sar:polarizations,:green:`queryable metadata`,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,,,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`,:green:`queryable metadata`
 sat:absolute_orbit,:green:`queryable metadata`,,:green:`queryable metadata`,,,,,,:green:`queryable metadata`,:green:`queryable metadata`,,:green:`queryable metadata`,
 sat:orbit_state,:green:`queryable metadata`,,:green:`queryable metadata`,,,,,,,:green:`queryable metadata`,,:green:`queryable metadata`,
-sat:relative_orbit,:green:`queryable metadata`,,:green:`queryable metadata`,,,,,,:green:`queryable metadata`,,,:green:`queryable metadata`,
+sat:relative_orbit,:green:`queryable metadata`,,:green:`queryable metadata`,,,,,,:green:`queryable metadata`,:green:`queryable metadata`,,:green:`queryable metadata`,
 services,,,,,,,,,,metadata only,,,
 size,,,,,,,metadata only,,,,,,
 start_datetime,:green:`queryable metadata`,,:green:`queryable metadata`,metadata only,metadata only,,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,:green:`queryable metadata`,metadata only,:green:`queryable metadata`,metadata only

--- a/docs/api_reference/assets.rst
+++ b/docs/api_reference/assets.rst
@@ -33,4 +33,3 @@ Pixel access
 .. automethod:: eodag_cube.api.product._assets.Asset.to_xarray
 .. automethod:: eodag_cube.api.product._assets.Asset.get_file_obj
 .. automethod:: eodag_cube.api.product._assets.Asset.rio_env
-.. automethod:: eodag_cube.api.product._assets.Asset.get_data

--- a/docs/api_reference/eoproduct.rst
+++ b/docs/api_reference/eoproduct.rst
@@ -57,4 +57,3 @@ Pixel access
 .. automethod:: eodag_cube.api.product._product.EOProduct.to_xarray
 .. automethod:: eodag_cube.api.product._product.EOProduct.get_file_obj
 .. automethod:: eodag_cube.api.product._product.EOProduct.rio_env
-.. automethod:: eodag_cube.api.product._product.EOProduct.get_data

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -6,8 +6,8 @@ Drivers
 Drivers enable additional methods to be called on the :class:`~eodag.api.product._product.EOProduct`. They are set as
 :attr:`~eodag.api.product._product.EOProduct.driver` attribute of the :class:`~eodag.api.product._product.EOProduct`
 during its initialization, using some criteria to determine the most adapted driver. The first driver having its
-associated criteria matching will be used. If no driver is found, the :class:`~eodag.api.product.drivers.base.NoDriver`
-criteria is used.
+associated criteria matching will be used. If no driver matches, the
+:class:`~eodag.api.product.drivers.generic.GenericDriver` driver is used by default.
 
 
 Criteria
@@ -17,8 +17,6 @@ Criteria
     :members:
 
 .. autodata:: DRIVERS
-    :no-value:
-.. autodata:: LEGACY_DRIVERS
     :no-value:
 
 
@@ -40,7 +38,6 @@ EODAG currently advertises the following drivers:
 .. autosummary::
    :toctree: drivers_generated/
 
-   base.NoDriver
    generic.GenericDriver
    sentinel1.Sentinel1Driver
    sentinel2.Sentinel2Driver

--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -38,7 +38,8 @@ try:
 except ImportError:
     from eodag.api.product._assets import AssetsDict
 
-from eodag.api.product.drivers import DRIVERS, LEGACY_DRIVERS, NoDriver
+from eodag.api.product.drivers import DRIVERS
+from eodag.api.product.drivers.generic import GenericDriver
 from eodag.api.product.metadata_mapping import (
     DEFAULT_GEOMETRY,
     NOT_AVAILABLE,
@@ -597,21 +598,10 @@ class EOProduct:
 
     def get_driver(self) -> DatasetDriver:
         """Get the most appropriate driver"""
-        try:
-            for driver_conf in DRIVERS:
-                if all([criteria(self) for criteria in driver_conf["criteria"]]):
-                    driver = driver_conf["driver"]
-                    break
-            # use legacy driver for deprecated get_data method usage
-            for lecacy_conf in LEGACY_DRIVERS:
-                if all([criteria(self) for criteria in lecacy_conf["criteria"]]):
-                    driver.legacy = lecacy_conf["driver"]
-                    break
-            return driver
-        except TypeError:
-            logger.info("No driver matching")
-            pass
-        return NoDriver()
+        for driver_conf in DRIVERS:
+            if all([criteria(self) for criteria in driver_conf["criteria"]]):
+                return driver_conf["driver"]
+        return GenericDriver()
 
     def _repr_html_(self):
         thumbnail = self.properties.get("eodag:thumbnail") or self.properties.get(

--- a/eodag/api/product/drivers/__init__.py
+++ b/eodag/api/product/drivers/__init__.py
@@ -20,26 +20,10 @@ from __future__ import annotations
 
 from typing import Callable, TypedDict
 
-from eodag.api.product.drivers.base import DatasetDriver, NoDriver
+from eodag.api.product.drivers.base import DatasetDriver
 from eodag.api.product.drivers.generic import GenericDriver
 from eodag.api.product.drivers.sentinel1 import Sentinel1Driver
 from eodag.api.product.drivers.sentinel2 import Sentinel2Driver
-
-try:
-    # import from eodag-cube if installed
-    from eodag_cube.api.product.drivers.generic import (  # pyright: ignore[reportMissingImports]; isort: skip
-        GenericDriver as GenericDriver_cube,
-    )
-    from eodag_cube.api.product.drivers.sentinel2_l1c import (  # pyright: ignore[reportMissingImports]; isort: skip
-        Sentinel2L1C as Sentinel2L1C_cube,
-    )
-    from eodag_cube.api.product.drivers.stac_assets import (  # pyright: ignore[reportMissingImports]; isort: skip
-        StacAssets as StacAssets_cube,
-    )
-except ImportError:
-    GenericDriver_cube = NoDriver
-    Sentinel2L1C_cube = NoDriver
-    StacAssets_cube = NoDriver
 
 
 class DriverCriteria(TypedDict):
@@ -76,29 +60,5 @@ DRIVERS: list[DriverCriteria] = [
 ]
 
 
-#: list of legacy drivers and their criteria
-LEGACY_DRIVERS: list[DriverCriteria] = [
-    {
-        "criteria": [
-            lambda prod: True if len(getattr(prod, "assets", {})) > 0 else False
-        ],
-        "driver": StacAssets_cube(),
-    },
-    {
-        "criteria": [lambda prod: True if "assets" in prod.properties else False],
-        "driver": StacAssets_cube(),
-    },
-    {
-        "criteria": [
-            lambda prod: True if getattr(prod, "collection") == "S2_MSI_L1C" else False
-        ],
-        "driver": Sentinel2L1C_cube(),
-    },
-    {
-        "criteria": [lambda prod: True],
-        "driver": GenericDriver_cube(),
-    },
-]
-
 # exportable content
-__all__ = ["DRIVERS", "DatasetDriver", "GenericDriver", "NoDriver", "Sentinel2Driver"]
+__all__ = ["DRIVERS", "DatasetDriver", "GenericDriver", "Sentinel2Driver"]

--- a/eodag/api/product/drivers/base.py
+++ b/eodag/api/product/drivers/base.py
@@ -44,9 +44,6 @@ class DatasetDriver(metaclass=type):
     criteria.
     """
 
-    #: legacy driver for deprecated :meth:`~eodag_cube.api.product._product.EOProduct.get_data` method usage
-    legacy: DatasetDriver
-
     #: list of patterns to match asset keys and roles
     ASSET_KEYS_PATTERNS_ROLES: list[AssetPatterns] = []
 
@@ -79,11 +76,3 @@ class DatasetDriver(metaclass=type):
                 return normalized_key or extracted_key, roles
         logger.debug(f"No key & roles could be guessed for {href}")
         return None, None
-
-
-class NoDriver(DatasetDriver):
-    """A default :attr:`~eodag.api.product.drivers.base.DatasetDriver.legacy` driver that does not implement any of the
-    methods it should implement, used for all collections for  which the deprecated
-    :meth:`~eodag_cube.api.product._product.EOProduct.get_data` method is not implemented. Expect a
-    :exc:`NotImplementedError` when trying to get the data in that case.
-    """

--- a/tests/context.py
+++ b/tests/context.py
@@ -33,7 +33,7 @@ from eodag.api.product.drivers import DRIVERS
 from eodag.api.product.drivers.generic import GenericDriver
 from eodag.api.product.drivers.sentinel1 import Sentinel1Driver
 from eodag.api.product.drivers.sentinel2 import Sentinel2Driver
-from eodag.api.product.drivers.base import DatasetDriver, NoDriver
+from eodag.api.product.drivers.base import DatasetDriver
 from eodag.api.product.metadata_mapping import (
     format_metadata,
     OFFLINE_STATUS,

--- a/tests/units/test_eoproduct_driver_generic.py
+++ b/tests/units/test_eoproduct_driver_generic.py
@@ -19,7 +19,7 @@
 import os
 
 from tests import TEST_RESOURCES_PATH, EODagTestCase
-from tests.context import EOProduct, GenericDriver, NoDriver
+from tests.context import EOProduct, GenericDriver
 
 
 class TestEOProductDriverGeneric(EODagTestCase):
@@ -37,16 +37,6 @@ class TestEOProductDriverGeneric(EODagTestCase):
     def test_driver_generic_init(self):
         """The appropriate driver must have been set"""
         self.assertIsInstance(self.product.driver, GenericDriver)
-        self.assertTrue(hasattr(self.product.driver, "legacy"))
-        try:
-            # import from eodag-cube if installed
-            from eodag_cube.api.product.drivers.base import (  # pyright: ignore[reportMissingImports]; isort: skip
-                DatasetDriver as DatasetDriver_cube,
-            )
-
-            self.assertIsInstance(self.product.driver.legacy, DatasetDriver_cube)
-        except ImportError:
-            self.assertIsInstance(self.product.driver.legacy, NoDriver)
 
     def test_driver_generic_guess_asset_key_and_roles(self):
         """The driver must guess appropriate asset key and roles"""

--- a/tests/units/test_eoproduct_driver_sentinel1.py
+++ b/tests/units/test_eoproduct_driver_sentinel1.py
@@ -19,7 +19,7 @@
 import os
 
 from tests import TEST_RESOURCES_PATH, EODagTestCase
-from tests.context import EOProduct, NoDriver, Sentinel1Driver
+from tests.context import EOProduct, Sentinel1Driver
 
 
 class TestEOProductDriverSentinel1Driver(EODagTestCase):
@@ -37,16 +37,6 @@ class TestEOProductDriverSentinel1Driver(EODagTestCase):
     def test_driver_s1_init(self):
         """The appropriate driver must have been set"""
         self.assertIsInstance(self.product.driver, Sentinel1Driver)
-        self.assertTrue(hasattr(self.product.driver, "legacy"))
-        try:
-            # import from eodag-cube if installed
-            from eodag_cube.api.product.drivers.base import (  # pyright: ignore[reportMissingImports]; isort: skip
-                DatasetDriver as DatasetDriver_cube,
-            )
-
-            self.assertIsInstance(self.product.driver.legacy, DatasetDriver_cube)
-        except ImportError:
-            self.assertIsInstance(self.product.driver.legacy, NoDriver)
 
     def test_driver_s1_guess_asset_key_and_roles(self):
         """The driver must guess appropriate asset key and roles"""

--- a/tests/units/test_eoproduct_driver_sentinel2.py
+++ b/tests/units/test_eoproduct_driver_sentinel2.py
@@ -19,7 +19,7 @@
 import os
 
 from tests import TEST_RESOURCES_PATH, EODagTestCase
-from tests.context import EOProduct, NoDriver, Sentinel2Driver
+from tests.context import EOProduct, Sentinel2Driver
 
 
 class TestEOProductDriverSentinel2Driver(EODagTestCase):
@@ -37,16 +37,6 @@ class TestEOProductDriverSentinel2Driver(EODagTestCase):
     def test_driver_s2_init(self):
         """The appropriate driver must have been set"""
         self.assertIsInstance(self.product.driver, Sentinel2Driver)
-        self.assertTrue(hasattr(self.product.driver, "legacy"))
-        try:
-            # import from eodag-cube if installed
-            from eodag_cube.api.product.drivers.base import (  # pyright: ignore[reportMissingImports]; isort: skip
-                DatasetDriver as DatasetDriver_cube,
-            )
-
-            self.assertIsInstance(self.product.driver.legacy, DatasetDriver_cube)
-        except ImportError:
-            self.assertIsInstance(self.product.driver.legacy, NoDriver)
 
     def test_driver_s2_guess_asset_key_and_roles(self):
         """The driver must guess appropriate asset key and roles"""


### PR DESCRIPTION
Following https://github.com/CS-SI/eodag-cube/pull/109, removes `get_data` documentation and deprecated legacy drivers from `eodag-cube`