### PR TITLE
fix(core): queryables alias usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Run Tests
 
 on:
   push:
-    branches: [master, develop]
+    branches: [master, develop, v3.10.x]
   pull_request:
-    branches: [master, develop]
+    branches: [master, develop, v3.10.x]
   schedule:
     - cron: "0 7 * * 1"
   workflow_dispatch:

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -56,7 +56,7 @@ from eodag.plugins.search import PreparedSearch
 from eodag.plugins.search.build_search_result import MeteoblueSearch
 from eodag.plugins.search.qssearch import PostJsonSearch
 from eodag.types import model_fields_to_annotated
-from eodag.types.queryables import CommonQueryables, QueryablesDict
+from eodag.types.queryables import CommonQueryables, Queryables, QueryablesDict
 from eodag.utils import (
     DEFAULT_DOWNLOAD_TIMEOUT,
     DEFAULT_DOWNLOAD_WAIT,
@@ -2318,8 +2318,14 @@ class EODataAccessGateway:
                         plugin.provider,
                     )
 
+            # use queryables aliases
+            kwargs_alias = {**kwargs}
+            for search_param, field_info in Queryables.model_fields.items():
+                if search_param in kwargs and field_info.alias:
+                    kwargs_alias[field_info.alias] = kwargs_alias.pop(search_param)
+
             plugin_queryables = plugin.list_queryables(
-                kwargs,
+                kwargs_alias,
                 available_product_types,
                 product_type_configs,
                 product_type,

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -723,7 +723,6 @@ class ECMWFSearch(PostJsonSearch):
             if key not in ALLOWED_KEYWORDS | {
                 START,
                 END,
-                "geom",
                 "geometry",
             }:
                 raise ValidationError(
@@ -780,7 +779,7 @@ class ECMWFSearch(PostJsonSearch):
                 | {
                     START,
                     END,
-                    "geom",
+                    "geometry",
                 }
                 and keyword not in [f["name"] for f in form]
                 and keyword.removeprefix(ECMWF_PREFIX)

--- a/eodag/types/queryables.py
+++ b/eodag/types/queryables.py
@@ -91,6 +91,7 @@ class Queryables(CommonQueryables):
         Union[str, dict[str, float], BaseGeometry],
         Field(
             None,
+            alias="geometry",
             description="Read EODAG documentation for all supported geometry format.",
         ),
     ]

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1449,6 +1449,44 @@ class TestCore(TestCoreBase):
             )
 
     @mock.patch(
+        "eodag.plugins.search.base.Search.list_queryables",
+        autospec=True,
+    )
+    def test_alias_in_list_queryables(self, mock_list_queryables: mock.Mock):
+        """queryables alias must be resolved in list_queryables"""
+        self.dag.list_queryables(
+            provider="peps",
+            productType="S2_MSI_L1C",
+            start="2025-01-01",
+            end="2025-01-31",
+            geom=[-10, 35, 10, 45],
+        )
+        search_plugin = next(
+            self.dag._plugins_manager.get_search_plugins(provider="peps")
+        )
+        mock_list_queryables.assert_called_with(
+            search_plugin,
+            dict(
+                productType="S2_MSI_L1C",
+                startTimeFromAscendingNode="2025-01-01",
+                completionTimeFromAscendingNode="2025-01-31",
+                geometry=[-10, 35, 10, 45],
+            ),
+            [
+                pt["ID"]
+                for pt in self.dag.list_product_types("peps", fetch_providers=False)
+            ],
+            {
+                "S2_MSI_L1C": {
+                    "productType": "S2_MSI_L1C",
+                    **self.dag.product_types_config["S2_MSI_L1C"],
+                }
+            },
+            "S2_MSI_L1C",
+            "S2_MSI_L1C",
+        )
+
+    @mock.patch(
         "eodag.plugins.search.build_search_result.ECMWFSearch.discover_queryables",
         autospec=True,
     )


### PR DESCRIPTION
When calling `list_queryables`, internally translate parameters using pydantic alias if available