### PR TITLE
fix(core): TypedDict from typing_extensions required by pydantic

### DIFF
--- a/eodag/api/product/drivers/__init__.py
+++ b/eodag/api/product/drivers/__init__.py
@@ -18,7 +18,9 @@
 """EODAG drivers package"""
 from __future__ import annotations
 
-from typing import Callable, TypedDict
+from typing import Callable
+
+from typing_extensions import TypedDict
 
 from eodag.api.product.drivers.base import DatasetDriver
 from eodag.api.product.drivers.generic import GenericDriver

--- a/eodag/api/product/drivers/base.py
+++ b/eodag/api/product/drivers/base.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import TYPE_CHECKING, Optional, TypedDict
+from typing import TYPE_CHECKING, Optional
+
+from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
     from eodag.api.product import EOProduct

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 import os
 from importlib.resources import files as res_files
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, Union
 
 import orjson
 import requests
@@ -28,6 +28,7 @@ import yaml
 import yaml.parser
 from annotated_types import Gt
 from jsonpath_ng import JSONPath
+from typing_extensions import TypedDict
 
 from eodag.utils import (
     HTTP_REQ_TIMEOUT,

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -27,16 +27,7 @@ from email.message import Message
 from itertools import chain
 from json import JSONDecodeError
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Iterator,
-    Literal,
-    Optional,
-    TypedDict,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Iterator, Literal, Optional, Union, cast
 from urllib.parse import parse_qs, urlparse
 
 import geojson
@@ -46,6 +37,7 @@ from lxml import etree
 from requests import RequestException
 from requests.auth import AuthBase
 from requests.structures import CaseInsensitiveDict
+from typing_extensions import TypedDict
 from zipstream import ZipStream
 
 from eodag.api.product.metadata_mapping import (

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -28,7 +28,6 @@ from typing import (
     Callable,
     Optional,
     Sequence,
-    TypedDict,
     cast,
     get_args,
 )
@@ -58,6 +57,7 @@ from pydantic.fields import FieldInfo
 from requests import Response
 from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase
+from typing_extensions import TypedDict
 from urllib3 import Retry
 
 from eodag.api.product import EOProduct

--- a/eodag/types/__init__.py
+++ b/eodag/types/__init__.py
@@ -19,17 +19,7 @@
 
 from __future__ import annotations
 
-from typing import (
-    Annotated,
-    Any,
-    Literal,
-    Optional,
-    Type,
-    TypedDict,
-    Union,
-    get_args,
-    get_origin,
-)
+from typing import Annotated, Any, Literal, Optional, Type, Union, get_args, get_origin
 
 from annotated_types import Gt, Lt
 from pydantic import BaseModel, ConfigDict, Field, create_model
@@ -37,6 +27,7 @@ from pydantic.annotated_handlers import GetJsonSchemaHandler
 from pydantic.fields import FieldInfo
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, PydanticUndefined
+from typing_extensions import TypedDict
 
 from eodag.utils import copy_deepcopy
 from eodag.utils.exceptions import ValidationError

--- a/eodag/types/download_args.py
+++ b/eodag/types/download_args.py
@@ -17,7 +17,9 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import Optional, TypedDict, Union
+from typing import Optional, Union
+
+from typing_extensions import TypedDict
 
 
 class DownloadConf(TypedDict, total=False):


### PR DESCRIPTION
use `typing_extensions.TypedDict` instead of `typing.TypedDict` as [required by Pydantic on Python < 3.12](https://docs.pydantic.dev/2.3/usage/types/types_fields/#typeddict)

> This is a new feature of the Python standard library as of Python 3.8. Because of limitations in `typing.TypedDict` before 3.12, the [typing-extensions](https://pypi.org/project/typing-extensions/) package is required for Python <3.12. You'll need to import `TypedDict` from `typing_extensions` instead of typing and will get a build time error if you don't.