### PR TITLE
fix(providers): Sentinel and CLMS datasets mapping updates for wekeo

### DIFF
--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -34,6 +34,7 @@ from dateutil.tz import tzutc
 from jsonpath_ng.jsonpath import Child, JSONPath
 from lxml import etree
 from lxml.etree import XPathEvalError
+from pydantic import AliasChoices
 from shapely import wkt
 from shapely.geometry import LineString, MultiPolygon, Point, Polygon
 from shapely.ops import transform
@@ -1861,12 +1862,17 @@ def _get_queryables(
 
 
 def get_queryable_from_provider(
-    provider_queryable: str, metadata_mapping: dict[str, Union[str, list[str]]]
+    provider_queryable: str,
+    metadata_mapping: dict[str, Union[str, list[str]]],
+    provider: Optional[str] = None,
 ) -> Optional[str]:
     """Get EODAG configured queryable parameter from provider queryable parameter
 
     :param provider_queryable: provider queryable parameter
     :param metadata_mapping: metadata-mapping configuration
+    :param provider: (optional) provider name. When given, the returned queryable
+                     may be resolved to its provider-prefixed STAC extension alias
+                     (e.g. ``wekeo_main_format``).
     :returns: EODAG configured queryable parameter or None
 
     >>> get_queryable_from_provider(
@@ -1879,6 +1885,12 @@ def get_queryable_from_provider(
     ...     {"start": ["start_datetime", "$.properties.datetime"]}
     ... ) is None
     True
+    >>> get_queryable_from_provider(
+    ...     "format",
+    ...     {},
+    ...     provider="wekeo_main"
+    ... )
+    'wekeo_main_format'
     """
     pattern = rf"\"{provider_queryable}\""
     # if 1:1 mapping exists privilege this one instead of other mapping
@@ -1887,19 +1899,62 @@ def get_queryable_from_provider(
         v[0] if isinstance(v, list) else "" for v in metadata_mapping.values()
     ]
     StacQueryables = Queryables.from_stac_models()
+
+    eodag_queryable: Optional[str] = None
     if provider_queryable in mapping_values:
         ind = mapping_values.index(provider_queryable)
-        return StacQueryables.get_queryable_from_alias(
+        eodag_queryable = StacQueryables.get_queryable_from_alias(
             list(metadata_mapping.keys())[ind]
         )
-    for param, param_conf in metadata_mapping.items():
-        if (
-            isinstance(param_conf, list)
-            and param_conf[0]
-            and re.search(pattern, param_conf[0])
-        ):
-            return StacQueryables.get_queryable_from_alias(param)
-    return None
+    else:
+        for param, param_conf in metadata_mapping.items():
+            if (
+                isinstance(param_conf, list)
+                and param_conf[0]
+                and re.search(pattern, param_conf[0])
+            ):
+                eodag_queryable = StacQueryables.get_queryable_from_alias(param)
+                break
+
+    # no provider-specific resolution
+    if provider is None:
+        return eodag_queryable
+
+    # check if eodag_queryable is defined in a Provider STAC Extension, possibly
+    # with the provider's prefix (e.g. wekeo_main_format vs wekeo_main:format)
+    eodag_queryable = eodag_queryable or StacQueryables.get_queryable_from_alias(
+        provider_queryable
+    )
+
+    # provider prefix regex
+    prefix_re = re.compile(r"^" + re.escape(provider) + r"[_:]")
+
+    for k, field_info in StacQueryables.model_fields.items():
+        queryable_alias = field_info.alias
+        # Collect every alias under which the queryable could appear in the
+        # metadata_mapping (model field name + declared alias(es)).
+        candidates: list[str] = (
+            [str(a[0]) for a in queryable_alias.convert_to_aliases()]
+            if isinstance(queryable_alias, AliasChoices)
+            else [queryable_alias]
+            if queryable_alias is not None
+            else []
+        )
+        candidates.append(k)
+        # Core search strips the ``<provider>:`` / ``<provider>_`` prefix
+        # from user-supplied keys before sending them to the plugin, so the
+        # metadata_mapping may store the queryable under its unprefixed name.
+        matches: list[str] = [
+            c for c in candidates if prefix_re.sub("", c) == eodag_queryable
+        ]
+        if k in matches:
+            # prefer the alias with underscore separator over the one with colon
+            # (e.g. wekeo_main_format vs wekeo_main:format)
+            return k
+        elif matches:
+            return matches[0]
+
+    return eodag_queryable
 
 
 def get_provider_queryable_path(

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -118,6 +118,16 @@ def get_metadata_path(
                       above. Or the string `$.properties.id`.
     :returns: Either, None and the path to the metadata value, or a list of converter
              and its args, and the path to the metadata value.
+
+    Non-queryable mapping (plain string) — no converter:
+
+    >>> get_metadata_path("$.properties.id")
+    (None, '$.properties.id')
+
+    Queryable mapping (list) with a converter:
+
+    >>> get_metadata_path(["platform", "{$.properties.platform#to_upper}"])
+    (['to_upper', None], '$.properties.platform')
     """
     path = get_metadata_path_value(map_value)
     try:
@@ -132,7 +142,13 @@ def get_metadata_path(
 
 
 def get_metadata_path_value(map_value: Union[str, list[str]]) -> str:
-    """Get raw metadata path without converter"""
+    """Get raw metadata path without converter
+
+    >>> get_metadata_path_value("$.properties.id")
+    '$.properties.id'
+    >>> get_metadata_path_value(["platform", "$.properties.platform"])
+    '$.properties.platform'
+    """
     return map_value[1] if isinstance(map_value, list) else map_value
 
 
@@ -142,6 +158,9 @@ def get_search_param(map_value: list[str]) -> str:
     :param map_value: The value originating from the definition of `metadata_mapping`
                       in the provider search config
     :returns: The value of the search parameter as defined in the provider config
+
+    >>> get_search_param(["platform", "$.properties.platform"])
+    'platform'
     """
     # Assume that caller will pass in the value as a list
     return map_value[0]
@@ -196,6 +215,11 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
     :param args: (optional) Additional arguments to use in the formatting process
     :param kwargs: (optional) Additional named-arguments to use when formatting
     :returns: The formatted string
+
+    >>> format_metadata("{date#to_iso_utc_datetime}", date="2021-04-21")
+    '2021-04-21T00:00:00.000Z'
+    >>> format_metadata("{values#csv_list}", values=["a", "b", "c"])
+    'a,b,c'
     """
 
     class MetadataFormatter(Formatter):
@@ -1447,6 +1471,21 @@ def mtd_cfg_as_conversion_and_querypath(
     :param src_dict: Input dict containing jsonpath str as values
     :param dest_dict: (optional) Output dict containing jsonpath objects as values
     :returns: dest_dict
+
+    For ``result_type="xml"``, xpath strings are kept as-is inside the tuple.
+    A queryable entry (list form) keeps its provider key in first position and
+    gets its second element replaced; a non-queryable string entry becomes a
+    ``(None, xpath_str)`` tuple:
+
+    >>> src = {
+    ...     "platform": ["platform", "//platform/text()"],
+    ...     "id": "//id/text()",
+    ... }
+    >>> result = mtd_cfg_as_conversion_and_querypath(src, result_type="xml")
+    >>> result["platform"]
+    ['platform', (None, '//platform/text()')]
+    >>> result["id"]
+    (None, '//id/text()')
     """
     # check if the configuration has already been converted
     some_configured_value = (
@@ -1492,7 +1531,32 @@ def format_query_params(
     query_dict: dict[str, Any],
     error_context: str = "",
 ) -> dict[str, Any]:
-    """format the search parameters to query parameters"""
+    """Format the search parameters to query parameters.
+
+    :param collection: collection name
+    :param config: plugin configuration
+    :param query_dict: search parameters to format
+    :param error_context: (optional) context string included in error messages
+    :returns: formatted query parameters dict
+
+    Eodag search keys are translated to provider-specific parameter names
+    according to the ``metadata_mapping`` configuration:
+
+    >>> from eodag.config import PluginConfig
+    >>> config = PluginConfig.from_mapping({
+    ...     "type": "QueryStringSearch",
+    ...     "metadata_mapping": {
+    ...         "start": ["startDate", "$.properties.start_datetime"],
+    ...         "platform": ["platformName", "$.properties.platform"],
+    ...     },
+    ...     "products": {},
+    ... })
+    >>> format_query_params(
+    ...     "S2_MSI_L1C", config,
+    ...     {"start": "2021-01-01", "platform": "SENTINEL-2"},
+    ... )
+    {'startDate': '2021-01-01', 'platformName': 'SENTINEL-2'}
+    """
     if "raise_errors" in query_dict.keys():
         del query_dict["raise_errors"]
     # . not allowed in eodag_search_key, replaced with %2E
@@ -1607,6 +1671,9 @@ def _resolve_hashes(formatted_query_param: str) -> str:
     resolves structures of the format {"a": "abc", "b": "cde"}["a"] given in the formatted_query_param
     the structure is replaced by the value corresponding to the given key in the hash
     (in this case "abc")
+
+    >>> _resolve_hashes('{"greeting": {"foo": "hello", "bar": "world"}["foo"]}')
+    '{"greeting": "hello"}'
     """
     # check if there is still a hash to be resolved
     while '}["' in formatted_query_param:
@@ -1634,7 +1701,31 @@ def _resolve_hashes(formatted_query_param: str) -> str:
 def _format_free_text_search(
     config: PluginConfig, metadata_mapping: dict[str, Any], **kwargs: Any
 ) -> dict[str, Any]:
-    """Build the free text search parameter using the search parameters"""
+    """Build the free text search parameter using the search parameters.
+
+    :param config: plugin configuration
+    :param metadata_mapping: metadata mapping for queryable fields
+    :param kwargs: user search parameters
+    :returns: provider free text query parameter(s)
+
+    >>> from eodag.config import PluginConfig
+    >>> config = PluginConfig.from_mapping({
+    ...     "type": "QueryStringSearch",
+    ...     "free_text_search_operations": {
+    ...         "q": {
+    ...             "union": " AND ",
+    ...             "operations": {"OR": ["{title}", "{id}"]},
+    ...         }
+    ...     }
+    ... })
+    >>> _format_free_text_search(
+    ...     config,
+    ...     {"title": ["title", "$.title"], "id": ["id", "$.id"]},
+    ...     title="foo",
+    ...     id="bar",
+    ... )
+    {'q': 'foo OR bar'}
+    """
     query_params: dict[str, Any] = {}
     if not getattr(config, "free_text_search_operations", None):
         return query_params
@@ -1680,7 +1771,33 @@ def _get_queryables(
     raise_mtd_discovery_error: bool,
     error_context: str,
 ) -> dict[str, Any]:
-    """Retrieve the metadata mappings that are query-able"""
+    """Retrieve the metadata mappings that are query-able.
+
+    :param search_params: search parameters given by user
+    :param config: plugin configuration
+    :param metadata_mapping: metadata mapping for the provider
+    :param raise_mtd_discovery_error: whether non-queryable parameters must raise
+    :param error_context: context string included in errors
+    :returns: mapping from eodag queryables to provider queryables
+
+    >>> from eodag.config import PluginConfig
+    >>> config = PluginConfig.from_mapping({
+    ...     "type": "QueryStringSearch",
+    ...     "discover_metadata": {
+    ...         "auto_discovery": True,
+    ...         "metadata_pattern": r"^x_.*",
+    ...         "search_param": "{metadata}",
+    ...     }
+    ... })
+    >>> _get_queryables(
+    ...     {"cloudCover": 10, "x_custom": "abc", "no_match": "ignored"},
+    ...     config,
+    ...     {"cloudCover": ["cloudCover", "$.properties.cloudCover"]},
+    ...     raise_mtd_discovery_error=False,
+    ...     error_context="",
+    ... )
+    {'cloudCover': 'cloudCover', 'x_custom': 'x_custom'}
+    """
     logger.debug("Retrieving queryable metadata from metadata_mapping")
     queryables: dict[str, Any] = {}
     for eodag_search_key, user_input in search_params.items():
@@ -1751,6 +1868,17 @@ def get_queryable_from_provider(
     :param provider_queryable: provider queryable parameter
     :param metadata_mapping: metadata-mapping configuration
     :returns: EODAG configured queryable parameter or None
+
+    >>> get_queryable_from_provider(
+    ...     "start_datetime",
+    ...     {"start": ["start_datetime", "$.properties.datetime"]}
+    ... )
+    'start'
+    >>> get_queryable_from_provider(
+    ...     "unknown_param",
+    ...     {"start": ["start_datetime", "$.properties.datetime"]}
+    ... ) is None
+    True
     """
     pattern = rf"\"{provider_queryable}\""
     # if 1:1 mapping exists privilege this one instead of other mapping
@@ -1782,6 +1910,17 @@ def get_provider_queryable_path(
     :param queryable: eodag queryable parameter
     :param metadata_mapping: metadata-mapping configuration
     :returns: EODAG configured queryable path or None
+
+    >>> get_provider_queryable_path(
+    ...     "start",
+    ...     {"start": ["start_datetime", "$.properties.datetime"]}
+    ... )
+    'start_datetime'
+    >>> get_provider_queryable_path(
+    ...     "start",
+    ...     {"start": "$.properties.datetime"}
+    ... ) is None
+    True
     """
     parameter_conf = metadata_mapping.get(queryable)
     if isinstance(parameter_conf, list):
@@ -1801,6 +1940,19 @@ def get_provider_queryable_key(
     :param provider_queryables: queryables returned from the provider
     :param metadata_mapping: metadata mapping from which the keys are retrieved
     :returns: provider queryable key
+
+    >>> get_provider_queryable_key(
+    ...     "start",
+    ...     {"start_datetime": {}},
+    ...     {"start": ["start_datetime", "$.properties.datetime"]}
+    ... )
+    'start_datetime'
+    >>> get_provider_queryable_key(
+    ...     "unknown",
+    ...     {"start_datetime": {}},
+    ...     {"start": ["start_datetime", "$.properties.datetime"]}
+    ... )
+    ''
     """
     if eodag_key not in metadata_mapping:
         return ""
@@ -1822,6 +1974,16 @@ def normalize_bands(data: Union[dict, Asset]) -> Union[dict, Asset]:
 
     :param data: properties dict or Asset to migrate
     :returns: the same data with migrated bands
+
+    >>> normalize_bands({"eo:bands": [{"name": "B04", "common_name": "red"}]})
+    {'bands': [{'name': 'B04', 'eo:common_name': 'red'}]}
+    >>> normalize_bands({
+    ...     "raster:bands": [
+    ...         {"name": "B04", "description": "surface reflectance"},
+    ...         {"name": "B08", "description": "surface reflectance"},
+    ...     ]
+    ... })
+    {'description': 'surface reflectance', 'bands': [{'name': 'B04'}, {'name': 'B08'}]}
     """
     UNPREFIX_BAND_FIELDNAME = [
         "name",

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import TYPE_CHECKING, Annotated, get_args
+from typing import TYPE_CHECKING, Annotated
 
 import orjson
 from pydantic import AliasChoices
@@ -40,7 +40,6 @@ from eodag.types.search_args import SortByList
 from eodag.types.stac_metadata import CommonStacMetadata, create_stac_metadata_model
 from eodag.utils import (
     GENERIC_COLLECTION,
-    copy_deepcopy,
     deepcopy,
     format_dict_items,
     format_pydantic_error,
@@ -477,9 +476,7 @@ class Search(PluginTopic):
         queryables_model = create_stac_metadata_model(
             base_models=[Queryables, CommonStacMetadata]
         )
-        eodag_queryables = copy_deepcopy(
-            model_fields_to_annotated(queryables_model.model_fields)
-        )
+        eodag_queryables = model_fields_to_annotated(queryables_model.model_fields)
         queryables["collection"] = eodag_queryables.pop("collection")
         # add default value for collection
         if collection_or_alias := alias or collection:
@@ -491,12 +488,8 @@ class Search(PluginTopic):
         prefix_re = re.compile(r"^" + re.escape(self.provider) + r"[_:]")
 
         for k, v in eodag_queryables.items():
-            eodag_queryable_field_info = (
-                get_args(v)[1] if len(get_args(v)) > 1 else None
-            )
-            if not isinstance(eodag_queryable_field_info, FieldInfo):
-                continue
-            queryable_alias = eodag_queryable_field_info.alias
+            field_info = queryables_model.model_fields[k]
+            queryable_alias = field_info.alias
             # Collect every alias under which the queryable could appear in the
             # metadata_mapping (model field name + declared alias(es)).
             candidates = (
@@ -513,7 +506,7 @@ class Search(PluginTopic):
                 for c in candidates
                 if c
             )
-            if eodag_queryable_field_info.is_required() or in_metadata:
+            if field_info.is_required() or in_metadata:
                 queryables[k] = v
         return queryables
 

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -457,6 +457,7 @@ class Search(PluginTopic):
     ) -> dict[str, Annotated[Any, FieldInfo]]:
         """
         Extract queryable parameters from collection metadata mapping.
+
         :param collection: collection id (optional)
         :param alias: (optional) alias of the collection
         :returns: dict of annotated queryables

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -2375,7 +2375,7 @@ class StacSearch(PostJsonSearch):
             provider_queryable, metadata_mapping
         ) or StacQueryables.get_queryable_from_alias(provider_queryable)
 
-        # step 2: check if metadata_param is defined in a Provider STAC Extension
+        # step 2: check if eodag_queryable is defined in a Provider STAC Extension
 
         # provider prefix regex
         prefix_re = re.compile(r"^" + re.escape(self.provider) + r"[_:]")

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -76,6 +76,7 @@ from eodag.plugins.search.base import Search
 from eodag.types import json_field_definition_to_python, model_fields_to_annotated
 from eodag.types.queryables import Queryables
 from eodag.types.search_args import SortByList
+from eodag.types.stac_extensions import STAC_EXTENSIONS, ProviderStacExtension
 from eodag.utils import (
     DEFAULT_LIMIT,
     DEFAULT_PAGE,
@@ -2192,6 +2193,17 @@ class StacSearch(PostJsonSearch):
                 f"Cannot fetch global queryables for {self.provider}. A collection must be specified"
             )
 
+        # get balcklist of provider's parameter names to exlude from queryables
+        exclude_field_names: list[str] = []
+        for ext in STAC_EXTENSIONS:
+            if not isinstance(ext, ProviderStacExtension):
+                continue
+            if ext.field_name_prefix != self.provider:
+                continue
+            if ext.exclude_field_names:
+                exclude_field_names = ext.exclude_field_names
+                break
+
         try:
             unparsed_fetch_url = (
                 self.config.discover_queryables["collection_fetch_url"]
@@ -2259,6 +2271,9 @@ class StacSearch(PostJsonSearch):
             field_definitions: dict[str, Any] = dict()
             StacQueryables = Queryables.from_stac_models()
             for json_param, json_mtd in json_queryables.items():
+                if json_param in exclude_field_names:
+                    continue
+
                 param = self._get_provider_specific_queryable(
                     json_param, self.get_metadata_mapping(collection)
                 )

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -28,7 +28,6 @@ from typing import (
     Callable,
     Optional,
     Sequence,
-    Union,
     cast,
     get_args,
 )
@@ -53,7 +52,7 @@ import requests
 import yaml
 from jsonpath_ng import JSONPath
 from lxml import etree
-from pydantic import AliasChoices, ConfigDict, Field, create_model
+from pydantic import ConfigDict, Field, create_model
 from pydantic.fields import FieldInfo
 from requests import Response
 from requests.adapters import HTTPAdapter
@@ -76,7 +75,6 @@ from eodag.plugins.search.base import Search
 from eodag.types import json_field_definition_to_python, model_fields_to_annotated
 from eodag.types.queryables import Queryables
 from eodag.types.search_args import SortByList
-from eodag.types.stac_extensions import STAC_EXTENSIONS, ProviderStacExtension
 from eodag.utils import (
     DEFAULT_LIMIT,
     DEFAULT_PAGE,
@@ -2193,17 +2191,6 @@ class StacSearch(PostJsonSearch):
                 f"Cannot fetch global queryables for {self.provider}. A collection must be specified"
             )
 
-        # get balcklist of provider's parameter names to exlude from queryables
-        exclude_field_names: list[str] = []
-        for ext in STAC_EXTENSIONS:
-            if not isinstance(ext, ProviderStacExtension):
-                continue
-            if ext.field_name_prefix != self.provider:
-                continue
-            if ext.exclude_field_names:
-                exclude_field_names = ext.exclude_field_names
-                break
-
         try:
             unparsed_fetch_url = (
                 self.config.discover_queryables["collection_fetch_url"]
@@ -2270,15 +2257,28 @@ class StacSearch(PostJsonSearch):
             # convert json results to pydantic model fields
             field_definitions: dict[str, Any] = dict()
             StacQueryables = Queryables.from_stac_models()
+            metadata_mapping = self.get_metadata_mapping(collection)
             for json_param, json_mtd in json_queryables.items():
-                if json_param in exclude_field_names:
-                    continue
-
-                param = self._get_provider_specific_queryable(
-                    json_param, self.get_metadata_mapping(collection)
+                param = get_queryable_from_provider(
+                    json_param,
+                    metadata_mapping,
+                    provider=self.provider,
                 )
                 # do not expose internal parameters, neither datetime
-                if param == "datetime" or param.startswith("_"):
+                if param is None or param == "datetime" or param.startswith("_"):
+                    continue
+                # do not expose provider-native parameters explicitly marked as
+                # non-queryable in the metadata_mapping: queryable entries are stored
+                # as a [query, path] list, while non-queryable ones are mapped to a
+                # single path value (stored as a tuple after config loading). eodag
+                # queryables (e.g. start/end) may legitimately use a single path
+                # mapping, so they are never excluded by this rule.
+                mtd_entry = metadata_mapping.get(param)
+                if (
+                    mtd_entry is not None
+                    and not isinstance(mtd_entry, list)
+                    and param not in StacQueryables.model_fields
+                ):
                     continue
 
                 # convert provider json field definition to python
@@ -2353,62 +2353,6 @@ class StacSearch(PostJsonSearch):
                 queryables_dict.setdefault("end", eodag_queryables["end"])
 
             return queryables_dict
-
-    def _get_provider_specific_queryable(
-        self,
-        provider_queryable: str,
-        metadata_mapping: dict[str, Union[str, list[str]]],
-    ) -> str:
-        """Get EODAG configured queryable parameter, possibly with provider's prefix,
-        from provider queryable parameter
-
-        See :func:`~eodag.plugins.search.base.Search.queryables_from_metadata_mapping`
-
-        :param provider_queryable: provider queryable parameter
-        :param metadata_mapping: metadata-mapping configuration
-        :returns: EODAG configured queryable parameter
-        """
-        StacQueryables = Queryables.from_stac_models()
-
-        # step 1: get the param name as defined in the metadata mapping
-        eodag_queryable: str = get_queryable_from_provider(
-            provider_queryable, metadata_mapping
-        ) or StacQueryables.get_queryable_from_alias(provider_queryable)
-
-        # step 2: check if eodag_queryable is defined in a Provider STAC Extension
-
-        # provider prefix regex
-        prefix_re = re.compile(r"^" + re.escape(self.provider) + r"[_:]")
-
-        for k, v in model_fields_to_annotated(StacQueryables.model_fields).items():
-            stac_queryable_field_info = get_args(v)[1] if len(get_args(v)) > 1 else None
-            if not isinstance(stac_queryable_field_info, FieldInfo):
-                continue
-            queryable_alias: Optional[str] = stac_queryable_field_info.alias
-            # Collect every alias under which the queryable could appear in the
-            # metadata_mapping (model field name + declared alias(es)).
-            candidates: list[str] = (
-                [str(a[0]) for a in queryable_alias.convert_to_aliases()]
-                if isinstance(queryable_alias, AliasChoices)
-                else [queryable_alias]
-                if queryable_alias is not None
-                else []
-            )
-            candidates.append(k)
-            # Core search strips the ``<provider>:`` / ``<provider>_`` prefix
-            # from user-supplied keys before sending them to the plugin, so the
-            # metadata_mapping may store the queryable under its unprefixed name.
-            matches: list[str] = [
-                c for c in candidates if prefix_re.sub("", c) == eodag_queryable
-            ]
-            if k in matches:
-                # prefer the alias with underscore separator over the one with colon
-                # (e.g. wekeo_main_format vs wekeo_main:format)
-                return k
-            elif matches:
-                return matches[0]
-
-        return eodag_queryable
 
 
 class WekeoSearch(StacSearch, PostJsonSearch):

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -28,6 +28,7 @@ from typing import (
     Callable,
     Optional,
     Sequence,
+    Union,
     cast,
     get_args,
 )
@@ -52,7 +53,7 @@ import requests
 import yaml
 from jsonpath_ng import JSONPath
 from lxml import etree
-from pydantic import ConfigDict, Field, create_model
+from pydantic import AliasChoices, ConfigDict, Field, create_model
 from pydantic.fields import FieldInfo
 from requests import Response
 from requests.adapters import HTTPAdapter
@@ -2258,9 +2259,9 @@ class StacSearch(PostJsonSearch):
             field_definitions: dict[str, Any] = dict()
             StacQueryables = Queryables.from_stac_models()
             for json_param, json_mtd in json_queryables.items():
-                param = get_queryable_from_provider(
+                param = self._get_provider_specific_queryable(
                     json_param, self.get_metadata_mapping(collection)
-                ) or StacQueryables.get_queryable_from_alias(json_param)
+                )
                 # do not expose internal parameters, neither datetime
                 if param == "datetime" or param.startswith("_"):
                     continue
@@ -2337,6 +2338,62 @@ class StacSearch(PostJsonSearch):
                 queryables_dict.setdefault("end", eodag_queryables["end"])
 
             return queryables_dict
+
+    def _get_provider_specific_queryable(
+        self,
+        provider_queryable: str,
+        metadata_mapping: dict[str, Union[str, list[str]]],
+    ) -> str:
+        """Get EODAG configured queryable parameter, possibly with provider's prefix,
+        from provider queryable parameter
+
+        See :func:`~eodag.plugins.search.base.Search.queryables_from_metadata_mapping`
+
+        :param provider_queryable: provider queryable parameter
+        :param metadata_mapping: metadata-mapping configuration
+        :returns: EODAG configured queryable parameter
+        """
+        StacQueryables = Queryables.from_stac_models()
+
+        # step 1: get the param name as defined in the metadata mapping
+        eodag_queryable: str = get_queryable_from_provider(
+            provider_queryable, metadata_mapping
+        ) or StacQueryables.get_queryable_from_alias(provider_queryable)
+
+        # step 2: check if metadata_param is defined in a Provider STAC Extension
+
+        # provider prefix regex
+        prefix_re = re.compile(r"^" + re.escape(self.provider) + r"[_:]")
+
+        for k, v in model_fields_to_annotated(StacQueryables.model_fields).items():
+            stac_queryable_field_info = get_args(v)[1] if len(get_args(v)) > 1 else None
+            if not isinstance(stac_queryable_field_info, FieldInfo):
+                continue
+            queryable_alias: Optional[str] = stac_queryable_field_info.alias
+            # Collect every alias under which the queryable could appear in the
+            # metadata_mapping (model field name + declared alias(es)).
+            candidates: list[str] = (
+                [str(a[0]) for a in queryable_alias.convert_to_aliases()]
+                if isinstance(queryable_alias, AliasChoices)
+                else [queryable_alias]
+                if queryable_alias is not None
+                else []
+            )
+            candidates.append(k)
+            # Core search strips the ``<provider>:`` / ``<provider>_`` prefix
+            # from user-supplied keys before sending them to the plugin, so the
+            # metadata_mapping may store the queryable under its unprefixed name.
+            matches: list[str] = [
+                c for c in candidates if prefix_re.sub("", c) == eodag_queryable
+            ]
+            if k in matches:
+                # prefer the alias with underscore separator over the one with colon
+                # (e.g. wekeo_main_format vs wekeo_main:format)
+                return k
+            elif matches:
+                return matches[0]
+
+        return eodag_queryable
 
 
 class WekeoSearch(StacSearch, PostJsonSearch):

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3131,6 +3131,21 @@
         processing:level:
           - '{{"processingLevel": "{processing:level}"}}'
           - '2'
+        platform:
+          - '{{"platformSerialIdentifier": "{platform}"}}'
+          - '$.null'
+        instruments:
+          - '{{"instrumentShortName": "{instruments#csv_list}"}}'
+          - '$.null'
+        sat:relative_orbit:
+          - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
+          - '$.null'
+        eo:cloud_cover:
+          - '{{"cloudCover": "{eo:cloud_cover}"}}'
+          - '$.null'
+        sortOrder:
+          - '{{"sortOrder": "{sortOrder}"}}'
+          - '$.null'
         eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:ESA:DAT:SENTINEL-3"}}'
     S3_LAN_SI:
       _collection: EO:ESA:DAT:SENTINEL-3

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3257,8 +3257,8 @@
         instruments:
           - '{{"instrumentShortName": "{instruments#csv_list}"}}'
           - '$.null'
-        processingMode:
-          - '{{"processingMode": "{processingMode}"}}'
+        processing_mode:
+          - '{{"processingMode": "{processing_mode}"}}'
           - '$.null'
         sat:absolute_orbit:
           - '{{"orbitNumber": "{sat:absolute_orbit}"}}'
@@ -3314,7 +3314,7 @@
         instruments:
           - '{{"instrumentShortName": "{instruments#csv_list}"}}'
           - '$.null'
-        wekeo_main:format:
+        format:
           - '{{"fileFormat": "{format}"}}'
           - '$.null'
         eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:JRC:DAT:CLMS"}}'

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3236,7 +3236,7 @@
         eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:SR_2_WAT___"}}'
     S5P_L1B_IR_ALL:
       _collection: EO:ESA:DAT:SENTINEL-5P
-      processing:level: L1B
+      processing:level: L1b
       metadata_mapping:
         processing:level:
           - '{{"processingLevel": "{processing:level}"}}'

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -2960,11 +2960,11 @@
     instruments:
       - '{{"instrumentShortName": "{instruments#csv_list}"}}'
       - '$.null'
-    online:
-      - '{{"online": "{online}"}}'
+    order:status:
+      - '{{"online": "{order:status#get_group_name((?P<true>succeeded)|(?P<false>orderable))}"}}'
       - '$.null'
-    polarisation:
-      - '{{"polarisationChannels": "{polarisation}"}}'
+    sar:polarizations:
+      - '{{"polarisationChannels": "{sar:polarizations#csv_list(%26)}"}}'
       - '$.null'
     sat:relative_orbit:
       - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
@@ -3314,7 +3314,7 @@
         instruments:
           - '{{"instrumentShortName": "{instruments#csv_list}"}}'
           - '$.null'
-        format:
+        wekeo_main:format:
           - '{{"fileFormat": "{format}"}}'
           - '$.null'
         eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:JRC:DAT:CLMS"}}'

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -2954,20 +2954,23 @@
     processing:level:
       - '{{"processingLevel": "{processing:level}"}}'
       - '$.id.`sub(/^[^_]([^_]+)_([^_]+)_([^_]+)_([0-4]+).*/, LEVEL\\4)`'
-    sar:instrument_mode:
-      - '{{"sensorMode": "{sar:instrument_mode}"}}'
-      - '$.id.`sub(/^[^_]([^_]+)_([^_]+)_.*/, \\2)`'
-    swath:
-      - '{{"swath": "{swath}"}}'
+    platform:
+      - '{{"platformSerialIdentifier": "{platform}"}}'
+      - '$.null'
+    instruments:
+      - '{{"instrumentShortName": "{instruments#csv_list}"}}'
+      - '$.null'
+    online:
+      - '{{"online": "{online}"}}'
       - '$.null'
     polarisation:
-      - '{{"polarisation": "{polarisation}"}}'
+      - '{{"polarisationChannels": "{polarisation}"}}'
       - '$.null'
     sat:relative_orbit:
       - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
       - '$.null'
-    missionTakeId:
-      - '{{"missionTakeId": "{missionTakeId}"}}'
+    sortOrder:
+      - '{{"sortOrder": "{sortOrder}"}}'
       - '$.null'
   anchor_orbit_cycle: &orbit_cycle
     sat:relative_orbit:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3241,8 +3241,17 @@
         processing:level:
           - '{{"processingLevel": "{processing:level}"}}'
           - '$.id.`sub(/^[^_]([^_]+)_([^_]+)_([^_]+)_.*/, \\3)`'
+        instruments:
+          - '{{"instrumentShortName": "{instruments#csv_list}"}}'
+          - '$.null'
         processingMode:
           - '{{"processingMode": "{processingMode}"}}'
+          - '$.null'
+        sortOrder:
+          - '{{"sortOrder": "{sortOrder}"}}'
+          - '$.null'
+        sat:absolute_orbit:
+          - '{{"orbitNumber": "{sat:absolute_orbit}"}}'
           - '$.null'
         eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.nc", "dataset_id": "EO:ESA:DAT:SENTINEL-5P"}}'
     S5P_L2_IR_ALL:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3005,7 +3005,7 @@
     sort:
       sort_by_tpl: '{{"sortOrder": "{sort_order}"}}'
       sort_param_mapping:
-      # start_datetime for consistency between providers, but it's unused for the actual sorting
+        # start_datetime for consistency between providers, but it's unused for the actual sorting
         start_datetime: unused
       sort_order_mapping:
         ascending: ASC

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3015,7 +3015,7 @@
         - '$.geometry'
       eodag:default_geometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
       id:
-        - '{{"productIdentifier": "{id}"}}'
+        - '{{"datasetIdentifier": "{id}"}}'
         - '{$.id#remove_extension}'
       start_datetime:
         - '{{"startdate": "{start_datetime}"}}'
@@ -3250,17 +3250,29 @@
     CLMS_GLO_NDVI_333M:
       _collection: EO:JRC:DAT:CLMS
       product:type: vegetation_indices
-      _product_identifier: ndvi_global_300m_10daily_v1
+      _dataset_identifier: ndvi_global_300m_10daily_v1
       metadata_mapping:
-        _product_identifier:
-        - '{{"productIdentifier": "{_product_identifier}"}}'
-        - '$.null'
+        _dataset_identifier:
+          - '{{"datasetIdentifier": "{_dataset_identifier}"}}'
+          - '$.null'
         id: '$.id'
+        platform:
+          - '{{"platformShortName": "{platform}"}}'
+          - '$.null'
+        instruments:
+          - '{{"instrumentShortName": "{instruments#csv_list}"}}'
+          - '$.null'
+        sortOrder:
+          - '{{"sortOrder": "{sortOrder}"}}'
+          - '$.null'
+        format: # TODO waiting confirmation from WEkEO
+          - '{{"fileFormat": "{format}"}}'
+          - '$.null'
         eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:JRC:DAT:CLMS"}}'
     CLMS_GLO_NDVI_1KM_LTS:
       _collection: EO:JRC:DAT:CLMS
       product:type: vegetation_indices
-      _product_identifier: ndvi-lts_global_1km_10daily_v2
+      _dataset_identifier: ndvi-lts_global_1km_10daily_v2
       metadata_mapping_from_product: CLMS_GLO_NDVI_333M
     CLMS_CORINE:
       _collection: EO:EEA:DAT:CORINE
@@ -3281,27 +3293,27 @@
     CLMS_GLO_FCOVER_333M:
       _collection: EO:JRC:DAT:CLMS
       product:type: vegetation_properties
-      _product_identifier: fcover_global_300m_10daily_v1
+      _dataset_identifier: fcover_global_300m_10daily_v1
       metadata_mapping_from_product: CLMS_GLO_NDVI_333M
     CLMS_GLO_DMP_333M:
       _collection: EO:JRC:DAT:CLMS
       product:type: dry-gross_dry_matter_productivity
-      _product_identifier: dry-gross_dry_matter_productivity/dmp_global_300m_10daily_v1
+      _dataset_identifier: dry-gross_dry_matter_productivity/dmp_global_300m_10daily_v1
       metadata_mapping_from_product: CLMS_GLO_NDVI_333M
     CLMS_GLO_GDMP_333M:
       _collection: EO:JRC:DAT:CLMS
       product:type: dry-gross_dry_matter_productivity
-      _product_identifier: gdmp_global_300m_10daily_v1
+      _dataset_identifier: gdmp_global_300m_10daily_v1
       metadata_mapping_from_product: CLMS_GLO_NDVI_333M
     CLMS_GLO_FAPAR_333M:
       _collection: EO:JRC:DAT:CLMS
       product:type: vegetation_properties
-      _product_identifier: fapar_global_300m_10daily_v1
+      _dataset_identifier: fapar_global_300m_10daily_v1
       metadata_mapping_from_product: CLMS_GLO_NDVI_333M
     CLMS_GLO_LAI_333M:
       _collection: EO:JRC:DAT:CLMS
       product:type: vegetation_properties
-      _product_identifier: lai_global_300m_10daily_v1
+      _dataset_identifier: lai_global_300m_10daily_v1
       metadata_mapping_from_product: CLMS_GLO_NDVI_333M
     CLMS_HRVPP_ST:
       _collection: EO:EEA:DAT:CLMS_HRVPP_ST

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -2969,9 +2969,6 @@
     sat:relative_orbit:
       - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
       - '$.null'
-    sortOrder:
-      - '{{"sortOrder": "{sortOrder}"}}'
-      - '$.null'
   anchor_orbit_cycle: &orbit_cycle
     sat:relative_orbit:
       - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
@@ -3122,9 +3119,6 @@
         eo:cloud_cover:
           - '{{"cloudCover": "{eo:cloud_cover}"}}'
           - '$.null'
-        sortOrder:
-          - '{{"sortOrder": "{sortOrder}"}}'
-          - '$.null'
         eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SAFE", "dataset_id": "EO:ESA:DAT:SENTINEL-2"}}'
     S2_MSI_L2A:
       _collection: EO:ESA:DAT:SENTINEL-2
@@ -3150,9 +3144,6 @@
           - '$.null'
         eo:cloud_cover:
           - '{{"cloudCover": "{eo:cloud_cover}"}}'
-          - '$.null'
-        sortOrder:
-          - '{{"sortOrder": "{sortOrder}"}}'
           - '$.null'
         eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:ESA:DAT:SENTINEL-3"}}'
     S3_LAN_SI:
@@ -3255,9 +3246,6 @@
         processingMode:
           - '{{"processingMode": "{processingMode}"}}'
           - '$.null'
-        sortOrder:
-          - '{{"sortOrder": "{sortOrder}"}}'
-          - '$.null'
         sat:absolute_orbit:
           - '{{"orbitNumber": "{sat:absolute_orbit}"}}'
           - '$.null'
@@ -3281,9 +3269,6 @@
       _collection: EO:ESA:DAT:COP-DEM
       product:type: DGE_30
       metadata_mapping:
-        sortOrder:
-          - '{{"sortOrder": "{sortOrder}"}}'
-          - '$.null'
         gsd:
           - '{{"spatialResolution": "{gsd}"}}'
           - '$.null'
@@ -3314,9 +3299,6 @@
           - '$.null'
         instruments:
           - '{{"instrumentShortName": "{instruments#csv_list}"}}'
-          - '$.null'
-        sortOrder:
-          - '{{"sortOrder": "{sortOrder}"}}'
           - '$.null'
         format:
           - '{{"fileFormat": "{format}"}}'

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3002,6 +3002,14 @@
       next_page_query_obj: '{{"itemsPerPage":{limit},"startIndex":{next_page_token}}}'
       max_limit: 200
       next_page_token_key: skip
+    sort:
+      sort_by_tpl: '{{"sortOrder": "{sort_order}"}}'
+      sort_param_mapping:
+      # start_datetime for consistency between providers, but it's unused for the actual sorting
+        start_datetime: unused
+      sort_order_mapping:
+        ascending: ASC
+        descending: DESC
     discover_collections:
       fetch_url: null
     discover_queryables:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -2986,7 +2986,7 @@
           "startdate": "{id#replace_str(r'^.*_([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])_.*$',r'\1-\2-\3T\4%3A\5%3A00Z')}",
           "enddate": "{id#replace_str(r'^.*_([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])_.*$',r'\1-\2-\3T\4%3A\5%3A00Z')}"
         }}
-      - '$.id'
+      - '{$.id#remove_extension}'
   search: !plugin
     type: WekeoSearch
     api_endpoint: https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/search
@@ -3086,6 +3086,13 @@
       product:type: GRD
       metadata_mapping:
         <<: *s1_sar_params
+        id:
+          - |
+            {{
+              "startdate": "{id#replace_str(r'^.*_([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])T([0-9][0-9])([0-9][0-9])([0-9][0-9])_.*$',r'\1-\2-\3T00%3A00%3A00Z')}",
+              "enddate": "{id#replace_str(r'^.*_([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])T([0-9][0-9])([0-9][0-9])([0-9][0-9])_.*$',r'\1-\2-\3T23%3A59%3A59Z')}"
+            }}
+          - '{$.id#remove_extension}'
         eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SAFE", "dataset_id": "EO:ESA:DAT:SENTINEL-1"}}'
     S1_SAR_RAW:
       _collection: EO:ESA:DAT:SENTINEL-1
@@ -3130,6 +3137,13 @@
       product:type: SR_2_LAN_HY
       processing:level: 2
       metadata_mapping:
+        id:
+            - |
+              {{
+                "startdate": "{id#replace_str(r'^.*[A-Z]_([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])T([0-9][0-9])([0-9][0-9])([0-9][0-9])_.*$',r'\1-\2-\3T\4%3A00%3A00Z')}",
+                "enddate": "{id#replace_str(r'^.*[A-Z]_([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])T([0-9][0-9])([0-9][0-9])([0-9][0-9])_.*$',r'\1-\2-\3T\4%3A59%3A59Z')}"
+              }}
+            - '{$.id#remove_extension}'
         processing:level:
           - '{{"processingLevel": "{processing:level}"}}'
           - '2'

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3234,6 +3234,12 @@
       _collection: EO:ESA:DAT:COP-DEM
       product:type: DGE_30
       metadata_mapping:
+        sortOrder:
+          - '{{"sortOrder": "{sortOrder}"}}'
+          - '$.null'
+        gsd:
+          - '{{"spatialResolution": "{gsd}"}}'
+          - '$.null'
         eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:ESA:DAT:COP-DEM"}}'
     COP_DEM_GLO30_DTED:
       _collection: EO:ESA:DAT:COP-DEM

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3080,6 +3080,11 @@
       satellite:
         - '{{"satellite": {satellite}}}'
         - '$.null'
+      # parameters returned by the provider queryables endpoint but not queryable
+      # in eodag (declared as simple string values to be excluded from queryables)
+      itemsPerPage: '$.null'
+      startIndex: '$.null'
+      sortOrder: '$.null'
   products:
     S1_SAR_GRD:
       _collection: EO:ESA:DAT:SENTINEL-1

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3102,8 +3102,20 @@
         processing:level:
           - '{{"processingLevel": "{processing:level}"}}'
           - '$.id.`sub(/^[^_]([^_]+)_([^_]+)_.*/, S2\\2)`'
+        platform:
+          - '{{"platformSerialIdentifier": "{platform}"}}'
+          - '$.null'
+        instruments:
+          - '{{"instrumentShortName": "{instruments#csv_list}"}}'
+          - '$.null'
+        sat:relative_orbit:
+          - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
+          - '$.null'
         eo:cloud_cover:
           - '{{"cloudCover": "{eo:cloud_cover}"}}'
+          - '$.null'
+        sortOrder:
+          - '{{"sortOrder": "{sortOrder}"}}'
           - '$.null'
         eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SAFE", "dataset_id": "EO:ESA:DAT:SENTINEL-2"}}'
     S2_MSI_L2A:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3333,7 +3333,7 @@
     CLMS_GLO_DMP_333M:
       _collection: EO:JRC:DAT:CLMS
       product:type: dry-gross_dry_matter_productivity
-      _dataset_identifier: dry-gross_dry_matter_productivity/dmp_global_300m_10daily_v1
+      _dataset_identifier: dmp_global_300m_10daily_v1
       metadata_mapping_from_product: CLMS_GLO_NDVI_333M
     CLMS_GLO_GDMP_333M:
       _collection: EO:JRC:DAT:CLMS

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3318,7 +3318,7 @@
         sortOrder:
           - '{{"sortOrder": "{sortOrder}"}}'
           - '$.null'
-        format: # TODO waiting confirmation from WEkEO
+        format:
           - '{{"fileFormat": "{format}"}}'
           - '$.null'
         eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:JRC:DAT:CLMS"}}'

--- a/eodag/types/stac_extensions.py
+++ b/eodag/types/stac_extensions.py
@@ -633,8 +633,6 @@ class ProviderStacExtension(BaseStacExtension):
     forms as input, while serializing as the stac-prefixed form.
     """
 
-    exclude_field_names: Optional[list[str]] = None
-
     @model_validator(mode="after")
     def setup_field_aliases(self) -> "ProviderStacExtension":
         """Set up dual (prefixed/unprefixed) aliases on extension fields."""
@@ -701,11 +699,6 @@ class WekeoExtension(ProviderStacExtension):
     FIELDS: type[BaseModel] = WekeoFields
 
     field_name_prefix: Optional[str] = "wekeo_main"
-    exclude_field_names: Optional[list[str]] = [
-        "itemsPerPage",
-        "startIndex",
-        "sortOrder",
-    ]
 
 
 STAC_EXTENSIONS = [

--- a/eodag/types/stac_extensions.py
+++ b/eodag/types/stac_extensions.py
@@ -676,6 +676,31 @@ class UsgsExtension(ProviderStacExtension):
     field_name_prefix: Optional[str] = "usgs"
 
 
+class WekeoFields(BaseModel):
+    """Custom fields for wekeo provider."""
+
+    wekeo_main_format: Annotated[str, Field(None)]
+    wekeo_main_level: Annotated[str, Field(None)]
+    wekeo_main_model: Annotated[str, Field(None)]
+    wekeo_main_processing_mode: Annotated[str, Field(None)]
+    wekeo_main_region: Annotated[str, Field(None)]
+    wekeo_main_satellite: Annotated[str, Field(None)]
+    wekeo_main_source: Annotated[str, Field(None)]
+    wekeo_main_step: Annotated[str, Field(None)]
+    wekeo_main_system: Annotated[str, Field(None)]
+    wekeo_main_type: Annotated[str, Field(None)]
+    wekeo_main_variable: Annotated[str, Field(None)]
+    wekeo_main_version: Annotated[str, Field(None)]
+
+
+class WekeoExtension(ProviderStacExtension):
+    """Custom extension for provider wekeo."""
+
+    FIELDS: type[BaseModel] = WekeoFields
+
+    field_name_prefix: Optional[str] = "wekeo_main"
+
+
 STAC_EXTENSIONS = [
     SarExtension(),
     SatelliteExtension(),
@@ -696,4 +721,5 @@ STAC_EXTENSIONS = [
     FederationExtension(),
     EcmwfExtension(),
     UsgsExtension(),
+    WekeoExtension(),
 ]

--- a/eodag/types/stac_extensions.py
+++ b/eodag/types/stac_extensions.py
@@ -633,6 +633,8 @@ class ProviderStacExtension(BaseStacExtension):
     forms as input, while serializing as the stac-prefixed form.
     """
 
+    exclude_field_names: Optional[list[str]] = None
+
     @model_validator(mode="after")
     def setup_field_aliases(self) -> "ProviderStacExtension":
         """Set up dual (prefixed/unprefixed) aliases on extension fields."""
@@ -699,6 +701,11 @@ class WekeoExtension(ProviderStacExtension):
     FIELDS: type[BaseModel] = WekeoFields
 
     field_name_prefix: Optional[str] = "wekeo_main"
+    exclude_field_names: Optional[list[str]] = [
+        "itemsPerPage",
+        "startIndex",
+        "sortOrder",
+    ]
 
 
 STAC_EXTENSIONS = [

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -2354,7 +2354,12 @@ class TestCore(TestCoreBase):
             "usgs_satapi_aws": {"max_sort_params": None, "sortables": []},
             "wekeo_cmems": None,
             "wekeo_ecmwf": None,
-            "wekeo_main": None,
+            "wekeo_main": {
+                "sortables": [
+                    "start_datetime",
+                ],
+                "max_sort_params": None,
+            },
         }
         sortables = self.dag.available_sortables()
         self.assertListEqual(


### PR DESCRIPTION
`metadata_mapping` updated according to https://help.wekeo.eu/en/articles/13791456-updates-to-hda-api-query-parameters-for-some-sentinel-and-clms-datasets

List of collections of the provider `wekeo_main` affected by this PR (grouped by dataset ID):

- EO:JRC:DAT:CLMS
  - CLMS_GLO_NDVI_333M
  - CLMS_GLO_NDVI_1KM_LTS
  - CLMS_GLO_FCOVER_333M
  - CLMS_GLO_DMP_333M
  - CLMS_GLO_GDMP_333M
  - CLMS_GLO_FAPAR_333M
  - CLMS_GLO_LAI_333M
- EO:ESA:DAT:COP-DEM
  - COP_DEM_GLO30_DGED
  - COP_DEM_GLO30_DTED
  - COP_DEM_GLO90_DGED
  - COP_DEM_GLO90_DTED
- EO:ESA:DAT:SENTINEL-1
  - S1_SAR_GRD
  - S1_SAR_RAW
  - S1_SAR_OCN
  - S1_SAR_SLC
- EO:ESA:DAT:SENTINEL-2
  - S2_MSI_L1C
  - S2_MSI_L2A
- EO:ESA:DAT:SENTINEL-3
  - S3_LAN_HY
  - S3_LAN_SI
  - S3_LAN_LI
  - S3_OLCI_L2LFR
  - S3_OLCI_L2LRR
  - S3_SLSTR_L2
- EO:ESA:DAT:SENTINEL-5P
  - S5P_L1B_IR_ALL
  - S5P_L2_IR_ALL

Fixed also a typo and added search_by id_mapping for Sentinel collections.

Test script:

```python
from eodag import EODataAccessGateway
from eodag.utils.logging import setup_logging

setup_logging(3)
dag = EODataAccessGateway()

dataset_id = "EO:JRC:DAT:CLMS"
queryables = dag.list_queryables(provider="wekeo_main", collection="CLMS_GLO_NDVI_333M")
queryables_keys = set(queryables.data.keys())
expected_keys = {"geom", "product_type", "platform", "instruments", "start", "end", "wekeo_main_format"}
assert queryables_keys == expected_keys, f"Unexpected queryables keys for dataset_id {dataset_id}: {queryables_keys}"

dataset_id = "EO:ESA:DAT:COP-DEM"
queryables = dag.list_queryables(provider="wekeo_main", collection="COP_DEM_GLO30_DGED")
queryables_keys = set(queryables.data.keys())
expected_keys = {"geom", "product_type", "gsd", "start", "end"}
assert queryables_keys == expected_keys, f"Unexpected queryables keys for dataset_id {dataset_id}: {queryables_keys}"

dataset_id = "EO:ESA:DAT:SENTINEL-1"
queryables = dag.list_queryables(provider="wekeo_main", collection="S1_SAR_GRD")
queryables_keys = set(queryables.data.keys())
expected_keys = {
  "geom",
  "product_type",
  "processing_level",
  "platform",
  "instruments",
  "order_status",
  "product_timeliness",
  "sar_polarizations",
  "sat_orbit_state",
  "sat_relative_orbit",
  "start",
  "end",
}
assert queryables_keys == expected_keys, f"Unexpected queryables keys for dataset_id {dataset_id}: {queryables_keys}"

dataset_id = "EO:ESA:DAT:SENTINEL-2"
queryables = dag.list_queryables(provider="wekeo_main", collection="S2_MSI_L1C")
queryables_keys = set(queryables.data.keys())
expected_keys = {
  "geom",
  "product_type",
  "processing_level",
  "platform",
  "instruments",
  "sat_orbit_state",
  "sat_relative_orbit",
  "eo_cloud_cover",
  "start",
  "end",
}
assert queryables_keys == expected_keys, f"Unexpected queryables keys for dataset_id {dataset_id}: {queryables_keys}"

dataset_id = "EO:ESA:DAT:SENTINEL-3"
queryables = dag.list_queryables(provider="wekeo_main", collection="S3_LAN_HY")
queryables_keys = set(queryables.data.keys())
expected_keys = {
  "geom",
  "product_type",
  "processing_level",
  "platform",
  "instruments",
  "product_timeliness",
  "sat_orbit_state",
  "sat_relative_orbit",
  "eo_cloud_cover",
  "start",
  "end",
}
assert queryables_keys == expected_keys, f"Unexpected queryables keys for dataset_id {dataset_id}: {queryables_keys}"

dataset_id = "EO:ESA:DAT:SENTINEL-5P"
queryables = dag.list_queryables(provider="wekeo_main", collection="S5P_L1B_IR_ALL")
queryables_keys = set(queryables.data.keys())
expected_keys = {
  "geom",
  "product_type",
  "processing_level",
  "instruments",
  "wekeo_main_processing_mode",
  "sat_absolute_orbit",
  "start",
  "end",
}
assert queryables_keys == expected_keys, f"Unexpected queryables keys for dataset_id {dataset_id}: {queryables_keys}"
```