### PR TITLE
build: bump alpine version on Dockerfile to prevent certificate error on geodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:alpine3.13
+FROM python:alpine3.23
 
 LABEL author="CS GROUP - France"
 


### PR DESCRIPTION
### Description
The current Docker file does not contain the latest Hellenic Academic and Research Institutions CA that is used by GEODES API (https://geodes-portal.cnes.fr). This lead to a download error from eodag cli.

```
/etc/ssl/certs $ eodag download -f /var/lib/data/lis-cwl/creds.yml --stac-item https://geo
des-portal.cnes.fr/api/stac/collections/THEIA_REFLECTANCE_SENTINEL2_L2A/items/URN:FEATURE:
DATA:gdh:a70f1345-1952-3104-80d3-d8e9b8acbe1b:V1
Traceback (most recent call last):
  File "/usr/local/bin/eodag", line 8, in <module>
    sys.exit(eodag())
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1406, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1904, in invoke
    rv.append(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/eodag/cli.py", line 612, in download
    search_results.extend(satim_api.import_stac_items(list(stac_items)))
  File "/usr/local/lib/python3.10/site-packages/eodag/api/core.py", line 2423, in import_stac_items
    json_items.extend(fetch_stac_items(item_url))
  File "/usr/local/lib/python3.10/site-packages/eodag/utils/stac_reader.py", line 128, in fetch_stac_items
    stac_obj = pystac.read_file(stac_path, stac_io=stac_io)
  File "/usr/local/lib/python3.10/site-packages/pystac/__init__.py", line 168, in read_file
    return stac_io.read_stac_object(href)
  File "/usr/local/lib/python3.10/site-packages/pystac/stac_io.py", line 229, in read_stac_object
    d = self.read_json(source, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/pystac/stac_io.py", line 200, in read_json
    txt = self.read_text(source, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/eodag/utils/stac_reader.py", line 101, in __call__
    raise STACOpenerError(f"No opener available to open {url}")
eodag.utils.exceptions.STACOpenerError: No opener available to open https://geodes-portal.cnes.fr/api/stac/collections/THEIA_REFLECTANCE_SENTINEL2_L2A/items/URN:FEATURE:DATA:gdh:a70f1345-1952-3104-80d3-d8e9b8acbe1b:V1
```
Certs installed: 
```
/etc/ssl/certs $ ls -al | grep Hellenic
lrwxrwxrwx    1 root     root            67 Nov 13  2021 1636090b.0 -> ca-cert-Hellenic_Academic_and_Research_Institutions_RootCA_2011.pem
lrwxrwxrwx    1 root     root            67 Nov 13  2021 32888f65.0 -> ca-cert-Hellenic_Academic_and_Research_Institutions_RootCA_2015.pem
lrwxrwxrwx    1 root     root            71 Nov 13  2021 7719f463.0 -> ca-cert-Hellenic_Academic_and_Research_Institutions_ECC_RootCA_2015.pem
lrwxrwxrwx    1 root     root            98 Nov 13  2021 ca-cert-Hellenic_Academic_and_Research_Institutions_ECC_RootCA_2015.pem -> /usr/share/ca-certificates/mozilla/Hellenic_Academic_and_Research_Institutions_ECC_RootCA_2015.crt
lrwxrwxrwx    1 root     root            94 Nov 13  2021 ca-cert-Hellenic_Academic_and_Research_Institutions_RootCA_2011.pem -> /usr/share/ca-certificates/mozilla/Hellenic_Academic_and_Research_Institutions_RootCA_2011.crt
lrwxrwxrwx    1 root     root            94 Nov 13  2021 ca-cert-Hellenic_Academic_and_Research_Institutions_RootCA_2015.pem -> /usr/share/ca-certificates/mozilla/Hellenic_Academic_and_Research_Institutions_RootCA_2015.crt
```
Certs used by GEODES API :
````
$ openssl s_client -showcerts -connect geodes-portal.cnes.fr:443
CONNECTED(00000003)
depth=2 C = GR, O = Hellenic Academic and Research Institutions CA, CN = HARICA TLS RSA Root CA 2021
verify return:1
depth=1 C = GR, O = Hellenic Academic and Research Institutions CA, CN = GEANT TLS RSA 1
verify return:1
depth=0 C = FR, ST = \C3\8Ele-de-France, L = Paris, O = Centre National D'\C3\A9tudes Spatiales, CN = geodes-portal.cnes.fr
verify return:1
````