### PR TITLE
test: use uv instead of pip from build command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -82,9 +82,10 @@ skip_install = true
 deps =
     build
     twine
+    uv
 commands =
     # build package to be checked
-    python -m build
+    python -m build --installer uv
     # Check that the long description is ready to be published on PyPI without errors
     python -m twine check dist/*
 


### PR DESCRIPTION
Following [build v1.4.1](https://github.com/pypa/build/releases/tag/1.4.1), we get the following issue from `tox -e pypi`:
```
subprocess.CalledProcessError: Command '['/home/runner/work/eodag/eodag/.tox/pypi/bin/python', '-m', 'pip', '--python', '/home/runner/work/eodag/eodag/.tox/pypi/tmp/build-env-suibt5vi/bin/python', 'install', '--use-pep517', '--no-warn-script-location', '--no-compile', '-r', '/home/runner/work/eodag/eodag/.tox/pypi/tmp/build-requirements-fj6utp9g.txt']' returned non-zero exit status 1.
```

Solved by using `uv` instead of `pip`  for installing packages in the isolated `build` environment.