### PR TITLE
test: end-to-end tests fixes

### DIFF
--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -404,7 +404,7 @@ class TestEODagEndToEnd(EndToEndBase):
 
     def test_end_to_end_search_download_creodias(self):
         product = self.execute_search(*CREODIAS_SEARCH_ARGS)
-        self.eodag.providers_config["creodias"].auth.credentials[
+        self.eodag._providers.configs["creodias"].auth.credentials[
             "totp"
         ] = "PLEASE_CHANGE_ME"
         expected_filename = "{}.zip".format(product.properties["title"])
@@ -573,32 +573,6 @@ class TestEODagEndToEnd(EndToEndBase):
                 msg=f"tileIdentifier not mapped for {provider}",
             )
 
-    def test_end_to_end_discover_collections_creodias(self):
-        """discover_collections() must return an external collections configuration for creodias"""
-        provider = "creodias"
-        ext_collections_conf = self.eodag.discover_collections(provider=provider)
-        self.assertEqual(
-            "SENTINEL-1",
-            ext_collections_conf[provider]["providers_config"]["SENTINEL-1"][
-                "collection"
-            ],
-        )
-        self.assertEqual(
-            "SENTINEL-1",
-            ext_collections_conf[provider]["collections_config"]["SENTINEL-1"]["title"],
-        )
-        # check that all pre-configured collections are listed by provider
-        provider_collections = [
-            v["collection"]
-            for k, v in self.eodag.providers_config[provider].products.items()
-            if k != GENERIC_COLLECTION
-        ]
-        for provider_collection in provider_collections:
-            self.assertIn(
-                provider_collection,
-                ext_collections_conf[provider]["providers_config"],
-            )
-
     def test_end_to_end_discover_collections_usgs_satapi_aws(self):
         """discover_collections() must return an external collections configuration for usgs_satapi_aws"""
         provider = "usgs_satapi_aws"
@@ -624,7 +598,7 @@ class TestEODagEndToEnd(EndToEndBase):
         # check that all pre-configured collections are listed by provider
         provider_collections = [
             v["_collection"]
-            for k, v in self.eodag.providers_config[provider].products.items()
+            for k, v in self.eodag.providers.configs[provider].products.items()
             if k != GENERIC_COLLECTION
         ]
         for provider_collection in provider_collections:
@@ -640,7 +614,7 @@ class TestEODagEndToEnd(EndToEndBase):
         self.assertEqual(
             "sentinel-2-l1c",
             ext_collections_conf[provider]["providers_config"]["sentinel-2-l1c"][
-                "collection"
+                "_collection"
             ],
         )
         self.assertEqual(
@@ -650,15 +624,15 @@ class TestEODagEndToEnd(EndToEndBase):
             ],
         )
         self.assertEqual(
-            "other",
+            "proprietary",
             ext_collections_conf[provider]["collections_config"]["sentinel-2-l1c"][
                 "license"
             ],
         )
         # check that all pre-configured collections are listed by provider
         provider_collections = [
-            v["collection"]
-            for k, v in self.eodag.providers_config[provider].products.items()
+            v["_collection"]
+            for k, v in self.eodag.providers.configs[provider].products.items()
             if k != GENERIC_COLLECTION
         ]
         for provider_collection in provider_collections:
@@ -671,7 +645,7 @@ class TestEODagEndToEnd(EndToEndBase):
         """discover_collections() must return None for earth_search_gcs"""
         provider = "earth_search_gcs"
         ext_collections_conf = self.eodag.discover_collections(provider=provider)
-        self.assertIsNone(ext_collections_conf[provider])
+        self.assertDictEqual(ext_collections_conf, {})
 
     def test_end_to_end_discover_collections_fedeo_ceda(self):
         """discover_collections() must return an external collections configuration for fedeo ceda"""
@@ -715,30 +689,17 @@ class TestEODagEndToEndComplete(EndToEndBase):
         cls.tmp_download_dir = TemporaryDirectory()
         cls.tmp_download_path = cls.tmp_download_dir.name
 
-        for provider, conf in cls.eodag.providers_config.items():
-            # Change download directory to cls.tmp_download_path for tests
-            if hasattr(conf, "download") and hasattr(conf.download, "output_dir"):
-                conf.download.output_dir = cls.tmp_download_path
-            elif hasattr(conf, "api") and hasattr(conf.api, "output_dir"):
-                conf.api.output_dir = cls.tmp_download_path
-            else:
-                # no output_dir found for provider
-                pass
-            # Force all providers implementing RestoSearch and defining how to retrieve
-            # products by specifying the
-            # location scheme to use https, enabling actual downloading of the product
-            if (
-                getattr(getattr(conf, "search", {}), "product_location_scheme", "https")
-                == "file"
-            ):
-                conf.search.product_location_scheme = "https"
-
     @classmethod
     def tearDownClass(cls):
         cls.tmp_download_dir.cleanup()
 
     def test_end_to_end_complete_peps(self):
         """Complete end-to-end test with PEPS for download and download_all"""
+
+        self.eodag._providers.configs[
+            "peps"
+        ].download.output_dir = self.tmp_download_path
+
         # Search for products that are succeeded and as small as possible
         today = datetime.date.today()
         month_span = datetime.timedelta(weeks=4)
@@ -751,7 +712,7 @@ class TestEODagEndToEndComplete(EndToEndBase):
             provider="peps",
         )
         prods_sorted_by_size = SearchResult(
-            sorted(search_results, key=lambda p: p.properties["resourceSize"])
+            sorted(search_results, key=lambda p: p.properties["peps:resourceSize"])
         )
         prods_online = [
             p
@@ -877,9 +838,11 @@ class TestEODagEndToEndComplete(EndToEndBase):
 
         # The returned paths must point to the downloaded archives
         # Each product's location must be a URI path to the archive
-        for product, archive_path in zip(products, archive_paths):
+        self.assertEqual(len(archive_paths), len(products))
+        for archive_path in archive_paths:
             self.assertTrue(os.path.isfile(archive_path))
-            self.assertEqual(uri_to_path(product.location), archive_path)
+        for product in products:
+            self.assertIn(uri_to_path(product.location), archive_paths)
 
         # Downloading the product again should not download them, since
         # they are all already there.


### PR DESCRIPTION
Updates end-to-end tests with:
- `threading` instead of `multiprocessing` usage for download handling
- updated syntax using `Providers` objects