### PR TITLE
refactor: quotas errors handling and order-status message

### DIFF
--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -73,6 +73,7 @@ from eodag.utils.exceptions import (
     DownloadError,
     MisconfiguredError,
     NotAvailableError,
+    QuotaExceededError,
     TimeOutError,
     ValidationError,
 )
@@ -223,6 +224,14 @@ class HTTPDownload(Download):
                 except RequestException as e:
                     self._check_auth_exception(e)
                     msg = f"{product.properties['title']} could not be ordered"
+                    if (
+                        e.response is not None
+                        and e.response.status_code
+                        and e.response.status_code == 429
+                    ):
+                        raise QuotaExceededError(
+                            f"Too many requests on provider {self.provider}, please check your quota!"
+                        )
                     if e.response is not None and e.response.status_code == 400:
                         raise ValidationError.from_error(e, msg) from e
                     else:
@@ -894,6 +903,14 @@ class HTTPDownload(Download):
         self, e: Optional[RequestException], product: EOProduct, ordered_message: str
     ) -> None:
         self._check_auth_exception(e)
+        if (
+            e.response is not None
+            and e.response.status_code
+            and e.response.status_code == 429
+        ):
+            raise QuotaExceededError(
+                f"Too many requests on provider {self.provider}, please check your quota!"
+            )
         response_text = (
             e.response.text.strip() if e is not None and e.response is not None else ""
         )
@@ -1363,6 +1380,14 @@ class HTTPDownload(Download):
 
     def _handle_asset_exception(self, e: RequestException, asset: Asset) -> None:
         # check if error is identified as auth_error in provider conf
+        if (
+            e.response is not None
+            and e.response.status_code
+            and e.response.status_code == 429
+        ):
+            raise QuotaExceededError(
+                f"Too many requests on provider {self.provider}, please check your quota!"
+            )
         auth_errors = getattr(self.config, "auth_error_code", [None])
         if not isinstance(auth_errors, list):
             auth_errors = [auth_errors]

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -223,15 +223,8 @@ class HTTPDownload(Download):
                     product.properties["order:status"] = STAGING_STATUS
                 except RequestException as e:
                     self._check_auth_exception(e)
+                    QuotaExceededError.raise_if_quota_exceeded(e, self.provider)
                     msg = f"{product.properties['title']} could not be ordered"
-                    if (
-                        e.response is not None
-                        and e.response.status_code
-                        and e.response.status_code == 429
-                    ):
-                        raise QuotaExceededError(
-                            f"Too many requests on provider {self.provider}, please check your quota!"
-                        )
                     if e.response is not None and e.response.status_code == 400:
                         raise ValidationError.from_error(e, msg) from e
                     else:
@@ -903,15 +896,8 @@ class HTTPDownload(Download):
         self, e: Optional[RequestException], product: EOProduct, ordered_message: str
     ) -> None:
         self._check_auth_exception(e)
-        if (
-            e
-            and e.response is not None
-            and e.response.status_code
-            and e.response.status_code == 429
-        ):
-            raise QuotaExceededError(
-                f"Too many requests on provider {self.provider}, please check your quota!"
-            )
+        if e is not None:
+            QuotaExceededError.raise_if_quota_exceeded(e, self.provider)
         response_text = (
             e.response.text.strip() if e is not None and e.response is not None else ""
         )
@@ -1380,29 +1366,11 @@ class HTTPDownload(Download):
         return fs_dir_path
 
     def _handle_asset_exception(self, e: RequestException, asset: Asset) -> None:
-        # check if error is identified as auth_error in provider conf
-        if (
-            e.response is not None
-            and e.response.status_code
-            and e.response.status_code == 429
-        ):
-            raise QuotaExceededError(
-                f"Too many requests on provider {self.provider}, please check your quota!"
-            )
-        auth_errors = getattr(self.config, "auth_error_code", [None])
-        if not isinstance(auth_errors, list):
-            auth_errors = [auth_errors]
-        if e.response is not None and e.response.status_code in auth_errors:
-            raise AuthenticationError(
-                f"Please check your credentials for {self.provider}.",
-                f"HTTP Error {e.response.status_code} returned.",
-                e.response.text.strip(),
-            )
-        else:
-            logger.error(
-                "Unexpected error at download of asset %s: %s", asset["href"], e
-            )
-            raise DownloadError(e)
+        # check if error is identified as auth_error or quota_exceeded in provider conf
+        self._check_auth_exception(e)
+        QuotaExceededError.raise_if_quota_exceeded(e, self.provider)
+        logger.error("Unexpected error at download of asset %s: %s", asset["href"], e)
+        raise DownloadError(e)
 
     def _get_asset_sizes(
         self,

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -450,11 +450,12 @@ class HTTPDownload(Download):
                 {k: v for k, v in status_dict.items() if v != NOT_AVAILABLE}
             )
 
