### PR TITLE
refactor(core): whole world as default product geometry and shapely stubs

### DIFF
--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -42,6 +42,7 @@ from shapely.ops import transform
 from eodag.types.queryables import Queryables
 from eodag.utils import (
     DEFAULT_PROJ,
+    DEFAULT_SHAPELY_GEOMETRY,
     deepcopy,
     dict_items_recursive_apply,
     format_string,
@@ -383,14 +384,16 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
         @staticmethod
         def convert_to_bounds(input_geom_unformatted: Any) -> list[float]:
             input_geom = get_geometry_from_various(geometry=input_geom_unformatted)
+            if input_geom is None:
+                input_geom = DEFAULT_SHAPELY_GEOMETRY
             if isinstance(input_geom, MultiPolygon):
                 geoms = [geom for geom in input_geom.geoms]
                 # sort with larger one at first (stac-browser only plots first one)
                 geoms.sort(key=lambda x: x.area, reverse=True)
-                min_lon = 180
-                min_lat = 90
-                max_lon = -180
-                max_lat = -90
+                min_lon = 180.0
+                min_lat = 90.0
+                max_lon = -180.0
+                max_lat = -90.0
                 for geom in geoms:
                     min_lon = min(min_lon, geom.bounds[0])
                     min_lat = min(min_lat, geom.bounds[1])

--- a/eodag/plugins/crunch/filter_latest_intersect.py
+++ b/eodag/plugins/crunch/filter_latest_intersect.py
@@ -70,6 +70,7 @@ class FilterLatestIntersect(Crunch):
         # Warning: May crash if start_datetime is not in the appropriate format
         products.sort(key=self.sort_product_by_start_date, reverse=True)
         filtered: list[EOProduct] = []
+        search_extent: BaseGeometry
         add_to_filtered = filtered.append
         footprint: Union[dict[str, Any], BaseGeometry, Any] = search_params.get(
             "geometry"

--- a/eodag/plugins/crunch/filter_overlap.py
+++ b/eodag/plugins/crunch/filter_overlap.py
@@ -20,14 +20,10 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from shapely.errors import ShapelyError
+
 from eodag.plugins.crunch.base import Crunch
 from eodag.utils import get_geometry_from_various
-
-try:
-    from shapely.errors import GEOSException
-except ImportError:
-    # shapely < 2.0 compatibility
-    from shapely.errors import TopologicalError as GEOSException
 
 if TYPE_CHECKING:
     from eodag.api.product import EOProduct
@@ -108,7 +104,7 @@ class FilterOverlap(Crunch):
                         product_geometry = product.geometry.buffer(0)
                         try:
                             intersection = search_geom.intersection(product_geometry)
-                        except GEOSException:
+                        except ShapelyError:
                             logger.debug(
                                 "Product geometry still invalid. Overlap test restricted to containment"
                             )

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -79,7 +79,7 @@ from jsonpath_ng import jsonpath
 from jsonpath_ng.ext import parse
 from jsonpath_ng.jsonpath import Child, Fields, Index, Root, Slice
 from requests import HTTPError, Response
-from shapely.geometry import Polygon, shape
+from shapely.geometry import Polygon, box, shape
 from shapely.geometry.base import GEOMETRY_TYPES, BaseGeometry
 from tqdm.auto import tqdm
 
@@ -133,6 +133,9 @@ DEFAULT_MAX_ITEMS_PER_PAGE = 50
 
 # default collections start date
 DEFAULT_MISSION_START_DATE = "2015-01-01T00:00:00.000Z"
+
+# default geometry / whole world bounding box
+DEFAULT_SHAPELY_GEOMETRY = box(-180, -90, 180, 90)
 
 # default token expiration margin in seconds
 DEFAULT_TOKEN_EXPIRATION_MARGIN = 60
@@ -1066,7 +1069,7 @@ def nested_pairs2dict(pairs: Union[list[Any], Any]) -> Union[Any, dict[Any, Any]
 
 def get_geometry_from_various(
     locations_config: list[dict[str, Any]] = [], **query_args: Any
-) -> BaseGeometry:
+) -> Optional[BaseGeometry]:
     """Creates a ``shapely.geometry`` using given query kwargs arguments
 
     :param locations_config: (optional) EODAG locations configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,6 @@ module = [
     "pygeofilter.*",
     "rasterio",
     "shapefile",
-    "shapely",
-    "shapely.*",
     "stream_zip",
     "usgs",
     "usgs.*",

--- a/setup.cfg
+++ b/setup.cfg
@@ -125,6 +125,7 @@ stubs =
     types-python-dateutil
     types-PyYAML
     types-setuptools
+    types-shapely
     types-tqdm
     types-urllib3
 docs =

--- a/tests/context.py
+++ b/tests/context.py
@@ -79,6 +79,7 @@ from eodag.types import model_fields_to_annotated
 from eodag.types.queryables import CommonQueryables, Queryables
 from eodag.utils import (
     DEFAULT_MISSION_START_DATE,
+    DEFAULT_SHAPELY_GEOMETRY,
     DEFAULT_STREAM_REQUESTS_TIMEOUT,
     HTTP_REQ_TIMEOUT,
     DEFAULT_SEARCH_TIMEOUT,

--- a/tests/units/test_eoproduct.py
+++ b/tests/units/test_eoproduct.py
@@ -33,6 +33,7 @@ from shapely import geometry
 
 from tests import EODagTestCase
 from tests.context import (
+    DEFAULT_SHAPELY_GEOMETRY,
     DEFAULT_STREAM_REQUESTS_TIMEOUT,
     NOT_AVAILABLE,
     USER_AGENT,
@@ -40,7 +41,6 @@ from tests.context import (
     Download,
     EOProduct,
     HTTPDownload,
-    MisconfiguredError,
     ProgressCallback,
     config,
 )
@@ -77,16 +77,18 @@ class TestEOProduct(EODagTestCase):
     def test_eoproduct_default_geom(self):
         """EOProduct needs a geometry or can use confired eodag:default_geometry by default"""
 
-        with self.assertRaisesRegex(MisconfiguredError, "No geometry available"):
-            self._dummy_product(properties={"geometry": NOT_AVAILABLE})
+        product_no_default_geom = self._dummy_product(
+            properties={"geometry": NOT_AVAILABLE}
+        )
+        self.assertEqual(product_no_default_geom.geometry, DEFAULT_SHAPELY_GEOMETRY)
 
-        product = self._dummy_product(
+        product_default_geom = self._dummy_product(
             properties={
                 "geometry": NOT_AVAILABLE,
                 "eodag:default_geometry": (0, 0, 1, 1),
             }
         )
-        self.assertEqual(product.geometry.bounds, (0.0, 0.0, 1.0, 1.0))
+        self.assertEqual(product_default_geom.geometry.bounds, (0.0, 0.0, 1.0, 1.0))
 
     def test_eoproduct_search_intersection_none(self):
         """EOProduct search_intersection attr must be None if shapely.errors.GEOSException when intersecting"""


### PR DESCRIPTION
Use whole-world as product geometry fallback and add `shapely` stubs