### PR TITLE
refactor: handle errors occuring during stream download

### DIFF
--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -1076,6 +1076,24 @@ class HTTPDownload(Download):
             product.filename = filename
             return product._stream.iter_content(chunk_size=64 * 1024)
 
+    def _handle_retry(self, asset_href: str, e: Exception, retries_sofar: int) -> int:
+        retries = retries_sofar
+        if retries > 2:
+            logger.error(
+                "Unexpected error at download of asset %s: %s",
+                asset_href,
+                e,
+            )
+            raise DownloadError(e)
+        else:
+            logger.warning(
+                "Retry because of unexpected error at download of asset %s: %s",
+                asset_href,
+                e,
+            )
+            retries += 1
+        return retries
+
     def _stream_download_assets(
         self,
         product: EOProduct,
@@ -1221,22 +1239,14 @@ class HTTPDownload(Download):
                         continue_requests = True
                     else:
                         # if range requests are not supported retry twice
-                        if retries > 2:
-                            logger.error(
-                                "Unexpected error at download of asset %s: %s",
-                                asset["href"],
-                                e,
-                            )
-                            raise DownloadError(e)
-                        else:
-                            logger.warning(
-                                "Retry because of unexpected error at download of asset %s: %s",
-                                asset["href"],
-                                e,
-                            )
-                            continue_requests = True
-                            partial_result = b""
-                            retries += 1
+                        continue_requests = True
+                        partial_result = b""
+                        retries = self._handle_retry(asset["href"], e, retries)
+                except requests.exceptions.ConnectionError as ce:
+                    # retry in case of connection problem
+                    continue_requests = True
+                    partial_result = b""
+                    retries = self._handle_retry(asset["href"], ce, retries)
                 except RequestException as e:
                     self._handle_asset_exception(e, asset)
 

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -1148,6 +1148,7 @@ class HTTPDownload(Download):
             # Make the request inside the generator
             partial_result = b""
             continue_requests = True
+            retries = 0
             while continue_requests:
                 continue_requests = False
                 headers = USER_AGENT
@@ -1218,12 +1219,21 @@ class HTTPDownload(Download):
                         )
                         continue_requests = True
                     else:
-                        logger.error(
-                            "Unexpected error at download of asset %s: %s",
-                            asset["href"],
-                            e,
-                        )
-                        raise DownloadError(e)
+                        if retries > 2:
+                            logger.error(
+                                "Unexpected error at download of asset %s: %s",
+                                asset["href"],
+                                e,
+                            )
+                            raise DownloadError(e)
+                        else:
+                            logger.warning(
+                                "Retry because of unexpected error at download of asset %s: %s",
+                                asset["href"],
+                                e,
+                            )
+                            continue_requests = True
+                            retries += 1
                 except RequestException as e:
                     self._handle_asset_exception(e, asset)
 

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -1146,58 +1146,86 @@ class HTTPDownload(Download):
                 auth_object = None
 
             # Make the request inside the generator
-            try:
-                with requests.get(
-                    asset_href,
-                    stream=True,
-                    auth=auth_object,
-                    params=params,
-                    headers=USER_AGENT,
-                    timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
-                    verify=ssl_verify,
-                ) as stream:
-                    stream.raise_for_status()
+            partial_result = b""
+            continue_requests = True
+            while continue_requests:
+                continue_requests = False
+                headers = USER_AGENT
+                if partial_result:
+                    headers["Range"] = "bytes=%d-" % len(partial_result)
+                try:
+                    with requests.get(
+                        asset_href,
+                        stream=True,
+                        auth=auth_object,
+                        params=params,
+                        headers=headers,
+                        timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT,
+                        verify=ssl_verify,
+                    ) as stream:
+                        stream.raise_for_status()
 