-            product.properties["eodag:order_status"] = status_dict.get(
-                "eodag:order_status"
-            )
+            order_status = status_dict.get("eodag:order_status")
+            product.properties["eodag:order_status"] = order_status
 
-            status_message = status_dict.get("eodag:order_message")
+            status_message = status_dict.get(
+                "eodag:order_message", f"request status: {order_status}"
+            )
 
             # handle status error
             errors: dict[str, Any] = status_config.get("error", {})

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -904,7 +904,8 @@ class HTTPDownload(Download):
     ) -> None:
         self._check_auth_exception(e)
         if (
-            e.response is not None
+            e
+            and e.response is not None
             and e.response.status_code
             and e.response.status_code == 429
         ):

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -1512,24 +1512,14 @@ class QueryStringSearch(Search):
             err = requests.exceptions.Timeout(request=requests.Request(url=url))
             raise TimeOutError(err, timeout=timeout)
         except HTTPError as e:  # raised by urlopen
-            if e.code and e.code == 429:
-                raise QuotaExceededError(
-                    f"Too many requests on provider {self.provider}, please check your quota!"
-                )
+            QuotaExceededError.raise_if_quota_exceeded(e, self.provider)
             err_msg = e.msg
             self._raise_request_error(err_msg, exception_message, url, e)
         except URLError as e:
             err_msg = str(e)
             self._raise_request_error(err_msg, exception_message, url, e)
         except requests.RequestException as err:
-            if (
-                err.response
-                and err.response.status_code
-                and err.response.status_code == 429
-            ):
-                raise QuotaExceededError(
-                    f"Too many requests on provider {self.provider}, please check your quota!"
-                )
+            QuotaExceededError.raise_if_quota_exceeded(err, self.provider)
             err_msg = err.readlines() if hasattr(err, "readlines") else ""
             self._raise_request_error(err_msg, exception_message, url, err)
         return response

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -1415,6 +1415,21 @@ class QueryStringSearch(Search):
         else:
             return tuple(provider_collection)
 
