### PR TITLE
fix(plugins): dates formatting and missing param in ECMWFSearch queryables

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -61,7 +61,11 @@ from eodag.utils import (
     get_geometry_from_various,
 )
 from eodag.utils.cache import instance_cached_method
-from eodag.utils.dates import DATE_RANGE_PATTERN, is_range_in_range
+from eodag.utils.dates import (
+    COMPACT_DATE_RANGE_PATTERN,
+    DATE_RANGE_PATTERN,
+    is_range_in_range,
+)
 from eodag.utils.exceptions import DownloadError, NotAvailableError, ValidationError
 from eodag.utils.requests import fetch_json
 
@@ -966,8 +970,13 @@ class ECMWFSearch(PostJsonSearch):
             # We strip values of superfluous quotes (added by mapping converter to_geojson).
             # ECMWF accept date ranges with /to/. We need to split it to an array
             # ECMWF accept date ranges in format val1/val2. We need to split it to an array
-            date_regex = re.compile(DATE_RANGE_PATTERN)
-            if any(date_regex.match(v) for v in filter_v):
+            date_regex = [
+                re.compile(p) for p in (DATE_RANGE_PATTERN, COMPACT_DATE_RANGE_PATTERN)
+            ]
+            is_date = any(
+                any(r.match(v) is not None for r in date_regex) for v in filter_v
+            )
+            if is_date:
                 sep = re.compile(r"/to/|/")
                 filter_v = [i for v in filter_v for i in sep.split(str(v))]
 

--- a/eodag/utils/dates.py
+++ b/eodag/utils/dates.py
@@ -35,7 +35,17 @@ RFC3339_PATTERN = (
     r"(Z|([+-])(\d{2}):(\d{2}))?)?$"
 )
 
-DATE_RANGE_PATTERN = r"\d{4}-\d{2}-\d{2}((/to/|/)\d{4}-\d{2}-\d{2})?"
+# yyyy-mm-dd
+DATE_PATTERN = r"\d{4}-(0[1-9]|1[1,2])-(0[1-9]|[12][0-9]|3[01])"
+
+# yyyymmdd
+COMPACT_DATE_PATTERN = r"\d{4}(0[1-9]|1[1,2])(0[1-9]|[12][0-9]|3[01])"
+
+# yyyy-mm-dd/yyyy-mm-dd, yyyy-mm-dd/to/yyyy-mm-dd
+DATE_RANGE_PATTERN = DATE_PATTERN + r"(/to/|/)" + DATE_PATTERN
+
+# yyyymmdd/yyyymmdd, yyyymmdd/to/yyyymmdd
+COMPACT_DATE_RANGE_PATTERN = COMPACT_DATE_PATTERN + r"(/to/|/)" + COMPACT_DATE_PATTERN
 
 
 def get_timestamp(date_time: str) -> float:


### PR DESCRIPTION
Fix in the queryables:

- add `satellite_mission` as allowed Copernicus keyword;
- interpret `/` and `/to/` as range separator for dates (e.g. `2004-01-01/2004-01-10`). Otherwise the values are used as simple strings (e.g. `"0.5/0.5"` is not interpreted as range, but as simple string).