### PR TITLE
fix(plugins): aws streamed downloads

### DIFF
--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -773,7 +773,6 @@ class AwsDownload(Download):
         )
 
         # check if auth is a S3 resource by verifying it has the meta.client attribute.
-        # isinstance() check is not possible here because it is a dynamically generated class.
         if auth and hasattr(auth, "meta") and hasattr(auth.meta, "client"):
             s3_resource = auth
         else:


### PR DESCRIPTION
Downloading products in streaming with `AwsDownload` plugin did not work anymore. This PR allows to fix it by coding an other way of checking if an object is a `boto3.resource` in the `_stream_download_dict()` method.