### PR TITLE
refactor(core): use collection alias in EOProduct

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -1849,12 +1849,6 @@ class EODataAccessGateway:
                     else:
                         eo_product.collection = guesses[0].id
 
-                try:
-                    if eo_product.collection is not None:
-                        self.get_collection_from_alias(eo_product.collection)
-                except NoMatchingCollection:
-                    logger.debug("collection %s not found", eo_product.collection)
-
                 if eo_product.search_intersection is not None:
                     eo_product._register_downloader_from_manager(self._plugins_manager)
 

--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -131,8 +131,7 @@ class EOProduct:
     ) -> None:
         self.provider = provider
         self.collection = (
-            properties.get("eodag:alias")
-            or kwargs.get("collection")
+            kwargs.get("collection")
             or properties.pop("collection", None)
             or properties.get("_collection")
         )

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -1292,7 +1292,7 @@ class ECMWFSearch(PostJsonSearch):
 
             # collection alias (required by opentelemetry-instrumentation-eodag)
             if alias := getattr(self.config, "collection_config", {}).get("alias"):
-                properties["eodag:alias"] = alias
+                kwargs["collection"] = alias
 
         qs = geojson.dumps(sorted_unpaginated_qp)
 
@@ -1534,7 +1534,7 @@ class MeteoblueSearch(ECMWFSearch):
         properties = {ecmwf_format(k): v for k, v in parsed_properties.items()}
         # collection alias (required by opentelemetry-instrumentation-eodag)
         if alias := getattr(self.config, "collection_config", {}).get("alias"):
-            properties["eodag:alias"] = alias
+            collection = alias
 
         def slugify(date_str: str) -> str:
             return date_str.split("T")[0].replace("-", "")

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -1283,7 +1283,7 @@ class QueryStringSearch(Search):
             )
             # collection alias (required by opentelemetry-instrumentation-eodag)
             if alias := getattr(self.config, "collection_config", {}).get("alias"):
-                properties["eodag:alias"] = alias
+                kwargs["collection"] = alias
             product = EOProduct(self.provider, properties, **kwargs)
 
             additional_assets = self.get_assets_from_mapping(result)

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2667,10 +2667,9 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
                 "spatial": {"bbox": [[-180.0, -90.0, 180.0, 90.0]]},
                 "temporal": {"interval": [["1985-10-26", "2015-10-21"]]},
             },
-            "alias": "THE.ALIAS",
         }
         results = self.search_plugin.query(
-            collection="THE.ALIAS",
+            collection=self.collection,
         )
         eoproduct = results.data[0]
         self.assertEqual(
@@ -2681,8 +2680,6 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
             eoproduct.properties["end_datetime"],
             "1985-10-26T00:00:00.000Z",
         )
-        self.assertEqual("THE.ALIAS", eoproduct.properties["eodag:alias"])
-        self.assertEqual("THE.ALIAS", eoproduct.collection)
 
         # restore previous config
         delattr(self.search_plugin.config, "dates_required")
@@ -2726,6 +2723,20 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
 
         # restore previous config
         delattr(self.search_plugin.config, "dates_required")
+
+    def test_plugins_search_ecmwfsearch_collection_with_alias(self):
+        """alias of collection must be used in search result"""
+        self.search_plugin.config.collection_config = {
+            "_collection": self.collection,
+            "alias": "THE.ALIAS",
+        }
+        results = self.search_plugin.query(
+            collection="THE.ALIAS",
+            start_datetime="2020-01-01",
+            end_datetime="2020-01-02",
+        )
+        eoproduct = results.data[0]
+        self.assertEqual("THE.ALIAS", eoproduct.collection)
 
     def test_plugins_search_ecmwfsearch_without_collection(self):
         """


### PR DESCRIPTION
- use the alias for the `collection` property of `EOProduct`
- remove the `eodag:alias` property
