### PR TITLE
fix(core): list queryables for custom collections

### DIFF
--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -80,7 +80,6 @@ from eodag.utils.exceptions import (
     NoMatchingCollection,
     PluginImplementationError,
     RequestError,
-    UnsupportedCollection,
     UnsupportedProvider,
     ValidationError,
 )
@@ -2183,13 +2182,13 @@ class EODataAccessGateway:
                             provider=provider, fetch_providers=True
                         )
                     ]
-                raise UnsupportedCollection(f"{collection} is not available.")
             try:
                 kwargs["collection"] = collection = self.get_collection_from_alias(
                     collection
                 )
-            except NoMatchingCollection as e:
-                raise UnsupportedCollection(f"{collection} is not available.") from e
+            except NoMatchingCollection:
+                # try fetching queryables for custom collection even if not known
+                pass
 
         if not provider and not collection:
             return QueryablesDict(

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -32,6 +32,7 @@ import yaml
 from concurrent.futures import ThreadPoolExecutor
 from lxml import html
 from pydantic import ValidationError as PydanticValidationError
+from requests.exceptions import RequestException
 from shapely import wkt
 from shapely.geometry import LineString, MultiPolygon, Polygon
 
@@ -53,7 +54,6 @@ from tests.context import (
     Queryables,
     RequestError,
     SearchResult,
-    UnsupportedCollection,
     UnsupportedProvider,
     get_geometry_from_various,
     load_default_config,
@@ -1470,6 +1470,11 @@ class TestCore(TestCoreBase):
         self.dag.update_providers_config(new_config)
 
     @mock.patch(
+        "eodag.utils.requests.requests.sessions.Session.get",
+        autospec=True,
+        side_effect=RequestException,
+    )
+    @mock.patch(
         "eodag.plugins.manager.PluginManager.get_auth_plugin",
         autospec=True,
     )
@@ -1486,13 +1491,14 @@ class TestCore(TestCoreBase):
         mock_stacsearch_discover_queryables: mock.Mock,
         mock_fetch_collections_list: mock.Mock,
         mock_auth_plugin: mock.Mock,
+        mock_requests_get: mock.Mock,
     ) -> None:
         """list_queryables must return queryables list adapted to provider and collection"""
 
         with self.assertRaises(UnsupportedProvider):
             self.dag.list_queryables(provider="not_supported_provider")
 
-        with self.assertRaises(UnsupportedCollection):
+        with self.assertRaises(RequestError):
             self.dag.list_queryables(collection="not_supported_collection")
 
         # No provider & no collection


### PR DESCRIPTION
Allows listing queryables for custom collections.

Before this fix:
```py
dag.list_queryables(provider="cop_cds", collection="reanalysis-era5-single-levels-timeseries")
```
raises
```
eodag.utils.exceptions.UnsupportedCollection: reanalysis-era5-single-levels-timeseries is not available.
```

After the fix, method returns:
```py
{'ecmwf_data_format': typing.Annotated[typing.Literal['csv', 'netcdf'], FieldInfo(an[...]}
```

Fixes #1615