### PR TITLE
chore: Allow Pydantic >= 2.12.0 by buiding docs with Python 3.13

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     jsonpath-ng
     lxml
     orjson
-    pydantic >= 2.1.0, != 2.10.0, < 2.12.0
+    pydantic >= 2.1.0, != 2.10.0
     pydantic_core
     PyJWT[crypto] >= 2.5.0
     pyproj >= 2.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ setenv =
     HOME={envtmpdir}
 
 [testenv:docs]
-basepython = python3.9
+basepython = python3.13
 changedir = {toxinidir}/docs
 usedevelop = false
 deps = -r{toxinidir}/requirements-docs.txt


### PR DESCRIPTION
### Description
Release [3.10.0](https://github.com/CS-SI/eodag/releases/tag/v3.10.0) pinned `pydantic < 2.12.0` to prevent sphinx failures in https://github.com/CS-SI/eodag/pull/1873, but this forces applications using eodag to have this unwanted limitation.

This PR removes this restriction by using Python 3.13 (thus a newer version of Sphinx) to build the docs.

### Further comments
Could we please have a 3.10.1 hotfix with this change?

Thank you!