### PR TITLE
fix(core): add Collection property for server extended metadata

### DIFF
--- a/eodag/api/collection.py
+++ b/eodag/api/collection.py
@@ -91,7 +91,7 @@ class Collection(BaseModel):
         repr=False,
     )
 
-    # path to external collection metadata file
+    # path to external collection metadata file (required by stac-fastapi-eodag)
     eodag_stac_collection: Optional[str] = Field(
         default=None, alias="stacCollection", exclude=True, repr=False
     )


### PR DESCRIPTION
adds a property `eodag_stac_collection` to the `Collection` object which is used by `stac-fastapi-eodag` to import collection metadata from an external file
