### PR TITLE
fix(plugins): replace deprecated items_per_page in CopMarineSearch

### DIFF
--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -328,7 +328,7 @@ class CopMarineSearch(StaticStacSearch):
         start_index = limit * (token - 1) + 1
         num_total = 0
         for i, dataset_item in enumerate(datasets_items_list):
-            if len(products) >= items_per_page and not prep.count:
+            if len(products) >= limit and not prep.count:
                 break
             # Filter by geometry
             if "id" not in kwargs and geometry:
@@ -498,7 +498,7 @@ class CopMarineSearch(StaticStacSearch):
                             if product:
                                 products.append(product)
                     current_object = item_key
-                    if len(products) >= items_per_page and not prep.count:
+                    if len(products) >= limit and not prep.count:
                         stop_search = True
                         break
 


### PR DESCRIPTION
Following #2014, fixes `CopMarineSearch` by replacing deprecated `items_per_page` with `limit` 