### PR TITLE
fix(plugins): add temporal resolution to ecmwf properties

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -188,6 +188,7 @@ COP_DS_KEYWORDS = {
     "statistic",
     "system_version",
     "temporal_aggregation",
+    "temporal_resolution",
     "time_aggregation",
     "time_reference",
     "time_step",


### PR DESCRIPTION
adds property temporal_resolution to the COP_DS_KEYWORDS so that it is available as a search parameter
