### PR TITLE
refactor(core): disable search pagination when less items got than expected

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -1462,6 +1462,7 @@ class EODataAccessGateway:
                 len(search_results),
                 search_results[0].provider,
             )
+            search_results.number_matched = len(search_results)
         except RequestError:
             logger.warning(
                 "Found %s result(s) on provider '%s', but it may be incomplete "
@@ -1902,6 +1903,10 @@ class EODataAccessGateway:
 
                 if eo_product.search_intersection is not None:
                     eo_product._register_downloader_from_manager(self._plugins_manager)
+
+            # Make next_page not available if the current one returned less than the maximum number of items asked for.
+            if not prep.items_per_page or len(search_result) < prep.items_per_page:
+                search_result.next_page_token = None
 
             search_result._dag = self
             return search_result

--- a/eodag/api/search_result.py
+++ b/eodag/api/search_result.py
@@ -19,16 +19,7 @@ from __future__ import annotations
 
 import logging
 from collections import UserList
-from typing import (
-    TYPE_CHECKING,
-    Annotated,
-    Any,
-    Iterable,
-    Iterator,
-    Optional,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Annotated, Any, Iterable, Iterator, Optional, Union
 
 from shapely.geometry import GeometryCollection
 from shapely.geometry import mapping as shapely_mapping
@@ -320,11 +311,7 @@ class SearchResult(UserList[EOProduct]):
 
         # Do not iterate if there is no next page token
         #  or if the current one returned less than the maximum number of items asked for.
-        if self.next_page_token is None or (
-            self.search_params
-            and self.search_params.get("items_per_page")
-            and len(self) < cast(int, self.search_params["items_per_page"])
-        ):
+        if self.next_page_token is None:
             return
 
         new_results = get_next_page(self)


### PR DESCRIPTION
Disable search pagination when less products are returned than expected.

This was previously checked on next page generation, now it is done at the end of search