+    def _raise_request_error(
+        self, err_msg: str, exception_message: Optional[str], url: str, e: Exception
+    ):
+        if exception_message:
+            logger.exception("%s %s" % (exception_message, err_msg))
+        else:
+            logger.exception(
+                "Skipping error while requesting: %s (provider:%s, plugin:%s): %s",
+                url,
+                self.provider,
+                self.__class__.__name__,
+                err_msg,
+            )
+        raise RequestError.from_error(e, exception_message) from e
+
     def _request(
         self,
         prep: PreparedSearch,
@@ -1501,7 +1516,12 @@ class QueryStringSearch(Search):
                 raise QuotaExceededError(
                     f"Too many requests on provider {self.provider}, please check your quota!"
                 )
-        except (requests.RequestException, URLError) as err:
+            err_msg = e.msg
+            self._raise_request_error(err_msg, exception_message, url, e)
+        except URLError as e:
+            err_msg = str(e)
+            self._raise_request_error(err_msg, exception_message, url, e)
+        except requests.RequestException as err:
             if (
                 err.response
                 and err.response.status_code
@@ -1511,17 +1531,7 @@ class QueryStringSearch(Search):
                     f"Too many requests on provider {self.provider}, please check your quota!"
                 )
             err_msg = err.readlines() if hasattr(err, "readlines") else ""
-            if exception_message:
-                logger.exception("%s %s" % (exception_message, err_msg))
-            else:
-                logger.exception(
-                    "Skipping error while requesting: %s (provider:%s, plugin:%s): %s",
-                    url,
-                    self.provider,
-                    self.__class__.__name__,
-                    err_msg,
-                )
-            raise RequestError.from_error(err, exception_message) from err
+            self._raise_request_error(err_msg, exception_message, url, err)
         return response
 
 

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -31,7 +31,7 @@ from typing import (
     cast,
     get_args,
 )
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 from urllib.parse import (
     parse_qs,
     parse_qsl,
@@ -99,6 +99,7 @@ from eodag.utils.exceptions import (
     AuthenticationError,
     MisconfiguredError,
     PluginImplementationError,
+    QuotaExceededError,
     RequestError,
     TimeOutError,
     ValidationError,
@@ -1495,7 +1496,20 @@ class QueryStringSearch(Search):
         except socket.timeout:
             err = requests.exceptions.Timeout(request=requests.Request(url=url))
             raise TimeOutError(err, timeout=timeout)
+        except HTTPError as e:  # raised by urlopen
+            if e.code and e.code == 429:
+                raise QuotaExceededError(
+                    f"Too many requests on provider {self.provider}, please check your quota!"
+                )
         except (requests.RequestException, URLError) as err:
+            if (
+                err.response
+                and err.response.status_code
+                and err.response.status_code == 429
+            ):
+                raise QuotaExceededError(
+                    f"Too many requests on provider {self.provider}, please check your quota!"
+                )
             err_msg = err.readlines() if hasattr(err, "readlines") else ""
             if exception_message:
                 logger.exception("%s %s" % (exception_message, err_msg))
@@ -1591,7 +1605,15 @@ class ODataV4Search(QueryStringSearch):
                     response.raise_for_status()
                 except requests.exceptions.Timeout as exc:
                     raise TimeOutError(exc, timeout=HTTP_REQ_TIMEOUT) from exc
-                except requests.RequestException:
+                except requests.RequestException as e:
+                    if (
+                        e.response
+                        and e.response.status_code
+                        and e.response.status_code == 429
+                    ):
+                        logger.error(
+                            f"Too many requests on provider {self.provider}, please check your quota!"
+                        )
                     logger.exception(
                         "Skipping error while searching for %s %s instance",
                         self.provider,
@@ -2036,6 +2058,10 @@ class PostJsonSearch(QueryStringSearch):
                     f"Please check your credentials for {self.provider}.",
                     f"HTTP Error {response.status_code} returned.",
                     response.text.strip(),
+                )
+            if response.status_code and response.status_code == 429:
+                raise QuotaExceededError(
+                    f"Too many requests on provider {self.provider}, please check your quota!"
                 )
             if exception_message:
                 logger.exception(exception_message)

--- a/eodag/utils/exceptions.py
+++ b/eodag/utils/exceptions.py
@@ -144,3 +144,27 @@ class TimeOutError(RequestError):
 
 class QuotaExceededError(RequestError):
     """An error indicating that too many requests were sent to a provider"""
+
+    @staticmethod
+    def raise_if_quota_exceeded(error: Exception, provider: str) -> None:
+        """Raise :class:`QuotaExceededError` if the HTTP status code is 429.
+
+        Supports ``requests.RequestException`` (via ``.response.status_code``) and
+        ``urllib.error.HTTPError`` (via ``.code``).
+
+        :param error: An exception to inspect for a 429 status code
+        :param provider: The provider name used in the error message
+        :raises QuotaExceededError: if the status code is 429
+        """
+        status_code = None
+        # requests.RequestException with .response
+        response = getattr(error, "response", None)
+        if response is not None:
+            status_code = getattr(response, "status_code", None)
+        # urllib HTTPError with .code
+        if status_code is None:
+            status_code = getattr(error, "code", None)
+        if status_code and status_code == 429:
+            raise QuotaExceededError(
+                f"Too many requests on provider {provider}, please check your quota!"
+            )

--- a/eodag/utils/exceptions.py
+++ b/eodag/utils/exceptions.py
@@ -140,3 +140,7 @@ class TimeOutError(RequestError):
             f"Request timeout {timeout_msg} for URL {url}" if url else str(exception)
         )
         super().__init__(message)
+
+
+class QuotaExceededError(RequestError):
+    """An error indicating that too many requests were sent to a provider"""

--- a/eodag/utils/exceptions.py
+++ b/eodag/utils/exceptions.py
@@ -166,5 +166,5 @@ class QuotaExceededError(RequestError):
             status_code = getattr(error, "code", None)
         if status_code and status_code == 429:
             raise QuotaExceededError(
-                f"Too many requests on provider {provider}, please check your quota!"
+                f"Too many requests on provider {provider}, please check your quota."
             )

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -36,6 +36,7 @@ from eodag.utils.exceptions import (
     DownloadError,
     MisconfiguredError,
     NoMatchingCollection,
+    QuotaExceededError,
     ValidationError,
 )
 from tests import TEST_RESOURCES_PATH
@@ -778,6 +779,28 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         # Product location not changed
         self.assertEqual(self.product.location, "http://somewhere")
         self.assertEqual(self.product.remote_location, "http://somewhere")
+
+    @mock.patch("eodag.plugins.download.http.HTTPDownload._get_asset_sizes")
+    @mock.patch("eodag.plugins.download.http.requests.head", autospec=True)
+    @mock.patch("eodag.plugins.download.http.requests.get", autospec=True)
+    def test_plugins_download_http_assets_too_many_requests_error(
+        self, mock_requests_get, mock_requests_head, mock_asset_size
+    ):
+        """HTTPDownload.download() must handle a 429 (Too many requests) error"""
+
+        plugin = self.get_download_plugin(self.product)
+        self.product.location = self.product.remote_location = "http://somewhere"
+        self.product.properties["id"] = "someproduct"
+        self.product.assets.clear()
+        self.product.assets.update({"foo": {"href": "http://somewhere/something"}})
+        self.product.assets.update({"bar": {"href": "http://somewhere/anotherthing"}})
+        res = MockResponse({"a": "a"}, 429)
+        mock_requests_get.side_effect = res
+        mock_requests_head.return_value.headers = CaseInsensitiveDict(
+            {"Content-Disposition": ""}
+        )
+        with self.assertRaises(QuotaExceededError):
+            plugin.download(self.product, output_dir=self.output_dir)
 
     def test_plugins_download_http_stream_dict_misconfigured(self):
         """HTTPDownload.stream_download() must raise an error if misconfigured"""

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -46,6 +46,7 @@ from eodag.api.provider import Provider, ProvidersDict
 from eodag.utils import deepcopy
 from eodag.utils.exceptions import (
     PluginImplementationError,
+    QuotaExceededError,
     UnsupportedCollection,
     ValidationError,
 )
@@ -415,6 +416,18 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
 
         # restore the original config
         self.sara_search_plugin.config = provider_search_plugin_config
+
+    @mock.patch("eodag.plugins.search.qssearch.requests.Session.get", autospec=True)
+    def test_plugins_search_querystringsearch_search_quota_exceeded(
+        self, mock__request
+    ):
+        """A query with a QueryStringSearch must handle a 429 response returned by the provider"""
+        response = MockResponse({}, status_code=429)
+        mock__request.side_effect = requests.exceptions.HTTPError(response=response)
+        with self.assertRaises(QuotaExceededError):
+            self.sara_search_plugin.query(
+                collection="S2_MSI_L1C", **{"eo:cloud_cover": 50}
+            )
 
     @mock.patch(
         "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
@@ -1115,6 +1128,20 @@ class TestSearchPluginPostJsonSearch(BaseSearchPluginTest):
                 )
 
         run()
+
+    @mock.patch("eodag.plugins.search.qssearch.requests.post", autospec=True)
+    def test_plugins_search_postjsonsearch_search_quota_exceeded(self, mock__request):
+        """A query with a PostJsonSearch must handle a 429 response returned by the provider"""
+
+        class MockResponseRequestsException(MockResponse):
+            def raise_for_status(self):
+                if self.status_code != 200:
+                    raise requests.RequestException()
+
+        response = MockResponseRequestsException({}, status_code=429)
+        mock__request.return_value = response
+        with self.assertRaises(QuotaExceededError):
+            self.awseos_search_plugin.query(collection="S2_MSI_L2A")
 
     @mock.patch("eodag.plugins.search.qssearch.PostJsonSearch._request", autospec=True)
     def test_plugins_search_postjsonsearch_count_and_search_awseos(self, mock__request):

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -424,9 +424,10 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
         """A query with a QueryStringSearch must handle a 429 response returned by the provider"""
         response = MockResponse({}, status_code=429)
         mock__request.side_effect = requests.exceptions.HTTPError(response=response)
+        prep = PreparedSearch(collection="S2_MSI_L1C", count=False)
         with self.assertRaises(QuotaExceededError):
             self.sara_search_plugin.query(
-                collection="S2_MSI_L1C", **{"eo:cloud_cover": 50}
+                prep=prep, collection="S2_MSI_L1C", **{"eo:cloud_cover": 50}
             )
 
     @mock.patch(


### PR DESCRIPTION
- handle 429 error response returned by provider
- use order status as status message if no message in provider response 