### PR TITLE
fix(core): serialized search results fixes

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -913,6 +913,7 @@ class ECMWFSearch(PostJsonSearch):
             # We convert every single value to a list of string
             filter_v = list(values) if isinstance(values, tuple) else values
             filter_v = filter_v if isinstance(filter_v, list) else [filter_v]
+            filter_v = [str(v) for v in filter_v]
 
             # We strip values of superfluous quotes (added by mapping converter to_geojson).
             # ECMWF accept date ranges with /to/. We need to split it to an array

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -37,9 +37,9 @@
       title: '$.displayId'
       description: '$.summary'
       eo:cloud_cover: '$.cloudCover'
-      start_datetime: '$.temporalCoverage.startDate'
-      end_datetime: '$.temporalCoverage.endDate'
-      published: '$.publishDate'
+      start_datetime: '{$.temporalCoverage.startDate#to_iso_utc_datetime}'
+      end_datetime: '{$.temporalCoverage.endDate#to_iso_utc_datetime}'
+      published: '{$.publishDate#to_iso_utc_datetime}'
       eodag:thumbnail: '$.browse[0].thumbnailPath'
       eodag:quicklook: '$.browse[0].browsePath'
       order:status: '{$.available#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
@@ -1835,13 +1835,13 @@
       description: '$.properties.description'
       gsd:
         - 'resolution'
-        - '$.properties.resolution'
+        - '{$.properties.resolution#replace_tuple(((0,"Not Available"),))}'
       _provider: '$.properties.organisationName'
       providers:
         - 'organisationName'
         - '[{{"name":"{_provider}","roles":["producer"]}}]'
       published: '$.properties.published'
-      license: '$.properties.license'
+      license: '$.properties.license.licenseId'
       # OpenSearch Parameters for Product Search (Table 5)
       product:acquisition_type: '$.properties.acquisitionType'
       sat:relative_orbit:

--- a/eodag/types/stac_metadata.py
+++ b/eodag/types/stac_metadata.py
@@ -65,6 +65,7 @@ class CommonStacMetadata(ItemProperties):
     title: Annotated[str, Field(None)]
     description: Annotated[str, Field(None)]
     license: Annotated[str, Field(None)]
+    keywords: Annotated[list[str], Field(None)]
 
     _conformance_classes: ClassVar[dict[str, str]]
     get_conformance_classes: ClassVar[Callable[[Any], list[str]]]


### PR DESCRIPTION
STAC formatting / serialization issues fixes:
- bad-formatted values in `ECMWFSearch.available_values_from_constraints`
- `usgs` dates format
- `gsd` and `license` metadata-mapping for `sara`  provider
- missing `keywords` in `CommonStacMetadata`