### PR TITLE
feat(core): move download_link property to an asset

### DIFF
--- a/eodag/api/product/_assets.py
+++ b/eodag/api/product/_assets.py
@@ -17,10 +17,15 @@
 # limitations under the License.
 from __future__ import annotations
 
+import logging
 import re
 from collections import UserDict
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
+from typing_extensions import override
+
+from eodag.api.product.metadata_mapping import NOT_AVAILABLE, OFFLINE_STATUS
+from eodag.utils import guess_file_type
 from eodag.utils.exceptions import NotAvailableError
 from eodag.utils.repr import dict_to_html_table
 
@@ -28,6 +33,8 @@ if TYPE_CHECKING:
     from eodag.api.product import EOProduct
     from eodag.types.download_args import DownloadConf
     from eodag.utils import StreamResponse, Unpack
+
+logger = logging.getLogger("eodag.api.product.assets")
 
 
 class AssetsDict(UserDict):
@@ -56,6 +63,8 @@ class AssetsDict(UserDict):
 
     product: EOProduct
 
+    TECHNICAL_ASSETS = ["download_link", "quicklook", "thumbnail"]
+
     def __init__(self, product: EOProduct, *args: Any, **kwargs: Any) -> None:
         self.product = product
         super(AssetsDict, self).__init__(*args, **kwargs)
@@ -65,7 +74,77 @@ class AssetsDict(UserDict):
         super().update(data)
 
     def __setitem__(self, key: str, value: dict[str, Any]) -> None:
+        if not self._check(key, value):
+            return
         super().__setitem__(key, Asset(self.product, key, value))
+        self.sort()
+
+    @override
+    def update(self, value: Union[dict[str, Any], AssetsDict]) -> None:  # type: ignore
+        """Used to self update with exernal value"""
+        buffer: dict = {}
+        for key in value:
+            if self._check(key, value[key]):
+                buffer[key] = value[key]
+        super().update(buffer)
+        self.sort()
+
+    def _check(self, asset_key: str, asset_values: dict[str, Any]) -> bool:
+
+        # Asset must have href or order_link
+        href = asset_values.pop("href", None)
+        if href not in [None, "", NOT_AVAILABLE]:
+            asset_values["href"] = href
+        order_link = asset_values.pop("order_link", None)
+        if order_link not in [None, "", NOT_AVAILABLE]:
+            asset_values["order_link"] = order_link
+
+        if "href" not in asset_values and "order_link" not in asset_values:
+            logger.warning(
+                "asset '{}' skipped ignored because neither href nor order_link is available".format(
+                    asset_key
+                ),
+            )
+            return False
+
+        def target_url(asset: dict) -> Optional[str]:
+            target_url = None
+            if "href" in asset:
+                target_url = asset["href"]
+            elif "order_link" in asset:
+                target_url = asset["order_link"]
+            return target_url
+
+        assets = self.as_dict()
+        used_urls = []
+        for key in assets:
+            if key == asset_key:
+                # Duplicated key
+                return False
+            used_urls.append(target_url(assets[key]))
+
+        # Prevent asset key / asset target url replication (out from technical ones)
+        # thumbnail and quicklook can share same url
+        url = target_url(asset_values)
+        if asset_key not in AssetsDict.TECHNICAL_ASSETS and (url in used_urls):
+            # Duplicated url
+            return False
+
+        return True
+
+    def sort(self):
+        """Used to self sort"""
+        sorted_assets = {}
+        data = self.as_dict()
+        # Keep technical assets first
+        for key in AssetsDict.TECHNICAL_ASSETS:
+            if key in data:
+                sorted_assets[key] = data.pop(key)
+        # Sort and add others
+        data = dict(sorted(data.items()))
+        for key in data:
+            sorted_assets[key] = data[key]
+        super().update(sorted_assets)
 
     def as_dict(self) -> dict[str, Any]:
         """Builds a representation of AssetsDict to enable its serialization
@@ -169,6 +248,12 @@ class Asset(UserDict):
     """
 
     product: EOProduct
+
+    # Location
+    location: Optional[str]
+    remote_location: Optional[str]
+
+    # File
     size: int
     filename: Optional[str]
     rel_path: str
@@ -176,7 +261,42 @@ class Asset(UserDict):
     def __init__(self, product: EOProduct, key: str, *args: Any, **kwargs: Any) -> None:
         self.product = product
         self.key = key
+        self.location = None
+        self.remote_location = None
         super(Asset, self).__init__(*args, **kwargs)
+        self._update()
+
+    def __setitem__(self, key, item):
+        super().__setitem__(key, item)
+        self._update()
+
+    def _update(self):
+
+        title = self.get("title", None)
+        if title is None:
+            super().__setitem__("title", self.key)
+
+        # Order link behaviour require order:status state
+        orderlink = self.get("order_link", None)
+        orderstatus = self.get("order:status", None)
+        if orderlink is not None and orderstatus is None:
+            super().__setitem__("order:status", OFFLINE_STATUS)
+
+        href = self.get("href", None)
+        if href is None:
+            super().__setitem__("href", "")
+            href = ""
+
+        if href != "":
+            # Provide location and remote_location when undefined and href updated
+            if self.location is None:
+                self.location = href
+            if self.remote_location is None:
+                self.remote_location = href
+            # With order behaviour, href can be fill later
+            content_type = self.get("type", None)
+            if content_type is None:
+                super().__setitem__("type", guess_file_type(href))
 
     def as_dict(self) -> dict[str, Any]:
         """Builds a representation of Asset to enable its serialization

--- a/eodag/api/product/_assets.py
+++ b/eodag/api/product/_assets.py
@@ -59,7 +59,7 @@ class AssetsDict(UserDict):
     True
     >>> product.assets.update({"foo": {"href": "http://somewhere/something"}})
     >>> product.assets
-    {'foo': {'href': 'http://somewhere/something', 'title': 'foo', 'type': None}}
+    {'foo': {'href': 'http://somewhere/something', 'title': 'foo', 'type': 'application/octet-stream'}}
     """
 
     product: EOProduct
@@ -69,10 +69,6 @@ class AssetsDict(UserDict):
     def __init__(self, product: EOProduct, *args: Any, **kwargs: Any) -> None:
         self.product = product
         super(AssetsDict, self).__init__(*args, **kwargs)
-
-    def update(self, data: dict[str, Any]) -> None:  # type: ignore
-        """Update assets"""
-        super().update(data)
 
     def __setitem__(self, key: str, value: dict[str, Any]) -> None:
         if not self._check(key, value):
@@ -139,8 +135,8 @@ class AssetsDict(UserDict):
         used_urls = []
         for key in assets:
             if key == asset_key:
-                # Duplicated key
-                return False
+                # Same key: this is an update, skip url collision check
+                continue
             used_urls.append(target_url(assets[key]))
 
         # Prevent asset key / asset target url replication (out from technical ones)
@@ -155,16 +151,14 @@ class AssetsDict(UserDict):
     def sort(self):
         """Used to self sort"""
         sorted_assets = {}
-        data = self.as_dict()
         # Keep technical assets first
         for key in AssetsDict.TECHNICAL_ASSETS:
-            if key in data:
-                sorted_assets[key] = data.pop(key)
+            if key in self.data:
+                sorted_assets[key] = self.data.pop(key)
         # Sort and add others
-        data = dict(sorted(data.items()))
-        for key in data:
-            sorted_assets[key] = data[key]
-        super().update(sorted_assets)
+        for key in sorted(self.data):
+            sorted_assets[key] = self.data[key]
+        self.data = sorted_assets
 
     def as_dict(self) -> dict[str, Any]:
         """Builds a representation of AssetsDict to enable its serialization
@@ -265,7 +259,7 @@ class Asset(UserDict):
     >>> isinstance(product.assets["foo"], Asset)
     True
     >>> product.assets["foo"]
-    {'href': 'http://somewhere/something', 'title': 'foo', 'type': None}
+    {'href': 'http://somewhere/something', 'title': 'foo', 'type': 'application/octet-stream'}
     """
 
     product: EOProduct

--- a/eodag/api/product/_assets.py
+++ b/eodag/api/product/_assets.py
@@ -36,6 +36,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("eodag.api.product.assets")
 
+TECHNICAL_ASSET_KEYS: tuple[str, ...] = ("download_link", "quicklook", "thumbnail")
+
 
 class AssetsDict(UserDict):
     """A UserDict object which values are :class:`~eodag.api.product._assets.Asset`
@@ -63,8 +65,6 @@ class AssetsDict(UserDict):
     """
 
     product: EOProduct
-
-    TECHNICAL_ASSETS = ["download_link", "quicklook", "thumbnail"]
 
     def __init__(self, product: EOProduct, *args: Any, **kwargs: Any) -> None:
         self.product = product
@@ -151,7 +151,7 @@ class AssetsDict(UserDict):
         # Prevent asset key / asset target url replication (out from technical ones)
         # thumbnail and quicklook can share same url
         url = target_url(asset_value)
-        if asset_key not in AssetsDict.TECHNICAL_ASSETS and (url in used_urls):
+        if asset_key not in TECHNICAL_ASSET_KEYS and (url in used_urls):
             # Duplicated url
             return False
 
@@ -161,7 +161,7 @@ class AssetsDict(UserDict):
         """Used to self sort"""
         sorted_assets = {}
         # Keep technical assets first
-        for key in AssetsDict.TECHNICAL_ASSETS:
+        for key in TECHNICAL_ASSET_KEYS:
             if key in self.data:
                 sorted_assets[key] = self.data.pop(key)
         # Sort and add others

--- a/eodag/api/product/_assets.py
+++ b/eodag/api/product/_assets.py
@@ -75,7 +75,7 @@ class AssetsDict(UserDict):
             return
         super().__setitem__(key, Asset(self.product, key, value))
         self.sort()
-        self._sync_to_product()
+        self._update_product_location()
 
     @override
     def update(self, value: Union[dict[str, Any], AssetsDict]) -> None:  # type: ignore
@@ -86,9 +86,9 @@ class AssetsDict(UserDict):
                 buffer[key] = value[key]
         super().update(buffer)
         self.sort()
-        self._sync_to_product()
+        self._update_product_location()
 
-    def _sync_to_product(self) -> None:
+    def _update_product_location(self) -> None:
         """Backward-compat: propagate ``download_link`` asset to product location.
 
         ``EOProduct.location`` / ``EOProduct.remote_location`` are still expected to
@@ -105,17 +105,26 @@ class AssetsDict(UserDict):
             if not self.product.remote_location:
                 self.product.remote_location = href
 
-    def _check(self, asset_key: str, asset_values: dict[str, Any]) -> bool:
+    def _check(self, asset_key: str, asset_value: dict[str, Any]) -> bool:
+        """Validate an asset before insertion.
 
+        Checks that the asset has a valid ``href`` or ``order_link`` and that its
+        URL is not already used by another (non-technical) asset.  Mutates
+        *asset_value* in place by stripping empty/unavailable href/order_link entries.
+
+        :param asset_key: Key under which the asset will be stored
+        :param asset_value: Mutable asset dictionary (modified in place)
+        :returns: ``True`` if the asset is valid and can be inserted, ``False`` otherwise
+        """
         # Asset must have href or order_link
-        href = asset_values.pop("href", None)
+        href = asset_value.pop("href", None)
         if href not in [None, "", NOT_AVAILABLE]:
-            asset_values["href"] = href
-        order_link = asset_values.pop("order_link", None)
+            asset_value["href"] = href
+        order_link = asset_value.pop("order_link", None)
         if order_link not in [None, "", NOT_AVAILABLE]:
-            asset_values["order_link"] = order_link
+            asset_value["order_link"] = order_link
 
-        if "href" not in asset_values and "order_link" not in asset_values:
+        if "href" not in asset_value and "order_link" not in asset_value:
             logger.warning(
                 "asset '{}' skipped ignored because neither href nor order_link is available".format(
                     asset_key
@@ -141,7 +150,7 @@ class AssetsDict(UserDict):
 
         # Prevent asset key / asset target url replication (out from technical ones)
         # thumbnail and quicklook can share same url
-        url = target_url(asset_values)
+        url = target_url(asset_value)
         if asset_key not in AssetsDict.TECHNICAL_ASSETS and (url in used_urls):
             # Duplicated url
             return False
@@ -286,18 +295,24 @@ class Asset(UserDict):
         self._update()
 
     def _update(self):
+        """Normalize asset fields and sync ``location``/``remote_location`` from ``href``.
 
-        title = self.get("title", None)
+        Fills in default ``title``, ``href``, ``order:status`` and ``type`` entries
+        when missing, and mirrors a non-empty ``href`` into the asset's
+        ``location`` / ``remote_location`` attributes.
+        """
+
+        title = self.get("title")
         if title is None:
             super().__setitem__("title", self.key)
 
         # Order link behaviour require order:status state
-        orderlink = self.get("order_link", None)
-        orderstatus = self.get("order:status", None)
+        orderlink = self.get("order_link")
+        orderstatus = self.get("order:status")
         if orderlink is not None and orderstatus is None:
             super().__setitem__("order:status", OFFLINE_STATUS)
 
-        href = self.get("href", None)
+        href = self.get("href")
         if href is None:
             super().__setitem__("href", "")
             href = ""
@@ -309,7 +324,7 @@ class Asset(UserDict):
             if self.remote_location is None:
                 self.remote_location = href
             # With order behaviour, href can be fill later
-            content_type = self.get("type", None)
+            content_type = self.get("type")
             if content_type is None:
                 super().__setitem__("type", guess_file_type(href))
 

--- a/eodag/api/product/_assets.py
+++ b/eodag/api/product/_assets.py
@@ -78,6 +78,7 @@ class AssetsDict(UserDict):
             return
         super().__setitem__(key, Asset(self.product, key, value))
         self.sort()
+        self._sync_to_product()
 
     @override
     def update(self, value: Union[dict[str, Any], AssetsDict]) -> None:  # type: ignore
@@ -88,6 +89,24 @@ class AssetsDict(UserDict):
                 buffer[key] = value[key]
         super().update(buffer)
         self.sort()
+        self._sync_to_product()
+
+    def _sync_to_product(self) -> None:
+        """Backward-compat: propagate ``download_link`` asset to product location.
+
+        ``EOProduct.location`` / ``EOProduct.remote_location`` are still expected to
+        carry the download URL by downstream code (download plugins, server-mode, ...).
+        Technical assets are NOT written back to ``EOProduct.properties``.
+        """
+        dl = self.data.get("download_link")
+        if dl is None:
+            return
+        href = dl.get("href") or ""
+        if href:
+            if not self.product.location:
+                self.product.location = href
+            if not self.product.remote_location:
+                self.product.remote_location = href
 
     def _check(self, asset_key: str, asset_values: dict[str, Any]) -> bool:
 

--- a/eodag/api/product/_assets.py
+++ b/eodag/api/product/_assets.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 import re
 from collections import UserDict
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from typing_extensions import override
 
@@ -78,13 +78,14 @@ class AssetsDict(UserDict):
         self._update_product_location()
 
     @override
-    def update(self, value: Union[dict[str, Any], AssetsDict]) -> None:  # type: ignore
-        """Used to self update with exernal value"""
-        buffer: dict = {}
-        for key in value:
-            if self._check(key, value[key]):
-                buffer[key] = value[key]
-        super().update(buffer)
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        """Used to self update with external value"""
+        incoming = {k: v for k, v in dict(*args, **kwargs).items() if self._check(k, v)}
+
+        if not incoming:
+            return
+
+        super().update(incoming)
         self.sort()
         self._update_product_location()
 

--- a/eodag/api/product/_assets.py
+++ b/eodag/api/product/_assets.py
@@ -54,11 +54,12 @@ class AssetsDict(UserDict):
     ...     provider="foo",
     ...     properties={"id": "bar", "geometry": "POINT (0 0)"}
     ... )
-    >>> type(product.assets)
-    <class 'eodag.api.product._assets.AssetsDict'>
+    >>> from eodag.api.product._assets import AssetsDict
+    >>> isinstance(product.assets, AssetsDict)
+    True
     >>> product.assets.update({"foo": {"href": "http://somewhere/something"}})
     >>> product.assets
-    {'foo': {'href': 'http://somewhere/something'}}
+    {'foo': {'href': 'http://somewhere/something', 'title': 'foo', 'type': None}}
     """
 
     product: EOProduct
@@ -260,10 +261,11 @@ class Asset(UserDict):
     ...     properties={"id": "bar", "geometry": "POINT (0 0)"}
     ... )
     >>> product.assets.update({"foo": {"href": "http://somewhere/something"}})
-    >>> type(product.assets["foo"])
-    <class 'eodag.api.product._assets.Asset'>
+    >>> from eodag.api.product._assets import Asset
+    >>> isinstance(product.assets["foo"], Asset)
+    True
     >>> product.assets["foo"]
-    {'href': 'http://somewhere/something'}
+    {'href': 'http://somewhere/something', 'title': 'foo', 'type': None}
     """
 
     product: EOProduct

--- a/eodag/api/product/_assets.py
+++ b/eodag/api/product/_assets.py
@@ -133,21 +133,13 @@ class AssetsDict(UserDict):
             )
             return False
 
-        def target_url(asset: dict) -> Optional[str]:
-            target_url = None
-            if "href" in asset:
-                target_url = asset["href"]
-            elif "order_link" in asset:
-                target_url = asset["order_link"]
-            return target_url
+        def target_url(asset: dict[str, Any]) -> Optional[str]:
+            return asset.get("href") or asset.get("order_link")
 
         assets = self.as_dict()
-        used_urls = []
-        for key in assets:
-            if key == asset_key:
-                # Same key: this is an update, skip url collision check
-                continue
-            used_urls.append(target_url(assets[key]))
+        used_urls = [
+            target_url(asset) for key, asset in assets.items() if key != asset_key
+        ]
 
         # Prevent asset key / asset target url replication (out from technical ones)
         # thumbnail and quicklook can share same url
@@ -186,28 +178,30 @@ class AssetsDict(UserDict):
         :param regex: Uses regex to match the asset key or simply compare strings
         :return: list of assets
         """
-        if asset_filter:
-            if regex:
-                filter_regex = re.compile(asset_filter)
-                assets_keys = list(self.keys())
-                assets_keys = list(filter(filter_regex.fullmatch, assets_keys))
-            else:
-                assets_keys = [a for a in self.keys() if a == asset_filter]
-            filtered_assets = {}
-            if len(assets_keys) > 0:
-                filtered_assets = {a_key: self.get(a_key) for a_key in assets_keys}
-            assets_values = [a for a in filtered_assets.values() if a and "href" in a]
-            if not assets_values and regex:
-                # retry without regex
-                return self.get_values(asset_filter, regex=False)
-            elif not assets_values:
-                raise NotAvailableError(
-                    rf"No asset key matching re.fullmatch(r'{asset_filter}') was found in {self.product}"
-                )
-            else:
-                return assets_values
-        else:
+        if not asset_filter:
             return [a for a in self.values() if "href" in a]
