### PR TITLE
build: updated package discovery pattern

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,7 @@ StacListAssets = "eodag.plugins.search.stac_list_assets:StacListAssets"
 include-package-data = true
 
 [tool.setuptools.packages.find]
-exclude = ["*.tests", "*.tests.*", "tests.*", "tests"]
+include = ["eodag*"]
 
 [tool.setuptools.package-data]
 "*" = ["LICENSE", "NOTICE", "py.typed"]


### PR DESCRIPTION
Fix setuptools package discovery.
Currently the wheel package contains unexpected contents:
```
eodag-4.0.1-py3-none-any
- docs
- eodag
- eodag-4.0.1.dist-info
- utils
```
The patch changes the package discovery configuration to include only "eodag*"


Thank you!
