### PR TITLE
refactor: boto3 ServiceResource type check

### DIFF
--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -710,7 +710,7 @@ class AwsDownload(Download):
             ignore_assets,
             product,
         )
-        if auth and isinstance(auth, boto3.resources.base.ServiceResource):
+        if auth and isinstance(auth, boto3.resource("s3").__class__):
             s3_resource = auth
         else:
             s3_resource = boto3.resource(


### PR DESCRIPTION
`auth` type checking update in `AwsDownload` plugin following `boto3` update and error raised by `mypy`:
```
eodag/plugins/download/aws.py:713: error: Module has no attribute "resources"; maybe "resource"?  [attr-defined]
```