### PR TITLE
fix(providers): search parameters parsing on hydroweb_next

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3044,9 +3044,18 @@
       end_datetime:
         - '{{"query":{{"start_datetime":{{"lte":"{end_datetime#to_iso_utc_datetime}"}}}}}}'
         - '$.properties.end_datetime'
+      processing:software:
+        - '{{"query":{{"processing:software":{{"eq":{processing:software}}}}}}}'
+        - '$.properties.processing:software'
+      spatial:cycle_id:
+        - '{{"query":{{"spatial:cycle_id":{{"eq":{spatial:cycle_id}}}}}}}'
+        - '$.properties.spatial:cycle_id'
       spatial:pass_id:
         - '{{"query":{{"spatial:pass_id":{{"eq":{spatial:pass_id}}}}}}}'
         - '$.properties.spatial:pass_id'
+      spatial:scene_id:
+        - '{{"query":{{"spatial:scene_id":{{"eq":{spatial:scene_id}}}}}}}'
+        - '$.properties.spatial:scene_id'
   products:
     GENERIC_COLLECTION:
       _collection: '{collection}'


### PR DESCRIPTION
Fixes #1980

Fixes parsing (quotes removed) on `hydroweb_next` for the following parameters:
- `processing:software` (json)
- `spatial:cycle_id` (int)
- `spatial:pass_id` (int)
- `spatial:scene_id` (int)