### PR TITLE
chore: update download progress bar when asset is skipped

### DIFF
--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -1300,6 +1300,12 @@ class HTTPDownload(Download):
                     os.path.basename(asset_abs_path),
                 )
                 os.rename(asset_abs_path_temp, asset_abs_path)
+            else:
+                skipped_size = os.path.getsize(asset_abs_path)
+                logger.debug(
+                    "Asset already exists at '%s', skipping download", asset_abs_path
+                )
+                progress_callback(skipped_size)
             return
 
         # use parallelization if possible


### PR DESCRIPTION
Update download progress bar when asset is skipped because already on filesystem, to avoid having the progress-bar broken as incomplete when download finishes