### PR TITLE
fix(plugins): order of values of EcmwfSearch bbox is N-W-S-E

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -265,6 +265,12 @@ def _update_properties_from_element(
                 "items": [
                     {
                         "type": "number",
+                        "maximum": 90,
+                        "minimum": -90,
+                        "description": "North border of the bounding box",
+                    },
+                    {
+                        "type": "number",
                         "maximum": 180,
                         "minimum": -180,
                         "description": "West border of the bounding box",
@@ -280,12 +286,6 @@ def _update_properties_from_element(
                         "maximum": 180,
                         "minimum": -180,
                         "description": "East border of the bounding box",
-                    },
-                    {
-                        "type": "number",
-                        "maximum": 90,
-                        "minimum": -90,
-                        "description": "North border of the bounding box",
                     },
                 ],
             }


### PR DESCRIPTION
The order of the values of the parameter `ecmwf:area` is N-W-S-E, as you can see from the [ADS portal](https://ads.atmosphere.copernicus.eu/datasets/cams-europe-air-quality-forecasts?tab=download).