### PR TITLE
fix(plugins): cop_marine search by id

### DIFF
--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -328,7 +328,7 @@ class CopMarineSearch(StaticStacSearch):
         start_index = limit * (token - 1) + 1
         num_total = 0
         for i, dataset_item in enumerate(datasets_items_list):
-            if len(products) >= limit and not prep.count:
+            if len(products) >= limit and not prep.count and limit > 0:
                 break
             # Filter by geometry
             if "id" not in kwargs and geometry:


### PR DESCRIPTION
Following #2014, the search by id was not working for `cop_marine`, this PR fix this. 
We stop the search if we reach the limit, if the limit is not -1