### PR TITLE
fix(plugins): missing order:status with CopMarineSearch

### DIFF
--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -229,7 +229,8 @@ class CopMarineSearch(StaticStacSearch):
             "geometry": geometry,
             "eodag:download_link": download_url,
             "dataset": dataset_item["id"],
-            "order:status": self.config.metadata_mapping["order:status"],
+            # order:status set to succeeded for consistency between providers
+            "order:status": "succeeded",
         }
         if use_dataset_dates:
             dates = _get_dates_from_dataset_data(dataset_item)

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -229,6 +229,7 @@ class CopMarineSearch(StaticStacSearch):
             "geometry": geometry,
             "eodag:download_link": download_url,
             "dataset": dataset_item["id"],
+            "order:status": self.config.metadata_mapping["order:status"],
         }
         if use_dataset_dates:
             dates = _get_dates_from_dataset_data(dataset_item)

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -5921,8 +5921,6 @@
       fetch_url: null
     metadata_mapping:
       eodag:default_geometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
-      # order:status set to succeeded for consistency between providers
-      order:status: 'succeeded'
   products:
     MO_GLOBAL_ANALYSISFORECAST_PHY_001_024:
       _collection: GLOBAL_ANALYSISFORECAST_PHY_001_024

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -5921,6 +5921,8 @@
       fetch_url: null
     metadata_mapping:
       eodag:default_geometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
+      # order:status set to succeeded for consistency between providers
+      order:status: 'succeeded'
   products:
     MO_GLOBAL_ANALYSISFORECAST_PHY_001_024:
       _collection: GLOBAL_ANALYSISFORECAST_PHY_001_024


### PR DESCRIPTION
The properties of a product should contain `order:status` for consistency between providers. If the product is immediately available (i.e. no product order is required) the property `order:status` should be set to `succeeded`. This property is used by `stac-fastapi-eodag` to set properly `storage:tier`.

This change has been applied to the provider `cop_marine`. This has been implemented with the same approach of the already used metadata mapping for `eodag:default_geometry`, that is directly applying the mapping.

The change can be tested with:

```python
from eodag import EODataAccessGateway

dag = EODataAccessGateway()

params = {
    "provider": "cop_marine",
    "collection": "MO_GLOBAL_ANALYSISFORECAST_WAV_001_027",
}

search_result = dag.search(**params)
if search_result:
    first_product = search_result[0]
    print(f"order:status={first_product.properties.get('order:status')}")
```
