### PR TITLE
test: remove warnings and test skip

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -300,7 +300,6 @@ class EODagTestBase(unittest.TestCase):
                 status=200,
                 content_type="application/zip",
                 auto_calculate_content_length=True,
-                stream=True,
             )
 
         # Mock asset download urls
@@ -318,7 +317,6 @@ class EODagTestBase(unittest.TestCase):
                             status=200,
                             content_type=asset_type,
                             auto_calculate_content_length=True,
-                            stream=True,
                         )
             product.assets.update(assets)
 

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -3924,18 +3924,33 @@ class TestCoreSearch(TestCoreBase):
 
         self.assertEqual(mock__do_search.call_args_list[0].kwargs["limit"], 7)
 
-    @unittest.skip("Disable until fixed")
-    def test_search_all_request_error(self):
+    @mock.patch(
+        "eodag.plugins.manager.PluginManager.get_auth",
+        autospec=True,
+    )
+    def test_search_all_request_error(self, mock_get_auth):
         """search_all must stop iteration and move to next provider when error occurs"""
 
         collection = "S2_MSI_L1C"
         dag = EODataAccessGateway()
 
         for plugin in dag._plugins_manager.get_search_plugins(collection=collection):
+            plugin.discover_queryables = mock.MagicMock()
             plugin.query = mock.MagicMock()
             plugin.query.side_effect = RequestError
 
-        dag.search_all(collection="S2_MSI_L1C")
+        results = dag.search_all(collection="S2_MSI_L1C")
+
+        self.assertEqual(len(results), 0)
+
+        for plugin in dag._plugins_manager.get_search_plugins(collection=collection):
+            self.assertEqual(
+                plugin.query.call_count,
+                1,
+                "Expected to be called once, {} call count = {}".format(
+                    plugin, plugin.query.call_count
+                ),
+            )
 
     @mock.patch(
         "eodag.api.core.EODataAccessGateway._do_search",

--- a/tests/units/test_eoproduct.py
+++ b/tests/units/test_eoproduct.py
@@ -181,7 +181,6 @@ class TestEOProduct(EODagTestBase):
             body=b"",
             status=200,
             auto_calculate_content_length=True,
-            stream=True,
         )
         product = self._dummy_product()
         product.properties["eodag:quicklook"] = None
@@ -208,7 +207,6 @@ class TestEOProduct(EODagTestBase):
             body=b"",
             status=404,
             auto_calculate_content_length=True,
-            stream=True,
         )
         # Download, and check request called
         quicklook_file_path = product.get_quicklook()
@@ -223,7 +221,6 @@ class TestEOProduct(EODagTestBase):
             "https://fake.url.to/quicklook",
             body=b"Quicklook content",
             status=200,
-            stream=True,
         )
         product.properties["eodag:quicklook"] = "https://fake.url.to/quicklook"
         product.register_downloader(self.get_mock_downloader(), None)
@@ -247,7 +244,6 @@ class TestEOProduct(EODagTestBase):
             "https://fake.url.to/quicklook",
             body=b"Quicklook content",
             status=200,
-            stream=True,
         )
         product.properties["eodag:quicklook"] = "https://fake.url.to/quicklook"
         product.register_downloader(self.get_mock_downloader(), None)
@@ -300,7 +296,6 @@ class TestEOProduct(EODagTestBase):
             "https://fake.url.to/quicklook",
             body=b"Quicklook content",
             status=200,
-            stream=True,
         )
 
         quicklook_file_path = product.get_quicklook(filename=quicklook_basename)


### PR DESCRIPTION
Remove warnings raised by `responses` usage with `stream` parameter.

Enable and fix `test_search_all_request_error` that was skipped.