-                    # Process asset path
-                    asset_rel_path = (
-                        asset.rel_path.replace(assets_common_subdir, "").strip(os.sep)
-                        if flatten_top_dirs
-                        else asset.rel_path
-                    )
-                    asset_rel_dir = os.path.dirname(asset_rel_path)
-
-                    if not getattr(asset, "filename", None):
-                        # try getting filename in GET header if was not found in HEAD result
-                        asset_content_disposition = stream.headers.get(
-                            "content-disposition"
-                        )
-                        if asset_content_disposition:
-                            asset.filename = cast(
-                                Optional[str],
-                                parse_header(asset_content_disposition).get_param(
-                                    "filename", None
-                                ),
+                        # Process asset path
+                        asset_rel_path = (
+                            asset.rel_path.replace(assets_common_subdir, "").strip(
+                                os.sep
                             )
+                            if flatten_top_dirs
+                            else asset.rel_path
+                        )
+                        asset_rel_dir = os.path.dirname(asset_rel_path)
 
-                    if not getattr(asset, "filename", None):
-                        # default filename extracted from path
-                        asset.filename = os.path.basename(asset.rel_path)
+                        if not getattr(asset, "filename", None):
+                            # try getting filename in GET header if was not found in HEAD result
+                            asset_content_disposition = stream.headers.get(
+                                "content-disposition"
+                            )
+                            if asset_content_disposition:
+                                asset.filename = cast(
+                                    Optional[str],
+                                    parse_header(asset_content_disposition).get_param(
+                                        "filename", None
+                                    ),
+                                )
 
-                    asset.rel_path = os.path.join(
-                        asset_rel_dir, cast(str, asset.filename)
-                    )
+                        if not getattr(asset, "filename", None):
+                            # default filename extracted from path
+                            asset.filename = os.path.basename(asset.rel_path)
 
-                    for chunk in stream.iter_content(chunk_size=64 * 1024):
-                        if chunk:
-                            progress_callback(len(chunk))
-                            yield chunk
+                        asset.rel_path = os.path.join(
+                            asset_rel_dir, cast(str, asset.filename)
+                        )
 
-            except requests.exceptions.Timeout as exc:
-                raise TimeOutError(
-                    exc, timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT
-                ) from exc
-            except RequestException as e:
-                self._handle_asset_exception(e, asset)
+                        for chunk in stream.iter_content(chunk_size=64 * 1024):
+                            if chunk:
+                                progress_callback(len(chunk))
+                                partial_result += chunk
+                                yield chunk
+
+                except requests.exceptions.Timeout as exc:
+                    raise TimeOutError(
+                        exc, timeout=DEFAULT_STREAM_REQUESTS_TIMEOUT
+                    ) from exc
+                except requests.exceptions.ChunkedEncodingError as e:
+                    # if stream download gets interrupted, try to store point of failure and resume
+                    # (if range requests are supported)
+                    if (
+                        "Accept-Ranges" in stream.headers
+                        and stream.headers["Accept-Ranges"] == "bytes"
+                    ):
+                        logger.warning(
+                            "Interruption of stream of asset: %s: %s", asset["href"], e
+                        )
+                        continue_requests = True
+                    else:
+                        logger.error(
+                            "Unexpected error at download of asset %s: %s",
+                            asset["href"],
+                            e,
+                        )
+                        raise DownloadError(e)
+                except RequestException as e:
+                    self._handle_asset_exception(e, asset)
 
         assets_stream_list = []
 

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -23,6 +23,7 @@ import re
 import shutil
 import tarfile
 import zipfile
+from copy import deepcopy
 from email.message import Message
 from itertools import chain
 from json import JSONDecodeError
@@ -1151,7 +1152,7 @@ class HTTPDownload(Download):
             retries = 0
             while continue_requests:
                 continue_requests = False
-                headers = USER_AGENT
+                headers = deepcopy(USER_AGENT)
                 if partial_result:
                     headers["Range"] = "bytes=%d-" % len(partial_result)
                 try:
@@ -1219,6 +1220,7 @@ class HTTPDownload(Download):
                         )
                         continue_requests = True
                     else:
+                        # if range requests are not supported retry twice
                         if retries > 2:
                             logger.error(
                                 "Unexpected error at download of asset %s: %s",
@@ -1233,6 +1235,7 @@ class HTTPDownload(Download):
                                 e,
                             )
                             continue_requests = True
+                            partial_result = b""
                             retries += 1
                 except RequestException as e:
                     self._handle_asset_exception(e, asset)


### PR DESCRIPTION
For provider `planetary_computer` it was observed that sometimes the stream download gets interrupted. To cope with this situation, the following error handling was implemented:
- If a `ChunkedEncodingError` occurs and range requests are available for the url-> retry with `Range` header starting from where the connection broke. 
-  If a `ChunkedEncodingError` occurs and range requests are not availble, retry the request. This is not ideal because some data will be sent twice but it invoids to completely in interrupt the download and return an invalid zip file. This case mainly occured for preview files.
- `ConnectionError`: retry request twice
