### PR TITLE
fix(search): search validation error when using ecmwf:longitude and e…

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -21,9 +21,10 @@ import hashlib
 import logging
 import re
 from collections import OrderedDict
+from collections.abc import Callable
 from datetime import datetime, timedelta
 from types import MethodType
-from typing import TYPE_CHECKING, Annotated, Any, Optional
+from typing import TYPE_CHECKING, Annotated, Any, Optional, Tuple
 from urllib.parse import quote_plus, unquote_plus
 
 import geojson
@@ -560,11 +561,8 @@ class ECMWFSearch(PostJsonSearch):
             if "/" in _dc_qp.get("area", ""):
                 params["geometry"] = _dc_qp["area"].split("/")
 
-        params = {
-            k.removeprefix(ECMWF_PREFIX).removeprefix(f"{ECMWF_PREFIX[:-1]}_"): v
-            for k, v in params.items()
-            if v is not None
-        }
+        # Remove parameters prefix
+        params = self._params_remove_prefixes(params)
 
         # dates
         # check if default dates have to be added
@@ -622,6 +620,29 @@ class ECMWFSearch(PostJsonSearch):
             params.pop("location")
 
         return params
+
+    def _params_remove_prefixes(self, params: dict = {}):
+        """Search key as recursive to remove prefixs"""
+
+        # Remove parameter name prefix
+        def remove_prefixes(name: str, value: Any) -> Tuple[str, Any]:
+            new_name = name
+            if value is not None:
+                for prefix in [ECMWF_PREFIX, f"{ECMWF_PREFIX[:-1]}_"]:
+                    new_name = new_name.removeprefix(prefix)
+            return new_name, value
+
+        # Recursive dict/tree crawl
+        def dict_walk(data, on_item: Callable):
+            if isinstance(data, dict):
+                formatted = {}
+                for name in data:
+                    new_name, new_value = on_item(name, data[name])
+                    formatted[new_name] = dict_walk(new_value, on_item)
+                data = formatted
+            return data
+
+        return dict_walk(params, remove_prefixes)
 
     def _check_date_params(
         self, keywords: dict[str, Any], collection: Optional[str]
@@ -754,9 +775,8 @@ class ECMWFSearch(PostJsonSearch):
             collection, deepcopy(processed_filters)
         )
         # we re-apply kwargs input to consider override of year, month, day and time.
-        for k, v in {**default_values, **kwargs}.items():
-            key = k.removeprefix(ECMWF_PREFIX).removeprefix(f"{ECMWF_PREFIX[:-1]}_")
-
+        params = self._params_remove_prefixes({**default_values, **kwargs})
+        for key, value in params.items():
             if key not in ALLOWED_KEYWORDS | {
                 START,
                 END,
@@ -766,7 +786,7 @@ class ECMWFSearch(PostJsonSearch):
                     f"'{key}' is not a queryable parameter for {self.provider}", {key}
                 )
 
-            formated_filters[key] = v
+            formated_filters[key] = value
 
         # we use non empty filters as default to integrate user inputs
         # it is needed because pydantic json schema does not represent "value"


### PR DESCRIPTION
From [#2060](https://github.com/CS-SI/eodag/issues/2060)
### What happened ?

The ECMWF parameter location has the following structure:
```
{
    "location" : {
        "longitude": "10",
        "latitude": "40"
    }
}
```
Using it with the prefix ecmwf: causes the validation error:
```
eodag.utils.exceptions.ValidationError: The location must contains the latitude and the longitude
```
It's possible to search and download the product if you omit the prefix `ecmwf: prefix

### What did you expect to happen ?

It should be possible to use the parameters `location`, `longitude`, `latitude` with and without the ecmwf: prefix.

###  How can we reproduce it (as minimally and precisely as possible)?

```
from pprint import pprint
from eodag.api.core import EODataAccessGateway
from eodag.utils.logging import setup_logging

setup_logging(3)
dag = EODataAccessGateway()

params = {
    "provider": "cop_ads",
    "collection": "CAMS_SOLAR_RADIATION",
    "ecmwf:sky_type": "clear",
    "ecmwf:data_format": "netcdf",
    "ecmwf:time_reference": "universal_time",
    "ecmwf:time_step": "1day",
    "ecmwf:date": "2026-02-10/2026-02-10",
    "ecmwf:location": {"ecmwf:longitude": 11, "ecmwf:latitude": 41},
    "ecmwf:altitude": "1",
}
res = dag.search(**params, raise_errors=True)
dag.download(res[0])
```

### Anything else we need to know ? Any hints on how to fix the problem?

The exception is raised by eodag.utils.__init__#get_geometry_from_ecmwf_location 