+
+        if regex:
+            filter_regex = re.compile(asset_filter)
+            assets_keys = [k for k in self.keys() if filter_regex.fullmatch(k)]
+        else:
+            assets_keys = [k for k in self.keys() if k == asset_filter]
+
+        assets_values = [
+            a
+            for k in assets_keys
+            for a in [self.get(k)]
+            if isinstance(a, Asset) and "href" in a
+        ]
+
+        if assets_values:
+            return assets_values
+        if regex:
+            # retry without regex
+            return self.get_values(asset_filter, regex=False)
+        raise NotAvailableError(
+            rf"No asset key matching re.fullmatch(r'{asset_filter}') was found in {self.product}"
+        )
 
     def _repr_html_(self, embeded=False):
         thead = (

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -1570,13 +1570,14 @@ def format_query_params(
 
             if len(parts) == 1:
 
-                # If part contains something to interprete
-                if parts[0].strip("{}").find("{") >= 0:
+                # If part contains something to interprete (nested braces or a converter)
+                inner = parts[0].strip("{}")
+                if inner.find("{") >= 0 or "#" in inner:
                     formatted_query_param = format_metadata(
                         provider_search_param, collection, **query_dict
                     )
                 else:
-                    formatted_query_param = "{" + parts[0].strip("{}") + "}"
+                    formatted_query_param = "{" + inner + "}"
 
                 formatted_query_param = formatted_query_param.replace("'", '"')
                 if "{{" in provider_search_param:

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -24,6 +24,7 @@ import logging
 import re
 from string import Formatter
 from typing import TYPE_CHECKING, Any, AnyStr, Callable, Iterator, Optional, Union, cast
+from urllib.parse import unquote
 
 import geojson
 import orjson
@@ -191,6 +192,8 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
         - ``to_rounded_wkt``: simplify the WKT of a geometry
         - ``to_title``: Convert a string to title case
         - ``to_upper``: Convert a string to uppercase
+        - ``url_decode``: Convert a string url_encoded to decoded ones
+        - ``round``: Convert a string number to another one without decimal part
 
     :param search_param: The string to be formatted
     :param args: (optional) Additional arguments to use in the formatting process
@@ -806,6 +809,28 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
         def convert_to_upper(string: str) -> str:
             """Convert a string to uppercase."""
             return string.upper()
+
+        @staticmethod
+        def convert_url_decode(string: str):
+            return unquote(string)
+
+        @staticmethod
+        def convert_round(string: Any) -> str:
+            """Convert a number string to integer string"""
+            if isinstance(string, float):
+                return str(int(string))
+            elif isinstance(string, int):
+                return str(string)
+            elif isinstance(string, str):
+                formatted = ""
+                for i in range(0, len(string)):
+                    char = string[i]
+                    if char == ".":
+                        break
+                    if "0123456789".find(char) >= 0:
+                        formatted += char
+                return formatted
+            return string
 
         @staticmethod
         def convert_to_title(string: str) -> str:
@@ -1542,10 +1567,17 @@ def format_query_params(
 
         if COMPLEX_QS_REGEX.match(provider_search_param):
             parts = provider_search_param.split("=")
+
             if len(parts) == 1:
-                formatted_query_param = format_metadata(
-                    provider_search_param, collection, **query_dict
-                )
+
+                # If part contains something to interprete
+                if parts[0].strip("{}").find("{") >= 0:
+                    formatted_query_param = format_metadata(
+                        provider_search_param, collection, **query_dict
+                    )
+                else:
+                    formatted_query_param = "{" + parts[0].strip("{}") + "}"
+
                 formatted_query_param = formatted_query_param.replace("'", '"')
                 if "{{" in provider_search_param:
                     # retrieve values from hashes where keys are given in the param

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -39,7 +39,6 @@ from shapely import wkt
 from shapely.geometry import LineString, MultiPolygon, Point, Polygon
 from shapely.ops import transform
 
-from eodag.api.product._assets import Asset
 from eodag.types.queryables import Queryables
 from eodag.utils import (
     DEFAULT_PROJ,
@@ -63,6 +62,7 @@ if TYPE_CHECKING:
 
     from shapely.geometry.base import BaseGeometry
 
+    from eodag.api.product._assets import Asset
     from eodag.config import PluginConfig
 
 logger = logging.getLogger("eodag.product.metadata_mapping")
@@ -1865,6 +1865,7 @@ def normalize_bands(data: Union[dict, Asset]) -> Union[dict, Asset]:
         "statistics",
     ]
     EXCLUDE_MOVE_TO_PARENT_BAND_FIELDNAME = ["name", "eo:common_name"]
+    from eodag.api.product._assets import Asset
 
     # https://github.com/radiantearth/stac-spec/blob/v1.1.0/best-practices.md#bands
     # Migrate band STAC 1.0 to 1.1

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -584,7 +584,7 @@ class PluginConfig(yaml.YAMLObject):
 
     def __or__(self, other: Union[Self, dict[str, Any]]) -> Self:
         """Return a new PluginConfig with merged values."""
-        new_config = self.__class__.from_mapping(self.__dict__)
+        new_config: Self = self.__class__.from_mapping(self.__dict__)
         new_config.update(other)
         return new_config
 

--- a/eodag/plugins/apis/ecmwf.py
+++ b/eodag/plugins/apis/ecmwf.py
@@ -242,7 +242,7 @@ class EcmwfApi(Api, ECMWFSearch):
             raise DownloadError(e)
 
         with open(record_filename, "w") as fh:
-            fh.write(product.properties["eodag:download_link"])
+            fh.write(product.remote_location)
         logger.debug("Download recorded in %s", record_filename)
 
         # do not try to extract a directory

--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -135,6 +135,8 @@ class UsgsApi(Api):
                     os.remove(api.TMPFILE)
                     continue
                 raise AuthenticationError("Please check your USGS credentials.") from e
+            except Exception as e:
+                raise AuthenticationError("Authentication failure") from e
 
     def query(
         self,

--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -262,7 +262,7 @@ class UsgsApi(Api):
                     provider=self.provider,
                     properties=product_properties,
                 )
-                product.assets.update(self.get_assets_from_mapping(result, product).data)
+                product.assets.update(self.build_assets_from_mapping(result, product))
                 final.append(product)
         except USGSError as e:
             logger.warning(

--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -257,13 +257,13 @@ class UsgsApi(Api):
                     result, self.config.metadata_mapping
                 )
 
-                final.append(
-                    EOProduct(
-                        collection=collection,
-                        provider=self.provider,
-                        properties=product_properties,
-                    )
+                product = EOProduct(
+                    collection=collection,
+                    provider=self.provider,
+                    properties=product_properties,
                 )
+                product.assets.update(self.get_assets_from_mapping(result, product).data)
+                final.append(product)
         except USGSError as e:
             logger.warning(
                 f"Collection {usgs_collection} may not exist on USGS EE catalog"

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -22,9 +22,9 @@ import re
 from typing import TYPE_CHECKING, Annotated, Callable, get_args
 
 import orjson
-from pydantic import AliasChoices
 from jsonpath_ng import JSONPath
 from jsonpath_ng.jsonpath import Child as JSONChild
+from pydantic import AliasChoices
 from pydantic import ValidationError as PydanticValidationError
 from pydantic.fields import Field, FieldInfo
 
@@ -196,12 +196,8 @@ class Search(PluginTopic):
         default value is returned.
 
         :param key: The configuration option key.
-        :type key: str
         :param default: The default value to be returned if the option is not found (default is None).
-        :type default: Any
-
         :return: The value of the specified configuration option or the default value.
-        :rtype: Any
         """
         collection_cfg = getattr(self.config, "collection_config", {})
         non_none_cfg = {k: v for k, v in collection_cfg.items() if v}
@@ -230,12 +226,13 @@ class Search(PluginTopic):
         self, collection: Optional[str] = None
     ) -> dict[str, Union[str, list[str]]]:
         """Get the plugin metadata mapping configuration (collection specific if exists)
+
         :param collection: the desired collection
-        :returns: The collection metadata assets-mapping
+        :returns: The collection specific metadata-mapping
         """
         metadata_mapping = getattr(self.config, "metadata_mapping", {})
-        if isinstance(collection, str):
-            # Special overfload for collection config
+        if collection is not None:
+            # Special overload for collection config
             # "metadata_mapping_from_product" overloaded by "current"
             collection_metadata_mapping: dict[str, Union[str, list[str]]] = {}
             target_collection: Optional[str] = collection
@@ -244,17 +241,17 @@ class Search(PluginTopic):
                 watchdog -= 1
                 # Check if collection has a specific configuration
                 collection_config = self.config.products.get(target_collection, {})
-                # Overload imported asset mapping configuration by current one
+                # Overload imported metadata mapping configuration by current one
                 buffer = collection_config.get("metadata_mapping", {})
                 buffer.update(collection_metadata_mapping)
                 collection_metadata_mapping = buffer
                 # This collection configuration can refer to another collection configuration
                 target_collection = collection_config.get(
-                    "metadata_mapping_from_product", None
+                    "metadata_mapping_from_product"
                 )
             metadata_mapping.update(collection_metadata_mapping)
             if watchdog == 0:
-                logger.warning("get_assets_mapping watchdog triggered")
+                logger.warning("get_metadata_mapping watchdog triggered")
 
         return metadata_mapping
 
@@ -262,12 +259,13 @@ class Search(PluginTopic):
         self, collection: Optional[str] = None
     ) -> Union[Any, dict[str, dict[str, Any]]]:
         """Get the plugin asset mapping configuration (collection specific if exists)
+
         :param collection: the desired collection
         :returns: The collection specific assets-mapping
         """
         assets_mapping = getattr(self.config, "assets_mapping", {})
-        if isinstance(collection, str):
-            # Special overfload for collection config
+        if collection is not None:
+            # Special overload for collection config
             # "metadata_mapping_from_product" overloaded by "current"
             collection_asset_mapping: dict[str, Union[str, list[str]]] = {}
             target_collection: Optional[str] = collection

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -19,16 +19,20 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import TYPE_CHECKING, Annotated, get_args
+from typing import TYPE_CHECKING, Annotated, Callable, get_args
 
 import orjson
 from pydantic import AliasChoices
+from jsonpath_ng import JSONPath
+from jsonpath_ng.jsonpath import Child as JSONChild
 from pydantic import ValidationError as PydanticValidationError
 from pydantic.fields import Field, FieldInfo
 
+from eodag.api.product import AssetsDict
 from eodag.api.product.metadata_mapping import (
     NOT_AVAILABLE,
     NOT_MAPPED,
+    format_metadata,
     mtd_cfg_as_conversion_and_querypath,
 )
 from eodag.api.search_result import SearchResult
@@ -56,6 +60,7 @@ if TYPE_CHECKING:
     from mypy_boto3_s3 import S3ServiceResource
     from requests.auth import AuthBase
 
+    from eodag import EOProduct
     from eodag.config import PluginConfig
 
 logger = logging.getLogger("eodag.search.base")
@@ -225,15 +230,65 @@ class Search(PluginTopic):
         self, collection: Optional[str] = None
     ) -> dict[str, Union[str, list[str]]]:
         """Get the plugin metadata mapping configuration (collection specific if exists)
-
         :param collection: the desired collection
-        :returns: The collection specific metadata-mapping
+        :returns: The collection metadata assets-mapping
         """
-        if collection:
-            return self.config.products.get(collection, {}).get(
-                "metadata_mapping", self.config.metadata_mapping
-            )
-        return self.config.metadata_mapping
+        metadata_mapping = getattr(self.config, "metadata_mapping", {})
+        if isinstance(collection, str):
+            # Special overfload for collection config
+            # "metadata_mapping_from_product" overloaded by "current"
+            collection_metadata_mapping: dict[str, Union[str, list[str]]] = {}
+            target_collection: Optional[str] = collection
+            watchdog = 10
+            while target_collection is not None and watchdog > 0:
+                watchdog -= 1
+                # Check if collection has a specific configuration
+                collection_config = self.config.products.get(target_collection, {})
+                # Overload imported asset mapping configuration by current one
+                buffer = collection_config.get("metadata_mapping", {})
+                buffer.update(collection_metadata_mapping)
+                collection_metadata_mapping = buffer
+                # This collection configuration can refer to another collection configuration
+                target_collection = collection_config.get(
+                    "metadata_mapping_from_product", None
+                )
+            metadata_mapping.update(collection_metadata_mapping)
+            if watchdog == 0:
+                logger.warning("get_assets_mapping watchdog triggered")
+
+        return metadata_mapping
+
+    def get_assets_mapping(
+        self, collection: Optional[str] = None
+    ) -> Union[Any, dict[str, dict[str, Any]]]:
+        """Get the plugin asset mapping configuration (collection specific if exists)
+        :param collection: the desired collection
+        :returns: The collection specific assets-mapping
+        """
+        assets_mapping = getattr(self.config, "assets_mapping", {})
+        if isinstance(collection, str):
+            # Special overfload for collection config
+            # "metadata_mapping_from_product" overloaded by "current"
+            collection_asset_mapping: dict[str, Union[str, list[str]]] = {}
+            target_collection: Optional[str] = collection
+            watchdog = 10
+            while target_collection is not None and watchdog > 0:
+                watchdog -= 1
+                # Check if collection has a specific configuration
+                collection_config = self.config.products.get(target_collection, {})
+                # Overload imported asset mapping configuration by current one
+                buffer = collection_config.get("assets_mapping", {})
+                buffer.update(collection_asset_mapping)
+                collection_asset_mapping = buffer
+                # This collection configuration can refer to another collection configuration
+                target_collection = collection_config.get(
+                    "metadata_mapping_from_product", None
+                )
+            assets_mapping.update(collection_asset_mapping)
+            if watchdog == 0:
+                logger.warning("get_assets_mapping watchdog triggered")
+
+        return assets_mapping
 
     def get_sort_by_arg(self, kwargs: dict[str, Any]) -> Optional[SortByList]:
         """Extract the ``sort_by`` argument from the kwargs or the provider default sort configuration
@@ -516,7 +571,9 @@ class Search(PluginTopic):
                 queryables[k] = v
         return queryables
 
-    def get_assets_from_mapping(self, provider_item: dict[str, Any]) -> dict[str, Any]:
+    def get_assets_from_mapping(
+        self, provider_item: dict[str, Any], product: EOProduct
+    ) -> AssetsDict:
         """
         Create assets based on the assets_mapping in the provider's config
         and an item returned by the provider
@@ -524,26 +581,232 @@ class Search(PluginTopic):
         :param provider_item: dict of item properties returned by the provider
         :returns: dict containing the asset metadata
         """
-        assets_mapping = getattr(self.config, "assets_mapping", None)
+
+        # Gather collection and product properties
+        collection = getattr(product, "collection", None)
+        properties = getattr(product, "properties", {})
+
+        # Complete given product properties with configuration by product
+        # (not always yet in product properties when current function called)
+        if isinstance(collection, str):
+            # Replace templated parameters by values from product properties and provider_item
+            collection_properties = MappingInterpretor.metadata_mapping_compute(
+                self.config.products.get(collection, {}),
+                properties=properties,
+                provider_item=provider_item,
+            )
+            # have to redo to consider new parameters just added
+            # (some parameters are filled by other ones just defined)
+            collection_properties = MappingInterpretor.metadata_mapping_compute(
+                collection_properties, properties=collection_properties
+            )
+            # extends base config
+            for field_name in collection_properties:
+                if field_name not in [
+                    "metadata_mapping",
+                    "assets_mapping",
+                    "metadata_mapping_from_product",
+                ]:
+                    properties[field_name] = collection_properties[field_name]
+
+        # Gather asset mapping
+        assets_mapping = self.get_assets_mapping(collection)
         if not assets_mapping:
             return {}
-        assets = {}
-        for key, values in assets_mapping.items():
-            asset_href = values.get("href")
-            if not asset_href:
-                logger.warning(
-                    "asset mapping %s skipped because no href is available", key
+        else:
+            # Compute asset mapping
+            assets_mapping = MappingInterpretor.metadata_mapping_compute(
+                assets_mapping, properties=properties, provider_item=provider_item
+            )
+
+        # Specifcs assets (like download_link, thumbnail or quicklook)
+        assets = AssetsDict(product)
+        assets.update(assets_mapping)
+
+        # Global imported assets
+        imported_assets = {}
+        if "assets" in properties:
+            imported_assets = product.properties.pop("assets", {})
+
+        # Process local assets through product driver
+        driver = getattr(product, "driver", None)
+        if driver is not None:
+            asset_key_from_href = getattr(self.config, "asset_key_from_href", True)
+            computed_assets = {}
+            for asset_key in imported_assets:
+                # Local transformation from driver
+                asset = imported_assets[asset_key]
+                norm_key, asset["roles"] = driver.guess_asset_key_and_roles(
+                    asset.get("href", "") if asset_key_from_href else asset_key,
+                    product,
                 )
-                continue
-            json_url_path = string_to_jsonpath(asset_href)
-            if isinstance(json_url_path, str):
-                url_path = json_url_path
-            else:
-                url_match = json_url_path.find(provider_item)
-                if len(url_match) == 1:
-                    url_path = url_match[0].value
-                else:
-                    url_path = NOT_AVAILABLE
-            assets[key] = deepcopy(values)
-            assets[key]["href"] = url_path
+                asset["title"] = norm_key
+                computed_assets[asset_key] = asset
+            imported_assets = computed_assets
+
+        assets.update(computed_assets)
+
         return assets
+
+
+class MappingInterpretor:
+    """Class to process configuration mapping"""
+
+    @staticmethod
+    def metadata_mapping_compute(
+        metadata_mapping_data: Optional[dict] = None,
+        properties: Optional[dict] = None,
+        provider_item: Optional[dict] = None,
+    ):
+        """Mapping from configuration with product properties and provider_item"""
+        # patch json_path without {...} to tag it as interpretable
+        metadata_mapping_data = MappingInterpretor.update_json_path_as_interpretable(
+            metadata_mapping_data
+        )
+
+        # all interpretable in {...}
+        return MappingInterpretor.replace_interpretable(
+            metadata_mapping_data,
+            MappingInterpretor.metadata_substitution,
+            properties=properties,
+            provider_item=provider_item,
+        )  # typing: ignore[arg-type]
+
+    @staticmethod
+    def update_json_path_as_interpretable(value: Any):
+        """Transform in crawled structure raw value '$.[...]' into '{$.[...]}'"""
+        if isinstance(value, str) and str != "":
+            if value.startswith("$."):
+                value = "{" + value + "}"
+        elif isinstance(value, dict):
+            for key in value:
+                value[key] = MappingInterpretor.update_json_path_as_interpretable(
+                    value[key]
+                )
+        elif isinstance(value, list):
+            for i in range(0, len(value)):
+                value[i] = MappingInterpretor.update_json_path_as_interpretable(
+                    value[i]
+                )
+        return value
+
+    @staticmethod
+    def metadata_substitution(
+        value: str,
+        properties: Optional[dict[str, Any]] = None,
+        provider_item: Optional[dict[str, Any]] = None,
+    ) -> Any:
+        """Mapping rules
+        replace field {value#filter} by property if possible
+        replace field {$.jsonpath#filter} by provider_item value if possible
+        """
+
+        # Properties substitution "{field}" matching with "properties" key
+        if isinstance(value, str) and properties is not None:
+            # Extract filters
+            filters = value.strip("{}").split("#")
+            # Parameters subtitution
+            field_name = filters.pop(0)
+            if field_name in properties:
+                value = properties[field_name]
+                # apply filters
+                for filter in filters:
+                    scheme = "{fieldname#" + filter + "}"
+                    try:
+                        value = format_metadata(scheme, fieldname=value)
+                    except Exception as e:
+                        logger.warning(
+                            "Error during properties substitution template '{}': {}".format(
+                                value, str(e)
+                            )
+                        )
+
+        # Provider item substitution "{$.jsonpath}" matching with "provider_item" json path resolve
+        if isinstance(value, str) and provider_item is not None:
+            # Extract filters
+            filters = value.strip("{}").split("#")
+            # Parameters subtitution
+            field_name = filters.pop(0)
+            if field_name.startswith("$."):
+                # Is a josn path ?
+                json_path = string_to_jsonpath(field_name)
+                if isinstance(json_path, JSONPath) or isinstance(json_path, JSONChild):
+                    match = json_path.find(provider_item)
+                    if len(match) == 1:
+                        value = match[0].value
+                    else:
+                        value = NOT_AVAILABLE
+                # Apply filters
+                for filter in filters:
+                    scheme = "{fieldname#" + filter + "}"
+                    try:
+                        value = format_metadata(scheme, fieldname=value)
+                    except Exception as e:
+                        logger.warning(
+                            "Error during provider_item substitution template {}: {}".format(
+                                value, str(e)
+                            )
+                        )
+
+        return value
+
+    @staticmethod
+    def replace_interpretable(value: Any, on_interpretable: Callable, *args, **kwargs):
+        """Helper used to parse mapping parameters
+
+        It extract sub element {...} from value, and call "on_interpretable"
+        to substitute this sub part and replace it in value
+        If value is not a string, ll try crawl by recursion to scan all data structure
+
+        in_interpretable is called chen a sub element {...} is found to substitute it.
+        args and kwargs are pass through on_interpretable function
+        """
+
+        if isinstance(value, str) and len(value) > 0:
+            # Extract level 1 layer {}
+            level = 0
+            start = 0
+            end = 0
+            i = 0
+            while i < len(value):
+                char = value[i]
+                if char == "{":
+                    level += 1
+                    if level == 1:
+                        start = i
+                if char == "}":
+                    level -= 1
+                    if level == 0:
+                        end = i + 1
+                        segment = value[start:end]
+                        if len(segment) >= 2 and segment[1:-1].find("{") >= 0:
+                            # Has sublevels ?
+                            result = (
+                                "{"
+                                + MappingInterpretor.replace_interpretable(
+                                    segment[1:-1], on_interpretable, *args, **kwargs
+                                )
+                                + "}"
+                            )
+                        else:
+                            # Direct interpretable substitution
+                            result = on_interpretable(segment, *args, **kwargs)
+                        if result != segment:
+                            value = value[0:start] + str(result) + value[end:]
+                            # Data moved, cursor is invalid
+                            i = -1
+                i += 1
+        elif isinstance(value, list):
+            # Crawl by recursion
+            for i in range(0, len(value)):
+                value[i] = MappingInterpretor.replace_interpretable(
+                    value[i], on_interpretable, *args, **kwargs
+                )
+        elif isinstance(value, dict):
+            # Crawl by recursion
+            for key in value:
+                value[key] = MappingInterpretor.replace_interpretable(
+                    value[key], on_interpretable, *args, **kwargs
+                )
+
+        return value

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -230,7 +230,8 @@ class Search(PluginTopic):
         :param collection: the desired collection
         :returns: The collection specific metadata-mapping
         """
-        metadata_mapping = getattr(self.config, "metadata_mapping", {})
+        # copy to avoid mutating the cached plugin configuration
+        metadata_mapping = dict(getattr(self.config, "metadata_mapping", {}))
         if collection is not None:
             # Special overload for collection config
             # "metadata_mapping_from_product" overloaded by "current"
@@ -268,7 +269,8 @@ class Search(PluginTopic):
         :param collection: the desired collection
         :returns: The collection specific assets-mapping
         """
-        assets_mapping = getattr(self.config, "assets_mapping", {})
+        # copy to avoid mutating the cached plugin configuration
+        assets_mapping = dict(getattr(self.config, "assets_mapping", {}))
         if collection is not None:
             # Special overload for collection config
             # "assets_mapping_from_product" overloaded by "current"
@@ -580,13 +582,14 @@ class Search(PluginTopic):
         return queryables
 
     def get_assets_from_mapping(
-        self, provider_item: dict[str, Any], product: EOProduct
+        self, provider_item: dict[str, Any], product: Optional[EOProduct] = None
     ) -> AssetsDict:
         """
         Create assets based on the assets_mapping in the provider's config
         and an item returned by the provider
 
         :param provider_item: dict of item properties returned by the provider
+        :param product: optional product against which assets are computed
         :returns: dict containing the asset metadata
         """
 
@@ -619,20 +622,22 @@ class Search(PluginTopic):
 
         # Gather asset mapping
         assets_mapping = self.get_assets_mapping(collection)
-        if not assets_mapping:
-            return {}
-        else:
+        if assets_mapping:
             # Compute asset mapping
             assets_mapping = MappingInterpretor.metadata_mapping_compute(
                 assets_mapping, properties=properties, provider_item=provider_item
             )
 
         # Specifcs assets (like download_link, thumbnail or quicklook)
+        if product is None:
+            # No product: return a plain mapping (used by unit tests / introspection)
+            return dict(assets_mapping) if assets_mapping else {}
+
         assets = AssetsDict(product)
         assets.update(assets_mapping)
 
         # Global imported assets
-        imported_assets = {}
+        imported_assets: dict[str, Any] = {}
         if "assets" in properties:
             imported_assets = product.properties.pop("assets", {})
 
@@ -649,10 +654,10 @@ class Search(PluginTopic):
                     product,
                 )
                 asset["title"] = norm_key
-                computed_assets[asset_key] = asset
+                computed_assets[norm_key] = asset
             imported_assets = computed_assets
 
-        assets.update(computed_assets)
+        assets.update(imported_assets)
 
         return assets
 
@@ -667,6 +672,9 @@ class MappingInterpretor:
         provider_item: Optional[dict] = None,
     ):
         """Mapping from configuration with product properties and provider_item"""
+        # deepcopy to avoid mutating the cached plugin configuration
+        # (replace_interpretable mutates nested dicts/lists in place)
+        metadata_mapping_data = copy_deepcopy(metadata_mapping_data)
         # patch json_path without {...} to tag it as interpretable
         metadata_mapping_data = MappingInterpretor.update_json_path_as_interpretable(
             metadata_mapping_data
@@ -725,6 +733,28 @@ class MappingInterpretor:
                     except Exception as e:
                         logger.warning(
                             "Error during properties substitution template '{}': {}".format(
+                                value, str(e)
+                            )
+                        )
+
+        # Plain field name fallback to provider_item when not found in properties
+        if (
+            isinstance(value, str)
+            and isinstance(provider_item, dict)
+            and value.startswith("{")
+            and value.endswith("}")
+        ):
+            filters = value.strip("{}").split("#")
+            field_name = filters.pop(0)
+            if not field_name.startswith("$.") and field_name in provider_item:
+                value = provider_item[field_name]
+                for filter in filters:
+                    scheme = "{fieldname#" + filter + "}"
+                    try:
+                        value = format_metadata(scheme, fieldname=value)
+                    except Exception as e:
+                        logger.warning(
+                            "Error during provider_item substitution template '{}': {}".format(
                                 value, str(e)
                             )
                         )

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -19,21 +19,18 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import TYPE_CHECKING, Annotated, Callable, get_args
+from typing import TYPE_CHECKING, Annotated, get_args
 
 import orjson
-from jsonpath_ng import JSONPath
-from jsonpath_ng.jsonpath import Child as JSONChild
 from pydantic import AliasChoices
 from pydantic import ValidationError as PydanticValidationError
 from pydantic.fields import Field, FieldInfo
 
 from eodag.api.product import AssetsDict
 from eodag.api.product.metadata_mapping import (
-    NOT_AVAILABLE,
     NOT_MAPPED,
-    format_metadata,
     mtd_cfg_as_conversion_and_querypath,
+    properties_from_json,
 )
 from eodag.api.search_result import SearchResult
 from eodag.plugins.base import PluginTopic
@@ -49,7 +46,6 @@ from eodag.utils import (
     format_dict_items,
     format_pydantic_error,
     get_collection_dates,
-    string_to_jsonpath,
     update_nested_dict,
 )
 from eodag.utils.exceptions import ValidationError
@@ -583,7 +579,7 @@ class Search(PluginTopic):
 
     def get_assets_from_mapping(
         self, provider_item: dict[str, Any], product: Optional[EOProduct] = None
-    ) -> AssetsDict:
+    ) -> Union[AssetsDict, dict[str, Any]]:
         """
         Create assets based on the assets_mapping in the provider's config
         and an item returned by the provider
@@ -592,49 +588,35 @@ class Search(PluginTopic):
         :param product: optional product against which assets are computed
         :returns: dict containing the asset metadata
         """
-
-        # Gather collection and product properties
         collection = getattr(product, "collection", None)
-        properties = getattr(product, "properties", {})
+        properties = getattr(product, "properties", {}) or {}
 
-        # Complete given product properties with configuration by product
-        # (not always yet in product properties when current function called)
-        if isinstance(collection, str):
-            # Replace templated parameters by values from product properties and provider_item
-            collection_properties = MappingInterpretor.metadata_mapping_compute(
-                self.config.products.get(collection, {}),
-                properties=properties,
-                provider_item=provider_item,
-            )
-            # have to redo to consider new parameters just added
-            # (some parameters are filled by other ones just defined)
-            collection_properties = MappingInterpretor.metadata_mapping_compute(
-                collection_properties, properties=collection_properties
-            )
-            # extends base config
-            for field_name in collection_properties:
-                if field_name not in [
-                    "metadata_mapping",
-                    "assets_mapping",
-                    "metadata_mapping_from_product",
-                ]:
-                    properties[field_name] = collection_properties[field_name]
-
-        # Gather asset mapping
         assets_mapping = self.get_assets_mapping(collection)
-        if assets_mapping:
-            # Compute asset mapping
-            assets_mapping = MappingInterpretor.metadata_mapping_compute(
-                assets_mapping, properties=properties, provider_item=provider_item
-            )
 
-        # Specifcs assets (like download_link, thumbnail or quicklook)
         if product is None:
-            # No product: return a plain mapping (used by unit tests / introspection)
-            return dict(assets_mapping) if assets_mapping else {}
+            # Plain mapping container used by unit tests / introspection
+            computed: dict[str, Any] = {}
+            for key, mapping in (assets_mapping or {}).items():
+                try:
+                    asset_querypaths = mtd_cfg_as_conversion_and_querypath(mapping)
+                    computed[key] = properties_from_json(
+                        provider_item, asset_querypaths
+                    )
+                except Exception as e:
+                    logger.warning("Could not resolve asset mapping '%s': %s", key, e)
+                    computed[key] = dict(mapping)
+            return computed
 
         assets = AssetsDict(product)
-        assets.update(assets_mapping)
+
+        for key, mapping in (assets_mapping or {}).items():
+            try:
+                asset_querypaths = mtd_cfg_as_conversion_and_querypath(mapping)
+                asset = properties_from_json(provider_item, asset_querypaths)
+            except Exception as e:
+                logger.warning("Could not resolve asset mapping '%s': %s", key, e)
+                asset = dict(mapping)
+            assets.update({key: asset})
 
         # Global imported assets
         imported_assets: dict[str, Any] = {}
@@ -660,191 +642,3 @@ class Search(PluginTopic):
         assets.update(imported_assets)
 
         return assets
-
-
-class MappingInterpretor:
-    """Class to process configuration mapping"""
-
-    @staticmethod
-    def metadata_mapping_compute(
-        metadata_mapping_data: Optional[dict] = None,
-        properties: Optional[dict] = None,
-        provider_item: Optional[dict] = None,
-    ):
-        """Mapping from configuration with product properties and provider_item"""
-        # deepcopy to avoid mutating the cached plugin configuration
-        # (replace_interpretable mutates nested dicts/lists in place)
-        metadata_mapping_data = copy_deepcopy(metadata_mapping_data)
-        # patch json_path without {...} to tag it as interpretable
-        metadata_mapping_data = MappingInterpretor.update_json_path_as_interpretable(
-            metadata_mapping_data
-        )
-
-        # all interpretable in {...}
-        return MappingInterpretor.replace_interpretable(
-            metadata_mapping_data,
-            MappingInterpretor.metadata_substitution,
-            properties=properties,
-            provider_item=provider_item,
-        )  # typing: ignore[arg-type]
-
-    @staticmethod
-    def update_json_path_as_interpretable(value: Any):
-        """Transform in crawled structure raw value '$.[...]' into '{$.[...]}'"""
-        if isinstance(value, str) and str != "":
-            if value.startswith("$."):
-                value = "{" + value + "}"
-        elif isinstance(value, dict):
-            for key in value:
-                value[key] = MappingInterpretor.update_json_path_as_interpretable(
-                    value[key]
-                )
-        elif isinstance(value, list):
-            for i in range(0, len(value)):
-                value[i] = MappingInterpretor.update_json_path_as_interpretable(
-                    value[i]
-                )
-        return value
-
-    @staticmethod
-    def metadata_substitution(
-        value: str,
-        properties: Optional[dict[str, Any]] = None,
-        provider_item: Optional[dict[str, Any]] = None,
-    ) -> Any:
-        """Mapping rules
-        replace field {value#filter} by property if possible
-        replace field {$.jsonpath#filter} by provider_item value if possible
-        """
-
-        # Properties substitution "{field}" matching with "properties" key
-        if isinstance(value, str) and properties is not None:
-            # Extract filters
-            filters = value.strip("{}").split("#")
-            # Parameters subtitution
-            field_name = filters.pop(0)
-            if field_name in properties:
-                value = properties[field_name]
-                # apply filters
-                for filter in filters:
-                    scheme = "{fieldname#" + filter + "}"
-                    try:
-                        value = format_metadata(scheme, fieldname=value)
-                    except Exception as e:
-                        logger.warning(
-                            "Error during properties substitution template '{}': {}".format(
-                                value, str(e)
-                            )
-                        )
-
-        # Plain field name fallback to provider_item when not found in properties
-        if (
-            isinstance(value, str)
-            and isinstance(provider_item, dict)
-            and value.startswith("{")
-            and value.endswith("}")
-        ):
-            filters = value.strip("{}").split("#")
-            field_name = filters.pop(0)
-            if not field_name.startswith("$.") and field_name in provider_item:
-                value = provider_item[field_name]
-                for filter in filters:
-                    scheme = "{fieldname#" + filter + "}"
-                    try:
-                        value = format_metadata(scheme, fieldname=value)
-                    except Exception as e:
-                        logger.warning(
-                            "Error during provider_item substitution template '{}': {}".format(
-                                value, str(e)
-                            )
-                        )
-
-        # Provider item substitution "{$.jsonpath}" matching with "provider_item" json path resolve
-        if isinstance(value, str) and provider_item is not None:
-            # Extract filters
-            filters = value.strip("{}").split("#")
-            # Parameters subtitution
-            field_name = filters.pop(0)
-            if field_name.startswith("$."):
-                # Is a josn path ?
-                json_path = string_to_jsonpath(field_name)
-                if isinstance(json_path, JSONPath) or isinstance(json_path, JSONChild):
-                    match = json_path.find(provider_item)
-                    if len(match) == 1:
-                        value = match[0].value
-                    else:
-                        value = NOT_AVAILABLE
-                # Apply filters
-                for filter in filters:
-                    scheme = "{fieldname#" + filter + "}"
-                    try:
-                        value = format_metadata(scheme, fieldname=value)
-                    except Exception as e:
-                        logger.warning(
-                            "Error during provider_item substitution template {}: {}".format(
-                                value, str(e)
-                            )
-                        )
-
-        return value
-
-    @staticmethod
-    def replace_interpretable(value: Any, on_interpretable: Callable, *args, **kwargs):
-        """Helper used to parse mapping parameters
-
-        It extract sub element {...} from value, and call "on_interpretable"
-        to substitute this sub part and replace it in value
-        If value is not a string, ll try crawl by recursion to scan all data structure
-
-        in_interpretable is called chen a sub element {...} is found to substitute it.
-        args and kwargs are pass through on_interpretable function
-        """
-
-        if isinstance(value, str) and len(value) > 0:
-            # Extract level 1 layer {}
-            level = 0
-            start = 0
-            end = 0
-            i = 0
-            while i < len(value):
-                char = value[i]
-                if char == "{":
-                    level += 1
-                    if level == 1:
-                        start = i
-                if char == "}":
-                    level -= 1
-                    if level == 0:
-                        end = i + 1
-                        segment = value[start:end]
-                        if len(segment) >= 2 and segment[1:-1].find("{") >= 0:
-                            # Has sublevels ?
-                            result = (
-                                "{"
-                                + MappingInterpretor.replace_interpretable(
-                                    segment[1:-1], on_interpretable, *args, **kwargs
-                                )
-                                + "}"
-                            )
-                        else:
-                            # Direct interpretable substitution
-                            result = on_interpretable(segment, *args, **kwargs)
-                        if result != segment:
-                            value = value[0:start] + str(result) + value[end:]
-                            # Data moved, cursor is invalid
-                            i = -1
-                i += 1
-        elif isinstance(value, list):
-            # Crawl by recursion
-            for i in range(0, len(value)):
-                value[i] = MappingInterpretor.replace_interpretable(
-                    value[i], on_interpretable, *args, **kwargs
-                )
-        elif isinstance(value, dict):
-            # Crawl by recursion
-            for key in value:
-                value[key] = MappingInterpretor.replace_interpretable(
-                    value[key], on_interpretable, *args, **kwargs
-                )
-
-        return value

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -577,7 +577,7 @@ class Search(PluginTopic):
                 queryables[k] = v
         return queryables
 
-    def get_assets_from_mapping(
+    def build_assets_from_mapping(
         self, provider_item: dict[str, Any], product: Optional[EOProduct] = None
     ) -> Union[AssetsDict, dict[str, Any]]:
         """

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -598,7 +598,7 @@ class Search(PluginTopic):
             computed: dict[str, Any] = {}
             for key, mapping in (assets_mapping or {}).items():
                 try:
-                    asset_querypaths = mtd_cfg_as_conversion_and_querypath(mapping)
+                    asset_querypaths = mtd_cfg_as_conversion_and_querypath(mapping, {})
                     computed[key] = properties_from_json(
                         provider_item, asset_querypaths
                     )
@@ -611,7 +611,7 @@ class Search(PluginTopic):
 
         for key, mapping in (assets_mapping or {}).items():
             try:
-                asset_querypaths = mtd_cfg_as_conversion_and_querypath(mapping)
+                asset_querypaths = mtd_cfg_as_conversion_and_querypath(mapping, {})
                 asset = properties_from_json(provider_item, asset_querypaths)
             except Exception as e:
                 logger.warning("Could not resolve asset mapping '%s': %s", key, e)
@@ -620,7 +620,7 @@ class Search(PluginTopic):
 
         # Global imported assets
         imported_assets: dict[str, Any] = {}
-        if "assets" in properties:
+        if isinstance(properties.get("assets"), dict):
             imported_assets = product.properties.pop("assets", {})
 
         # Process local assets through product driver
@@ -628,9 +628,8 @@ class Search(PluginTopic):
         if driver is not None:
             asset_key_from_href = getattr(self.config, "asset_key_from_href", True)
             computed_assets = {}
-            for asset_key in imported_assets:
+            for asset_key, asset in imported_assets.items():
                 # Local transformation from driver
-                asset = imported_assets[asset_key]
                 norm_key, asset["roles"] = driver.guess_asset_key_and_roles(
                     asset.get("href", "") if asset_key_from_href else asset_key,
                     product,

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -593,30 +593,27 @@ class Search(PluginTopic):
 
         assets_mapping = self.get_assets_mapping(collection)
 
+        def resolve_asset_from_mapping(
+            key: str, mapping: dict[str, Any]
+        ) -> dict[str, Any]:
+            try:
+                asset_querypaths = mtd_cfg_as_conversion_and_querypath(mapping, {})
+                return properties_from_json(provider_item, asset_querypaths)
+            except Exception as e:
+                logger.warning("Could not resolve asset mapping '%s': %s", key, e)
+                return dict(mapping)
+
         if product is None:
             # Plain mapping container used by unit tests / introspection
             computed: dict[str, Any] = {}
             for key, mapping in (assets_mapping or {}).items():
-                try:
-                    asset_querypaths = mtd_cfg_as_conversion_and_querypath(mapping, {})
-                    computed[key] = properties_from_json(
-                        provider_item, asset_querypaths
-                    )
-                except Exception as e:
-                    logger.warning("Could not resolve asset mapping '%s': %s", key, e)
-                    computed[key] = dict(mapping)
+                computed[key] = resolve_asset_from_mapping(key, mapping)
             return computed
 
         assets = AssetsDict(product)
 
         for key, mapping in (assets_mapping or {}).items():
-            try:
-                asset_querypaths = mtd_cfg_as_conversion_and_querypath(mapping, {})
-                asset = properties_from_json(provider_item, asset_querypaths)
-            except Exception as e:
-                logger.warning("Could not resolve asset mapping '%s': %s", key, e)
-                asset = dict(mapping)
-            assets.update({key: asset})
+            assets.update({key: resolve_asset_from_mapping(key, mapping)})
 
         # Global imported assets
         imported_assets: dict[str, Any] = {}

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -236,22 +236,27 @@ class Search(PluginTopic):
             # "metadata_mapping_from_product" overloaded by "current"
             collection_metadata_mapping: dict[str, Union[str, list[str]]] = {}
             target_collection: Optional[str] = collection
-            watchdog = 10
-            while target_collection is not None and watchdog > 0:
-                watchdog -= 1
+            visited: set[str] = set()
+            while target_collection is not None and target_collection not in visited:
+                visited.add(target_collection)
                 # Check if collection has a specific configuration
                 collection_config = self.config.products.get(target_collection, {})
                 # Overload imported metadata mapping configuration by current one
-                buffer = collection_config.get("metadata_mapping", {})
+                # (copy to avoid mutating the cached collection configuration)
+                buffer = dict(collection_config.get("metadata_mapping", {}))
                 buffer.update(collection_metadata_mapping)
                 collection_metadata_mapping = buffer
                 # This collection configuration can refer to another collection configuration
                 target_collection = collection_config.get(
                     "metadata_mapping_from_product"
                 )
+            if target_collection is not None:
+                logger.warning(
+                    "Could not resolve metadata_mapping_from_product for %s, cycle detected at %s",
+                    collection,
+                    target_collection,
+                )
             metadata_mapping.update(collection_metadata_mapping)
-            if watchdog == 0:
-                logger.warning("get_metadata_mapping watchdog triggered")
 
         return metadata_mapping
 
@@ -266,25 +271,30 @@ class Search(PluginTopic):
         assets_mapping = getattr(self.config, "assets_mapping", {})
         if collection is not None:
             # Special overload for collection config
-            # "metadata_mapping_from_product" overloaded by "current"
+            # "assets_mapping_from_product" overloaded by "current"
             collection_asset_mapping: dict[str, Union[str, list[str]]] = {}
             target_collection: Optional[str] = collection
-            watchdog = 10
-            while target_collection is not None and watchdog > 0:
-                watchdog -= 1
+            visited: set[str] = set()
+            while target_collection is not None and target_collection not in visited:
+                visited.add(target_collection)
                 # Check if collection has a specific configuration
                 collection_config = self.config.products.get(target_collection, {})
                 # Overload imported asset mapping configuration by current one
-                buffer = collection_config.get("assets_mapping", {})
+                # (copy to avoid mutating the cached collection configuration)
+                buffer = dict(collection_config.get("assets_mapping", {}))
                 buffer.update(collection_asset_mapping)
                 collection_asset_mapping = buffer
                 # This collection configuration can refer to another collection configuration
                 target_collection = collection_config.get(
-                    "metadata_mapping_from_product", None
+                    "assets_mapping_from_product", None
+                )
+            if target_collection is not None:
+                logger.warning(
+                    "Could not resolve assets_mapping_from_product for %s, cycle detected at %s",
+                    collection,
+                    target_collection,
                 )
             assets_mapping.update(collection_asset_mapping)
-            if watchdog == 0:
-                logger.warning("get_assets_mapping watchdog triggered")
 
         return assets_mapping
 

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -630,10 +630,18 @@ class Search(PluginTopic):
             computed_assets = {}
             for asset_key, asset in imported_assets.items():
                 # Local transformation from driver
-                norm_key, asset["roles"] = driver.guess_asset_key_and_roles(
+                norm_key, norm_roles = driver.guess_asset_key_and_roles(
                     asset.get("href", "") if asset_key_from_href else asset_key,
                     product,
                 )
+                # If the driver could not normalize the key/roles
+                # (e.g. no extension in href), keep the original key/roles.
+                if norm_key is None:
+                    computed_assets[asset_key] = asset
+                    if "title" not in asset:
+                        asset["title"] = asset_key
+                    continue
+                asset["roles"] = norm_roles
                 asset["title"] = norm_key
                 computed_assets[norm_key] = asset
             imported_assets = computed_assets

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -1111,7 +1111,7 @@ class ECMWFSearch(PostJsonSearch):
 
         else:
             # use all available query_params to parse properties
-            result_data: dict[str, Any] = {
+            result_data = {
                 **results.collection_def_params,
                 **sorted_unpaginated_qp,
                 **{"qs": sorted_unpaginated_qp},
@@ -1182,7 +1182,7 @@ class ECMWFSearch(PostJsonSearch):
         )
 
         # "Technicals" assets as (downloadlink, quicklook, thumbnail)
-        product.assets.update(self.get_assets_from_mapping(result_data, product))
+        product.assets.update(self.build_assets_from_mapping(result_data, product))
 
         # backup original register_downloader to register_downloader_only
         product.register_downloader_only = product.register_downloader
@@ -1442,7 +1442,7 @@ class MeteoblueSearch(ECMWFSearch):
         )
 
         # "Technicals" assets as (downloadlink, quicklook, thumbnail)
-        product.assets.update(self.get_assets_from_mapping(result, product))
+        product.assets.update(self.build_assets_from_mapping(result, product))
 
         return [
             product,

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -1107,6 +1107,7 @@ class ECMWFSearch(PostJsonSearch):
             start, end = ecmwf_temporal_to_eodag(properties)
             properties["start_datetime"] = start
             properties["end_datetime"] = end
+            result_data = result
 
         else:
             # use all available query_params to parse properties
@@ -1181,7 +1182,7 @@ class ECMWFSearch(PostJsonSearch):
         )
 
         # "Technicals" assets as (downloadlink, quicklook, thumbnail)
-        product.assets.update(self.get_assets_from_mapping(result, product))
+        product.assets.update(self.get_assets_from_mapping(result_data, product))
 
         # backup original register_downloader to register_downloader_only
         product.register_downloader_only = product.register_downloader
@@ -1439,6 +1440,9 @@ class MeteoblueSearch(ECMWFSearch):
             collection=collection,
             properties=properties,
         )
+
+        # "Technicals" assets as (downloadlink, quicklook, thumbnail)
+        product.assets.update(self.get_assets_from_mapping(result, product))
 
         return [
             product,

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -37,7 +37,6 @@ from eodag.api.product import EOProduct
 from eodag.api.product.metadata_mapping import (
     DEFAULT_GEOMETRY,
     NOT_AVAILABLE,
-    OFFLINE_STATUS,
     STAGING_STATUS,
     format_metadata,
     mtd_cfg_as_conversion_and_querypath,
@@ -314,8 +313,6 @@ class ECMWFSearch(PostJsonSearch):
             **{
                 "id": "$.id",
                 "title": "$.id",
-                "order:status": OFFLINE_STATUS,
-                "eodag:download_link": "$.null",
                 "geometry": ["feature", "$.geometry"],
                 "eodag:default_geometry": "POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))",
             },
@@ -1182,6 +1179,9 @@ class ECMWFSearch(PostJsonSearch):
             properties={ecmwf_format(k): v for k, v in properties.items()},
             **kwargs,
         )
+
+        # "Technicals" assets as (downloadlink, quicklook, thumbnail)
+        product.assets.update(self.get_assets_from_mapping(result, product))
 
         # backup original register_downloader to register_downloader_only
         product.register_downloader_only = product.register_downloader

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -32,7 +32,6 @@ from dateutil.tz import tzutc
 from dateutil.utils import today
 
 from eodag import EOProduct
-from eodag.api.product import AssetsDict
 from eodag.api.search_result import SearchResult
 from eodag.config import PluginConfig
 from eodag.plugins.search import PreparedSearch
@@ -207,11 +206,19 @@ class CopMarineSearch(StaticStacSearch):
             "id": item_id,
             "title": item_id,
             "geometry": geometry,
-            "eodag:download_link": download_url,
             "dataset": dataset_item["id"],
             # order:status set to succeeded for consistency between providers
             "order:status": "succeeded",
         }
+        assets = {
+            "download_link": {
+                "title": "downloadlink",
+                "href": download_url,
+                "roles": ["archive", "data"],
+                "type": "application/x-netcdf",
+            }
+        }
+
         if use_dataset_dates:
             dates = _get_dates_from_dataset_data(dataset_item)
             if not dates:
@@ -254,24 +261,26 @@ class CopMarineSearch(StaticStacSearch):
 
         _check_int_values_properties(properties)
 
-        properties["eodag:thumbnail"] = collection_dict["assets"]["thumbnail"]["href"]
-        if "omiFigure" in collection_dict["assets"]:
-            properties["eodag:quicklook"] = collection_dict["assets"]["omiFigure"][
-                "href"
-            ]
-
-        asset_native = {
-            "title": "native",
-            "href": download_url,
-            "type": "application/x-netcdf",
+        assets["thumbnail"] = {
+            "title": "thumbnail",
+            "href": collection_dict["assets"]["thumbnail"]["href"],
+            "roles": ["thumbnail"],
+            "type": "image/jpeg",
         }
-        asset_native.update(asset_properties)
-        assets = {"native": asset_native}
-        additional_assets = self.get_assets_from_mapping(dataset_item)
-        assets.update(additional_assets)
+        if "omiFigure" in collection_dict["assets"]:
+            assets["quicklook"] = {
+                "title": "quicklook",
+                "href": collection_dict["assets"]["omiFigure"]["href"],
+                "roles": ["overview"],
+                "type": "image/jpeg",
+            }
 
+        # List current asset urls
         product = EOProduct(self.provider, properties, collection=collection)
-        product.assets = AssetsDict(product, assets)
+        merged_assets = self.get_assets_from_mapping(dataset_item, product)
+        merged_assets.update(assets)
+        product.assets.update(merged_assets)
+
         product._normalize_bands()
         return product
 

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -278,7 +278,7 @@ class CopMarineSearch(StaticStacSearch):
 
         # List current asset urls
         product = EOProduct(self.provider, properties, collection=collection)
-        merged_assets = self.get_assets_from_mapping(dataset_item, product)
+        merged_assets = self.build_assets_from_mapping(dataset_item, product)
         merged_assets.update(assets)
         product.assets.update(merged_assets)
 

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -216,6 +216,7 @@ class CopMarineSearch(StaticStacSearch):
                 "href": download_url,
                 "roles": ["archive", "data"],
                 "type": "application/x-netcdf",
+                **asset_properties,
             }
         }
 

--- a/eodag/plugins/search/eumetsat_ds.py
+++ b/eodag/plugins/search/eumetsat_ds.py
@@ -47,7 +47,7 @@ class EumetsatDsSearch(QueryStringSearch):
         for index in range(0, len(processed_results)):
             result = processed_results[index]
             if hasattr(result, "assets"):
-                for name, asset in result.assets.items():
+                for name, asset in list(result.assets.items()):
                     if "type" in asset:
                         asset["eumesat_ds:type"] = asset["type"]
                         del asset["type"]

--- a/eodag/plugins/search/geodes.py
+++ b/eodag/plugins/search/geodes.py
@@ -110,9 +110,11 @@ class GeodesSearch(StacSearch):
     ) -> List[EOProduct]:
         """Build EOProducts from provider results"""
 
-        # Preprocess parsable description
+        # Parse description fields and build a href -> extra_props mapping
+        href_extra_props: dict[str, dict[str, Any]] = {}
         for result in results:
             for asset in result.get("assets", {}).values():
+                extra_props: dict[str, Any] = {}
                 for segment in asset.get("description", "").split("\n"):
                     key, sep, value = segment.strip("\r\t").partition(":")
                     if not sep:
@@ -124,17 +126,27 @@ class GeodesSearch(StacSearch):
                             value.removesuffix("bytes").removesuffix("byte").strip()
                         )
                         if filesize.isnumeric():
-                            asset["file:size"] = int(filesize)
+                            extra_props["file:size"] = int(filesize)
                     elif key == "Is reference":
-                        asset["geodes:reference"] = value.lower() == "true"
+                        extra_props["geodes:reference"] = value.lower() == "true"
                     elif key == "Is online":
-                        asset["geodes:online"] = value.lower() == "true"
+                        extra_props["geodes:online"] = value.lower() == "true"
                     elif key == "Datatype":
-                        asset["geodes:datatype"] = value
+                        extra_props["geodes:datatype"] = value
                     elif key == "Checksum MD5":
-                        asset["file:checksum"] = value.lower()
+                        extra_props["file:checksum"] = value.lower()
+
+                if extra_props and asset.get("href"):
+                    href_extra_props[asset["href"]] = extra_props
 
         products = super(GeodesSearch, self).normalize_results(results, **kwargs)
+
+        # Apply parsed properties to normalized assets by matching on href
+        for product in products:
+            for asset in product.assets.values():
+                href = asset.get("href", "")
+                if href in href_extra_props:
+                    asset.update(href_extra_props[href])
 
         self._set_availability(products)
 

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -423,9 +423,6 @@ class QueryStringSearch(Search):
                     other_collection_mtd_mapping = mtd_cfg_as_conversion_and_querypath(
                         other_collection_def_params.get("metadata_mapping", {})
                     )
-                else:
-                    msg = f"Cannot reuse empty metadata_mapping from {other_product_for_mapping} for {collection}"
-                    raise MisconfiguredError(msg)
                 # update mapping
                 for metadata, mapping in other_collection_mtd_mapping.items():
                     collection_metadata_mapping.pop(metadata, None)
@@ -1299,7 +1296,6 @@ class QueryStringSearch(Search):
             % normalize_remaining_count
         )
         products: list[EOProduct] = []
-        asset_key_from_href = getattr(self.config, "asset_key_from_href", True)
         product_kwargs = deepcopy(kwargs)
 
         # collection alias as collection property for product
@@ -1313,28 +1309,12 @@ class QueryStringSearch(Search):
             )
             product = EOProduct(self.provider, properties, **product_kwargs)
 
-            additional_assets = self.get_assets_from_mapping(result)
-            product.assets.update(additional_assets)
+            # "Technicals" assets as (downloadlink, quicklook, thumbnail)
+            product.assets.update(self.get_assets_from_mapping(result, product))
 
-            # move assets from properties to product's attr, normalize keys & roles
-            for key, asset in product.properties.pop("assets", {}).items():
-                url = asset.get("href", "")
-                norm_key, roles = product.driver.guess_asset_key_and_roles(
-                    url if asset_key_from_href else key,
-                    product,
-                )
-                if norm_key is not None:
-                    asset["title"] = norm_key
-                    asset["roles"] = roles
-                    product.assets[norm_key] = asset
-                else:
-                    asset["title"] = asset.get("title", key)
-                    product.assets[key] = asset
-
-            # sort assets
-            product.assets.data = dict(sorted(product.assets.data.items()))
             product._normalize_bands()
             products.append(product)
+
         return products
 
     def count_hits(self, count_url: str, result_type: Optional[str] = "json") -> int:

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -1310,7 +1310,7 @@ class QueryStringSearch(Search):
             product = EOProduct(self.provider, properties, **product_kwargs)
 
             # "Technicals" assets as (downloadlink, quicklook, thumbnail)
-            product.assets.update(self.get_assets_from_mapping(result, product))
+            product.assets.update(self.build_assets_from_mapping(result, product))
 
             product._normalize_bands()
             products.append(product)

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -194,13 +194,13 @@
           - 'data'
           order:status: 'succeded'
         quicklook:
-          href: 'https://s3.amazonaws.com/cbers-meta-pds/{$.downloadUrl}/{$.sceneID#replace_str("_L2","")}.jpg'
+          href: 'https://s3.amazonaws.com/cbers-meta-pds/{$.downloadUrl}/{$.sceneID#replace_str("_L[24]$","")}.jpg'
           title: "quicklook"
           roles:
           - 'overwiev'
           type: 'image/jpeg'
         thumbnail:
-          href: 'https://s3.amazonaws.com/cbers-meta-pds/{$.downloadUrl}/{$.sceneID#replace_str("_L2","")}_small.jpeg'
+          href: 'https://s3.amazonaws.com/cbers-meta-pds/{$.downloadUrl}/{$.sceneID#replace_str("_L[24]$","")}_small.jpeg'
           title: "thumbnail"
           roles:
           - 'thumbnail'
@@ -210,49 +210,43 @@
       _collection: cbers4
       processing:level: 4
       metadata_mapping_from_product: CBERS4_PAN10M_L2
-      assets_mapping:
-        quicklook:
-          href: 'https://s3.amazonaws.com/cbers-meta-pds/{$.downloadUrl}/{$.sceneID#replace_str("_L4","")}.jpg'
-          title: "quicklook"
-          roles:
-          - 'overwiev'
-          type: 'image/jpeg'
-        thumbnail:
-          href: 'https://s3.amazonaws.com/cbers-meta-pds/{$.downloadUrl}/{$.sceneID#replace_str("_L4","")}_small.jpeg'
-          title: "thumbnail"
-          roles:
-          - 'thumbnail'
-          type: 'image/jpeg'
+      assets_mapping_from_product:   CBERS4_PAN10M_L2
     CBERS4_PAN5M_L2:
       instruments: PAN5M
       _collection: cbers4
       processing:level: 2
       metadata_mapping_from_product: CBERS4_PAN10M_L2
+      assets_mapping_from_product:   CBERS4_PAN10M_L2
     CBERS4_PAN5M_L4:
       instruments: PAN5M
       _collection: cbers4
       processing:level: 4
-      metadata_mapping_from_product: CBERS4_PAN10M_L4
+      metadata_mapping_from_product: CBERS4_PAN10M_L2
+      assets_mapping_from_product:   CBERS4_PAN10M_L2
     CBERS4_MUX_L2:
       instruments: MUX
       _collection: cbers4
       processing:level: 2
       metadata_mapping_from_product: CBERS4_PAN10M_L2
+      assets_mapping_from_product:   CBERS4_PAN10M_L2
     CBERS4_MUX_L4:
       instruments: MUX
       _collection: cbers4
       processing:level: 4
-      metadata_mapping_from_product: CBERS4_PAN10M_L4
+      metadata_mapping_from_product: CBERS4_PAN10M_L2
+      assets_mapping_from_product:   CBERS4_PAN10M_L2
     CBERS4_AWFI_L2:
       instruments: AWFI
       _collection: cbers4
       processing:level: 2
       metadata_mapping_from_product: CBERS4_PAN10M_L2
+      assets_mapping_from_product:   CBERS4_PAN10M_L2
     CBERS4_AWFI_L4:
       instruments: AWFI
       _collection: cbers4
       processing:level: 4
-      metadata_mapping_from_product: CBERS4_PAN10M_L4
+      metadata_mapping_from_product: CBERS4_PAN10M_L2
+      assets_mapping_from_product:   CBERS4_PAN10M_L2
     L8_OLI_TIRS_C1L1:
       _collection: landsat8
       _on_amazon: true
@@ -573,6 +567,7 @@
           - '{{"search":{{"processedL2A":"{_processed_l2a}" }} }}'
           - '$.processedL2A'
         _aws_path_l2a: '$.awsPathL2A'
+      assets_mapping_from_product: S2_MSI_L1C
       assets_mapping:
         download_link:
           href: 's3://sentinel-s2-l2a/{$.awsPathL2A}'
@@ -581,18 +576,6 @@
           - 'data'
           type: 'application/octet-stream'
           order:status: 'succeded'
-        quicklook:
-          href: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
-          title: "quicklook"
-          roles:
-          - 'overwiev'
-          type: 'image/jpeg'
-        thumbnail:
-          href: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
-          title: "thumbnail"
-          roles:
-          - 'thumbnail'
-          type: 'image/jpeg'
   download: !plugin
     type: AwsDownload
     ssl_verify: true
@@ -1562,6 +1545,7 @@
       metadata_mapping:
         wrsPath: '$.properties."landsat:wrs_path"'
         wrsRow: '$.properties."landsat:wrs_row"'
+      assets_mapping_from_product: S2_MSI_L1C
       assets_mapping:
         download_link:
           href: 's3://gcp-public-data-landsat/LC08/01/{wrsPath:03d}/{wrsRow:03d}/{title}'
@@ -1570,18 +1554,6 @@
           - 'data'
           type: 'application/octet-stream'
           order:status: 'succeeded'
-        quicklook:
-          href: '$.assets.thumbnail.href'
-          title: "thumbnail"
-          roles:
-          - 'overwiev'
-          type: '$.assets.thumbnail.type'
-        thumbnail:
-          href: '$.assets.thumbnail.href'
-          title: "thumbnail"
-          roles:
-          - 'thumbnail'
-          type: '$.assets.thumbnail.type'
     GENERIC_COLLECTION:
       _collection: '{collection}'
   download: !plugin
@@ -3298,13 +3270,13 @@
         - '$.null'
     assets_mapping:
       download_link:
-        href: '$.properties.location'
+        href: ''
         roles:
         - 'archive'
         - 'data'
-        type: ''
-        file:size: '$.properties.size'
+        type: 'application/octet-stream'
         order:status: 'orderable'
+        order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}'
       quicklook:
         href: '$.properties.thumbnail'
         title: "quicklook"
@@ -3340,15 +3312,6 @@
         missionTakeId:
           - '{{"missionTakeId": "{missionTakeId}"}}'
           - '$.null'
-      assets_mapping:
-        download_link:
-          href: ''
-          roles:
-          - 'archive'
-          - 'data'
-          type: 'application/octet-stream'
-          order:status: 'orderable'
-          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}'
     S1_SAR_RAW:
       _collection: EO:ESA:DAT:SENTINEL-1
       product:type: RAW
@@ -3372,15 +3335,6 @@
         eo:cloud_cover:
           - '{{"cloudCover": "{eo:cloud_cover}"}}'
           - '$.null'
-      assets_mapping:
-        download_link:
-          href: ''
-          roles:
-          - 'archive'
-          - 'data'
-          type: 'application/octet-stream'
-          order:status: 'orderable'
-          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{__collection}"}'
     S2_MSI_L2A:
       _collection: EO:ESA:DAT:SENTINEL-2
       product:type: S2MSI2A
@@ -3394,15 +3348,6 @@
         processing:level:
           - '{{"processingLevel": "{processing:level}"}}'
           - '2'
-      assets_mapping:
-        download_link:
-          href: ''
-          roles:
-          - 'archive'
-          - 'data'
-          type: 'application/octet-stream'
-          order:status: 'orderable'
-          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "EO:ESA:DAT:SENTINEL-3"}'
     S3_LAN_SI:
       _collection: EO:ESA:DAT:SENTINEL-3
       product:type: SR_2_LAN_SI
@@ -3447,15 +3392,6 @@
         sat:orbit_cycle:
           - '{{"cycle": "{sat:orbit_cycle}"}}'
           - '$.null'
-      assets_mapping:
-        download_link:
-          href: ''
-          roles:
-          - 'archive'
-          - 'data'
-          type: 'application/octet-stream'
-          order:status: 'orderable'
-          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}'
     S3_ERR:
       _collection: EO:EUM:DAT:SENTINEL-3:OL_1_ERR___
       metadata_mapping_from_product: S3_EFR
@@ -3494,30 +3430,12 @@
         sat:orbit_cycle:
           - '{{"cycle": "{sat:orbit_cycle}"}}'
           - '$.null'
-      assets_mapping:
-        download_link:
-          href: ''
-          roles:
-          - 'archive'
-          - 'data'
-          type: 'application/octet-stream'
-          order:status: 'orderable'
-          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     S3_WAT:
       _collection: EO:EUM:DAT:SENTINEL-3:SR_2_WAT___
       metadata_mapping:
         id:
           - '{{"type": "SR_2_WAT___", "timeliness": {id#split_id_into_s3_params}["timeliness"], "sat": {id#split_id_into_s3_params}["sat"], "startdate": {id#split_id_into_s3_params}["startDate"], "enddate": {id#split_id_into_s3_params}["endDate"]}}'
           - '{$.id#remove_extension}'
-      assets_mapping:
-        download_link:
-          href: ''
-          roles:
-          - 'archive'
-          - 'data'
-          type: 'application/octet-stream'
-          order:status: 'orderable'
-          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     S5P_L1B_IR_ALL:
       _collection: EO:ESA:DAT:SENTINEL-5P
       processing:level: L1B
@@ -3528,15 +3446,6 @@
         processingMode:
           - '{{"processingMode": "{processingMode}"}}'
           - '$.null'
-      assets_mapping:
-        download_link:
-          href: ''
-          roles:
-          - 'archive'
-          - 'data'
-          type: 'application/octet-stream'
-          order:status: 'orderable'
-          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     S5P_L2_IR_ALL:
       _collection: EO:ESA:DAT:SENTINEL-5P
       processing:level: L2
@@ -3551,27 +3460,9 @@
           resolution:
               - '{{"resolution": "{resolution}"}}'
               - '{$.id#replace_str(r"^.*_R([0-9]+m)_.*$",r"\1")}'
-      assets_mapping:
-        download_link:
-          href: ''
-          roles:
-          - 'archive'
-          - 'data'
-          type: 'application/octet-stream'
-          order:status: 'orderable'
-          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     COP_DEM_GLO30_DGED:
       _collection: EO:ESA:DAT:COP-DEM
       product:type: DGE_30
-      assets_mapping:
-        download_link:
-          href: ''
-          roles:
-          - 'archive'
-          - 'data'
-          type: 'application/octet-stream'
-          order:status: 'orderable'
-          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     COP_DEM_GLO30_DTED:
       _collection: EO:ESA:DAT:COP-DEM
       product:type: DTE_30
@@ -3592,15 +3483,6 @@
         - '{{"productIdentifier": "ndvi_global_300m_10daily_v1"}'
         - '$.null'
         id: '$.id'
-      assets_mapping:
-        download_link:
-          href: ''
-          roles:
-          - 'archive'
-          - 'data'
-          type: 'application/octet-stream'
-          order:status: 'orderable'
-          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     CLMS_GLO_NDVI_1KM_LTS:
       _collection: EO:JRC:DAT:CLMS
       product:type: vegetation_indices
@@ -3629,15 +3511,6 @@
           - '{{"format": "{format}"}}'
           - '{$.id#get_group_name((?P<GeoPackage>geoPackage)|(?P<ESRI fgdb>fgdb)|(?P<GeoTiff100mt>raster100m))}'
         eodag:default_geometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
-      assets_mapping:
-        download_link:
-          href: ''
-          roles:
-          - 'archive'
-          - 'data'
-          type: 'application/octet-stream'
-          order:status: 'orderable'
-          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     CLMS_GLO_FCOVER_333M:
       _collection: EO:JRC:DAT:CLMS
       product:type: vegetation_properties
@@ -3684,60 +3557,24 @@
         id:
           - '{{"uid": "{id}"}}'
           - '$.id'
-      assets_mapping:
-        download_link:
-          href: ''
-          roles:
-          - 'archive'
-          - 'data'
-          type: 'application/octet-stream'
-          order:status: 'orderable'
-          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     CLMS_HRVPP_ST_LAEA:
       _collection: EO:EEA:DAT:CLMS_HRVPP_ST-LAEA
       metadata_mapping:
         id:
           - '{{"uid": "{id}"}}'
           - '$.id'
-      assets_mapping:
-        download_link:
-          href: ''
-          roles:
-          - 'archive'
-          - 'data'
-          type: 'application/octet-stream'
-          order:status: 'orderable'
-          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     CLMS_HRVPP_VPP:
       _collection: EO:EEA:DAT:CLMS_HRVPP_VPP
       metadata_mapping:
         id:
           - '{{"uid": "{id}"}}'
           - '$.id'
-      assets_mapping:
-        download_link:
-          href: ''
-          roles:
-          - 'archive'
-          - 'data'
-          type: 'application/octet-stream'
-          order:status: 'orderable'
-          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     CLMS_HRVPP_VPP_LAEA:
       _collection: EO:EEA:DAT:CLMS_HRVPP_VPP-LAEA
       metadata_mapping:
         id:
           - '{{"uid": "{id}"}}'
           - '$.id'
-      assets_mapping:
-        download_link:
-          href: ''
-          roles:
-          - 'archive'
-          - 'data'
-          type: 'application/octet-stream'
-          order:status: 'orderable'
-          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
   auth: !plugin
     type: TokenAuth
     matching_url: https://[-\w\.]+.wekeo2.eu

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -57,13 +57,29 @@
       scene_filter:
         - '{{"scene_filter": {scene_filter#to_geojson} }}'
         - $.null
-      eodag:thumbnail: '$.browse[0].thumbnailPath'
-      eodag:quicklook: '$.browse[0].browsePath'
-      order:status: '{$.available#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
-      eodag:download_link: 'https://earthexplorer.usgs.gov/download/external/options/{_collection}/{entityId}/M2M/'
       # metadata needed for download
       usgs:entityId: '$.entityId'
       usgs:productId: '$.id'
+    assets_mapping:
+      download_link:
+        href: 'https://earthexplorer.usgs.gov/download/external/options/{_collection}/{$.entityId}/M2M/'
+        roles:
+        - 'archive'
+        - 'data'
+        type: 'application/octet-stream'
+        order:status: '{$.available#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
+      quicklook:
+        href: '$.browse[0].browsePath'
+        title: "quicklook"
+        roles:
+        - 'overwiev'
+        type: 'image/jpeg'
+      thumbnail:
+        href: '$.browse[0].thumbnailPath'
+        title: "thumbnail"
+        roles:
+        - 'thumbnail'
+        type: 'image/jpeg'
     extract: True
     order_enabled: true
     max_workers: 2
@@ -127,8 +143,9 @@
       geometry:
         - '{{"search":{{"shape": {geometry#to_geojson} }} }}'
         - '$.dataGeometry'
-      # order:status set to succeeded for consistency between providers
-      order:status: '{$.null#replace_str("Not Available","succeeded")}'
+    assets_mapping:
+      download_link:
+        order:status: 'succeeded'
   products:
     CBERS4_PAN10M_L2:
       instruments: PAN10M
@@ -165,24 +182,47 @@
           - '$.sunElevation'
         # Custom parameters (not defined in the base document referenced above)
         _aws_path: '$.downloadUrl'
-        eodag:download_link: 's3://cbers-pds/{_aws_path}'
         eodag:mtd_download_link: 's3://cbers-meta-pds/{_aws_path}'
-        _preview_basename: '{$.sceneID#replace_str("_L2","")}'
-        eodag:thumbnail: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}_small.jpeg'
-        eodag:quicklook: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}.jpg'
         id:
           - '{{"search":{{"sceneID":"{id}" }} }}'
           - '{title}'
+      assets_mapping:
+        download_link:
+          href: 's3://cbers-pds/{$.downloadUrl}'
+          roles:
+          - 'archive'
+          - 'data'
+          order:status: 'succeded'
+        quicklook:
+          href: 'https://s3.amazonaws.com/cbers-meta-pds/{$.downloadUrl}/{$.sceneID#replace_str("_L2","")}.jpg'
+          title: "quicklook"
+          roles:
+          - 'overwiev'
+          type: 'image/jpeg'
+        thumbnail:
+          href: 'https://s3.amazonaws.com/cbers-meta-pds/{$.downloadUrl}/{$.sceneID#replace_str("_L2","")}_small.jpeg'
+          title: "thumbnail"
+          roles:
+          - 'thumbnail'
+          type: 'image/jpeg'
     CBERS4_PAN10M_L4:
       instruments: PAN10M
       _collection: cbers4
       processing:level: 4
       metadata_mapping_from_product: CBERS4_PAN10M_L2
-      metadata_mapping:
-        # Custom parameters (not defined in the base document referenced above)
-        _preview_basename: '{$.sceneID#replace_str("_L4","")}'
-        eodag:thumbnail: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}_small.jpeg'
-        eodag:quicklook: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}.jpg'
+      assets_mapping:
+        quicklook:
+          href: 'https://s3.amazonaws.com/cbers-meta-pds/{$.downloadUrl}/{$.sceneID#replace_str("_L4","")}.jpg'
+          title: "quicklook"
+          roles:
+          - 'overwiev'
+          type: 'image/jpeg'
+        thumbnail:
+          href: 'https://s3.amazonaws.com/cbers-meta-pds/{$.downloadUrl}/{$.sceneID#replace_str("_L4","")}_small.jpeg'
+          title: "thumbnail"
+          roles:
+          - 'thumbnail'
+          type: 'image/jpeg'
     CBERS4_PAN5M_L2:
       instruments: PAN5M
       _collection: cbers4
@@ -192,12 +232,7 @@
       instruments: PAN5M
       _collection: cbers4
       processing:level: 4
-      metadata_mapping_from_product: CBERS4_PAN10M_L2
-      metadata_mapping:
-        # Custom parameters (not defined in the base document referenced above)
-        _preview_basename: '{$.sceneID#replace_str("_L4","")}'
-        eodag:thumbnail: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}_small.jpeg'
-        eodag:quicklook: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}.jpg'
+      metadata_mapping_from_product: CBERS4_PAN10M_L4
     CBERS4_MUX_L2:
       instruments: MUX
       _collection: cbers4
@@ -207,12 +242,7 @@
       instruments: MUX
       _collection: cbers4
       processing:level: 4
-      metadata_mapping_from_product: CBERS4_PAN10M_L2
-      metadata_mapping:
-        # Custom parameters (not defined in the base document referenced above)
-        _preview_basename: '{$.sceneID#replace_str("_L4","")}'
-        eodag:thumbnail: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}_small.jpeg'
-        eodag:quicklook: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}.jpg'
+      metadata_mapping_from_product: CBERS4_PAN10M_L4
     CBERS4_AWFI_L2:
       instruments: AWFI
       _collection: cbers4
@@ -222,12 +252,7 @@
       instruments: AWFI
       _collection: cbers4
       processing:level: 4
-      metadata_mapping_from_product: CBERS4_PAN10M_L2
-      metadata_mapping:
-        # Custom parameters (not defined in the base document referenced above)
-        _preview_basename: '{$.sceneID#replace_str("_L4","")}'
-        eodag:thumbnail: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}_small.jpeg'
-        eodag:quicklook: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}.jpg'
+      metadata_mapping_from_product: CBERS4_PAN10M_L4
     L8_OLI_TIRS_C1L1:
       _collection: landsat8
       _on_amazon: true
@@ -272,6 +297,25 @@
         id:
           - '{{"search":{{"productID":"{id}" }} }}'
           - '{title}'
+      assets_mapping:
+        download_link:
+          href: 's3://landsat-pds/c1/L8/{_path:03.0f}/{_row:03.0f}/{title}/'
+          roles:
+          - 'archive'
+          - 'data'
+          order:status: 'succeded'
+        quicklook:
+          href: 'https://landsat-pds.s3.amazonaws.com/c1/L8/{_path:03.0f}/{_row:03.0f}/{title}/{title}_thumb_large.jpg'
+          title: "quicklook"
+          roles:
+          - 'overwiev'
+          type: 'image/jpeg'
+        thumbnail:
+          href: '$.thumbnail'
+          title: "thumbnail"
+          roles:
+          - 'thumbnail'
+          type: 'image/jpeg'
     MODIS_MCD43A4:
       _collection: modis
       metadata_mapping:
@@ -296,15 +340,29 @@
           - '{{"search":{{"date":{{"to":"{end_datetime}"}} }} }}'
           - '$.EndingDateTime'
         # Custom parameters (not defined in the base document referenced above)
-        _vertical_tile_nb: '$.verticalTileNumber'
-        _horizontal_tile_nb: '$.horizontalTileNumber'
-        _doy_date: '{$.sceneID#slice_str(9,16,1)}'
-        eodag:download_link: 's3://modis-pds/MCD43A4.006/{_horizontal_tile_nb:02.0f}/{_vertical_tile_nb:02.0f}/{_doy_date}/'
-        eodag:thumbnail: '$.thumbnail'
-        eodag:quicklook: '$.thumbnail'
         id:
           - '{{"search":{{"sceneID":"{id}" }} }}'
           - '{title}'
+      assets_mapping:
+        download_link:
+          href: 's3://modis-pds/MCD43A4.006/{$.horizontalTileNumber#round}/{$.verticalTileNumber#round}/{$.sceneID#slice_str(9,16,1)}/'
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'succeded'
+        quicklook:
+          href: '$.thumbnail'
+          title: "quicklook"
+          roles:
+          - 'overwiev'
+          type: 'image/jpeg'
+        thumbnail:
+          href: '$.thumbnail'
+          title: "thumbnail"
+          roles:
+          - 'thumbnail'
+          type: 'image/jpeg'
     NAIP:
       _collection: naip
       metadata_mapping:
@@ -325,11 +383,17 @@
           - '{{"search":{{"date":{{"to":"{end_datetime}"}} }} }}'
           - '$.date'
         # Custom parameters (not defined in the base document referenced above)
-        _aws_path: '$.awsPath'
-        eodag:download_link: 's3://naip-analytic/{_aws_path}'
         id:
           - '{{"search":{{"sceneID":"{id}" }} }}'
           - '{title}'
+      assets_mapping:
+        download_link:
+          href: 's3://naip-analytic/{$.awsPath}'
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'succeded'
     S1_SAR_GRD:
       product:type: GRD
       _collection: sentinel1
@@ -364,13 +428,29 @@
           - '{{"search":{{"polarization":"{sar:polarizations#replace_tuple(((["HH"],"SH"),(["VV"],"SV"),(["HH","HV"], "DH"),(["VV","VH"],"DV")))}" }} }}'
           - '{$.polarization#replace_tuple((("SH",["HH"]),("SV",["VV"]),("DH",["HH","HV"]),("DV",["VV","VH"])))}'
         # Custom parameters (not defined in the base document referenced above)
-        _aws_path: '$.awsPath'
-        eodag:download_link: 's3://sentinel-s1-l1c/{_aws_path}'
-        eodag:thumbnail: 'https://render.eosda.com/S1/thumb/{title}.png'
-        eodag:quicklook: 'https://render.eosda.com/S1/thumb/{title}.png'
         id:
           - '{{"search":{{"sceneID":"{id}" }} }}'
           - '{title}'
+      assets_mapping:
+        download_link:
+          href: 's3://sentinel-s1-l1c/{$.awsPath}'
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'succeded'
+        quicklook:
+          href: 'https://render.eosda.com/S1/thumb/{title}.png'
+          title: "quicklook"
+          roles:
+          - 'overwiev'
+          type: 'image/png'
+        thumbnail:
+          href: 'https://render.eosda.com/S1/thumb/{title}.png'
+          title: "thumbnail"
+          roles:
+          - 'thumbnail'
+          type: 'image/png'
     S2_MSI_L1C:
       _collection: sentinel2
       metadata_mapping:
@@ -410,6 +490,26 @@
           - '{title}'
         _processed_l2a: '$.null'
         _aws_path_l2a: '$.null'
+      assets_mapping:
+        download_link:
+          href: 's3://sentinel-s2-l1c/{$.awsPath}'
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'succeded'
+        quicklook:
+          href: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
+          title: "quicklook"
+          roles:
+          - 'overwiev'
+          type: 'image/jpeg'
+        thumbnail:
+          href: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
+          title: "thumbnail"
+          roles:
+          - 'thumbnail'
+          type: 'image/jpeg'
     S2_MSI_L2A:
       _collection: sentinel2
       _processed_l2a: true
@@ -464,10 +564,6 @@
           - '{{"search":{{"zenithAngle":"{view:incidence_angle}" }} }}'
           - '$.zenithAngle'
         # Custom parameters (not defined in the base document referenced above)
-        eodag:thumbnail: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
-        eodag:quicklook: '{eodag:thumbnail}'
-        eodag:download_link: 's3://sentinel-s2-l2a/{_aws_path_l2a}'
-        _aws_path: '$.null'
         eodag:product_path: '$.null'
         eodag:product_info: 'https://roda.sentinel-hub.com/sentinel-s2-l2a/{_aws_path_l2a}/productInfo.json'
         id:
@@ -477,7 +573,26 @@
           - '{{"search":{{"processedL2A":"{_processed_l2a}" }} }}'
           - '$.processedL2A'
         _aws_path_l2a: '$.awsPathL2A'
-
+      assets_mapping:
+        download_link:
+          href: 's3://sentinel-s2-l2a/{$.awsPathL2A}'
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'succeded'
+        quicklook:
+          href: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
+          title: "quicklook"
+          roles:
+          - 'overwiev'
+          type: 'image/jpeg'
+        thumbnail:
+          href: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
+          title: "thumbnail"
+          roles:
+          - 'thumbnail'
+          type: 'image/jpeg'
   download: !plugin
     type: AwsDownload
     ssl_verify: true
@@ -756,19 +871,34 @@
       geometry:
         - null
         - '{$.Footprint#from_ewkt}'
-      type: "$.ContentType"
-      file:size: "$.ContentLength"
-      file:checksum: '$.Checksum[?Algorithm="MD5"].Value'
-      # The url to download the product "as is" (literal or as a template to be completed either after the search result
-      # is obtained from the provider or during the eodag download phase)
-      eodag:download_link: 'https://zipper.creodias.eu/odata/v1/Products({uid})/$value'
-      # order:status: must be one of succeeded, ordered, orderable
-      order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
       collection:
         - null
         - $.null
-      eodag:quicklook: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
-      eodag:thumbnail: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+      assets: '$.Assets'
+    assets_mapping:
+      download_link:
+        title: 'downloadlink'
+        href: 'https://zipper.creodias.eu/odata/v1/Products({uid})/$value'
+        roles:
+        - 'archive'
+        - 'data'
+        type: '$.ContentType'
+        file:checksum: '$.Checksum[?Algorithm="MD5"].Value'
+        file:size: '$.ContentLength'
+        # order:status: must be one of succeeded, ordered, orderable
+        order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
+      quicklook:
+        href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+        title: "quicklook"
+        roles:
+        - 'overwiev'
+        type: "image/jpeg"
+      thumbnail:
+        href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+        title: "thumbnail"
+        roles:
+        - 'thumbnail'
+        type: "image/jpeg"
   download: !plugin
     type: HTTPDownload
     extract: true
@@ -1205,6 +1335,19 @@
     # Note: Sorting is intentionally disabled for this provider, as enabling it causes pagination to malfunction.
     metadata_mapping:
       assets: '{$.assets#from_alternate(s3)}'
+    assets_mapping:
+      quicklook:
+        href: '$.assets.reduced_resolution_browse.alternate.s3.href'
+        title: "quicklook"
+        roles:
+        - 'overwiev'
+        type: '$.assets.reduced_resolution_browse.type'
+      thumbnail:
+        href: '$.assets.thumbnail.alternate.s3.href'
+        title: "thumbnail"
+        roles:
+        - 'thumbnail'
+        type: '$.assets.thumbnail.type'
   products:
     LANDSAT_C2L1:
       _collection: landsat-c2l1
@@ -1289,6 +1432,16 @@
         - '{{"query":{{"grid:code":{{"eq":"{grid:code}"}}}}}}'
         - '$.properties.grid:code'
       assets: '{$.assets#dict_filter($[?(href=~"^s3.*")])}'
+  assets_mapping:
+    download_link:
+      title: "downloadlink"
+      href: '$.links[?(@.rel="self")].href'
+      roles:
+      - 'archive'
+      - 'data'
+      type: 'aplication/json'
+      # order:status set to succeeded for consistency between providers
+      order:status: 'succeeded'
   products:
     S1_SAR_GRD:
       _collection: sentinel-1-grd
@@ -1384,13 +1537,51 @@
         mgrs:utm_zone: '$.properties."sentinel:utm_zone"'
         mgrs:latitude_band: '$.properties."sentinel:latitude_band"'
         mgrs:grid_square: '$.properties."sentinel:grid_square"'
-        eodag:download_link: 's3://gcp-public-data-sentinel-2/tiles/{mgrs:utm_zone}/{mgrs:latitude_band}/{mgrs:grid_square}/{title}.SAFE'
+      assets_mapping:
+        download_link:
+          href: 's3://gcp-public-data-sentinel-2/tiles/{mgrs:utm_zone}/{mgrs:latitude_band}/{mgrs:grid_square}/{title}.SAFE'
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'succeeded'
+        quicklook:
+          href: '$.assets.thumbnail.href'
+          title: "thumbnail"
+          roles:
+          - 'overwiev'
+          type: '$.assets.thumbnail.type'
+        thumbnail:
+          href: '$.assets.thumbnail.href'
+          title: "thumbnail"
+          roles:
+          - 'thumbnail'
+          type: '$.assets.thumbnail.type'
     L8_OLI_TIRS_C1L1:
       _collection: landsat-8-l1-c1
       metadata_mapping:
         wrsPath: '$.properties."landsat:wrs_path"'
         wrsRow: '$.properties."landsat:wrs_row"'
-        eodag:download_link: 's3://gcp-public-data-landsat/LC08/01/{wrsPath:03d}/{wrsRow:03d}/{title}'
+      assets_mapping:
+        download_link:
+          href: 's3://gcp-public-data-landsat/LC08/01/{wrsPath:03d}/{wrsRow:03d}/{title}'
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'succeeded'
+        quicklook:
+          href: '$.assets.thumbnail.href'
+          title: "thumbnail"
+          roles:
+          - 'overwiev'
+          type: '$.assets.thumbnail.type'
+        thumbnail:
+          href: '$.assets.thumbnail.href'
+          title: "thumbnail"
+          roles:
+          - 'thumbnail'
+          type: '$.assets.thumbnail.type'
     GENERIC_COLLECTION:
       _collection: '{collection}'
   download: !plugin
@@ -1430,10 +1621,16 @@
         - 'area={geometry#to_nwse_bounds_str(/)}'
         - '$.geometry'
       eodag:default_geometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
-      # order:status set to succeeded for consistency between providers
-      order:status: '{$.null#replace_str("Not Available","succeeded")}'
       qs: $.qs
-      eodag:download_link: 'https://apps.ecmwf.int/datasets/data/{dataset}?{qs#to_geojson}'
+    assets_mapping:
+      download_link:
+        href: 'https://apps.ecmwf.int/datasets/data/{dataset}?{qs#to_geojson}'
+        roles:
+        - 'archive'
+        - 'data'
+        type: 'application/octet-stream'
+        # order:status set to succeeded for consistency between providers
+        order:status: 'succeeded'
   products:
     # See Archive Catalog in https://apps.ecmwf.int/archive-catalogue/
     # See available Public Datasets in https://apps.ecmwf.int/datasets/
@@ -1517,7 +1714,15 @@
         - '{{"area": {geometry#to_nwse_bounds}}}'
         - $.geometry
       qs: $.qs
-      eodag:order_link: 'https://ads.atmosphere.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{{"inputs": {qs#to_geojson}}}'
+    assets_mapping:
+      download_link:
+        title: "downloadlink"
+        href: ""
+        roles:
+        - archive
+        - data
+        type: "application/netcdf"
+        order_link: 'https://ads.atmosphere.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{"inputs": {qs#to_geojson}}'
   products:
     # See available Public Datasets in https://ads.atmosphere.copernicus.eu/cdsapp#!/search?type=dataset
     CAMS_GAC_FORECAST:
@@ -1687,7 +1892,15 @@
         - '{{"area": {geometry#to_nwse_bounds}}}'
         - $.geometry
       qs: $.qs
-      eodag:order_link: 'https://cds.climate.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{{"inputs": {qs#to_geojson}}}'
+    assets_mapping:
+      download_link:
+        title: "downloadlink"
+        href: ""
+        roles:
+        - archive
+        - data
+        type: "application/netcdf"
+        order_link: 'https://ads.atmosphere.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{"inputs": {qs#to_geojson}}'
   products:
     # See available Public Datasets in https://cds.climate.copernicus.eu/cdsapp#!/search?type=dataset
     AG_ERA5:
@@ -1907,18 +2120,34 @@
       geometry:
         - 'geometry={geometry#to_rounded_wkt}'
         - '$.geometry'
-      # The url of the quicklook
-      eodag:quicklook: '$.properties.quicklook'
-      # The url to download the product "as is" (literal or as a template to be completed either after the search result
-      # is obtained from the provider or during the eodag download phase)
-      eodag:download_link: '$.properties.services.download.url'
-      type: '{$.properties.services.download.mimeType#replace_str("application/unknown","application/octet-stream")}'
-      file:size: '$.properties.services.download.size'
-      file:checksum: '{$.properties.services.download.checksum#replace_str("md5=","")}'
-      # order:status set to succeeded for consistency between providers
-      order:status: '{$.null#replace_str("Not Available","succeeded")}'
-      # Additional metadata provided by the providers but that don't appear in the reference spec
-      eodag:thumbnail: '$.properties.thumbnail'
+      # Unset field from product
+      sara:quicklook: '$.null'
+      sara:thumbnail: '$.null'
+    assets_mapping:
+      download_link:
+        # The url to download the product "as is" (literal or as a template to be completed either after the search result
+        # is obtained from the provider or during the eodag download phase)
+        href: '$.properties.services.download.url'
+        roles:
+        - 'archive'
+        - 'data'
+        type: '{$.properties.services.download.mimeType#replace_str("application/unknown","application/octet-stream")}'
+        file:size: '$.properties.services.download.size'
+        file:checksum: '{$.properties.services.download.checksum#replace_str("md5=","")#to_lower'
+        # order:status set to succeeded for consistency between providers
+        order:status: 'succeeded'
+      quicklook:
+        href: '$.properties.quicklook'
+        title: "quicklook"
+        roles:
+        - 'overwiev'
+        type: "image/png"
+      thumbnail:
+        href: '$.properties.thumbnail'
+        title: "thumbnail"
+        roles:
+        - 'thumbnail'
+        type: "image/png"
   products:
     # Sentinel 1
     S1_SAR_OCN:
@@ -2106,9 +2335,7 @@
         - '$.geometry'
       eodag:default_geometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
       collection: '$.queries[0].domain'
-      order:status: '{$.requiresJobQueue#get_group_name((?P<succeeded>False)|(?P<orderable>True))}'
       qs: $.qs
-      eodag:download_link: https://my.meteoblue.com/dataset/query?{qs#to_geojson}
       # Meteoblue specific parameters
       datapoints: '$.datapoints'
       requiresJobQueue: '$.requiresJobQueue'
@@ -2125,7 +2352,15 @@
       timeIntervalsAlignment:
         - '{{"timeIntervalsAlignment": {timeIntervalsAlignment#to_geojson} }}'
         - '$.timeIntervalsAlignment'
-      eodag:order_link: https://my.meteoblue.com/dataset/query?{qs#replace_str(r"^(.*)(\")(queries\")(.)",r"\1\2runOnJobQueue\2\4 true, \2\3\4")}
+    assets_mapping:
+      download_link:
+        href: https://my.meteoblue.com/dataset/query?{qs#to_geojson}
+        roles:
+        - 'archive'
+        - 'data'
+        type: 'application/octet-stream'
+        order:status: '{$.requiresJobQueue#get_group_name((?P<succeeded>False)|(?P<orderable>True))}'
+        order_link: https://my.meteoblue.com/dataset/query?{qs#replace_str(r"^(.*)(\")(queries\")(.)",r"\1\2runOnJobQueue\2\4 true, \2\3\4")}
   products:
     NEMSGLOBAL_TCDC:
       product:type: NEMSGLOBAL
@@ -2415,14 +2650,32 @@
         - '{$.Footprint#from_ewkt}'
       # The url to download the product "as is" (literal or as a template to be completed either after the search result
       # is obtained from the provider or during the eodag download phase)
-      eodag:download_link: 'https://catalogue.dataspace.copernicus.eu/odata/v1/Products({uid})/$value'
-      # order:status: must be one of succeeded, ordered, orderable
-      order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
       collection:
         - null
         - $.null
-      eodag:quicklook: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
-      eodag:thumbnail: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+    assets_mapping:
+      download_link:
+        href: 'https://catalogue.dataspace.copernicus.eu/odata/v1/Products({uid})/$value'
+        roles:
+        - 'archive'
+        - 'data'
+        type: '$.ContentType'
+        file:checksum: '$.Checksum[?Algorithm="MD5"].Value'
+        file:size: '$.ContentLength'
+        # order:status: must be one of succeeded, ordered, orderable
+        order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
+      quicklook:
+        href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+        title: "quicklook"
+        roles:
+        - 'overwiev'
+        type: "image/jpeg"
+      thumbnail:
+        href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+        title: "thumbnail"
+        roles:
+        - 'thumbnail'
+        type: "image/jpeg"
   download: !plugin
     type: HTTPDownload
     extract: true
@@ -2845,6 +3098,20 @@
       grid:code:
         - '{{"query":{{"s2:mgrs_tile":{{"eq":"{grid:code#replace_str("MGRS-","")}"}}}}}}'
         - '{$.properties."s2:mgrs_tile"#replace_str(r"^T?(.*)$",r"MGRS-\1")}'
+      assets: '$.assets'
+    assets_mapping:
+      quicklook:
+        href: '$.assets[?(@.rel == "preview")].href'
+        title: "quicklook"
+        roles:
+        - 'overwiev'
+        type: '$.assets[?(@.rel == "preview")].type'
+      thumbnail:
+        href: '$.assets[?(@.rel == "preview")].href'
+        title: "thumbnail"
+        roles:
+        - 'thumbnail'
+        type: '$.assets[?(@.rel == "preview")].type'
   products:
     S1_SAR_GRD:
       _collection: sentinel-1-grd
@@ -2927,6 +3194,7 @@
       spatial:scene_id:
         - '{{"query":{{"spatial:scene_id":{{"eq":{spatial:scene_id}}}}}}}'
         - '$.properties.spatial:scene_id'
+      assets: '$.assets'
   products:
     GENERIC_COLLECTION:
       _collection: '{collection}'
@@ -2949,44 +3217,6 @@
     - host
   description: WEkEO - Sentinel and some various Copernicus data
   url: https://www.wekeo.eu/
-  # anchors to avoid duplications
-  anchor_s1_sar: &s1_sar_params
-    processing:level:
-      - '{{"processingLevel": "{processing:level}"}}'
-      - '$.id.`sub(/^[^_]([^_]+)_([^_]+)_([^_]+)_([0-4]+).*/, LEVEL\\4)`'
-    sar:instrument_mode:
-      - '{{"sensorMode": "{sar:instrument_mode}"}}'
-      - '$.id.`sub(/^[^_]([^_]+)_([^_]+)_.*/, \\2)`'
-    swath:
-      - '{{"swath": "{swath}"}}'
-      - '$.null'
-    polarisation:
-      - '{{"polarisation": "{polarisation}"}}'
-      - '$.null'
-    sat:relative_orbit:
-      - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
-      - '$.null'
-    missionTakeId:
-      - '{{"missionTakeId": "{missionTakeId}"}}'
-      - '$.null'
-  anchor_orbit_cycle: &orbit_cycle
-    sat:relative_orbit:
-      - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
-      - '$.null'
-    sat:absolute_orbit:
-      - '{{"orbit": "{sat:absolute_orbit}"}}'
-      - '$.null'
-    sat:orbit_cycle:
-      - '{{"cycle": "{sat:orbit_cycle}"}}'
-      - '$.null'
-  anchor_id_from_date: &id_from_date
-    id:
-      - |
-        {{
-          "startdate": "{id#replace_str(r'^.*_([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])_.*$',r'\1-\2-\3T\4%3A\5%3A00Z')}",
-          "enddate": "{id#replace_str(r'^.*_([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])_.*$',r'\1-\2-\3T\4%3A\5%3A00Z')}"
-        }}
-      - '$.id'
   search: !plugin
     type: WekeoSearch
     api_endpoint: https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/search
@@ -3023,13 +3253,7 @@
       end_datetime:
         - '{{"enddate": "{end_datetime}"}}'
         - '$.properties.enddate'
-      eodag:download_link: '$.properties.location'
-      file:size: '$.properties.size'
-      file:local_path: '$.properties.localpath'
-      eodag:quicklook: '$.properties.thumbnail'
-      eodag:thumbnail: '$.properties.thumbnail'
       title: '$.id'
-      order:status: 'orderable'
       processing:level:
         - '{{"processingLevel": "{processing:level}"}}'
         - '$.null'
@@ -3072,13 +3296,59 @@
       satellite:
         - '{{"satellite": {satellite}}}'
         - '$.null'
+    assets_mapping:
+      download_link:
+        href: '$.properties.location'
+        roles:
+        - 'archive'
+        - 'data'
+        type: ''
+        file:size: '$.properties.size'
+        order:status: 'orderable'
+      quicklook:
+        href: '$.properties.thumbnail'
+        title: "quicklook"
+        roles:
+        - 'overwiev'
+        type: 'image/jpeg'
+      thumbnail:
+        href: '$.properties.thumbnail'
+        title: "thumbnail"
+        roles:
+        - 'thumbnail'
+        type: 'image/jpeg'
   products:
     S1_SAR_GRD:
       _collection: EO:ESA:DAT:SENTINEL-1
       product:type: GRD
       metadata_mapping:
-        <<: *s1_sar_params
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SAFE", "dataset_id": "EO:ESA:DAT:SENTINEL-1"}}'
+        processing:level:
+          - '{{"processingLevel": "{processing:level}"}}'
+          - '$.id.`sub(/^[^_]([^_]+)_([^_]+)_([^_]+)_([0-4]+).*/, LEVEL\\4)`'
+        sar:instrument_mode:
+          - '{{"sensorMode": "{sar:instrument_mode}"}}'
+          - '$.id.`sub(/^[^_]([^_]+)_([^_]+)_.*/, \\2)`'
+        swath:
+          - '{{"swath": "{swath}"}}'
+          - '$.null'
+        polarisation:
+          - '{{"polarisation": "{polarisation}"}}'
+          - '$.null'
+        sat:relative_orbit:
+          - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
+          - '$.null'
+        missionTakeId:
+          - '{{"missionTakeId": "{missionTakeId}"}}'
+          - '$.null'
+      assets_mapping:
+        download_link:
+          href: ''
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'orderable'
+          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}'
     S1_SAR_RAW:
       _collection: EO:ESA:DAT:SENTINEL-1
       product:type: RAW
@@ -3102,7 +3372,15 @@
         eo:cloud_cover:
           - '{{"cloudCover": "{eo:cloud_cover}"}}'
           - '$.null'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SAFE", "dataset_id": "EO:ESA:DAT:SENTINEL-2"}}'
+      assets_mapping:
+        download_link:
+          href: ''
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'orderable'
+          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{__collection}"}'
     S2_MSI_L2A:
       _collection: EO:ESA:DAT:SENTINEL-2
       product:type: S2MSI2A
@@ -3116,7 +3394,15 @@
         processing:level:
           - '{{"processingLevel": "{processing:level}"}}'
           - '2'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:ESA:DAT:SENTINEL-3"}}'
+      assets_mapping:
+        download_link:
+          href: ''
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'orderable'
+          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "EO:ESA:DAT:SENTINEL-3"}'
     S3_LAN_SI:
       _collection: EO:ESA:DAT:SENTINEL-3
       product:type: SR_2_LAN_SI
@@ -3152,38 +3438,42 @@
           - '{{"sat": "{constellation}"}}'
           - '$.id.`sub(/^[^_]([^_]+)_.*/, Sentinel-\\1)`'
         platform: '$.id.`sub(/^[^_]([^_]+)_.*/, S\\1)`'
-        <<: *orbit_cycle
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:OL_1_EFR___"}}'
+        sat:relative_orbit:
+          - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
+          - '$.null'
+        sat:absolute_orbit:
+          - '{{"orbit": "{sat:absolute_orbit}"}}'
+          - '$.null'
+        sat:orbit_cycle:
+          - '{{"cycle": "{sat:orbit_cycle}"}}'
+          - '$.null'
+      assets_mapping:
+        download_link:
+          href: ''
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'orderable'
+          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}'
     S3_ERR:
       _collection: EO:EUM:DAT:SENTINEL-3:OL_1_ERR___
       metadata_mapping_from_product: S3_EFR
-      metadata_mapping:
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:OL_1_ERR___"}}'
     S3_OLCI_L2WFR:
       _collection: EO:EUM:DAT:SENTINEL-3:OL_2_WFR___
       metadata_mapping_from_product: S3_EFR
-      metadata_mapping:
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:OL_2_WFR___"}}'
     S3_OLCI_L2WRR:
       _collection: EO:EUM:DAT:SENTINEL-3:OL_2_WRR___
       metadata_mapping_from_product: S3_EFR
-      metadata_mapping:
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:OL_2_WRR___"}}'
     S3_SRA:
       _collection: EO:EUM:DAT:SENTINEL-3:SR_1_SRA___
       metadata_mapping_from_product: S3_EFR
-      metadata_mapping:
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:SR_1_SRA___"}}'
     S3_SRA_A:
       _collection: EO:EUM:DAT:SENTINEL-3:SR_1_SRA_A_
       metadata_mapping_from_product: S3_EFR
-      metadata_mapping:
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:SR_1_SRA_A_"}}'
     S3_SRA_BS:
       _collection: EO:EUM:DAT:SENTINEL-3:SR_1_SRA_BS
       metadata_mapping_from_product: S3_EFR
-      metadata_mapping:
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:SR_1_SRA_BS"}}'
     S3_SLSTR_L1RBT:
       _collection: EO:EUM:DAT:SENTINEL-3:SL_1_RBT___
       product:type: SL_1_RBT___
@@ -3195,15 +3485,39 @@
           - '{{"sat": "{constellation}"}}'
           - '$.id.`sub(/^[^_]([^_]+)_.*/, Sentinel-\\1)`'
         platform: '$.id.`sub(/^[^_]([^_]+)_.*/, S\\1)`'
-        <<: *orbit_cycle
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:SL_1_RBT___"}}'
+        sat:relative_orbit:
+          - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
+          - '$.null'
+        sat:absolute_orbit:
+          - '{{"orbit": "{sat:absolute_orbit}"}}'
+          - '$.null'
+        sat:orbit_cycle:
+          - '{{"cycle": "{sat:orbit_cycle}"}}'
+          - '$.null'
+      assets_mapping:
+        download_link:
+          href: ''
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'orderable'
+          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     S3_WAT:
       _collection: EO:EUM:DAT:SENTINEL-3:SR_2_WAT___
       metadata_mapping:
         id:
           - '{{"type": "SR_2_WAT___", "timeliness": {id#split_id_into_s3_params}["timeliness"], "sat": {id#split_id_into_s3_params}["sat"], "startdate": {id#split_id_into_s3_params}["startDate"], "enddate": {id#split_id_into_s3_params}["endDate"]}}'
           - '{$.id#remove_extension}'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:SR_2_WAT___"}}'
+      assets_mapping:
+        download_link:
+          href: ''
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'orderable'
+          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     S5P_L1B_IR_ALL:
       _collection: EO:ESA:DAT:SENTINEL-5P
       processing:level: L1B
@@ -3214,7 +3528,15 @@
         processingMode:
           - '{{"processingMode": "{processingMode}"}}'
           - '$.null'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.nc", "dataset_id": "EO:ESA:DAT:SENTINEL-5P"}}'
+      assets_mapping:
+        download_link:
+          href: ''
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'orderable'
+          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     S5P_L2_IR_ALL:
       _collection: EO:ESA:DAT:SENTINEL-5P
       processing:level: L2
@@ -3229,12 +3551,27 @@
           resolution:
               - '{{"resolution": "{resolution}"}}'
               - '{$.id#replace_str(r"^.*_R([0-9]+m)_.*$",r"\1")}'
-          eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:EEA:DAT:HRL:TCF"}}'
+      assets_mapping:
+        download_link:
+          href: ''
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'orderable'
+          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     COP_DEM_GLO30_DGED:
       _collection: EO:ESA:DAT:COP-DEM
       product:type: DGE_30
-      metadata_mapping:
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:ESA:DAT:COP-DEM"}}'
+      assets_mapping:
+        download_link:
+          href: ''
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'orderable'
+          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     COP_DEM_GLO30_DTED:
       _collection: EO:ESA:DAT:COP-DEM
       product:type: DTE_30
@@ -3250,17 +3587,28 @@
     CLMS_GLO_NDVI_333M:
       _collection: EO:JRC:DAT:CLMS
       product:type: vegetation_indices
-      _product_identifier: ndvi_global_300m_10daily_v1
       metadata_mapping:
         _product_identifier:
-        - '{{"productIdentifier": "{_product_identifier}"}}'
+        - '{{"productIdentifier": "ndvi_global_300m_10daily_v1"}'
         - '$.null'
         id: '$.id'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:JRC:DAT:CLMS"}}'
+      assets_mapping:
+        download_link:
+          href: ''
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'orderable'
+          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     CLMS_GLO_NDVI_1KM_LTS:
       _collection: EO:JRC:DAT:CLMS
       product:type: vegetation_indices
-      _product_identifier: ndvi-lts_global_1km_10daily_v2
+      metadata_mapping:
+        _product_identifier:
+        - '{{"productIdentifier": "ndvi-lts_global_1km_10daily_v2"}'
+        - '$.null'
+        id: '$.id'
       metadata_mapping_from_product: CLMS_GLO_NDVI_333M
     CLMS_CORINE:
       _collection: EO:EEA:DAT:CORINE
@@ -3271,37 +3619,64 @@
         id:
           - '{{"format": "{id#get_group_name((?P<GeoPackage>geoPackage)|(?P<ESRI fgdb>fgdb)|(?P<GeoTiff100mt>raster100m))}"}}'
           - '$.id'
-        start_datetime: '$.properties.startdate'
-        end_datetime: '$.properties.enddate'
+        start_datetime:
+          - $.null
+          - '$.properties.startdate'
+        end_datetime:
+          - $.null
+          - '$.properties.enddate'
         format:
           - '{{"format": "{format}"}}'
           - '{$.id#get_group_name((?P<GeoPackage>geoPackage)|(?P<ESRI fgdb>fgdb)|(?P<GeoTiff100mt>raster100m))}'
         eodag:default_geometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:EEA:DAT:CORINE"}}'
+      assets_mapping:
+        download_link:
+          href: ''
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'orderable'
+          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     CLMS_GLO_FCOVER_333M:
       _collection: EO:JRC:DAT:CLMS
       product:type: vegetation_properties
-      _product_identifier: fcover_global_300m_10daily_v1
+      metadata_mapping:
+        _product_identifier:
+        - '{{"productIdentifier": "fcover_global_300m_10daily_v1"}'
+        - '$.null'
       metadata_mapping_from_product: CLMS_GLO_NDVI_333M
     CLMS_GLO_DMP_333M:
       _collection: EO:JRC:DAT:CLMS
       product:type: dry-gross_dry_matter_productivity
-      _product_identifier: dry-gross_dry_matter_productivity/dmp_global_300m_10daily_v1
+      metadata_mapping:
+        _product_identifier:
+        - '{{"productIdentifier": "dry-gross_dry_matter_productivity/dmp_global_300m_10daily_v1"}'
+        - '$.null'
       metadata_mapping_from_product: CLMS_GLO_NDVI_333M
     CLMS_GLO_GDMP_333M:
       _collection: EO:JRC:DAT:CLMS
       product:type: dry-gross_dry_matter_productivity
-      _product_identifier: gdmp_global_300m_10daily_v1
+      metadata_mapping:
+        _product_identifier:
+        - '{{"productIdentifier": "gdmp_global_300m_10daily_v1"}'
+        - '$.null'
       metadata_mapping_from_product: CLMS_GLO_NDVI_333M
     CLMS_GLO_FAPAR_333M:
       _collection: EO:JRC:DAT:CLMS
       product:type: vegetation_properties
-      _product_identifier: fapar_global_300m_10daily_v1
+      metadata_mapping:
+        _product_identifier:
+        - '{{"productIdentifier": "fapar_global_300m_10daily_v1"}'
+        - '$.null'
       metadata_mapping_from_product: CLMS_GLO_NDVI_333M
     CLMS_GLO_LAI_333M:
       _collection: EO:JRC:DAT:CLMS
       product:type: vegetation_properties
-      _product_identifier: lai_global_300m_10daily_v1
+      metadata_mapping:
+        _product_identifier:
+        - '{{"productIdentifier": "lai_global_300m_10daily_v1"}'
+        - '$.null'
       metadata_mapping_from_product: CLMS_GLO_NDVI_333M
     CLMS_HRVPP_ST:
       _collection: EO:EEA:DAT:CLMS_HRVPP_ST
@@ -3309,28 +3684,60 @@
         id:
           - '{{"uid": "{id}"}}'
           - '$.id'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:EEA:DAT:CLMS_HRVPP_ST"}}'
+      assets_mapping:
+        download_link:
+          href: ''
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'orderable'
+          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     CLMS_HRVPP_ST_LAEA:
       _collection: EO:EEA:DAT:CLMS_HRVPP_ST-LAEA
       metadata_mapping:
         id:
           - '{{"uid": "{id}"}}'
           - '$.id'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:EEA:DAT:CLMS_HRVPP_ST-LAEA"}}'
+      assets_mapping:
+        download_link:
+          href: ''
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'orderable'
+          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     CLMS_HRVPP_VPP:
       _collection: EO:EEA:DAT:CLMS_HRVPP_VPP
       metadata_mapping:
         id:
           - '{{"uid": "{id}"}}'
           - '$.id'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:EEA:DAT:CLMS_HRVPP_VPP"}}'
+      assets_mapping:
+        download_link:
+          href: ''
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'orderable'
+          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
     CLMS_HRVPP_VPP_LAEA:
       _collection: EO:EEA:DAT:CLMS_HRVPP_VPP-LAEA
       metadata_mapping:
         id:
           - '{{"uid": "{id}"}}'
           - '$.id'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:EEA:DAT:CLMS_HRVPP_VPP-LAEA"}}'
+      assets_mapping:
+        download_link:
+          href: ''
+          roles:
+          - 'archive'
+          - 'data'
+          type: 'application/octet-stream'
+          order:status: 'orderable'
+          order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}}'
   auth: !plugin
     type: TokenAuth
     matching_url: https://[-\w\.]+.wekeo2.eu
@@ -3473,12 +3880,20 @@
       product:type:
         - dataset_id
         - $.dataset
-      eodag:download_link: $.properties.location
-      file:size: '$.properties.size'
       dataset:
         - dataset_id
         - $.dataset
+      eodag:download_link: $.properties.location
       eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "{dataset}"}}'
+    assets_mapping:
+      download_link:
+        href: ''
+        roles:
+        - 'archive'
+        - 'data'
+        type: '$.ContentType'
+        "order_link": 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location#url_decode}","product_id":"{id}", "dataset_id": "{dataset}"}'
+        order:status: 'orderable'
   products:
     SATELLITE_CARBON_DIOXIDE:
       dataset: EO:ECMWF:DAT:SATELLITE_CARBON_DIOXIDE
@@ -3755,10 +4170,16 @@
       variable:
         - '{{"variable": "{variable}"}}'
         - '{$.properties.location#get_variables_from_path}'
-      eodag:download_link: '$.properties.location'
       title: '$.id'
-      order:status: 'orderable'
-      eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "cacheable": "true", "dataset_id": "productType"}}'
+    assets_mapping:
+      download_link:
+        href: '$.properties.location'
+        roles:
+        - 'archive'
+        - 'data'
+        type: 'application/octet-stream'
+        order:status: 'orderable'
+        order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "cacheable": "true", "dataset_id": "productType"}'
   products:
     GENERIC_COLLECTION:
       _collection: '{collection}'
@@ -4031,16 +4452,30 @@
       geometry:
         - null
         - '{$.Footprint#from_ewkt}'
-      # The url to download the product "as is" (literal or as a template to be completed either after the search result
-      # is obtained from the provider or during the eodag download phase)
-      eodag:download_link: '$.S3Path.`sub(/^(.*)$/, s3:/\\1)`'
-      # order:status: must be one of succeeded, ordered, orderable
-      order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
       collection:
         - null
         - $.null
-      eodag:quicklook: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
-      eodag:thumbnail: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+    assets_mapping:
+      download_link:
+        href: '$.S3Path.`sub(/^(.*)$/, s3:/\\1)`'
+        roles:
+        - 'archive'
+        - 'data'
+        type: 'application/octet-stream'
+        # order:status: must be one of succeeded, ordered, orderable
+        order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
+      quicklook:
+        href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+        title: "quicklook"
+        roles:
+        - 'overwiev'
+        type: "image/jpeg"
+      thumbnail:
+        href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+        title: "thumbnail"
+        roles:
+        - 'thumbnail'
+        type: "image/jpeg"
   download: !plugin
     type: AwsDownload
     s3_endpoint: 'https://eodata.cloudferro.com'
@@ -4476,7 +4911,16 @@
         - dataset
         - $.dataset
       qs: $.qs
-      eodag:order_link: 'https://polytope.lumi.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{{"verb": "retrieve", "request": {qs#to_geojson} }}'
+    assets_mapping:
+      download_link:
+        title: "downloadlink"
+        href: ''
+        roles:
+        - 'archive'
+        - 'data'
+        type: 'application/octet-stream'
+        order_link: 'https://polytope.lumi.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{"verb": "retrieve", "request": {qs#to_geojson} }'
+        order:status: 'orderable'
   products:
     DT_CLIMATE_ADAPTATION:
       discover_queryables:
@@ -4749,7 +5193,16 @@
         - dataset
         - $.dataset
       qs: $.qs
-      eodag:order_link: 'https://polytope.mn5.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{{"verb": "retrieve", "request": {qs#to_geojson} }}'
+    assets_mapping:
+      download_link:
+        title: "downloadlink"
+        href: ''
+        roles:
+        - 'archive'
+        - 'data'
+        type: 'application/octet-stream'
+        order_link: 'https://polytope.mn5.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{{"verb": "retrieve", "request": {qs#to_geojson} }}'
+        order:status: 'orderable'
   products:
     DT_CLIMATE_G1_HIGHRESMIP_CONT_IFS_FESOM_R1:
       dataset: climate-dt
@@ -5066,13 +5519,34 @@
     asset_key_from_href: false
     metadata_mapping:
       eodag:default_geometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
-      eodag:quicklook: '{eodag:thumbnail}'
-      order:status: '{$.properties."order:status"#get_group_name((?P<succeeded>succeeded)|(?P<ordered>shipping)|(?P<orderable>orderable))}'
-      eodag:download_link: '$.assets.downloadLink.href'
       federation:backends: '$.null'
       storage:schemes: '$.null'
       storage:tier: '$.null'
-      assets: '$.null'
+      assets: '$.assets'
+    assets_mapping:
+      download_link:
+        title: "downloadlink"
+        href: '$.assets.downloadLink.href'
+        roles:
+        - 'archive'
+        - 'data'
+        type: '$.assets.downloadLink.type'
+        alternate: '$.assets.downloadLink.alternate'
+        order:status: '{$.properties."order:status"#get_group_name((?P<succeeded>succeeded)|(?P<ordered>shipping)|(?P<orderable>orderable))}'
+      quicklook:
+        href: '$.assets["ql.jpg"].href'
+        title: "quicklook"
+        roles:
+        - 'overwiev'
+        type: '$.assets["ql.jpg"].type'
+        alternate: '$.assets["ql.jpg"].alternate'
+      thumbnail:
+        href: '$.assets["ql.jpg"].href'
+        title: "thumbnail"
+        roles:
+        - 'thumbnail'
+        type: $.assets["ql.jpg"].type
+        alternate: '$.assets["ql.jpg"].alternate'
     discover_collections:
       fetch_url: 'https://hda.data.destination-earth.eu/stac/v2/collections'
       result_type: json
@@ -5717,13 +6191,6 @@
         - 'geo={geometry#to_rounded_wkt}'
         - '$.geometry'
       eodag:default_geometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
-      # The url of the quicklook
-      eodag:quicklook: '$.properties.links.previews[?(@.title="Quicklook")].href'
-      # The url to download the product "as is" (literal or as a template to be completed either after the search result
-      # is obtained from the provider or during the eodag download phase)
-      eodag:download_link: '$.properties.links.data[?(@.title="Product download")].href'
-      # order:status set to succeeded for consistency between providers
-      order:status: '{$.null#replace_str("Not Available","succeeded")}'
       assets: '{$.properties.links.sip-entries#assets_list_to_dict}'
       # Additional metadata provided by the providers but that don't appear in the reference spec
       size: '$.properties.productInformation.size'
@@ -5732,6 +6199,27 @@
       acquisitionInformation: '$.null'
       productInformation: '$.null'
       extraInformation: '$.null'
+    assets_mapping:
+      download_link:
+        title: 'downloadlink'
+        href: '$.properties.links.data[?(@.title="Product download")].href'
+        roles:
+        - 'archive'
+        - 'data'
+        type: '$.properties.links.data[?(@.title="Product download")].mediaType'
+        order:status: 'succeeded'
+      quicklook:
+        href: '$.properties.links.previews[?(@.title="Quicklook")].href'
+        title: "quicklook"
+        roles:
+        - 'overwiev'
+        type: "image/jpeg"
+      thumbnail:
+        href: '$.properties.links.previews[?(@.title="Quicklook")].href'
+        title: "thumbnail"
+        roles:
+        - 'thumbnail'
+        type: "image/jpeg"
   products:
     # S3 SRAL
     S3_SRA:
@@ -6356,11 +6844,26 @@
         - '{$.properties."grid:code"#replace_str(r"^T?(.*)$",r"MGRS-\1")}'
       sci:doi: '{$.properties.sci:doi#replace_str(r"^\[\]$","Not Available")}'
       published: '$.properties.datetime'
-      eodag:download_link: '$.assets[?(@.roles[0] == "data") & (@.type != "application/xml")].href'
-      eodag:quicklook: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
-      eodag:thumbnail: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
-      # order:status set to orderable by default and then updated from plugin
-      order:status: '{$.null#replace_str("Not Available","orderable")}'
+    assets_mapping:
+      download_link:
+        title: 'downloadlink'
+        href: '$.assets[?(@.roles[0] == "data") & (@.type == "application/zip")].href'
+        roles:
+        - 'archive'
+        - 'data'
+        order:status: 'succeeded'
+      quicklook:
+        href: '$.assets[?(@.roles[0] == "overview")].href'
+        title: "quicklook"
+        roles:
+        - 'overwiev'
+        type: "image/jpeg"
+      thumbnail:
+        href: '$.assets[?(@.roles[0] == "overview")].href'
+        title: "thumbnail"
+        roles:
+        - 'thumbnail'
+        type: "image/jpeg"
   products:
     S1_SAR_OCN:
       product:type: OCN
@@ -6490,11 +6993,26 @@
         - '{$.properties."grid:code"#replace_str(r"^T?(.*)$",r"MGRS-\1")}'
       sci:doi: '{$.properties.sci:doi#replace_str(r"^\[\]$","Not Available")}'
       published: '$.properties.datetime'
-      eodag:download_link: '$.properties.endpoint_url'
-      eodag:quicklook: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
-      eodag:thumbnail: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
-      # order:status set to succeeded for consistency between providers
-      order:status: '{$.null#replace_str("Not Available","succeeded")}'
+    assets_mapping:
+      download_link:
+        href: '$.properties.endpoint_url'
+        roles:
+        - 'archive'
+        - 'data'
+        type: 'application/octet-stream'
+        order:status: 'succeeded'
+      quicklook:
+        href: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
+        title: "quicklook"
+        roles:
+        - 'overwiev'
+        type: 'image/jpeg'
+      thumbnail:
+        href: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
+        title: "thumbnail"
+        roles:
+        - 'thumbnail'
+        type: 'image/jpeg'
   products:
     S1_SAR_OCN:
       product:type: OCN
@@ -6655,7 +7173,15 @@
         - '{{"area": {geometry#to_nwse_bounds}}}'
         - $.geometry
       qs: $.qs
-      eodag:order_link: 'https://ewds.climate.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{{"inputs": {qs#to_geojson}}}'
+    assets_mapping:
+      download_link:
+        href: ''
+        title: "downloadlink"
+        roles:
+        - 'archive'
+        - 'data'
+        type: 'application/octet-stream'
+        order_link: 'https://ewds.climate.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{"inputs": {qs#to_geojson}}'
   products:
     EFAS_HISTORICAL:
       dataset: efas-historical

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -62,23 +62,21 @@
       usgs:productId: '$.id'
     assets_mapping:
       download_link:
-        href: 'https://earthexplorer.usgs.gov/download/external/options/{_collection}/{$.entityId}/M2M/'
-        roles:
-        - 'archive'
-        - 'data'
+        _collection: '$.collection'
+        _entity_id: '$.entityId'
+        href: 'https://earthexplorer.usgs.gov/download/external/options/{_collection}/{_entity_id}/M2M/'
+        roles: '["archive", "data"]'
         type: 'application/octet-stream'
         order:status: '{$.available#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
       quicklook:
         href: '$.browse[0].browsePath'
         title: "quicklook"
-        roles:
-        - 'overwiev'
+        roles: '["overwiev"]'
         type: 'image/jpeg'
       thumbnail:
         href: '$.browse[0].thumbnailPath'
         title: "thumbnail"
-        roles:
-        - 'thumbnail'
+        roles: '["thumbnail"]'
         type: 'image/jpeg'
     extract: True
     order_enabled: true
@@ -188,22 +186,23 @@
           - '{title}'
       assets_mapping:
         download_link:
-          href: 's3://cbers-pds/{$.downloadUrl}'
-          roles:
-          - 'archive'
-          - 'data'
+          _download_url: '$.downloadUrl'
+          href: 's3://cbers-pds/{_download_url}'
+          roles: '["archive", "data"]'
           order:status: 'succeded'
         quicklook:
-          href: 'https://s3.amazonaws.com/cbers-meta-pds/{$.downloadUrl}/{$.sceneID#replace_str("_L[24]$","")}.jpg'
+          _download_url: '$.downloadUrl'
+          _scene_id: '{$.sceneID#replace_str("_L[24]$","")}'
+          href: 'https://s3.amazonaws.com/cbers-meta-pds/{_download_url}/{_scene_id}.jpg'
           title: "quicklook"
-          roles:
-          - 'overwiev'
+          roles: '["overwiev"]'
           type: 'image/jpeg'
         thumbnail:
-          href: 'https://s3.amazonaws.com/cbers-meta-pds/{$.downloadUrl}/{$.sceneID#replace_str("_L[24]$","")}_small.jpeg'
+          _download_url: '$.downloadUrl'
+          _scene_id: '{$.sceneID#replace_str("_L[24]$","")}'
+          href: 'https://s3.amazonaws.com/cbers-meta-pds/{_download_url}/{_scene_id}_small.jpeg'
           title: "thumbnail"
-          roles:
-          - 'thumbnail'
+          roles: '["thumbnail"]'
           type: 'image/jpeg'
     CBERS4_PAN10M_L4:
       instruments: PAN10M
@@ -294,21 +293,17 @@
       assets_mapping:
         download_link:
           href: 's3://landsat-pds/c1/L8/{_path:03.0f}/{_row:03.0f}/{title}/'
-          roles:
-          - 'archive'
-          - 'data'
+          roles: '["archive", "data"]'
           order:status: 'succeded'
         quicklook:
           href: 'https://landsat-pds.s3.amazonaws.com/c1/L8/{_path:03.0f}/{_row:03.0f}/{title}/{title}_thumb_large.jpg'
           title: "quicklook"
-          roles:
-          - 'overwiev'
+          roles: '["overwiev"]'
           type: 'image/jpeg'
         thumbnail:
           href: '$.thumbnail'
           title: "thumbnail"
-          roles:
-          - 'thumbnail'
+          roles: '["thumbnail"]'
           type: 'image/jpeg'
     MODIS_MCD43A4:
       _collection: modis
@@ -339,23 +334,22 @@
           - '{title}'
       assets_mapping:
         download_link:
-          href: 's3://modis-pds/MCD43A4.006/{$.horizontalTileNumber#round}/{$.verticalTileNumber#round}/{$.sceneID#slice_str(9,16,1)}/'
-          roles:
-          - 'archive'
-          - 'data'
+          _h_tile: '{$.horizontalTileNumber#round}'
+          _v_tile: '{$.verticalTileNumber#round}'
+          _scene_id: '{$.sceneID#slice_str(9,16,1)}'
+          href: 's3://modis-pds/MCD43A4.006/{_h_tile}/{_v_tile}/{_scene_id}/'
+          roles: '["archive", "data"]'
           type: 'application/octet-stream'
           order:status: 'succeded'
         quicklook:
           href: '$.thumbnail'
           title: "quicklook"
-          roles:
-          - 'overwiev'
+          roles: '["overwiev"]'
           type: 'image/jpeg'
         thumbnail:
           href: '$.thumbnail'
           title: "thumbnail"
-          roles:
-          - 'thumbnail'
+          roles: '["thumbnail"]'
           type: 'image/jpeg'
     NAIP:
       _collection: naip
@@ -382,10 +376,9 @@
           - '{title}'
       assets_mapping:
         download_link:
-          href: 's3://naip-analytic/{$.awsPath}'
-          roles:
-          - 'archive'
-          - 'data'
+          _aws_path: '$.awsPath'
+          href: 's3://naip-analytic/{_aws_path}'
+          roles: '["archive", "data"]'
           type: 'application/octet-stream'
           order:status: 'succeded'
     S1_SAR_GRD:
@@ -427,23 +420,20 @@
           - '{title}'
       assets_mapping:
         download_link:
-          href: 's3://sentinel-s1-l1c/{$.awsPath}'
-          roles:
-          - 'archive'
-          - 'data'
+          _aws_path: '$.awsPath'
+          href: 's3://sentinel-s1-l1c/{_aws_path}'
+          roles: '["archive", "data"]'
           type: 'application/octet-stream'
           order:status: 'succeded'
         quicklook:
           href: 'https://render.eosda.com/S1/thumb/{title}.png'
           title: "quicklook"
-          roles:
-          - 'overwiev'
+          roles: '["overwiev"]'
           type: 'image/png'
         thumbnail:
           href: 'https://render.eosda.com/S1/thumb/{title}.png'
           title: "thumbnail"
-          roles:
-          - 'thumbnail'
+          roles: '["thumbnail"]'
           type: 'image/png'
     S2_MSI_L1C:
       _collection: sentinel2
@@ -486,23 +476,20 @@
         _aws_path_l2a: '$.null'
       assets_mapping:
         download_link:
-          href: 's3://sentinel-s2-l1c/{$.awsPath}'
-          roles:
-          - 'archive'
-          - 'data'
+          _aws_path: '$.awsPath'
+          href: 's3://sentinel-s2-l1c/{_aws_path}'
+          roles: '["archive", "data"]'
           type: 'application/octet-stream'
           order:status: 'succeded'
         quicklook:
           href: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
           title: "quicklook"
-          roles:
-          - 'overwiev'
+          roles: '["overwiev"]'
           type: 'image/jpeg'
         thumbnail:
           href: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
           title: "thumbnail"
-          roles:
-          - 'thumbnail'
+          roles: '["thumbnail"]'
           type: 'image/jpeg'
     S2_MSI_L2A:
       _collection: sentinel2
@@ -570,10 +557,9 @@
       assets_mapping_from_product: S2_MSI_L1C
       assets_mapping:
         download_link:
-          href: 's3://sentinel-s2-l2a/{$.awsPathL2A}'
-          roles:
-          - 'archive'
-          - 'data'
+          _aws_path_l2a: '$.awsPathL2A'
+          href: 's3://sentinel-s2-l2a/{_aws_path_l2a}'
+          roles: '["archive", "data"]'
           type: 'application/octet-stream'
           order:status: 'succeded'
   download: !plugin
@@ -862,9 +848,7 @@
       download_link:
         title: 'downloadlink'
         href: 'https://zipper.creodias.eu/odata/v1/Products({uid})/$value'
-        roles:
-        - 'archive'
-        - 'data'
+        roles: '["archive", "data"]'
         type: '$.ContentType'
         file:checksum: '$.Checksum[?Algorithm="MD5"].Value'
         file:size: '$.ContentLength'
@@ -873,14 +857,12 @@
       quicklook:
         href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
         title: "quicklook"
-        roles:
-        - 'overwiev'
+        roles: '["overwiev"]'
         type: "image/jpeg"
       thumbnail:
         href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
         title: "thumbnail"
-        roles:
-        - 'thumbnail'
+        roles: '["thumbnail"]'
         type: "image/jpeg"
   download: !plugin
     type: HTTPDownload
@@ -1322,14 +1304,12 @@
       quicklook:
         href: '$.assets.reduced_resolution_browse.alternate.s3.href'
         title: "quicklook"
-        roles:
-        - 'overwiev'
+        roles: '["overwiev"]'
         type: '$.assets.reduced_resolution_browse.type'
       thumbnail:
         href: '$.assets.thumbnail.alternate.s3.href'
         title: "thumbnail"
-        roles:
-        - 'thumbnail'
+        roles: '["thumbnail"]'
         type: '$.assets.thumbnail.type'
   products:
     LANDSAT_C2L1:
@@ -1419,9 +1399,7 @@
     download_link:
       title: "downloadlink"
       href: '$.links[?(@.rel="self")].href'
-      roles:
-      - 'archive'
-      - 'data'
+      roles: '["archive", "data"]'
       type: 'aplication/json'
       # order:status set to succeeded for consistency between providers
       order:status: 'succeeded'
@@ -1523,22 +1501,18 @@
       assets_mapping:
         download_link:
           href: 's3://gcp-public-data-sentinel-2/tiles/{mgrs:utm_zone}/{mgrs:latitude_band}/{mgrs:grid_square}/{title}.SAFE'
-          roles:
-          - 'archive'
-          - 'data'
+          roles: '["archive", "data"]'
           type: 'application/octet-stream'
           order:status: 'succeeded'
         quicklook:
           href: '$.assets.thumbnail.href'
           title: "thumbnail"
-          roles:
-          - 'overwiev'
+          roles: '["overwiev"]'
           type: '$.assets.thumbnail.type'
         thumbnail:
           href: '$.assets.thumbnail.href'
           title: "thumbnail"
-          roles:
-          - 'thumbnail'
+          roles: '["thumbnail"]'
           type: '$.assets.thumbnail.type'
     L8_OLI_TIRS_C1L1:
       _collection: landsat-8-l1-c1
@@ -1549,9 +1523,7 @@
       assets_mapping:
         download_link:
           href: 's3://gcp-public-data-landsat/LC08/01/{wrsPath:03d}/{wrsRow:03d}/{title}'
-          roles:
-          - 'archive'
-          - 'data'
+          roles: '["archive", "data"]'
           type: 'application/octet-stream'
           order:status: 'succeeded'
     GENERIC_COLLECTION:
@@ -1596,10 +1568,10 @@
       qs: $.qs
     assets_mapping:
       download_link:
-        href: 'https://apps.ecmwf.int/datasets/data/{dataset}?{qs#to_geojson}'
-        roles:
-        - 'archive'
-        - 'data'
+        _dataset: '$.dataset'
+        _qs: '$.qs'
+        href: 'https://apps.ecmwf.int/datasets/data/{_dataset}?{_qs#to_geojson}'
+        roles: '["archive", "data"]'
         type: 'application/octet-stream'
         # order:status set to succeeded for consistency between providers
         order:status: 'succeeded'
@@ -1690,9 +1662,7 @@
       download_link:
         title: "downloadlink"
         href: ""
-        roles:
-        - archive
-        - data
+        roles: '["archive", "data"]'
         type: "application/netcdf"
         order_link: 'https://ads.atmosphere.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{"inputs": {qs#to_geojson}}'
   products:
@@ -1868,9 +1838,7 @@
       download_link:
         title: "downloadlink"
         href: ""
-        roles:
-        - archive
-        - data
+        roles: '["archive", "data"]'
         type: "application/netcdf"
         order_link: 'https://ads.atmosphere.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{"inputs": {qs#to_geojson}}'
   products:
@@ -2100,9 +2068,7 @@
         # The url to download the product "as is" (literal or as a template to be completed either after the search result
         # is obtained from the provider or during the eodag download phase)
         href: '$.properties.services.download.url'
-        roles:
-        - 'archive'
-        - 'data'
+        roles: '["archive", "data"]'
         type: '{$.properties.services.download.mimeType#replace_str("application/unknown","application/octet-stream")}'
         file:size: '$.properties.services.download.size'
         file:checksum: '{$.properties.services.download.checksum#replace_str("md5=","")#to_lower'
@@ -2111,14 +2077,12 @@
       quicklook:
         href: '$.properties.quicklook'
         title: "quicklook"
-        roles:
-        - 'overwiev'
+        roles: '["overwiev"]'
         type: "image/png"
       thumbnail:
         href: '$.properties.thumbnail'
         title: "thumbnail"
-        roles:
-        - 'thumbnail'
+        roles: '["thumbnail"]'
         type: "image/png"
   products:
     # Sentinel 1
@@ -2326,10 +2290,9 @@
         - '$.timeIntervalsAlignment'
     assets_mapping:
       download_link:
+        qs: '$.qs'
         href: https://my.meteoblue.com/dataset/query?{qs#to_geojson}
-        roles:
-        - 'archive'
-        - 'data'
+        roles: '["archive", "data"]'
         type: 'application/octet-stream'
         order:status: '{$.requiresJobQueue#get_group_name((?P<succeeded>False)|(?P<orderable>True))}'
         order_link: https://my.meteoblue.com/dataset/query?{qs#replace_str(r"^(.*)(\")(queries\")(.)",r"\1\2runOnJobQueue\2\4 true, \2\3\4")}
@@ -2628,9 +2591,7 @@
     assets_mapping:
       download_link:
         href: 'https://catalogue.dataspace.copernicus.eu/odata/v1/Products({uid})/$value'
-        roles:
-        - 'archive'
-        - 'data'
+        roles: '["archive", "data"]'
         type: '$.ContentType'
         file:checksum: '$.Checksum[?Algorithm="MD5"].Value'
         file:size: '$.ContentLength'
@@ -2639,14 +2600,12 @@
       quicklook:
         href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
         title: "quicklook"
-        roles:
-        - 'overwiev'
+        roles: '["overwiev"]'
         type: "image/jpeg"
       thumbnail:
         href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
         title: "thumbnail"
-        roles:
-        - 'thumbnail'
+        roles: '["thumbnail"]'
         type: "image/jpeg"
   download: !plugin
     type: HTTPDownload
@@ -3075,14 +3034,12 @@
       quicklook:
         href: '$.assets[?(@.rel == "preview")].href'
         title: "quicklook"
-        roles:
-        - 'overwiev'
+        roles: '["overwiev"]'
         type: '$.assets[?(@.rel == "preview")].type'
       thumbnail:
         href: '$.assets[?(@.rel == "preview")].href'
         title: "thumbnail"
-        roles:
-        - 'thumbnail'
+        roles: '["thumbnail"]'
         type: '$.assets[?(@.rel == "preview")].type'
   products:
     S1_SAR_GRD:
@@ -3271,23 +3228,19 @@
     assets_mapping:
       download_link:
         href: ''
-        roles:
-        - 'archive'
-        - 'data'
+        roles: '["archive", "data"]'
         type: 'application/octet-stream'
         order:status: 'orderable'
         order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}'
       quicklook:
         href: '$.properties.thumbnail'
         title: "quicklook"
-        roles:
-        - 'overwiev'
+        roles: '["overwiev"]'
         type: 'image/jpeg'
       thumbnail:
         href: '$.properties.thumbnail'
         title: "thumbnail"
-        roles:
-        - 'thumbnail'
+        roles: '["thumbnail"]'
         type: 'image/jpeg'
   products:
     S1_SAR_GRD:
@@ -3725,9 +3678,7 @@
     assets_mapping:
       download_link:
         href: ''
-        roles:
-        - 'archive'
-        - 'data'
+        roles: '["archive", "data"]'
         type: '$.ContentType'
         "order_link": 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location#url_decode}","product_id":"{id}", "dataset_id": "{dataset}"}'
         order:status: 'orderable'
@@ -4011,9 +3962,7 @@
     assets_mapping:
       download_link:
         href: '$.properties.location'
-        roles:
-        - 'archive'
-        - 'data'
+        roles: '["archive", "data"]'
         type: 'application/octet-stream'
         order:status: 'orderable'
         order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "cacheable": "true", "dataset_id": "productType"}'
@@ -4295,23 +4244,19 @@
     assets_mapping:
       download_link:
         href: '$.S3Path.`sub(/^(.*)$/, s3:/\\1)`'
-        roles:
-        - 'archive'
-        - 'data'
+        roles: '["archive", "data"]'
         type: 'application/octet-stream'
         # order:status: must be one of succeeded, ordered, orderable
         order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
       quicklook:
         href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
         title: "quicklook"
-        roles:
-        - 'overwiev'
+        roles: '["overwiev"]'
         type: "image/jpeg"
       thumbnail:
         href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
         title: "thumbnail"
-        roles:
-        - 'thumbnail'
+        roles: '["thumbnail"]'
         type: "image/jpeg"
   download: !plugin
     type: AwsDownload
@@ -4752,9 +4697,7 @@
       download_link:
         title: "downloadlink"
         href: ''
-        roles:
-        - 'archive'
-        - 'data'
+        roles: '["archive", "data"]'
         type: 'application/octet-stream'
         order_link: 'https://polytope.lumi.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{"verb": "retrieve", "request": {qs#to_geojson} }'
         order:status: 'orderable'
@@ -5034,9 +4977,7 @@
       download_link:
         title: "downloadlink"
         href: ''
-        roles:
-        - 'archive'
-        - 'data'
+        roles: '["archive", "data"]'
         type: 'application/octet-stream'
         order_link: 'https://polytope.mn5.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{{"verb": "retrieve", "request": {qs#to_geojson} }}'
         order:status: 'orderable'
@@ -5364,24 +5305,20 @@
       download_link:
         title: "downloadlink"
         href: '$.assets.downloadLink.href'
-        roles:
-        - 'archive'
-        - 'data'
+        roles: '["archive", "data"]'
         type: '$.assets.downloadLink.type'
         alternate: '$.assets.downloadLink.alternate'
         order:status: '{$.properties."order:status"#get_group_name((?P<succeeded>succeeded)|(?P<ordered>shipping)|(?P<orderable>orderable))}'
       quicklook:
         href: '$.assets["ql.jpg"].href'
         title: "quicklook"
-        roles:
-        - 'overwiev'
+        roles: '["overwiev"]'
         type: '$.assets["ql.jpg"].type'
         alternate: '$.assets["ql.jpg"].alternate'
       thumbnail:
         href: '$.assets["ql.jpg"].href'
         title: "thumbnail"
-        roles:
-        - 'thumbnail'
+        roles: '["thumbnail"]'
         type: $.assets["ql.jpg"].type
         alternate: '$.assets["ql.jpg"].alternate'
     discover_collections:
@@ -6040,22 +5977,18 @@
       download_link:
         title: 'downloadlink'
         href: '$.properties.links.data[?(@.title="Product download")].href'
-        roles:
-        - 'archive'
-        - 'data'
+        roles: '["archive", "data"]'
         type: '$.properties.links.data[?(@.title="Product download")].mediaType'
         order:status: 'succeeded'
       quicklook:
         href: '$.properties.links.previews[?(@.title="Quicklook")].href'
         title: "quicklook"
-        roles:
-        - 'overwiev'
+        roles: '["overwiev"]'
         type: "image/jpeg"
       thumbnail:
         href: '$.properties.links.previews[?(@.title="Quicklook")].href'
         title: "thumbnail"
-        roles:
-        - 'thumbnail'
+        roles: '["thumbnail"]'
         type: "image/jpeg"
   products:
     # S3 SRAL
@@ -6685,21 +6618,17 @@
       download_link:
         title: 'downloadlink'
         href: '$.assets[?(@.roles[0] == "data") & (@.type == "application/zip")].href'
-        roles:
-        - 'archive'
-        - 'data'
+        roles: '["archive", "data"]'
         order:status: 'succeeded'
       quicklook:
         href: '$.assets[?(@.roles[0] == "overview")].href'
         title: "quicklook"
-        roles:
-        - 'overwiev'
+        roles: '["overwiev"]'
         type: "image/jpeg"
       thumbnail:
         href: '$.assets[?(@.roles[0] == "overview")].href'
         title: "thumbnail"
-        roles:
-        - 'thumbnail'
+        roles: '["thumbnail"]'
         type: "image/jpeg"
   products:
     S1_SAR_OCN:
@@ -6833,22 +6762,18 @@
     assets_mapping:
       download_link:
         href: '$.properties.endpoint_url'
-        roles:
-        - 'archive'
-        - 'data'
+        roles: '["archive", "data"]'
         type: 'application/octet-stream'
         order:status: 'succeeded'
       quicklook:
         href: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
         title: "quicklook"
-        roles:
-        - 'overwiev'
+        roles: '["overwiev"]'
         type: 'image/jpeg'
       thumbnail:
         href: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
         title: "thumbnail"
-        roles:
-        - 'thumbnail'
+        roles: '["thumbnail"]'
         type: 'image/jpeg'
   products:
     S1_SAR_OCN:
@@ -7014,9 +6939,7 @@
       download_link:
         href: ''
         title: "downloadlink"
-        roles:
-        - 'archive'
-        - 'data'
+        roles: '["archive", "data"]'
         type: 'application/octet-stream'
         order_link: 'https://ewds.climate.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{"inputs": {qs#to_geojson}}'
   products:

--- a/eodag/resources/stac_provider.yml
+++ b/eodag/resources/stac_provider.yml
@@ -113,11 +113,5 @@ search:
     eo:cloud_cover:
       - '{{"query":{{"eo:cloud_cover":{{"lte":{eo:cloud_cover}}}}}}}'
       - '$.properties."eo:cloud_cover"'
-    # eodag metadata
-    eodag:download_link: '$.links[?(@.rel="self")].href'
-    eodag:quicklook: '$.assets.quicklook.href'
-    eodag:thumbnail: '$.assets.thumbnail.href'
-    # order:status set to succeeded for consistency between providers
-    order:status: '{$.null#replace_str("Not Available","succeeded")}'
     # Normalization code moves assets from properties to product's attr
     assets: '$.assets'

--- a/eodag/utils/s3.py
+++ b/eodag/utils/s3.py
@@ -530,6 +530,8 @@ def update_assets_from_s3(
     if content_url is None and "download_link" in product.assets:
         content_url = product.assets["download_link"].remote_location
     if content_url is None:
+        # nothing to list, but still refresh driver based on current assets
+        product.driver = product.get_driver()
         return None
 
     bucket, prefix = get_bucket_name_and_prefix(content_url)

--- a/eodag/utils/s3.py
+++ b/eodag/utils/s3.py
@@ -515,8 +515,8 @@ def update_assets_from_s3(
     s3_endpoint: Optional[str] = None,
     content_url: Optional[str] = None,
 ) -> None:
-    """Update ``EOProduct.assets`` using content listed in its ``remote_location`` or given
-    ``content_url``.
+    """Update ``EOProduct.assets`` using content listed in its ``product.assets["downloadlink"].remote_location``
+    or given ``content_url``.
 
     If url points to a zipped archive, its content will also be be listed.
 
@@ -524,11 +524,13 @@ def update_assets_from_s3(
     :param auth: Authentication plugin
     :param s3_endpoint: s3 endpoint if not hosted on AWS
     :param content_url: s3 URL pointing to the content that must be listed (defaults to
-                        ``product.remote_location`` if empty)
+                        ``product.assets['downloadlink'].remote_location`` if empty)
     """
 
+    if content_url is None and "download_link" in product.assets:
+        content_url = product.assets["download_link"].remote_location
     if content_url is None:
-        content_url = product.remote_location
+        return None
 
     bucket, prefix = get_bucket_name_and_prefix(content_url)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -355,9 +355,12 @@ class EODagTestCase(EODagTestBase):
         super().setUp()
         self.requests_http_get_patcher = mock.patch("requests.get", autospec=True)
         self.requests_http_get = self.requests_http_get_patcher.start()
+        self.requests_request_patcher = mock.patch("requests.request", autospec=True)
+        self.requests_request = self.requests_request_patcher.start()
 
     def tearDown(self):
         self.requests_http_get_patcher.stop()
+        self.requests_request_patcher.stop()
         super().tearDown()
 
     def assertHttpGetCalledOnceWith(self, expected_url, expected_params=None):

--- a/tests/integration/test_core_search.py
+++ b/tests/integration/test_core_search.py
@@ -858,6 +858,8 @@ class TestCoreSearch(unittest.TestCase):
         self.assertEqual(product.properties["grid:code"], "MGRS-14ULD")
         self.assertIsNotNone(product.geometry)
         # download link from assets
-        self.assertIn("api/download", product.properties.get("eodag:download_link", ""))
+        self.assertIn("api/download", product.assets["download_link"]["href"])
         # quicklook from assets
-        self.assertIn("api/quicklook", product.properties.get("eodag:quicklook", ""))
+        self.assertIn(
+            "api/quicklook", product.assets.get("quicklook", {}).get("href", "")
+        )

--- a/tests/integration/test_core_search_results.py
+++ b/tests/integration/test_core_search_results.py
@@ -59,8 +59,24 @@ STAC_SCHEMA_MAP = _build_stac_schema_map()
 
 
 class TestCoreSearchResults(EODagTestCase):
+    def assert_stac_messages_valid(self, messages):
+        for msg in messages:
+            self.assertTrue(
+                msg.get("valid_stac"),
+                messages,
+            )
+
     def setUp(self):
         super(TestCoreSearchResults, self).setUp()
+        # Give deterministic, JSON-serializable payloads to globally mocked requests
+        # used by stac_validator while avoiding network access in tests.
+        self.requests_http_get.return_value.raise_for_status.return_value = None
+        self.requests_http_get.return_value.status_code = 200
+        self.requests_http_get.return_value.json.return_value = {}
+
+        self.requests_request.return_value.raise_for_status.return_value = None
+        self.requests_request.return_value.status_code = 200
+        self.requests_request.return_value.json.return_value = {}
         # Mock home and eodag conf directory to tmp dir
         self.tmp_home_dir = tempfile.TemporaryDirectory()
         self.expanduser_mock = mock.patch(
@@ -164,8 +180,7 @@ class TestCoreSearchResults(EODagTestCase):
                 schema_map=STAC_SCHEMA_MAP,
             )
             stac.validate_item_collection()
-            for msg in stac.message:
-                self.assertTrue(msg["valid_stac"], stac.message)
+            self.assert_stac_messages_valid(stac.message)
             with open(path, "r") as f:
                 self.make_assertions(f)
 
@@ -194,8 +209,7 @@ class TestCoreSearchResults(EODagTestCase):
                 schema_map=STAC_SCHEMA_MAP,
             )
             stac.run()
-            for msg in stac.message:
-                self.assertTrue(msg["valid_stac"], stac.message)
+            self.assert_stac_messages_valid(stac.message)
             with open(collection_path) as f:
                 collection_dict = json.load(f)
             self.assertEqual(len(collection_dict["links"]), 1)
@@ -227,8 +241,7 @@ class TestCoreSearchResults(EODagTestCase):
                 schema_map=STAC_SCHEMA_MAP,
             )
             stac.validate_item_collection()
-            for msg in stac.message:
-                self.assertTrue(msg["valid_stac"], stac.message)
+            self.assert_stac_messages_valid(stac.message)
 
             # check associated serialized collection
             collection1_path = tmpdir_path / f"{self.search_result[0].collection}.json"
@@ -250,8 +263,7 @@ class TestCoreSearchResults(EODagTestCase):
                 schema_map=STAC_SCHEMA_MAP,
             )
             stac.run()
-            for msg in stac.message:
-                self.assertTrue(msg["valid_stac"], stac.message)
+            self.assert_stac_messages_valid(stac.message)
 
     def test_core_serialize_search_results_without_filename(self):
         """The core api must serialize a search results to STAC feature collection without filename"""

--- a/tests/integration/test_core_search_results.py
+++ b/tests/integration/test_core_search_results.py
@@ -765,7 +765,7 @@ class TestCoreSearchResults(EODagTestCase):
         self.assertEqual(results[0].properties["id"], "stac-fastapi-eodag-id")
         self.assertEqual(results[0].collection, "foo-collection")
         self.assertEqual(len(results[0].assets), 0)
-        self.assertEqual(results[0].location, "https://provider-url/origin-link")
+        self.assertEqual(results[0].location, "")
         self.assertIsInstance(results[0].downloader, Download)
 
         self.assertEqual(results[1].provider, "earth_search")

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -576,7 +576,8 @@ class TestApisPluginUsgsApi(BaseApisPluginTest):
             ),
         )
         self.assertEqual(
-            search_results.data[0].properties["order:status"], ONLINE_STATUS
+            search_results.data[0].assets["download_link"]["order:status"],
+            ONLINE_STATUS,
         )
         self.assertEqual(
             search_results.number_matched,

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -109,10 +109,14 @@ class BaseSearchPluginTest(unittest.TestCase):
     def test_get_assets_from_mapping(self):
         search_plugin = self.get_search_plugin(provider="geodes")
         search_plugin.config.assets_mapping = {
-            "one": {"href": "$.properties.href", "roles": ["a_role"], "title": "One"},
+            "one": {
+                "href": "$.properties.href",
+                "roles": '["a_role"]',
+                "title": "One",
+            },
             "two": {
                 "href": "https://a.static_url.com",
-                "roles": ["a_role"],
+                "roles": '["a_role"]',
                 "title": "Two",
             },
         }

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -106,7 +106,7 @@ class BaseSearchPluginTest(unittest.TestCase):
     def get_auth_plugin(self, search_plugin):
         return self.plugins_manager.get_auth_plugin(search_plugin)
 
-    def test_get_assets_from_mapping(self):
+    def test_build_assets_from_mapping(self):
         search_plugin = self.get_search_plugin(provider="geodes")
         search_plugin.config.assets_mapping = {
             "one": {
@@ -121,7 +121,7 @@ class BaseSearchPluginTest(unittest.TestCase):
             },
         }
         provider_item = {"id": "ID123456", "properties": {"href": "a.product.com/ONE"}}
-        asset_mappings = search_plugin.get_assets_from_mapping(provider_item)
+        asset_mappings = search_plugin.build_assets_from_mapping(provider_item)
         self.assertEqual(2, len(asset_mappings))
         self.assertEqual("a.product.com/ONE", asset_mappings["one"]["href"])
         self.assertEqual("One", asset_mappings["one"]["title"])

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -3033,13 +3033,6 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
 
         with open(self.provider_resp_dir / "geodes_search.json", encoding="utf-8") as f:
             raw_features = json.load(f)["features"]
-        raw_assets = raw_features[0]["assets"]
-        quicklook_asset = raw_assets[
-            "2025/04/02/S2A/S2A_MSIL1C_20250402T175741_N0511_R141_T14ULD_20250403T022035_quicklook.jpg"
-        ]
-        zip_asset = raw_assets[
-            "S2A_MSIL1C_20250402T175741_N0511_R141_T14ULD_20250403T022035.zip"
-        ]
 
         search_plugin = self.get_search_plugin(provider="geodes")
         normalized = search_plugin.normalize_results(RawSearchResult(raw_features))
@@ -3048,29 +3041,36 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
         self.assertDictEqual(
             dict(normalized[0].assets),
             {
-                "quicklook.jpg": {
-                    "href": quicklook_asset["href"],
-                    "title": "quicklook.jpg",
-                    "description": quicklook_asset["description"],
-                    "type": "image/jpeg",
-                    "roles": ["overview"],
-                    "file:size": 18684,
-                    "geodes:reference": False,
-                    "geodes:online": True,
-                    "geodes:datatype": "QUICKLOOK_SD",
-                    "file:checksum": "1003ae6b1edf05adf7c46cb759ffeaec",
+                "download_link": {
+                    "href": (
+                        "https://geodes-portal.cnes.fr/api/download/"
+                        "URN:FEATURE:DATA:gdh:25416e3f-1a7f-379a-9b65-a6539b1fd95b:V1"
+                        "/files/86f828c4c7e921615d1cd0476604f780"
+                    ),
+                    "order:status": "succeeded",
+                    "roles": ["archive", "data"],
+                    "title": "downloadlink",
+                    "type": "application/octet-stream",
                 },
-                "zip": {
-                    "href": zip_asset["href"],
-                    "title": "zip",
-                    "description": zip_asset["description"],
-                    "type": "application/zip",
-                    "roles": ["auxiliary"],
-                    "file:size": 764210185,
-                    "geodes:reference": False,
-                    "geodes:online": False,
-                    "geodes:datatype": "RAWDATA",
-                    "file:checksum": "86f828c4c7e921615d1cd0476604f780",
+                "quicklook": {
+                    "href": (
+                        "https://geodes-portal.cnes.fr/api/quicklook/"
+                        "URN:FEATURE:DATA:gdh:25416e3f-1a7f-379a-9b65-a6539b1fd95b:V1"
+                        "/files/1003ae6b1edf05adf7c46cb759ffeaec?scope=gdh"
+                    ),
+                    "roles": ["overwiev"],
+                    "title": "quicklook",
+                    "type": "image/jpeg",
+                },
+                "thumbnail": {
+                    "href": (
+                        "https://geodes-portal.cnes.fr/api/quicklook/"
+                        "URN:FEATURE:DATA:gdh:25416e3f-1a7f-379a-9b65-a6539b1fd95b:V1"
+                        "/files/1003ae6b1edf05adf7c46cb759ffeaec?scope=gdh"
+                    ),
+                    "roles": ["thumbnail"],
+                    "title": "thumbnail",
+                    "type": "image/jpeg",
                 },
             },
         )
@@ -4779,9 +4779,9 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
                 end_datetime="2020-02-01T01:00:00Z",
             )
 
-        self.assertIn("native", result[0].assets)
-        asset = result[0].assets["native"]
-        self.assertEqual(asset.get("title"), "native")
+        self.assertIn("download_link", result[0].assets)
+        asset = result[0].assets["download_link"]
+        self.assertEqual(asset.get("title"), "downloadlink")
         self.assertEqual(
             asset.get("href"),
             "https://s3.test.com/bucket1/native/PRODUCT_A/dataset-number-one/"
@@ -4821,16 +4821,16 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
         )
         self.assertEqual("2001-05-01T00:00:00.000Z", product.properties["end_datetime"])
         self.assertEqual(
-            "https://www.abc.com/thumbnailA", product.properties["eodag:thumbnail"]
+            "https://www.abc.com/thumbnailA", product.assets["thumbnail"]["href"]
         )
         self.assertEqual("dataset-number-one", product.properties["dataset"])
         self.assertEqual("a", product.properties["a"])
         self.assertEqual("b", product.properties["b"])
         self.assertEqual("c", product.properties["c"])
-        self.assertIn("native", product.assets)
+        self.assertIn("download_link", product.assets)
         self.assertEqual(
             "https://s3.test.com/bucket1/native/PRODUCT_A/dataset-number-one/item1_20010501",
-            product.assets["native"]["href"],
+            product.assets["download_link"]["href"],
         )
 
         # with use of dataset dates
@@ -4852,13 +4852,11 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
             asset_properties={"z": "z"},
         )
         self.assertEqual("item1_20010501", product.properties["id"])
-        self.assertIn("native", product.assets)
+        self.assertIn("download_link", product.assets)
         self.assertEqual(
             "https://s3.test.com/bucket1/native/PRODUCT_A/dataset-number-one/item1_20010501",
-            product.assets["native"]["href"],
+            product.assets["download_link"]["href"],
         )
-        self.assertIn("z", product.assets["native"])
-        self.assertEqual("z", product.assets["native"]["z"])
 
     def test_plugins_search_cop_marine_discover_queryables(self):
         """Queryables discovery with a CopMarineSearch must return static queryables with an adaptative default value"""  # noqa
@@ -5677,6 +5675,15 @@ class TestSearchPluginEumetsatDsSearch(BaseSearchPluginTest):
         self.assertDictEqual(
             dict(normalized[0].assets),
             {
+                "download_link": {
+                    "href": "https://api.eumetsat.int/data/download/1.0.0/collections/"
+                    "EO%3AEUM%3ADAT%3A0921/products/PREmm20201201000000120IMPGS01GL",
+                    "title": "downloadlink",
+                    "roles": ["archive", "data"],
+                    "eumesat_ds:type": "application/zip",
+                    "type": "application/octet-stream",
+                    "order:status": "succeeded",
+                },
                 "EOPMetadata.xml": {
                     "href": base_href + "EOPMetadata.xml",
                     "title": "EOPMetadata.xml",

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -127,6 +127,129 @@ class BaseSearchPluginTest(unittest.TestCase):
         self.assertEqual("Two", asset_mappings["two"]["title"])
         self.assertListEqual(["a_role"], asset_mappings["two"]["roles"])
 
+    def test_get_assets_mapping_from_product_inherits(self):
+        """A product with only ``assets_mapping_from_product`` inherits the parent's mapping fully"""
+        search_plugin = self.get_search_plugin(provider="geodes")
+        search_plugin.config.assets_mapping = {}
+        parent_mapping = {
+            "download_link": {"href": "parent_href", "roles": ["data"]},
+            "quicklook": {"href": "parent_ql", "roles": ["overview"]},
+        }
+        search_plugin.config.products = {
+            "PARENT_COLLECTION": {"assets_mapping": parent_mapping},
+            "CHILD_COLLECTION": {"assets_mapping_from_product": "PARENT_COLLECTION"},
+        }
+        resolved = search_plugin.get_assets_mapping("CHILD_COLLECTION")
+        self.assertEqual(parent_mapping, resolved)
+
+    def test_get_assets_mapping_from_product_per_asset_override(self):
+        """A child product can override one asset and inherit the others from the parent"""
+        search_plugin = self.get_search_plugin(provider="geodes")
+        search_plugin.config.assets_mapping = {}
+        search_plugin.config.products = {
+            "PARENT_COLLECTION": {
+                "assets_mapping": {
+                    "download_link": {"href": "parent_dl", "roles": ["data"]},
+                    "quicklook": {"href": "parent_ql", "roles": ["overview"]},
+                    "thumbnail": {"href": "parent_tn", "roles": ["thumbnail"]},
+                }
+            },
+            "CHILD_COLLECTION": {
+                "assets_mapping_from_product": "PARENT_COLLECTION",
+                "assets_mapping": {
+                    "download_link": {"href": "child_dl", "roles": ["data"]},
+                },
+            },
+        }
+        resolved = search_plugin.get_assets_mapping("CHILD_COLLECTION")
+        # download_link overridden, others inherited
+        self.assertEqual("child_dl", resolved["download_link"]["href"])
+        self.assertEqual("parent_ql", resolved["quicklook"]["href"])
+        self.assertEqual("parent_tn", resolved["thumbnail"]["href"])
+
+    def test_get_assets_mapping_from_product_does_not_mutate_parent(self):
+        """Resolving a child product must not mutate the parent's cached config"""
+        search_plugin = self.get_search_plugin(provider="geodes")
+        search_plugin.config.assets_mapping = {}
+        parent_mapping = {
+            "download_link": {"href": "parent_dl", "roles": ["data"]},
+            "quicklook": {"href": "parent_ql", "roles": ["overview"]},
+        }
+        search_plugin.config.products = {
+            "PARENT_COLLECTION": {"assets_mapping": copy_deepcopy(parent_mapping)},
+            "CHILD_COLLECTION": {
+                "assets_mapping_from_product": "PARENT_COLLECTION",
+                "assets_mapping": {
+                    "download_link": {"href": "child_dl", "roles": ["data"]},
+                },
+            },
+        }
+        # Resolve the child first; this previously polluted the parent's config
+        search_plugin.get_assets_mapping("CHILD_COLLECTION")
+        # PARENT_COLLECTION must still expose its original mapping
+        self.assertEqual(
+            parent_mapping,
+            search_plugin.config.products["PARENT_COLLECTION"]["assets_mapping"],
+        )
+        # And resolving the parent after the child must still return the parent's mapping
+        self.assertEqual(
+            parent_mapping, search_plugin.get_assets_mapping("PARENT_COLLECTION")
+        )
+
+    def test_get_assets_mapping_from_product_chain(self):
+        """Multi-hop ``assets_mapping_from_product`` chain resolves transitively, leaf overrides win"""
+        search_plugin = self.get_search_plugin(provider="geodes")
+        search_plugin.config.assets_mapping = {}
+        search_plugin.config.products = {
+            "GRANDPARENT_COLLECTION": {
+                "assets_mapping": {
+                    "download_link": {"href": "gp_dl"},
+                    "quicklook": {"href": "gp_ql"},
+                    "thumbnail": {"href": "gp_tn"},
+                }
+            },
+            "PARENT_COLLECTION": {
+                "assets_mapping_from_product": "GRANDPARENT_COLLECTION",
+                "assets_mapping": {
+                    "quicklook": {"href": "parent_ql"},
+                },
+            },
+            "CHILD_COLLECTION": {
+                "assets_mapping_from_product": "PARENT_COLLECTION",
+                "assets_mapping": {
+                    "download_link": {"href": "child_dl"},
+                },
+            },
+        }
+        resolved = search_plugin.get_assets_mapping("CHILD_COLLECTION")
+        self.assertEqual("child_dl", resolved["download_link"]["href"])
+        self.assertEqual("parent_ql", resolved["quicklook"]["href"])
+        self.assertEqual("gp_tn", resolved["thumbnail"]["href"])
+
+    def test_get_assets_mapping_from_product_cycle(self):
+        """A cycle in ``assets_mapping_from_product`` is detected, logged and broken"""
+        search_plugin = self.get_search_plugin(provider="geodes")
+        search_plugin.config.assets_mapping = {}
+        search_plugin.config.products = {
+            "LEFT_COLLECTION": {
+                "assets_mapping_from_product": "RIGHT_COLLECTION",
+                "assets_mapping": {"download_link": {"href": "left_dl"}},
+            },
+            "RIGHT_COLLECTION": {
+                "assets_mapping_from_product": "LEFT_COLLECTION",
+                "assets_mapping": {"quicklook": {"href": "right_ql"}},
+            },
+        }
+        with self.assertLogs("eodag.search.base", level="WARNING") as logs:
+            resolved = search_plugin.get_assets_mapping("LEFT_COLLECTION")
+        self.assertTrue(
+            any("cycle detected" in msg for msg in logs.output),
+            msg=f"expected cycle warning, got: {logs.output}",
+        )
+        # Both assets are merged once; leaf (LEFT_COLLECTION) wins on collisions
+        self.assertEqual("left_dl", resolved["download_link"]["href"])
+        self.assertEqual("right_ql", resolved["quicklook"]["href"])
+
 
 class TestSearchPluginQueryStringSearchXml(BaseSearchPluginTest):
     def setUp(self):

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -60,7 +60,6 @@ from eodag.utils.exceptions import (
 from tests.context import (
     DEFAULT_SEARCH_TIMEOUT,
     HTTP_REQ_TIMEOUT,
-    NOT_AVAILABLE,
     TEST_RESOURCES_PATH,
     USER_AGENT,
     AuthenticationError,
@@ -3118,14 +3117,15 @@ class TestSearchPluginMeteoblueSearch(BaseSearchPluginTest):
             ],
             "type": "Polygon",
         }
-        # check eodag:download_link
+        # check download_link asset href
+        download_asset = products.data[0].assets["download_link"]
         self.assertEqual(
-            products.data[0].properties["eodag:download_link"],
+            download_asset["href"],
             f"{endpoint}?" + json.dumps({"geometry": default_geom, **custom_query}),
         )
-        # check eodag:order_link
+        # check download_link asset order_link
         self.assertEqual(
-            products.data[0].properties["eodag:order_link"],
+            download_asset["order_link"],
             f"{endpoint}?"
             + json.dumps(
                 {
@@ -3201,10 +3201,15 @@ class TestSearchPluginCreodiasS3Search(BaseSearchPluginTest):
             }
             product.register_downloader(download_plugin, auth_plugin)
         assets = res.data[0].assets
-        self.assertEqual(3, len(assets))
-        # check if s3 links have been created correctly
-        for asset in assets.values():
+        # 1 download_link asset (from assets_mapping) + 3 s3-listed assets
+        self.assertEqual(4, len(assets))
+        # check if s3 links have been created correctly for s3-listed assets
+        s3_listed_assets = {k: v for k, v in assets.items() if k != "download_link"}
+        self.assertEqual(3, len(s3_listed_assets))
+        for asset in s3_listed_assets.values():
             self.assertIn("s3://eodata/Sentinel-1/SAR/GRD/2014/10/10", asset["href"])
+        # download_link asset is set from the product's metadata
+        self.assertTrue(assets["download_link"]["href"].startswith("s3://eodata/"))
 
         # no occur should occur and assets should be empty if list_objects does not have content
         # (this situation will occur if the product does not have assets but is a tar file)
@@ -3482,8 +3487,8 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         assert eoproduct.properties["title"].startswith(
             f"{self.product_dataset.upper()}"
         )
-        assert eoproduct.properties["eodag:order_link"].startswith("http")
-        assert NOT_AVAILABLE in eoproduct.location
+        assert eoproduct.assets["download_link"]["order_link"].startswith("http")
+        assert eoproduct.location == ""
 
     def test_plugins_search_ecmwfsearch_with_collection(self):
         """ECMWFSearch.query must build a EOProduct from input parameters with predefined collection"""
@@ -4883,13 +4888,17 @@ class TestSearchPluginWekeoSearch(BaseSearchPluginTest):
         """Check that the WekeoSearch plugin is initialized correctly for wekeo_main provider"""
 
         default_config = load_default_config()["wekeo_main"]
-        # "eodag:order_link" in S1_SAR_GRD but not in provider conf or S1_SAR_SLC conf
+        # order_link is defined once at the provider-level assets_mapping
+        # (no per-product eodag:order_link in metadata_mapping anymore)
         self.assertNotIn("eodag:order_link", default_config.search.metadata_mapping)
-        self.assertIn(
+        self.assertNotIn(
             "eodag:order_link",
-            default_config.products["S1_SAR_GRD"]["metadata_mapping"],
+            default_config.products["S1_SAR_GRD"].get("metadata_mapping", {}),
         )
-        self.assertNotIn("metadata_mapping", default_config.products["S1_SAR_SLC"])
+        self.assertIn(
+            "order_link",
+            default_config.search.assets_mapping["download_link"],
+        )
 
         # metadata_mapping_from_product: from S1_SAR_GRD to S1_SAR_SLC
         self.assertEqual(
@@ -4897,7 +4906,7 @@ class TestSearchPluginWekeoSearch(BaseSearchPluginTest):
             "S1_SAR_GRD",
         )
 
-        # check initialized plugin configuration
+        # check initialized plugin configuration: S1_SAR_SLC inherits S1_SAR_GRD
         self.assertDictEqual(
             self.wekeomain_search_plugin.config.products["S1_SAR_GRD"][
                 "metadata_mapping"
@@ -4907,27 +4916,10 @@ class TestSearchPluginWekeoSearch(BaseSearchPluginTest):
             ],
         )
 
-        # S3_SRA_BS has both metadata_mapping_from_product and metadata_mapping
-        # "metadata_mapping" must override "metadata_mapping_from_product"
-        self.assertIn(
-            "eodag:order_link",
-            default_config.products["S3_SRA_BS"]["metadata_mapping"],
-        )
-        self.assertIn(
-            "eodag:order_link",
-            default_config.products["S3_EFR"]["metadata_mapping"],
-        )
+        # S3_SRA_BS inherits from S3_EFR via metadata_mapping_from_product
         self.assertEqual(
             default_config.products["S3_SRA_BS"]["metadata_mapping_from_product"],
             "S3_EFR",
-        )
-        self.assertNotEqual(
-            self.wekeomain_search_plugin.config.products["S3_SRA_BS"][
-                "metadata_mapping"
-            ]["eodag:order_link"],
-            self.wekeomain_search_plugin.config.products["S3_EFR"]["metadata_mapping"][
-                "eodag:order_link"
-            ],
         )
 
     @mock.patch(

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -3051,6 +3051,11 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
                     "roles": ["archive", "data"],
                     "title": "downloadlink",
                     "type": "application/octet-stream",
+                    "file:size": 764210185,
+                    "geodes:reference": False,
+                    "geodes:online": False,
+                    "geodes:datatype": "RAWDATA",
+                    "file:checksum": "86f828c4c7e921615d1cd0476604f780",
                 },
                 "quicklook": {
                     "href": (
@@ -3061,6 +3066,11 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
                     "roles": ["overwiev"],
                     "title": "quicklook",
                     "type": "image/jpeg",
+                    "file:size": 18684,
+                    "geodes:reference": False,
+                    "geodes:online": True,
+                    "geodes:datatype": "QUICKLOOK_SD",
+                    "file:checksum": "1003ae6b1edf05adf7c46cb759ffeaec",
                 },
                 "thumbnail": {
                     "href": (
@@ -3071,6 +3081,11 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
                     "roles": ["thumbnail"],
                     "title": "thumbnail",
                     "type": "image/jpeg",
+                    "file:size": 18684,
+                    "geodes:reference": False,
+                    "geodes:online": True,
+                    "geodes:datatype": "QUICKLOOK_SD",
+                    "file:checksum": "1003ae6b1edf05adf7c46cb759ffeaec",
                 },
             },
         )


### PR DESCRIPTION
From #1929

Fixes #2069

# Task

move `eodag:download_link` property to an asset when it is downloadable (do not keep it has a fake-value and when product download was performed from other assets). If the download_link is not required, remove it and do not add it to assets.

- use [assets_mapping](https://eodag.readthedocs.io/en/latest/plugins.html#eodag.config.PluginConfig.assets_mapping), see https://github.com/CS-SI/eodag/pull/1711
- use `download_link` as key
- use `archive, data` as roles

When downloading a whole product:
- download only assets having `archive` in roles
- if no asset has `archive` in roles, download all assets

Note:
- do not keep assets that do not have `href` or `order_link`

# Work on
- update/complete asset mapping behaviour
- isolate in separated code extra behaviour in asset config interpretation.
- update provider configuration when find mappable extra data
- update specific providers
- centralize/deduplicate source on asset management if possible

