### PR TITLE
refactor(providers): next_page_token_key added to confs

### DIFF
--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -1150,6 +1150,7 @@ class QueryStringSearch(Search):
         }
         raw_search_results.query_params = prep.query_params
         raw_search_results.collection_def_params = prep.collection_def_params
+        raw_search_results.next_page_token_key = prep.next_page_token_key
 
         # If no JSON response is available, return the result as is
         if resp_as_json is None:
@@ -1168,7 +1169,7 @@ class QueryStringSearch(Search):
             jsonpath_match = jsonpath_expr.find(resp_as_json)
             if jsonpath_match:
                 next_page_query_obj = jsonpath_match[0].value
-                next_page_token_key = self.config.pagination.get("next_page_token_key")
+                next_page_token_key = raw_search_results.next_page_token_key
                 if next_page_token_key and next_page_token_key in next_page_query_obj:
                     raw_search_results.next_page_token = next_page_query_obj[
                         next_page_token_key
@@ -1203,8 +1204,9 @@ class QueryStringSearch(Search):
                 next_page_token_key = (
                     unquote(self.config.pagination["parse_url_key"])
                     if "parse_url_key" in self.config.pagination
-                    else self.config.pagination.get("next_page_token_key")
+                    else raw_search_results.next_page_token_key
                 )
+                raw_search_results.next_page_token_key = next_page_token_key
                 # Try to extract the token from the found value
                 if next_page_token_key in href_value:
                     raw_search_results.next_page_token = href_value[next_page_token_key]
@@ -1222,9 +1224,7 @@ class QueryStringSearch(Search):
                 raw_search_results.next_page_token = None
         else:
             # pagination using next_page_token_key
-            next_page_token_key = str(
-                self.config.pagination.get("next_page_token_key", "page")
-            )
+            next_page_token_key = raw_search_results.next_page_token_key
             next_page_token = prep.next_page_token
             # page number as next_page_token_key
             if next_page_token is not None and next_page_token_key == "page":

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -1335,6 +1335,7 @@
       # but in practive if an Internal Server Error is returned for more than
       # about 500 products.
       max_items_per_page: 500
+      next_page_token_key: next
     # Note: Sorting is intentionally disabled for this provider, as enabling it causes pagination to malfunction.
     metadata_mapping:
       assets: '{$.assets#from_alternate(s3)}'
@@ -1492,6 +1493,7 @@
       # Remove that entry if Earth Search updates that and returns a valid link.
       next_page_url_key_path: null
       next_page_query_obj_key_path: null
+      next_page_token_key: page
       # 2021/04/28: Earth-Search relies on Sat-API whose docs (http://sat-utils.github.io/sat-api/#search-stac-items-by-simple-filtering-)
       # say the max is 10_000. In practice a too high number (e.g. 5_000) returns a 502 error ({"message": "Internal server error"}).
       # Let's set it to a more robust number: 500
@@ -2962,6 +2964,7 @@
     ssl_verify: true
     pagination:
       max_items_per_page: 1000
+      next_page_token_key: token
     sort:
       sort_param_mapping:
         id: id
@@ -3022,6 +3025,9 @@
       collection_fetch_url: null
     pagination:
       max_items_per_page: 10_000
+      next_page_url_key_path: null
+      next_page_query_obj_key_path: null
+      next_page_token_key: page
     sort:
       sort_by_default:
         - !!python/tuple [start_datetime, ASC]
@@ -4838,6 +4844,7 @@
         extent: '$.extent'
     pagination:
       max_items_per_page: 100
+      next_page_token_key: page
     sort:
       sort_param_mapping:
         id: id


### PR DESCRIPTION
Adds `next_page_token_key` to STAC providers search pagination configuration.

It is not mandatory, but allows to directly search next page from `stac-fastapi-eodag`.