### PR TITLE
refactor: cli.py collision name on eodag

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -155,11 +155,14 @@ class EODataAccessGateway:
             user_conf_file_path = os.getenv(env_var_name)
             if user_conf_file_path is None:
                 user_conf_file_path = standard_configuration_path
-                if not os.path.isfile(standard_configuration_path):
+                source = str(
+                    res_files("eodag") / "resources" / "user_conf_template.yml"
+                )
+                if os.path.isfile(source) and not os.path.isfile(
+                    standard_configuration_path
+                ):
                     shutil.copy(
-                        str(
-                            res_files("eodag") / "resources" / "user_conf_template.yml"
-                        ),
+                        source,
                         standard_configuration_path,
                     )
         self._providers.update_from_config_file(user_conf_file_path)

--- a/eodag/cli.py
+++ b/eodag/cli.py
@@ -123,14 +123,14 @@ def _deprecated_cli(message: str, version: Optional[str] = None) -> Callable[...
     help="Control the verbosity of the logs. For maximum verbosity, type -vvv",
 )
 @click.pass_context
-def eodag(ctx: Context, verbose: int) -> None:
+def eodag_cli(ctx: Context, verbose: int) -> None:
     """Earth Observation Data Access Gateway: work on EO products from any provider"""
     if ctx.obj is None:
         ctx.obj = {}
     ctx.obj["verbosity"] = verbose
 
 
-@eodag.command(name="version", help="Print eodag version and exit")
+@eodag_cli.command(name="version", help="Print eodag version and exit")
 def version() -> None:
     """Print eodag version and exit"""
     click.echo(
@@ -142,7 +142,7 @@ def version() -> None:
     )
 
 
