### PR TITLE
fix(plugins): EOIAMAuth missing consent link in some auth errors

### DIFF
--- a/eodag/plugins/authentication/eoiam.py
+++ b/eodag/plugins/authentication/eoiam.py
@@ -152,17 +152,21 @@ class EOIAMAuth(Authentication):
             error_text = resp_final.text
 
             if "wants to access your account" in error_text:
-                raise AuthenticationError(
-                    "Consent required: please log in to the EOIAM portal and grant consent to EO Data Access Gateway"
+                msg = (
+                    "Consent required: please log in to the EOIAM portal "
+                    f"and grant consent through this link {final_url}"
                 )
+                raise AuthenticationError(msg)
 
             if (
                 "not yet performed the necessary steps in order to access this data."
                 in error_text
             ):
-                raise AuthenticationError(
-                    "Data access request required: please log in to the EOIAM portal and request access to the data"
+                msg = (
+                    f"Data access request required: please log in to the EOIAM portal "
+                    f"and request access to the data through this link {final_url}"
                 )
+                raise AuthenticationError(msg)
 
             raise AuthenticationError("Unexpected HTML response after SAML login")
 

--- a/tests/units/test_auth_plugins.py
+++ b/tests/units/test_auth_plugins.py
@@ -1226,14 +1226,17 @@ class TestAuthPluginEOIAMAuth(BaseAuthPluginTest):
             headers={"Location": "http://final.url"},
         )
         # GET final URL -> consent page
+        final_url = "http://final.url"
         responses.add(
             responses.GET,
-            "http://final.url",
+            final_url,
             body="wants to access your account",
             headers={"Content-Type": "text/html"},
         )
 
-        with self.assertRaisesRegex(AuthenticationError, "Consent required"):
+        with self.assertRaisesRegex(
+            AuthenticationError, f"Consent required: .* {final_url}"
+        ):
             auth_plugin._login_from_html(login_html, req_url="http://test.url")
 
     @responses.activate
@@ -1279,15 +1282,16 @@ class TestAuthPluginEOIAMAuth(BaseAuthPluginTest):
             headers={"Location": "http://final.url"},
         )
         # GET final URL -> data access required page
+        final_url = "http://final.url"
         responses.add(
             responses.GET,
-            "http://final.url",
+            final_url,
             body="not yet performed the necessary steps in order to access this data.",
             headers={"Content-Type": "text/html"},
         )
 
         with self.assertRaisesRegex(
-            AuthenticationError, "Data access request required"
+            AuthenticationError, f"Data access request required: .* {final_url}"
         ):
             auth_plugin._login_from_html(login_html, req_url="http://test.url")
 


### PR DESCRIPTION
Following #1811 ,

adds the link to fill the consent form whenever it is expected, when using `EOIAMAuth` (`eocat` provider).

