### PR TITLE
chore: labextension conf in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ search_results.geojson
 ext_collections.json
 !eodag/resources/ext_collections.json
 !tests/resources/ext_collections.json
+eodag-config
 
 # IDE
 # Pycharm


### PR DESCRIPTION
add `eodag-config` from `eodag-labextension` to `.gitignore`