### PR TITLE
ci: pre-commit replaced with faster prek

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint:
-    name: Linting (pre-commit and mypy)
+    name: Linting (prek/pre-commit and mypy)
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the repo

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -37,11 +37,10 @@ If you intend to contribute to eodag source code:
     git clone https://github.com/CS-SI/eodag.git
     cd eodag
     python -m pip install -r requirements-dev.txt
-    pre-commit install
 
-We use ``pre-commit`` to run a suite of linters, formatters and pre-commit hooks (``black``, ``isort``, ``flake8``) to
-ensure the code base is homogeneously formatted and easier to read. It's important that you install it, since we run
-the exact same hooks in the Continuous Integration.
+We use ``prek`` (faster ``pre-commit``) to run a suite of linters, formatters and pre-commit hooks (``black``, ``isort``
+, ``flake8``) to ensure the code base is homogeneously formatted and easier to read. It's important that you install it,
+since we run the exact same hooks in the Continuous Integration.
 
 To run the default test suite (which excludes end-to-end tests):
 

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -241,7 +241,8 @@ class PluginConfig(yaml.YAMLObject):
         next_page_url_tpl: str
         #: The query-object for POST pagination requests.
         next_page_query_obj: str
-        #: Next page token key used in pagination
+        #: Next page token key used in pagination. Can be guessed from ``KNOWN_NEXT_PAGE_TOKEN_KEYS`` (but needed by
+        # ``stac-fastapi-eodag`` that cannot guess and will use ``page`` as default).
         next_page_token_key: str
         #: The endpoint for counting the number of items satisfying a request
         count_endpoint: str

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,7 +112,7 @@ dev =
     twine
     wheel
     flake8
-    pre-commit
+    prek
     responses != 0.24.0
     fastapi[all]
     stdlib-list

--- a/tox.ini
+++ b/tox.ini
@@ -87,5 +87,5 @@ commands =
 [testenv:linters]
 basepython = python3.9
 commands =
-    pre-commit run --all-files
+    prek run --all-files
     python -m mypy -p eodag


### PR DESCRIPTION
`pre-commit` replaced with faster [prek](https://github.com/j178/prek)
> ⚡ Better `pre-commit`, re-engineered in Rust 

if you were already using `pre-commit` on your project, you may need to re-install git hooks with
```sh
prek install -f
```
(see https://prek.j178.dev/quickstart/#already-using-pre-commit)