### PR TITLE
chore: update assets rendering depth

### DIFF
--- a/eodag/api/product/_assets.py
+++ b/eodag/api/product/_assets.py
@@ -129,7 +129,7 @@ class AssetsDict(UserDict):
                         ...
                     }}
                 </summary>
-                    {dict_to_html_table(v, depth=1)}
+                    {dict_to_html_table(v, depth=2)}
                 </details>
                 </td></tr>
                 """


### PR DESCRIPTION
Updates assets html rendering depth in notebooks for better representation when dictionaries in their metadata

<img width="969" height="478" alt="image" src="https://github.com/user-attachments/assets/82fa1a0c-bf09-4a24-8399-5cd1d4304b92" />
