### PR TITLE
ci: gitleaks in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,8 @@ repos:
     rev: v5.10.1
     hooks:
     -   id: isort
+
+-   repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.2
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
Fixes #1957 

Adds `gitleaks` in `pre-commit`

> Gitleaks is a tool for detecting secrets like passwords, API keys, and tokens in git repos, files, and whatever else you wanna throw at it via stdin.