### PR TITLE
fix(providers): renamed THEIA collections on geodes

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -6131,11 +6131,11 @@
     S2_MSI_L1C:
       _collection: PEPS_S2_L1C
     S2_MSI_L2A_MAJA:
-      _collection: MUSCATE_SENTINEL2_SENTINEL2_L2A
+      _collection: THEIA_REFLECTANCE_SENTINEL2_L2A
     S2_MSI_L2B_MAJA_SNOW:
-      _collection: MUSCATE_Snow_SENTINEL2_L2B-SNOW
+      _collection: THEIA_SNOW_SENTINEL2_L2B
     S2_MSI_L2B_MAJA_WATER:
-      _collection: MUSCATE_WaterQual_SENTINEL2_L2B-WATER
+      _collection: THEIA_WATERQUAL_SENTINEL2_L2B
     GENERIC_COLLECTION:
       _collection: '{collection}'
   download: !plugin
@@ -6261,11 +6261,11 @@
     S2_MSI_L1C:
       _collection: PEPS_S2_L1C
     S2_MSI_L2A_MAJA:
-      _collection: MUSCATE_SENTINEL2_SENTINEL2_L2A
+      _collection: THEIA_REFLECTANCE_SENTINEL2_L2A
     S2_MSI_L2B_MAJA_SNOW:
-     _collection: MUSCATE_Snow_SENTINEL2_L2B-SNOW
+      _collection: THEIA_SNOW_SENTINEL2_L2B
     S2_MSI_L2B_MAJA_WATER:
-      _collection: MUSCATE_WaterQual_SENTINEL2_L2B-WATER
+      _collection: THEIA_WATERQUAL_SENTINEL2_L2B
     GENERIC_COLLECTION:
       _collection: '{collection}'
   download: !plugin


### PR DESCRIPTION
Fixes #1918

Renames THEIA-related collections on `geodes` following their update