### PR TITLE
build: add docker image

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,57 @@
+name: Build and publish a container image
+
+on:
+  push:
+    branches: ['master']
+    tags: ['v*']
+  workflow_dispatch:
+  repository_dispatch:
+    types: [release]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract container metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.title=eodag
+            org.opencontainers.image.description=Earth Observation Data Access Gateway
+            org.opencontainers.image.url=https://github.com/{{ github.repository }}
+            org.opencontainers.image.source=https://github.com/{{ github.repository }}.git
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.authors=CS GROUP - France (CSSI) <eodag@csgroup.space>
+
+      - name: Build and push container image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright 2025, CS GROUP - France, https://www.csgroup.eu/
+#
+# This file is part of EODAG project
+#     https://www.github.com/CS-SI/EODAG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:alpine3.13
+
+LABEL author="CS GROUP - France"
+
+# build-base is required to enable logging
+RUN apk add --no-cache build-base && \
+    pip install --no-cache-dir ".[all-providers]" && \
+    apk del build-base
+
+# Create a non-root user to run the application
+RUN addgroup -g 1000 eodag && \
+    adduser -u 1000 -G eodag \
+        -h /home/eodag \
+        -s /bin/sh \
+        -D eodag
+USER eodag
+
+ENTRYPOINT ["eodag"]
+CMD ["--help"]


### PR DESCRIPTION
Adds `Dockerfile` and github action to publish official EODAG docker images