### PR TITLE
fix(providers): creodias processing:version as str

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -797,7 +797,7 @@
         - '$.Attributes.processingCenter'
       processing:version:
         - null
-        - '$.Attributes.processorVersion'
+        - '{$.Attributes.processorVersion#to_geojson}'
       _processor_name:
         - null
         - '$.Attributes.processorName'
@@ -2438,7 +2438,7 @@
         - '$.Attributes.processingCenter'
       processing:version:
         - null
-        - '$.Attributes.processorVersion'
+        - '{$.Attributes.processorVersion#to_geojson}'
       _processor_name:
         - null
         - '$.Attributes.processorName'
@@ -4060,7 +4060,7 @@
         - '$.Attributes.processingCenter'
       processing:version:
         - null
-        - '$.Attributes.processorVersion'
+        - '{$.Attributes.processorVersion#to_geojson}'
       _processor_name:
         - null
         - '$.Attributes.processorName'


### PR DESCRIPTION
Updates `creodias*` and `cop_dataspace` metadata-mapping to return `processing:version` as str as [expected](https://github.com/stac-extensions/processing?tab=readme-ov-file#fields)