-@eodag.command(
+@eodag_cli.command(
     name="search",
     help="Search satellite images by their collections, instruments, constellation, "
     "platform, processing level or sensor type. It is mandatory to provide "
@@ -407,7 +407,7 @@ def search_crunch(ctx: Context, **kwargs: Any) -> None:
     ctx.obj["search_results"] = results
 
 
-@eodag.command(name="list", help="List supported collections")
+@eodag_cli.command(name="list", help="List supported collections")
 @click.option("-p", "--provider", help="List collections supported by this provider")
 @click.option(
     "--instruments", help="List collections originating from these instruments"
@@ -489,7 +489,7 @@ def list_col(ctx: Context, **kwargs: Any) -> None:
         sys.exit(1)
 
 
-@eodag.command(name="discover", help="Fetch providers to discover collections")
+@eodag_cli.command(name="discover", help="Fetch providers to discover collections")
 @click.option("-p", "--provider", help="Fetch only the given provider")
 @click.option(
     "--storage",
@@ -520,7 +520,7 @@ def discover_col(ctx: Context, **kwargs: Any) -> None:
     click.echo("Results stored at '{}'".format(storage_filepath))
 
 
-@eodag.command(
+@eodag_cli.command(
     help="""Download a list of products from a serialized search result or STAC items URLs/paths
 
 Examples:
@@ -626,4 +626,4 @@ def download(ctx: Context, **kwargs: Any) -> None:
 
 
 if __name__ == "__main__":
-    eodag(obj={})
+    eodag_cli(obj={})

--- a/setup.cfg
+++ b/setup.cfg
@@ -151,7 +151,7 @@ exclude =
 
 [options.entry_points]
 console_scripts =
-    eodag = eodag.cli:eodag
+    eodag = eodag.cli:eodag_cli
 eodag.plugins.api =
     UsgsApi = eodag.plugins.apis.usgs:UsgsApi [usgs]
     EcmwfApi = eodag.plugins.apis.ecmwf:EcmwfApi [ecmwf]

--- a/tests/context.py
+++ b/tests/context.py
@@ -25,8 +25,6 @@ import os
 import sys
 from unittest import mock
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-
 from eodag import EODataAccessGateway, api, config, setup_logging
 from eodag.api.core import DEFAULT_ITEMS_PER_PAGE, DEFAULT_MAX_ITEMS_PER_PAGE
 from eodag.api.product import EOProduct
@@ -45,7 +43,7 @@ from eodag.api.product.metadata_mapping import (
 )
 from eodag.api.collection import Collection, CollectionsDict, CollectionsList
 from eodag.api.search_result import SearchResult
-from eodag.cli import download, eodag, list_col, search_crunch
+from eodag.cli import download, eodag_cli, list_col, search_crunch
 from eodag.config import (
     load_default_config,
     load_stac_provider_config,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import logging
 import os
 import re
@@ -24,8 +23,10 @@ from contextlib import contextmanager
 from datetime import datetime
 from importlib.resources import files as res_files
 from tempfile import TemporaryDirectory
+from typing import Optional, Tuple
 
 import click
+import shapely
 from click.testing import CliRunner
 from faker import Faker
 from packaging import version
@@ -33,6 +34,7 @@ from packaging import version
 from eodag.api.collection import Collection, CollectionsList
 from eodag.api.search_result import SearchResult
 from eodag.utils import GENERIC_COLLECTION
+from eodag.utils.exceptions import UnsupportedProvider
 from tests import TEST_RESOURCES_PATH
 from tests.context import (
     DEFAULT_ITEMS_PER_PAGE,
@@ -40,7 +42,7 @@ from tests.context import (
     MisconfiguredError,
     NoMatchingCollection,
     download,
-    eodag,
+    eodag_cli,
     mock,
     search_crunch,
 )
@@ -90,34 +92,64 @@ class TestEodagCli(unittest.TestCase):
         logger.handlers = []
         logger.level = 0
 
+    def eodag_command(
+        self, command_list: list = [], env: dict = {}
+    ) -> Tuple[int, str, Optional[Exception]]:
+        """Eodag command line
+
+        :param command_list: command line
+        :param env: environment variables
+        :returns: exit_code, stdout, stderr
+        """
+
+        # Force str parameters
+        str_command_list = list(map(lambda x: "{}".format(x), command_list))
+        result = self.runner.invoke(eodag_cli, str_command_list, env=env)
+
+        exit_code = 1
+        output = ""
+        error = RuntimeError(
+            "runner.invoke does not return expected result object, given {}".format(
+                type(result)
+            )
+        )
+        if isinstance(result, click.testing.Result):
+            exit_code = result.exit_code
+            output = result.output
+            error = result.exception
+
+        return exit_code, output, error
+
     def test_eodag_without_args(self):
         """Calling eodag without arguments should print help message"""
-        result = self.runner.invoke(eodag)
+        exit_code, output, _ = self.eodag_command()
         self.assertIn(
-            "Usage: eodag [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...",
-            result.output,
+            "Usage: eodag-cli [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...",
+            output,
         )
         # Exit status 2 with no_args_is_help starting click >= 8.2.0
-        self.assertIn(result.exit_code, (0, 2))
+        self.assertIn(exit_code, (0, 2))
 
     def test_eodag_with_only_verbose_opt(self):
         """Calling eodag only with -v option should print error message"""
-        result = self.runner.invoke(eodag, ["-v"])
-        self.assertIn("Error: Missing command.", result.output)
-        self.assertNotEqual(result.exit_code, 0)
+        exit_code, output, error = self.eodag_command(["-v"])
+        self.assertIn("Error: Missing command.", output)
+        self.assertNotEqual(exit_code, 0)
+        self.assertIsInstance(error, SystemExit)
 
     def test_eodag_cli_version(self):
         """Calling eodag version should return the version"""
-        result = self.runner.invoke(eodag, ["version"])
-        version_str = re.search(r"eodag .* version (.+)\s*$", result.output).group(1)
+        _, output, error = self.eodag_command(["version"])
+        version_str = re.search(r"eodag .* version (.+)\s*$", output).group(1)
+        self.assertIsNone(error)
         self.assertGreater(version.parse(version_str), version.parse("2.0.0"))
 
     def test_eodag_search_without_args(self):
         """Calling eodag search subcommand without arguments should print help message and return error code"""  # noqa
-        result = self.runner.invoke(eodag, ["search"])
+        exit_code, output, error = self.eodag_command(["search"])
         with click.Context(search_crunch) as ctx:
             self.assertEqual(
-                no_blanks(result.output),
+                no_blanks(output),
                 no_blanks(
                     "".join(
                         (
@@ -127,16 +159,19 @@ class TestEodagCli(unittest.TestCase):
                     )
                 ),
             )
-        self.assertNotEqual(result.exit_code, 0)
+        self.assertNotEqual(exit_code, 0)
+        self.assertIsInstance(error, SystemExit)
 
     def test_eodag_search_without_collection_arg(self):
         """Calling eodag search without -p | --collection should print the help message and return error code"""  # noqa
         start_date = self.faker.date()
         end_date = self.faker.date()
-        result = self.runner.invoke(eodag, ["search", "-s", start_date, "-e", end_date])
+        exit_code, output, error = self.eodag_command(
+            ["search", "-s", start_date, "-e", end_date]
+        )
         with click.Context(search_crunch) as ctx:
             self.assertEqual(
-                no_blanks(result.output),
+                no_blanks(output),
                 no_blanks(
                     "".join(
                         (
@@ -146,28 +181,27 @@ class TestEodagCli(unittest.TestCase):
                     )
                 ),
             )
-        self.assertNotEqual(result.exit_code, 0)
+        self.assertNotEqual(exit_code, 0)
+        self.assertIsInstance(error, SystemExit)
 
     def test_eodag_search_with_conf_file_inexistent(self):
         """Calling eodag search with --conf | -f set to a non-existent file should print error message"""  # noqa
         conf_file = "does_not_exist.yml"
-        result = self.runner.invoke(
-            eodag, ["search", "--conf", conf_file, "-p", "whatever"]
+        exit_code, output, error = self.eodag_command(
+            ["search", "--conf", conf_file, "-p", "whatever"]
         )
         expect_output = "Error: Invalid value for '-f' / '--conf': Path '{}' does not exist.".format(  # noqa
             conf_file
         )
-        self.assertTrue(
-            expect_output in result.output or expect_output.replace("'", '"')
-        )
-        self.assertNotEqual(result.exit_code, 0)
+        self.assertTrue(expect_output in output or expect_output.replace("'", '"'))
+        self.assertNotEqual(exit_code, 0)
+        self.assertIsInstance(error, SystemExit)
 
     def test_eodag_search_with_max_cloud_out_of_range(self):
         """Calling eodag search with -c | --maxCloud set to a value < 0 or > 100 should print error message"""  # noqa
         with self.user_conf() as conf_file:
             for max_cloud in (110, -1):
-                result = self.runner.invoke(
-                    eodag,
+                exit_code, output, error = self.eodag_command(
                     ["search", "--conf", conf_file, "-p", "whatever", "-c", max_cloud],
                 )
                 expect_output = (
@@ -175,29 +209,34 @@ class TestEodagCli(unittest.TestCase):
                     " valid range of 0 to 100."
                 ).format(max_cloud)
                 self.assertTrue(
-                    expect_output in result.output or expect_output.replace("'", '"')
+                    expect_output in output or expect_output.replace("'", '"')
                 )
-                self.assertNotEqual(result.exit_code, 0)
+                self.assertNotEqual(exit_code, 0)
+                self.assertIsInstance(error, UnsupportedProvider)
 
     def test_eodag_search_bbox_invalid(self):
         """Calling eodag search with -b | --bbox set with less than 4 params should print error message"""  # noqa
         with self.user_conf() as conf_file:
-            result = self.runner.invoke(
-                eodag, ["search", "--conf", conf_file, "-p", "whatever", "-b", 1, 2]
+            exit_code, output, error = self.eodag_command(
+                ["search", "--conf", conf_file, "-p", "whatever", "-b", 1, 2]
             )
-            self.assertIn("-b", result.output)
-            self.assertIn("requires 4 arguments", result.output)
-            self.assertNotEqual(result.exit_code, 0)
+            self.assertIn("-b", output)
+            self.assertIn("requires 4 arguments", output)
+            self.assertNotEqual(exit_code, 0)
+            self.assertIsInstance(error, SystemExit)
 
     @mock.patch("eodag.cli.EODataAccessGateway", autospec=True)
     def test_eodag_search_bbox_valid(self, dag):
         """Calling eodag search with --bbox argument valid"""
         with self.user_conf() as conf_file:
             collection = "whatever"
-            self.runner.invoke(
-                eodag,
+            exit_code, output, error = self.eodag_command(
                 ["search", "--conf", conf_file, "-c", collection, "-b", 1, 43, 2, 44],
             )
+            self.assertEqual(exit_code, 0)
+            self.assertIn("Results stored at", output)
+            self.assertIsNone(error)
+
             api_obj = dag.return_value
             api_obj.search.assert_called_once_with(
                 provider=None,
@@ -223,21 +262,19 @@ class TestEodagCli(unittest.TestCase):
     def test_eodag_search_geom_wkt_invalid(self):
         """Calling eodag search with -g | --geom set with invalit WKT geometry string"""  # noqa
         with self.user_conf() as conf_file:
-            result = self.runner.invoke(
-                eodag,
-                ["search", "--conf", conf_file, "-c", "whatever", "-g", "not a wkt"],
+            exit_code, _, error = self.eodag_command(
+                ["search", "--conf", conf_file, "-c", "whatever", "-g", "not a wkt"]
             )
+            self.assertNotEqual(exit_code, 0)
             # GEOSException for shapely >= 2.0
-            assert "WKTReadingError" in str(result) or "GEOSException" in str(result)
-            self.assertNotEqual(result.exit_code, 0)
+            self.assertTrue(isinstance(error, shapely.errors.GEOSException))
 
     @mock.patch("eodag.cli.EODataAccessGateway", autospec=True)
     def test_eodag_search_geom_wkt_valid(self, dag):
         """Calling eodag search with --geom WKT argument valid"""
         with self.user_conf() as conf_file:
             collection = "whatever"
-            self.runner.invoke(
-                eodag,
+            exit_code, output, error = self.eodag_command(
                 [
                     "search",
                     "--conf",
@@ -248,6 +285,10 @@ class TestEodagCli(unittest.TestCase):
                     "POLYGON ((1 43, 1 44, 2 44, 2 43, 1 43))",
                 ],
             )
+            self.assertEqual(exit_code, 0)
+            self.assertIn("Results stored at", output)
+            self.assertIsNone(error)
+
             api_obj = dag.return_value
             api_obj.search.assert_called_once_with(
                 provider=None,
@@ -273,8 +314,7 @@ class TestEodagCli(unittest.TestCase):
     def test_eodag_search_bbox_geom_mutually_exclusive(self):
         """Calling eodag search with both --geom and --box"""  # noqa
         with self.user_conf() as conf_file:
-            result = self.runner.invoke(
-                eodag,
+            exit_code, output, error = self.eodag_command(
                 [
                     "search",
                     "--conf",
@@ -288,10 +328,11 @@ class TestEodagCli(unittest.TestCase):
                     4,
                     "-g",
                     "a wkt",
-                ],
+                ]
             )
-            self.assertIn("Illegal usage", result.output)
-            self.assertNotEqual(result.exit_code, 0)
+            self.assertIn("Illegal usage", output)
+            self.assertNotEqual(exit_code, 0)
+            self.assertIsInstance(error, SystemExit)
 
     @mock.patch("eodag.cli.EODataAccessGateway", autospec=True)
     def test_eodag_search_storage_arg(self, dag):
@@ -299,8 +340,7 @@ class TestEodagCli(unittest.TestCase):
         with self.user_conf() as conf_file:
             api_obj = dag.return_value
             api_obj.search.return_value = SearchResult([mock.MagicMock() * 2], 2)
-            self.runner.invoke(
-                eodag,
+            exit_code, output, error = self.eodag_command(
                 [
                     "search",
                     "--conf",
@@ -309,8 +349,12 @@ class TestEodagCli(unittest.TestCase):
                     "whatever",
                     "--storage",
                     "results",
-                ],
+                ]
             )
+            self.assertEqual(exit_code, 0)
+            self.assertIn("Results stored at", output)
+            self.assertIsNone(error)
+
             api_obj.serialize.assert_called_with(
                 api_obj.search.return_value, filename="results.geojson"
             )
@@ -341,10 +385,12 @@ class TestEodagCli(unittest.TestCase):
                     "eodag:sensor_type": None,
                 },
             )
-            self.runner.invoke(
-                eodag,
-                ["search", "-f", conf_file, "-c", collection, "--cruncher", cruncher],
+            exit_code, output, error = self.eodag_command(
+                ["search", "-f", conf_file, "-c", collection, "--cruncher", cruncher]
             )
+            self.assertEqual(exit_code, 0)
+            self.assertIn("Results stored at", output)
+            self.assertIsNone(error)
 
             search_results = api_obj.search.return_value
             crunch_results = api_obj.crunch.return_value
@@ -365,8 +411,7 @@ class TestEodagCli(unittest.TestCase):
 
             # Call with a cruncher taking arguments
             cruncher = "FilterOverlap"
-            self.runner.invoke(
-                eodag,
+            exit_code, output, error = self.eodag_command(
                 [
                     "search",
                     "-f",
@@ -379,8 +424,13 @@ class TestEodagCli(unittest.TestCase):
                     cruncher,
                     "minimum_overlap",
                     "10",
-                ],
+                ]
             )
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn("Results stored at", output)
+            self.assertIsNone(error)
+
             api_obj.crunch.assert_called_with(
                 search_results,
                 search_criteria=criteria,
@@ -415,7 +465,7 @@ class TestEodagCli(unittest.TestCase):
                 },
             )
             self.runner.invoke(
-                eodag,
+                eodag_cli,
                 ["search", "-f", conf_file, "-c", collection, "download"],
             )
 
@@ -434,8 +484,7 @@ class TestEodagCli(unittest.TestCase):
         """Calling eodag search with --bbox argument valid"""
         with self.user_conf() as conf_file:
             collection = "whatever"
-            self.runner.invoke(
-                eodag,
+            exit_code, output, error = self.eodag_command(
                 [
                     "search",
                     "--conf",
@@ -445,8 +494,12 @@ class TestEodagCli(unittest.TestCase):
                     "-g",
                     "POLYGON ((1 43, 1 44, 2 44, 2 43, 1 43))",
                     "--all",
-                ],
+                ]
             )
+            self.assertEqual(exit_code, 0)
+            self.assertIn("Results stored at", output)
+            self.assertIsNone(error)
+
             api_obj = dag.return_value
             api_obj.search_all.assert_called_once_with(
                 provider=None,
@@ -472,8 +525,7 @@ class TestEodagCli(unittest.TestCase):
         """Calling eodag search with --query argument"""
         with self.user_conf() as conf_file:
             collection = "whatever"
-            self.runner.invoke(
-                eodag,
+            exit_code, output, error = self.eodag_command(
                 [
                     "search",
                     "--conf",
@@ -482,8 +534,12 @@ class TestEodagCli(unittest.TestCase):
                     collection,
                     "--query",
                     "foo=1&bar=2&bar=3",
-                ],
+                ]
             )
+            self.assertEqual(exit_code, 0)
+            self.assertIn("Results stored at", output)
+            self.assertIsNone(error)
+
             api_obj = dag.return_value
             api_obj.search.assert_called_once_with(
                 provider=None,
@@ -513,8 +569,7 @@ class TestEodagCli(unittest.TestCase):
         """Calling eodag search with --locations argument"""
         with self.user_conf() as conf_file:
             collection = "whatever"
-            self.runner.invoke(
-                eodag,
+            exit_code, output, error = self.eodag_command(
                 [
                     "search",
                     "--conf",
@@ -523,8 +578,12 @@ class TestEodagCli(unittest.TestCase):
                     collection,
                     "--locations",
                     "country=FRA&continent=Africa",
-                ],
+                ]
             )
+            self.assertEqual(exit_code, 0)
+            self.assertIn("Results stored at", output)
+            self.assertIsNone(error)
+
             api_obj = dag.return_value
             api_obj.search.assert_called_once_with(
                 provider=None,
@@ -556,8 +615,7 @@ class TestEodagCli(unittest.TestCase):
             start_date_datetime = datetime.strptime(
                 start_date_str, "%Y-%m-%d"
             ).isoformat()
-            self.runner.invoke(
-                eodag,
+            exit_code, output, error = self.eodag_command(
                 [
                     "search",
                     "--conf",
@@ -566,8 +624,12 @@ class TestEodagCli(unittest.TestCase):
                     collection,
                     "--start",
                     start_date_str,
-                ],
+                ]
             )
+            self.assertEqual(exit_code, 0)
+            self.assertIn("Results stored at", output)
+            self.assertIsNone(error)
+
             api_obj = dag.return_value
             api_obj.search.assert_called_once_with(
                 provider=None,
@@ -599,8 +661,7 @@ class TestEodagCli(unittest.TestCase):
             stop_date_datetime = datetime.strptime(
                 stop_date_str, "%Y-%m-%d"
             ).isoformat()
-            self.runner.invoke(
-                eodag,
+            exit_code, output, error = self.eodag_command(
                 [
                     "search",
                     "--conf",
@@ -610,8 +671,12 @@ class TestEodagCli(unittest.TestCase):
                     "--end",
                     stop_date_str,
                     "--count",
-                ],
+                ]
             )
+            self.assertEqual(exit_code, 0)
+            self.assertIn("Results stored at", output)
+            self.assertIsNone(error)
+
             api_obj = dag.return_value
             api_obj.search.assert_called_once_with(
                 provider=None,
@@ -641,8 +706,7 @@ class TestEodagCli(unittest.TestCase):
             locs_file = os.path.join(TEST_RESOURCES_PATH, "file_locations_override.yml")
 
             collection = "whatever"
-            self.runner.invoke(
-                eodag,
+            exit_code, output, error = self.eodag_command(
                 [
                     "search",
                     "--conf",
@@ -651,8 +715,11 @@ class TestEodagCli(unittest.TestCase):
                     locs_file,
                     "-c",
                     collection,
-                ],
+                ]
             )
+            self.assertEqual(exit_code, 0)
+            self.assertIn("Results stored at", output)
+            self.assertIsNone(error)
 
             dag.assert_called_once_with(
                 user_conf_file_path=conf_file,
@@ -666,10 +733,11 @@ class TestEodagCli(unittest.TestCase):
             for col, provs in test_core.TestCore.SUPPORTED_COLLECTIONS.items()
             if len(provs) != 0 and col != GENERIC_COLLECTION
         ]
-        result = self.runner.invoke(eodag, ["list", "--no-fetch"])
-        self.assertEqual(result.exit_code, 0)
+        exit_code, output, error = self.eodag_command(["list", "--no-fetch"])
+        self.assertEqual(exit_code, 0)
+        self.assertIsNone(error)
         for col in all_supported_collections:
-            self.assertIn(col, result.output)
+            self.assertIn(col, output)
 
     def test_eodag_list_collection_with_provider_ok(self):
         """Calling eodag list with provider should return all supported collections of specified provider"""  # noqa
@@ -680,39 +748,55 @@ class TestEodagCli(unittest.TestCase):
                 if provider in provs
                 if col != GENERIC_COLLECTION
             ]
-            result = self.runner.invoke(eodag, ["list", "-p", provider, "--no-fetch"])
-            self.assertEqual(result.exit_code, 0)
+            exit_code, output, error = self.eodag_command(
+                ["list", "-p", provider, "--no-fetch"]
+            )
+            self.assertEqual(exit_code, 0)
+            self.assertIsNone(error)
             for col in provider_supported_collections:
                 self.assertIn(
                     col,
-                    result.output,
+                    output,
                     f"{col} was not found in {provider} supported collections",
                 )
 
     def test_eodag_list_collection_with_provider_ko(self):
         """Calling eodag list with unsupported provider should fail and print a list of available providers"""  # noqa
         provider = "random"
-        result = self.runner.invoke(eodag, ["list", "-p", provider, "--no-fetch"])
-        self.assertEqual(result.exit_code, 1)
-        self.assertIn("Unsupported provider. You may have a typo", result.output)
+        exit_code, output, error = self.eodag_command(
+            ["list", "-p", provider, "--no-fetch"]
+        )
+        self.assertEqual(exit_code, 1)
+        self.assertIsInstance(error, SystemExit)
+        self.assertIn("Unsupported provider. You may have a typo", output)
         self.assertIn(
             f"Available providers: {', '.join(test_core.TestCore.SUPPORTED_PROVIDERS)}",
-            result.output,
+            output,
         )
 
     @mock.patch("eodag.cli.EODataAccessGateway.fetch_collections_list", autospec=True)
     def test_eodag_list_collection_fetch(self, mock_fetch_collections_list):
         """Calling eodag list should fetch for new collections depending on passed option"""
-        result = self.runner.invoke(eodag, ["list", "--no-fetch"])
-        self.assertEqual(result.exit_code, 0)
+
+        exit_code, output, error = self.eodag_command(["list", "--no-fetch"])
+        self.assertEqual(exit_code, 0)
+        self.assertIn("Listing available collections:", output)
+        self.assertIsNone(error)
+
         assert not mock_fetch_collections_list.called
 
-        result = self.runner.invoke(eodag, ["list"])
-        self.assertEqual(result.exit_code, 0)
+        exit_code, output, error = self.eodag_command(["list"])
+        self.assertEqual(exit_code, 0)
+        self.assertIn("Listing available collections:", output)
+        self.assertIsNone(error)
+
         mock_fetch_collections_list.assert_called_once_with(mock.ANY, provider=None)
 
-        result = self.runner.invoke(eodag, ["list", "-p", "peps"])
-        self.assertEqual(result.exit_code, 0)
+        exit_code, output, error = self.eodag_command(["list", "-p", "peps"])
+        self.assertEqual(exit_code, 0)
+        self.assertIn("Listing available collections:", output)
+        self.assertIsNone(error)
+
         mock_fetch_collections_list.assert_called_with(mock.ANY, provider="peps")
         self.assertEqual(mock_fetch_collections_list.call_count, 2)
 
@@ -737,16 +821,15 @@ class TestEodagCli(unittest.TestCase):
                 Collection.create_with_dag(dag=dag, id="baz", title="this is baz"),
             ]
         )
-
-        result = self.runner.invoke(
-            eodag,
-            ["list", "-p", provider, "--platform", "S2A", "--no-fetch"],
+        exit_code, output, error = self.eodag_command(
+            ["list", "-p", provider, "--platform", "S2A", "--no-fetch"]
         )
-        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(exit_code, 0)
+        self.assertIsNone(error)
 
-        self.assertIn("foo", result.output)
-        self.assertIn("bar", result.output)
-        self.assertNotIn("baz", result.output)
+        self.assertIn("foo", output)
+        self.assertIn("bar", output)
+        self.assertNotIn("baz", output)
 
         dag.return_value.list_collections.assert_called_with(
             provider=provider, fetch_providers=False
@@ -761,15 +844,15 @@ class TestEodagCli(unittest.TestCase):
         """Calling eodag list with invalid collection feature(s) should print a
         'no matching' type message and return error code.
         """
-        result = self.runner.invoke(
-            eodag,
-            ["list", "--platform", "fake_identifier", "--no-fetch"],
+        exit_code, output, error = self.eodag_command(
+            ["list", "--platform", "fake_identifier", "--no-fetch"]
         )
+        self.assertNotEqual(exit_code, 0)
+        self.assertIsInstance(error, SystemExit)
         self.assertIn(
             "No collection match the following criteria you provided:\n",
-            result.output,
+            output,
         )
-        self.assertNotEqual(result.exit_code, 0)
 
     @mock.patch(
         "eodag.cli.EODataAccessGateway.discover_collections",
@@ -787,14 +870,20 @@ class TestEodagCli(unittest.TestCase):
             self.assertFalse(os.path.isfile(default_output_path))
 
             # call without any arg
-            result = self.runner.invoke(eodag, ["discover"])
-            self.assertEqual(result.exit_code, 0)
+            exit_code, output, error = self.eodag_command(["discover"])
+            self.assertEqual(exit_code, 0)
+            self.assertIsNone(error)
+            self.assertIn("Results stored at", output)
+
             mock_discover_collections.assert_called_once_with(mock.ANY)
             self.assertTrue(os.path.isfile(default_output_path))
 
             # call with provider
-            result = self.runner.invoke(eodag, ["discover", "-p", "peps"])
-            self.assertEqual(result.exit_code, 0)
+            exit_code, output, error = self.eodag_command(["discover", "-p", "peps"])
+            self.assertEqual(exit_code, 0)
+            self.assertIsNone(error)
+            self.assertIn("Results stored at", output)
+
             mock_discover_collections.assert_called_with(mock.ANY, provider="peps")
             self.assertEqual(mock_discover_collections.call_count, 2)
             os.remove(default_output_path)
@@ -803,8 +892,14 @@ class TestEodagCli(unittest.TestCase):
             # call with filename without extension
             self.assertFalse(os.path.isfile(other_file_path))
             self.assertFalse(os.path.isfile(f"{other_file_path}.json"))
-            result = self.runner.invoke(eodag, ["discover", "--storage", "toto"])
-            self.assertEqual(result.exit_code, 0)
+
+            exit_code, output, error = self.eodag_command(
+                ["discover", "--storage", "toto"]
+            )
+            self.assertEqual(exit_code, 0)
+            self.assertIsNone(error)
+            self.assertIn("Results stored at 'toto.json'", output)
+
             mock_discover_collections.assert_called_with(mock.ANY)
             self.assertEqual(mock_discover_collections.call_count, 3)
             self.assertFalse(os.path.isfile(other_file_path))
@@ -813,8 +908,14 @@ class TestEodagCli(unittest.TestCase):
 
             # call with filename with extension
             self.assertFalse(os.path.isfile(f"{other_file_path}.json"))
-            result = self.runner.invoke(eodag, ["discover", "--storage", "toto.json"])
-            self.assertEqual(result.exit_code, 0)
+
+            exit_code, output, error = self.eodag_command(
+                ["discover", "--storage", "toto.json"]
+            )
+            self.assertEqual(exit_code, 0)
+            self.assertIsNone(error)
+            self.assertIn("Results stored at 'toto.json'", output)
+
             mock_discover_collections.assert_called_with(mock.ANY)
             self.assertEqual(mock_discover_collections.call_count, 4)
             self.assertTrue(os.path.isfile(f"{other_file_path}.json"))
@@ -824,10 +925,13 @@ class TestEodagCli(unittest.TestCase):
 
     def test_eodag_download_no_search_results_arg(self):
         """Calling eodag download without a path to a search result should fail"""
-        result = self.runner.invoke(eodag, ["download"])
+        exit_code, output, error = self.eodag_command(["download"])
+        self.assertEqual(exit_code, 1)
+        self.assertIsInstance(error, SystemExit)
+
         with click.Context(download) as ctx:
             self.assertEqual(
-                no_blanks(result.output),
+                no_blanks(output),
                 no_blanks(
                     "".join(
                         (
@@ -837,7 +941,6 @@ class TestEodagCli(unittest.TestCase):
                     )
                 ),
             )
-        self.assertEqual(result.exit_code, 1)
 
     @mock.patch("eodag.cli.EODataAccessGateway", autospec=True)
     def test_eodag_download_ok(self, dag):
@@ -847,31 +950,35 @@ class TestEodagCli(unittest.TestCase):
         )
         config_path = os.path.join(TEST_RESOURCES_PATH, "file_config_override.yml")
         dag.return_value.download_all.return_value = ["/fake_path"]
-        result = self.runner.invoke(
-            eodag,
+
+        exit_code, output, error = self.eodag_command(
             ["download", "--search-results", search_results_path, "-f", config_path],
         )
+        self.assertEqual(exit_code, 0)
+        self.assertIsNone(error)
+        self.assertIn("Downloaded", output)
+
         dag.assert_called_once_with(user_conf_file_path=config_path)
         dag.return_value.deserialize_and_register.assert_called_once_with(
             search_results_path
         )
         self.assertEqual(dag.return_value.download_all.call_count, 1)
-        self.assertEqual("Downloaded /fake_path\n", result.output)
+        self.assertEqual("Downloaded /fake_path\n", output)
 
         # Testing the case when no downloaded path is returned
         dag.return_value.download_all.return_value = [None]
-        result = self.runner.invoke(
-            eodag,
+        exit_code, output, error = self.eodag_command(
             ["download", "--search-results", search_results_path, "-f", config_path],
         )
+        self.assertEqual(exit_code, 0)
+        self.assertIsNone(error)
         self.assertEqual(
-            "A file may have been downloaded but we cannot locate it\n", result.output
+            "A file may have been downloaded but we cannot locate it\n", output
         )
 
         # Testing output directory
         output_dir = os.path.join(self.tmp_home_dir.name, "downloads")
-        result = self.runner.invoke(
-            eodag,
+        exit_code, output, error = self.eodag_command(
             [
                 "download",
                 "--search-results",
@@ -882,6 +989,10 @@ class TestEodagCli(unittest.TestCase):
                 output_dir,
             ],
         )
+        self.assertEqual(exit_code, 0)
+        self.assertIsNone(error)
+        self.assertIn("A file may have been downloaded but we cannot locate it", output)
+
         dag.return_value.download_all.assert_called_with(
             mock.ANY, output_dir=output_dir, executor=mock.ANY
         )
@@ -894,13 +1005,14 @@ class TestEodagCli(unittest.TestCase):
         )
         config_path = os.path.join(TEST_RESOURCES_PATH, "file_config_override.yml")
         dag.return_value.download_all.return_value = []
-        result = self.runner.invoke(
-            eodag,
+        exit_code, output, error = self.eodag_command(
             ["download", "--search-results", search_results_path, "-f", config_path],
         )
+        self.assertEqual(exit_code, 0)
+        self.assertIsNone(error)
         self.assertEqual(
             "Error during download, a file may have been downloaded but we cannot locate it\n",
-            result.output,
+            output,
         )
 
     @mock.patch("eodag.cli.EODataAccessGateway", autospec=True)
@@ -909,8 +1021,7 @@ class TestEodagCli(unittest.TestCase):
         fake_result = SearchResult([mock.MagicMock() * 2], 2)
         dag.return_value.import_stac_items.return_value = fake_result
         with self.user_conf() as conf_file:
-            self.runner.invoke(
-                eodag,
+            exit_code, output, error = self.eodag_command(
                 [
                     "download",
                     "--conf",
@@ -921,6 +1032,13 @@ class TestEodagCli(unittest.TestCase):
                     "bar",
                 ],
             )
+            self.assertEqual(exit_code, 0)
+            self.assertIsNone(error)
+            self.assertIn(
+                "Error during download, a file may have been downloaded but we cannot locate it",
+                output,
+            )
+
             dag.return_value.import_stac_items.assert_called_once_with(
                 ["foo", "bar"],
             )
@@ -936,18 +1054,17 @@ class TestEodagCli(unittest.TestCase):
         default_conf_file = str(
             res_files("eodag") / "resources" / "user_conf_template.yml"
         )
-        result = self.runner.invoke(
-            eodag,
+        exit_code, _, error = self.eodag_command(
             [
                 "download",
                 "--search-results",
                 search_results_path,
                 "-f",
                 default_conf_file,
-            ],
+            ]
         )
-        self.assertEqual(result.exit_code, 1)
-        self.assertIsInstance(result.exception, MisconfiguredError)
+        self.assertEqual(exit_code, 1)
+        self.assertIsInstance(error, MisconfiguredError)
 
     @mock.patch("eodag.plugins.download.http.HTTPDownload.download", autospec=True)
     def test_eodag_download_wrongcredentials(self, download):
@@ -959,8 +1076,7 @@ class TestEodagCli(unittest.TestCase):
         search_results_path = os.path.join(
             TEST_RESOURCES_PATH, "eodag_search_result.geojson"
         )
-        result = self.runner.invoke(
-            eodag,
+        exit_code, _, error = self.eodag_command(
             ["download", "--search-results", search_results_path],
             # We override the default (empty) credentials with dummy values not
             # to raise a MisconfiguredError.
@@ -969,8 +1085,8 @@ class TestEodagCli(unittest.TestCase):
                 "EODAG__PEPS__AUTH__CREDENTIALS__PASSWORD": "dummy",
             },
         )
-        self.assertEqual(result.exit_code, 1)
-        self.assertIsInstance(result.exception, AuthenticationError)
+        self.assertEqual(exit_code, 1)
+        self.assertIsInstance(error, AuthenticationError)
         self.assertEqual(download.call_count, 1)
 
     @mock.patch("eodag.api.product._product.EOProduct.get_quicklook", autospec=True)
@@ -981,8 +1097,7 @@ class TestEodagCli(unittest.TestCase):
         )
         config_path = os.path.join(TEST_RESOURCES_PATH, "file_config_override.yml")
         mock_get_quicklook.return_value = "/fake_path"
-        result = self.runner.invoke(
-            eodag,
+        exit_code, output, error = self.eodag_command(
             [
                 "download",
                 "--search-results",
@@ -992,19 +1107,20 @@ class TestEodagCli(unittest.TestCase):
                 "--quicklooks",
             ],
         )
+        self.assertEqual(exit_code, 0)
+        self.assertIsNone(error)
         self.assertIn(
             "Flag 'quicklooks' specified, downloading only quicklooks of products\n",
-            result.output,
+            output,
         )
 
         # 2 quicklooks are called in search_results_path
         self.assertEqual(mock_get_quicklook.call_count, 2)
-        self.assertIn("Downloaded /fake_path\n", result.output)
+        self.assertIn("Downloaded /fake_path\n", output)
 
         # change output dir
         output_dir = os.path.join(self.tmp_home_dir.name, "quicklooks")
-        result = self.runner.invoke(
-            eodag,
+        exit_code, output, error = self.eodag_command(
             [
                 "download",
                 "--search-results",
@@ -1014,14 +1130,17 @@ class TestEodagCli(unittest.TestCase):
                 "--quicklooks",
                 "--output-dir",
                 output_dir,
-            ],
+            ]
         )
+        self.assertEqual(exit_code, 0)
+        self.assertIsNone(error)
+        self.assertIn("Downloaded", output)
+
         mock_get_quicklook.assert_called_with(mock.ANY, output_dir=output_dir)
 
         # Testing the case when no quicklook path is returned
         mock_get_quicklook.return_value = None
-        result = self.runner.invoke(
-            eodag,
+        exit_code, output, error = self.eodag_command(
             [
                 "download",
                 "--search-results",
@@ -1031,8 +1150,10 @@ class TestEodagCli(unittest.TestCase):
                 "--quicklooks",
             ],
         )
+        self.assertEqual(exit_code, 0)
+        self.assertIsNone(error)
         self.assertIn(
             "A quicklook may have been downloaded but we cannot locate it. "
             "Increase verbosity for more details: `eodag -v download [OPTIONS]`",
-            result.output,
+            output,
         )

--- a/tests/units/test_eoproduct.py
+++ b/tests/units/test_eoproduct.py
@@ -24,6 +24,7 @@ import random
 import shutil
 import string
 import tempfile
+import time
 import zipfile
 
 import geojson
@@ -479,9 +480,14 @@ class TestEOProduct(EODagTestCase):
         # should be product id cast to str
         self.assertEqual(progress_callback.desc, "12345")
 
+        # Progressbar need at least "progress_callback.mininterval" seconds, here 0.1 second
+        # Wait 0.2 to be sure progress ends
+        time.sleep(0.2)
+
         # progress bar finished
-        self.assertEqual(progress_callback.n, progress_callback.total)
-        self.assertGreater(progress_callback.total, 0)
+        self.assertEqual(progress_callback.initial, 0)
+        self.assertEqual(progress_callback.total, 1)
+        self.assertEqual(progress_callback.pos, 1)
 
     def test_eoproduct_register_downloader(self):
         """eoproduct.register_donwloader must set download and auth plugins"""

--- a/tests/units/test_provider.py
+++ b/tests/units/test_provider.py
@@ -372,7 +372,3 @@ class TestProvidersDict:
             providers_dict.update_from_configs(invalid_configs)
             mock_logger.warning.assert_called()
             assert len(providers_dict) == 0
-
-
-if __name__ == "__main__":
-    pytest.main([__file__])

--- a/tests/units/test_utils_cache.py
+++ b/tests/units/test_utils_cache.py
@@ -81,7 +81,3 @@ class TestCachedMethodDecorator(unittest.TestCase):
         # Calling with 1 again is a cache miss (evicted), so call_count increments
         obj.method(1)
         self.assertEqual(obj.call_count, 4)
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
__________________________________________________________________________

Resolve collision on name "eodag", is module and cli root object "eodag"
Proposal: remane cli root function as "eodag_cli":

def eodag_cli(ctx: Context, verbose: int) -> None:
[...]
@eodag_cli.command
[...]
if __name__ == "__main__":
    eodag_cli(obj={})

__________________________________________________________________________

By fixing tests, see some lack on syspath / bootstrap set, it fixed.
Steadify cli test by ensure assert on each command line
__________________________________________________________________________


Fix eoproduct test to be able to validate PR
test_eoproduct.py:482
```
        # progress bar finished
        self.assertEqual(progress_callback.n, progress_callback.total)
```
Progressbar has a temporal behaviour, then depens of 100ms passed, progress_callback.n can be ==0 or ==1
By waiting de safe duration to ensure progress bar completed, test is safe now

```
        # Progressbar need at least "progress_callback.mininterval" seconds, here 0.1 second
        # Wait 0.2 to be sure progress ends
        time.sleep(0.2)

        # progress bar finished
        self.assertEqual(progress_callback.n, 1)
```
__________________________________________________________________________

Test concurency troubleshot: 
```
  _______________ TestCollectionsList.test_search_result_repr_html _______________
  [gw3] linux -- Python 3.14.2 /home/runner/work/eodag/eodag/.tox/py314/bin/python3
  
  self = <tests.units.test_collection.TestCollectionsList testMethod=test_search_result_repr_html>
  
      def setUp(self):
          super(TestCollectionsList, self).setUp()
  >       self.dag = EODataAccessGateway()
                     ^^^^^^^^^^^^^^^^^^^^^
  
  tests/units/test_collection.py:298: 
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  eodag/api/core.py:158: in __init__
      copyfile(src, dst, follow_symlinks=follow_symlinks)
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  
  src = '/home/runner/work/eodag/eodag/eodag/resources/user_conf_template.yml'
  dst = '/home/runner/work/eodag/eodag/.tox/py314/tmp/.config/eodag/eodag.yml'
  
      def copyfile(src, dst, *, follow_symlinks=True):
          """Copy data from src to dst in the most efficient way possible.
      
          If follow_symlinks is not set and src is a symbolic link, a new
          symlink will be created instead of copying the file it points to.
      
          """
          sys.audit("shutil.copyfile", src, dst)
      
          if _samefile(src, dst):
              raise SameFileError("{!r} and {!r} are the same file".format(src, dst))
      
          file_size = 0
          for i, fn in enumerate([src, dst]):
              try:
                  st = _stat(fn)
              except OSError:
                  # File most likely does not exist
                  pass
              else:
                  # XXX What about other special files? (sockets, devices...)
                  if stat.S_ISFIFO(st.st_mode):
                      fn = fn.path if isinstance(fn, os.DirEntry) else fn
                      raise SpecialFileError("`%s` is a named pipe" % fn)
                  if _WINDOWS and i == 0:
                      file_size = st.st_size
      
          if not follow_symlinks and _islink(src):
              os.symlink(os.readlink(src), dst)
          else:
              with open(src, 'rb') as fsrc:
                  try:
  >                   with open(dst, 'wb') as fdst:
                           ^^^^^^^^^^^^^^^
  E                   FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/work/eodag/eodag/.tox/py314/tmp/.config/eodag/eodag.yml'
  
  ../../../.local/share/uv/python/cpython-3.14.2-linux-x86_64-gnu/lib/python3.14/shutil.py:315: FileNotFoundError
```
Config files are manipulated from multiple instance of EODataAccessGateway, from multiple test thread, have to steadify concurency manage.

