### PR TITLE
fix(queryables): required parameters, defaults and allowed combinations

### DIFF
--- a/eodag/config.py
+++ b/eodag/config.py
@@ -211,10 +211,12 @@ class PluginConfig(yaml.YAMLObject):
         result_type: str
         #: JsonPath to retrieve the queryables from the provider result
         results_entry: str
-        #: :class:`~eodag.plugins.search.base.Search` URL of the constraint file used to build queryables
-        constraints_url: str
         #: :class:`~eodag.plugins.search.base.Search` Key in the json result where the constraints can be found
         constraints_entry: str
+        #: :class:`~eodag.plugins.search.base.Search` URL of the constraint file used to build queryables
+        constraints_url: str
+        #: :class:`~eodag.plugins.search.base.Search` URL of the form file used to build queryables
+        form_url: str
 
     class CollectionSelector(TypedDict, total=False):
         """Define the criteria to select a collection in :class:`~eodag.config.PluginConfig.DynamicDiscoverQueryables`.

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -795,7 +795,7 @@ class ECMWFSearch(PostJsonSearch):
             available_values = self.available_values_from_constraints(
                 constraints,
                 non_empty_formated,
-                form_keywords=[f["name"] for f in form],
+                form,
             )
 
             # Pre-compute the required keywords (present in all constraint dicts)
@@ -878,7 +878,7 @@ class ECMWFSearch(PostJsonSearch):
         self,
         constraints: list[dict[str, Any]],
         input_keywords: dict[str, Any],
-        form_keywords: list[str],
+        form: list[dict[str, Any]],
     ) -> dict[str, list[str]]:
         """
         Filter constraints using input_keywords. Return list of available queryables.
@@ -886,9 +886,13 @@ class ECMWFSearch(PostJsonSearch):
 
         :param constraints: list of constraints received from the provider
         :param input_keywords: dict of input parameters given by the user
-        :param form_keywords: list of keyword names from the provider form endpoint
+        :param form: form received from the provider
         :return: dict with available values for each parameter
         """
+        # get form keywords and form required keywords
+        form_keywords = [f["name"] for f in form]
+        required_by_form = [f["name"] for f in form if f.get("required", False)]
+
         # get ordered constraint keywords
         constraints_keywords = list(
             OrderedDict.fromkeys(k for c in constraints for k in c.keys())
@@ -947,15 +951,9 @@ class ECMWFSearch(PostJsonSearch):
 
             # Filter constraints and check for missing values
             filtered_constraints = []
-            # True if some constraint is defined for this keyword.
-            # In other words: if no constraint defines a list of values
-            # then any value is allowed for this keyword
-            keyword_constrained = False
             for entry in constraints:
                 # Filter based on the presence of any value in filter_v
                 entry_values = entry.get(keyword, [])
-                if entry_values:
-                    keyword_constrained = True
 
                 # date constraint may be intervals. We identify intervals with a "/" in the value.
                 # date constraint can be a mixed list of single values (e.g "2023-06-27")
@@ -983,9 +981,23 @@ class ECMWFSearch(PostJsonSearch):
                 if present_values:
                     filtered_constraints.append(entry)
 
+            any_value_allowed = False
+            if not filtered_constraints or missing_values:
+                allowed_values = list(
+                    {value for c in constraints for value in c.get(keyword, [])}
+                )
+                # if keyword in required_by_form then any_value_allowed = False
+                #   use constraints file to determine if the parameter match the allowed values
+                # if allowed_values then any_value_allowed = False
+                #   use constraints file: the parameter must match the allowed values
+                if keyword not in required_by_form and not allowed_values:
+                    # keyword not required by form and the list of allowed values is empty:
+                    # accept any value for this keyword
+                    any_value_allowed = True
+
             # raise an error as no constraint entry matched the input keywords
             # raise an error if one value from input is not allowed
-            if keyword_constrained and (not filtered_constraints or missing_values):
+            if not any_value_allowed and (not filtered_constraints or missing_values):
                 allowed_values = list(
                     {value for c in constraints for value in c.get(keyword, [])}
                 )
@@ -1001,19 +1013,26 @@ class ECMWFSearch(PostJsonSearch):
                     ]
                     all_keywords_str = f" with {', '.join(keywords)}"
 
+                if allowed_values:
+                    allowed_values_str = (
+                        f" Allowed values are {', '.join(allowed_values)}."
+                    )
+                else:
+                    allowed_values_str = "No value allowed."
                 raise ValidationError(
                     f"{keyword}={values} is not available"
                     f"{all_keywords_str}."
-                    f" Allowed values are {', '.join(allowed_values)}.",
+                    f" {allowed_values_str}",
                     set(
                         [keyword] + [k for k in parsed_keywords if k in input_keywords]
                     ),
                 )
 
             parsed_keywords.append(keyword)
-            # if the keyword is not constrained then any value is allowed
-            if keyword_constrained:
+            if not any_value_allowed:
+                # the parameter must match the allowed values in the constraints file
                 constraints = filtered_constraints
+            # else any value is allowed
 
         available_values: dict[str, Any] = {k: set() for k in ordered_keywords}
 

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -957,7 +957,9 @@ class ECMWFSearch(PostJsonSearch):
             # updates the properties with the values given based on the information from the element
             _update_properties_from_element(prop, element, values)
 
-            default = defaults.get(name)
+            # default value is set with the following priority:
+            # input default values > form details default value > no default value
+            default = defaults.get(name, details.get("default"))
 
             if details:
                 fields = details.get("fields")
@@ -974,10 +976,9 @@ class ECMWFSearch(PostJsonSearch):
             is_required: bool
             if bool(element.get("required", False)):
                 # required by form
-                if available_values.get(name):
-                    is_required = True
-                else:
-                    # keyword required and the list of available values is empty:
+                is_required = True
+                if name in available_values and not available_values[name]:
+                    # keyword required by form, defined in some constraint and the list of available values is empty:
                     # don't add this keyword to the list of queryables because
                     # it cannot be used with this combination of parameters
                     continue

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -883,7 +883,9 @@ class ECMWFSearch(PostJsonSearch):
                         f" Allowed values are {', '.join(allowed_values)}."
                     )
                 else:
-                    allowed_values_str = "No value allowed."
+                    allowed_values_str = (
+                        f"{keyword} cannot be used with this combination of parameters."
+                    )
                 raise ValidationError(
                     f"{keyword}={values} is not available"
                     f"{all_keywords_str}."

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -851,10 +851,10 @@ class ECMWFSearch(PostJsonSearch):
                 allowed_values = list(
                     {value for c in constraints for value in c.get(keyword, [])}
                 )
-                # if keyword in required_by_form then any_value_allowed = False
-                #   use constraints file to determine if the parameter match the allowed values
-                # if allowed_values then any_value_allowed = False
-                #   use constraints file: the parameter must match the allowed values
+                # if keyword in required_by_form then any_value_allowed = False:
+                #   use constraints file to determine if the parameter matches the allowed values
+                # if allowed_values is not empty then any_value_allowed = False:
+                #   use constraints file to determine if the parameter matches the allowed values
                 if keyword not in required_by_form and not allowed_values:
                     # keyword not required by form and the list of allowed values is empty:
                     # accept any value for this keyword
@@ -880,7 +880,7 @@ class ECMWFSearch(PostJsonSearch):
 
                 if allowed_values:
                     allowed_values_str = (
-                        f" Allowed values are {', '.join(allowed_values)}."
+                        f"Allowed values are {', '.join(allowed_values)}."
                     )
                 else:
                     allowed_values_str = (

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -972,16 +972,15 @@ class ECMWFSearch(PostJsonSearch):
                 default = ",".join(default)
 
             is_required: bool
-            if available_values.get(name):
-                # required by the filtered constraints (available_values[name] is a not empty list)
-                is_required = True
-            elif bool(element.get("required")):
-                if name in available_values and not available_values[name]:
-                    # not required by the filtered constraints (available_values[name] is an empty list)
-                    is_required = False
-                else:
-                    # required only by form
+            if bool(element.get("required", False)):
+                # required by form
+                if available_values.get(name):
                     is_required = True
+                else:
+                    # keyword required and the list of available values is empty:
+                    # don't add this keyword to the list of queryables because
+                    # it cannot be used with this combination of parameters
+                    continue
             else:
                 # not required by form
                 is_required = False

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -284,6 +284,8 @@ class ECMWFSearch(PostJsonSearch):
             queryables for a specific collection
           * :attr:`~eodag.config.PluginConfig.DiscoverQueryables.constraints_url` (``str``): url of the constraint file
             used to build queryables
+          * :attr:`~eodag.config.PluginConfig.DiscoverQueryables.form_url` (``str``): url of the form file
+            used to build queryables
 
         * :attr:`~eodag.config.PluginConfig.dynamic_discover_queryables`
           (``list`` [:class:`~eodag.config.PluginConfig.DynamicDiscoverQueryables`]): list of configurations to fetch

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -661,7 +661,7 @@ class ECMWFSearch(PostJsonSearch):
             available_values = self.available_values_from_constraints(
                 constraints,
                 non_empty_formated,
-                form_keywords=[f["name"] for f in form],
+                form,
             )
 
             # Pre-compute the required keywords (present in all constraint dicts)
@@ -743,7 +743,7 @@ class ECMWFSearch(PostJsonSearch):
         self,
         constraints: list[dict[str, Any]],
         input_keywords: dict[str, Any],
-        form_keywords: list[str],
+        form: list[dict[str, Any]],
     ) -> dict[str, list[str]]:
         """
         Filter constraints using input_keywords. Return list of available queryables.
@@ -751,9 +751,13 @@ class ECMWFSearch(PostJsonSearch):
 
         :param constraints: list of constraints received from the provider
         :param input_keywords: dict of input parameters given by the user
-        :param form_keywords: list of keyword names from the provider form endpoint
+        :param form: form received from the provider
         :return: dict with available values for each parameter
         """
+        # get form keywords and form required keywords
+        form_keywords = [f["name"] for f in form]
+        required_by_form = [f["name"] for f in form if f.get("required", False)]
+
         # get ordered constraint keywords
         constraints_keywords = list(
             OrderedDict.fromkeys(k for c in constraints for k in c.keys())
@@ -812,15 +816,9 @@ class ECMWFSearch(PostJsonSearch):
 
             # Filter constraints and check for missing values
             filtered_constraints = []
-            # True if some constraint is defined for this keyword.
-            # In other words: if no constraint defines a list of values
-            # then any value is allowed for this keyword
-            keyword_constrained = False
             for entry in constraints:
                 # Filter based on the presence of any value in filter_v
                 entry_values = entry.get(keyword, [])
-                if entry_values:
-                    keyword_constrained = True
 
                 # date constraint may be intervals. We identify intervals with a "/" in the value.
                 # date constraint can be a mixed list of single values (e.g "2023-06-27")
@@ -848,9 +846,23 @@ class ECMWFSearch(PostJsonSearch):
                 if present_values:
                     filtered_constraints.append(entry)
 
+            any_value_allowed = False
+            if not filtered_constraints or missing_values:
+                allowed_values = list(
+                    {value for c in constraints for value in c.get(keyword, [])}
+                )
+                # if keyword in required_by_form then any_value_allowed = False
+                #   use constraints file to determine if the parameter match the allowed values
+                # if allowed_values then any_value_allowed = False
+                #   use constraints file: the parameter must match the allowed values
+                if keyword not in required_by_form and not allowed_values:
+                    # keyword not required by form and the list of allowed values is empty:
+                    # accept any value for this keyword
+                    any_value_allowed = True
+
             # raise an error as no constraint entry matched the input keywords
             # raise an error if one value from input is not allowed
-            if keyword_constrained and (not filtered_constraints or missing_values):
+            if not any_value_allowed and (not filtered_constraints or missing_values):
                 allowed_values = list(
                     {value for c in constraints for value in c.get(keyword, [])}
                 )
@@ -866,19 +878,26 @@ class ECMWFSearch(PostJsonSearch):
                     ]
                     all_keywords_str = f" with {', '.join(keywords)}"
 
+                if allowed_values:
+                    allowed_values_str = (
+                        f" Allowed values are {', '.join(allowed_values)}."
+                    )
+                else:
+                    allowed_values_str = "No value allowed."
                 raise ValidationError(
                     f"{keyword}={values} is not available"
                     f"{all_keywords_str}."
-                    f" Allowed values are {', '.join(allowed_values)}.",
+                    f" {allowed_values_str}",
                     set(
                         [keyword] + [k for k in parsed_keywords if k in input_keywords]
                     ),
                 )
 
             parsed_keywords.append(keyword)
-            # if the keyword is not constrained then any value is allowed
-            if keyword_constrained:
+            if not any_value_allowed:
+                # the parameter must match the allowed values in the constraints file
                 constraints = filtered_constraints
+            # else any value is allowed
 
         available_values: dict[str, Any] = {k: set() for k in ordered_keywords}
 

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2886,12 +2886,15 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
             {"date": ["2025-01-01/2025-06-01"], "variable": ["a", "b"]},
             {"date": ["2024-01-01/2024-12-01"], "variable": ["a", "b", "c"]},
         ]
-        form_keywords = ["date", "variable"]
+        form = [
+            {"name": "date", "required": True},
+            {"name": "variable", "required": True},
+        ]
 
         # with a date range as a string
         input_keywords = {"date": "2025-01-01/2025-02-01", "variable": "a"}
         available_values = self.search_plugin.available_values_from_constraints(
-            constraints, input_keywords, form_keywords
+            constraints, input_keywords, form
         )
         available_values = {k: sorted(v) for k, v in available_values.items()}
         self.assertIn("variable", available_values)
@@ -2901,7 +2904,7 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         # with a date range as the first element of a string list
         input_keywords = {"date": ["2025-01-01/2025-02-01"], "variable": "a"}
         available_values = self.search_plugin.available_values_from_constraints(
-            constraints, input_keywords, form_keywords
+            constraints, input_keywords, form
         )
         available_values = {k: sorted(v) for k, v in available_values.items()}
         self.assertIn("variable", available_values)

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -3610,8 +3610,8 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
             {"name": "variable", "required": False},
         ]
 
-        # "variable" is *not* required by form and *no* constraint with the given "date" defines values
-        # for "variable": any value for "variable" can be used as input keyword.
+        # "variable" is *not* required by form and after applying the filter there is *no* constraint that defines
+        # any values for "variable": any value for "variable" can be used as input keyword.
         input_keywords = {"date": "2024-01-01/2024-01-01", "variable": "c"}
         available_values = self.search_plugin.available_values_from_constraints(
             constraints, input_keywords, form
@@ -3621,8 +3621,8 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         self.assertListEqual([], available_values["variable"])
         self.assertIn("date", available_values)
 
-        # "variable" is *not* required by form and *some* constraints with the given "date" defines values
-        # for "variable": "variable" must match the available values.
+        # "variable" is *not* required by form and after applying the filter there are *some* constraints that
+        # define  values for "variable": "variable" must match the available values.
         # case 1: the value "a" is available
         input_keywords = {"date": "2025-01-01/2025-01-01", "variable": "a"}
         available_values = self.search_plugin.available_values_from_constraints(
@@ -3885,6 +3885,108 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
 
         # restore the original config
         self.search_plugin.config = provider_search_plugin_config
+
+    @mock.patch(
+        "eodag.plugins.search.build_search_result.ECMWFSearch._fetch_data",
+        autospec=True,
+    )
+    def test_plugins_search_ecmwfsearch_discover_queryables_default_by_form(
+        self, mock__fetch_data
+    ):
+        """A queryable with a default value must use that default value and being not required."""
+        constraints_path = os.path.join(TEST_RESOURCES_PATH, "constraints.json")
+        with open(constraints_path) as f:
+            constraints = json.load(f)
+        form_path = os.path.join(TEST_RESOURCES_PATH, "form.json")
+        with open(form_path) as f:
+            form = json.load(f)
+        mock__fetch_data.side_effect = [constraints, form]
+
+        default_values = deepcopy(
+            getattr(self.search_plugin.config, "products", {}).get(
+                "CAMS_EU_AIR_QUALITY_RE", {}
+            )
+        )
+        default_values.pop("metadata_mapping", None)
+        params = deepcopy(default_values)
+        params["collection"] = "CAMS_EU_AIR_QUALITY_RE"
+        params["download_format"] = "zip"  # override default in form file
+
+        queryables = self.search_plugin.discover_queryables(**params)
+        self.assertIsNotNone(queryables)
+        for element in form:
+            if "details" not in element:
+                # skip form elements missing details
+                continue
+            name: str = element["name"]
+            ecmwf_name: str = f"ecmwf_{name}"
+            details = element.get("details", {})
+            default_by_params = params.get(name)
+            default_by_form = details.get("default")
+            if default_by_params is not None:
+                # default value defined in the provider config
+                self.assertIn(ecmwf_name, queryables.keys())
+                self.assertFalse(
+                    get_args(queryables[ecmwf_name])[1].is_required(),
+                    f"Keyword {ecmwf_name} must be not required",
+                )
+                self.assertEqual(
+                    default_by_params, get_args(queryables[ecmwf_name])[1].default
+                )
+            elif default_by_form is not None:
+                # default value defined in the form file and not in the provider config
+                self.assertIn(ecmwf_name, queryables.keys())
+                self.assertFalse(
+                    get_args(queryables[ecmwf_name])[1].is_required(),
+                    f"Keyword {ecmwf_name} must be not required",
+                )
+                # default value defined as list in the form file
+                self.assertEqual(
+                    default_by_form[0], get_args(queryables[ecmwf_name])[1].default
+                )
+
+    @mock.patch(
+        "eodag.plugins.search.build_search_result.ECMWFSearch._fetch_data",
+        autospec=True,
+    )
+    def test_plugins_search_ecmwfsearch_discover_queryables_not_allowed_parameters(
+        self, mock__fetch_data
+    ):
+        """A not allowed parameter must not be listed in the queryables.
+
+        A parameter is not allowed if all the following conditions are true:
+
+        - the keyword is required by form;
+        - the keyword is used by some constraint;
+        - the list of available values is empty.
+
+        In this case don't add the keyword to the list of queryables because
+        it cannot be used with the given combination of parameters.
+        """
+        constraints = [
+            {"date": ["2025-01-01/2025-06-01"], "variable": ["a", "b"]},
+            {"date": ["2024-01-01/2024-12-01"]},
+        ]
+        form = [
+            {"name": "date", "type": "StringListWidget", "required": True},
+            {"name": "variable", "type": "StringListWidget", "required": True},
+        ]
+        mock__fetch_data.side_effect = [constraints, form]
+
+        params = {
+            "collection": "CAMS_EU_AIR_QUALITY_RE",
+            "date": "2024-01-01",
+        }
+        queryables = self.search_plugin.discover_queryables(**params)
+        self.assertIsNotNone(queryables)
+        # ecmwf_date is queryable with a default value -> not required
+        self.assertIn("ecmwf_date", queryables)
+        self.assertFalse(
+            get_args(queryables["ecmwf_date"])[1].is_required(),
+            "Keyword ecmwf_date must be not required",
+        )
+        # ecmwf_variable is not queryable
+        self.assertNotIn("ecmwf_variable", queryables)
 
     @mock.patch(
         "eodag.plugins.search.build_search_result.ECMWFSearch._fetch_data",

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -3538,6 +3538,111 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         self.assertListEqual(["a", "b"], available_values["variable"])
         self.assertIn("date", available_values)
 
+    def test_plugins_search_ecmwfsearch_get_available_values_from_contraints_with_keyword_required_by_form(
+        self,
+    ):
+        """An input keyword cannot be used if it's required by form and no constraint with the given
+        combination of parameters exists"""
+        constraints = [
+            {"date": ["2025-01-01/2025-06-01"], "variable": ["a", "b"]},
+            {"date": ["2024-01-01/2024-12-01"]},
+        ]
+        form = [
+            {"name": "date", "required": True},
+            {"name": "variable", "required": True},
+        ]
+
+        # "variable" is *required* by form and *some* constraints with the given "date" defines values
+        # for "variable": "variable" must be used as input keyword
+        # case 1: the input value "a" is available
+        input_keywords = {"date": "2025-01-01/2025-01-01", "variable": "a"}
+        available_values = self.search_plugin.available_values_from_constraints(
+            constraints, input_keywords, form
+        )
+        available_values = {k: sorted(v) for k, v in available_values.items()}
+        self.assertIn("variable", available_values)
+        self.assertListEqual(["a", "b"], available_values["variable"])
+        self.assertIn("date", available_values)
+        # case 2: the input value "c" is not available
+        input_keywords = {"date": "2025-01-01/2025-01-01", "variable": "c"}
+        with self.assertRaises(ValidationError) as ex:
+            self.search_plugin.available_values_from_constraints(
+                constraints, input_keywords, form
+            )
+        self.assertIn(
+            "ecmwf:variable=c is not available. Allowed values are ",
+            ex.exception.message,
+        )
+
+        # "variable" is *required* by form and *no* constraint with the given "date" defines values
+        # for "variable": "variable" cannot be used as input keyword with this value of "date".
+        input_keywords = {"date": "2024-01-01/2024-01-01", "variable": "a"}
+        with self.assertRaises(ValidationError) as ex:
+            self.search_plugin.available_values_from_constraints(
+                constraints, input_keywords, form
+            )
+        self.assertEqual(
+            "ecmwf:variable=a is not available. ecmwf:variable cannot be used with this combination of parameters.",
+            ex.exception.message,
+        )
+
+        # "variable" is *required* by form and *no* constraint with the given "date" defines values
+        # for "variable": "variable" is not used as input keyword and no available value for "variable" is returned
+        input_keywords = {"date": "2024-01-01/2024-01-01"}
+        available_values = self.search_plugin.available_values_from_constraints(
+            constraints, input_keywords, form
+        )
+        available_values = {k: sorted(v) for k, v in available_values.items()}
+        self.assertIn("variable", available_values)
+        self.assertListEqual([], available_values["variable"])
+        self.assertIn("date", available_values)
+
+    def test_plugins_search_ecmwfsearch_get_available_values_from_contraints_with_keyword_not_required_by_form(
+        self,
+    ):
+        """Any value is accepted if a keyword is not required by form and its list of allowed values is empty"""
+        constraints = [
+            {"date": ["2025-01-01/2025-06-01"], "variable": ["a", "b"]},
+            {"date": ["2024-01-01/2024-12-01"]},
+        ]
+        form = [
+            {"name": "date", "required": True},
+            {"name": "variable", "required": False},
+        ]
+
+        # "variable" is *not* required by form and *no* constraint with the given "date" defines values
+        # for "variable": any value for "variable" can be used as input keyword.
+        input_keywords = {"date": "2024-01-01/2024-01-01", "variable": "c"}
+        available_values = self.search_plugin.available_values_from_constraints(
+            constraints, input_keywords, form
+        )
+        available_values = {k: sorted(v) for k, v in available_values.items()}
+        self.assertIn("variable", available_values)
+        self.assertListEqual([], available_values["variable"])
+        self.assertIn("date", available_values)
+
+        # "variable" is *not* required by form and *some* constraints with the given "date" defines values
+        # for "variable": "variable" must match the available values.
+        # case 1: the value "a" is available
+        input_keywords = {"date": "2025-01-01/2025-01-01", "variable": "a"}
+        available_values = self.search_plugin.available_values_from_constraints(
+            constraints, input_keywords, form
+        )
+        available_values = {k: sorted(v) for k, v in available_values.items()}
+        self.assertIn("variable", available_values)
+        self.assertListEqual(["a", "b"], available_values["variable"])
+        self.assertIn("date", available_values)
+        # case 2: the value "c" is not available
+        input_keywords = {"date": "2025-01-01/2025-01-01", "variable": "c"}
+        with self.assertRaises(ValidationError) as ex:
+            self.search_plugin.available_values_from_constraints(
+                constraints, input_keywords, form
+            )
+        self.assertIn(
+            "ecmwf:variable=c is not available. Allowed values are ",
+            ex.exception.message,
+        )
+
     @mock.patch(
         "eodag.plugins.search.build_search_result.ECMWFSearch._fetch_data",
         autospec=True,

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -3513,12 +3513,15 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
             {"date": ["2025-01-01/2025-06-01"], "variable": ["a", "b"]},
             {"date": ["2024-01-01/2024-12-01"], "variable": ["a", "b", "c"]},
         ]
-        form_keywords = ["date", "variable"]
+        form = [
+            {"name": "date", "required": True},
+            {"name": "variable", "required": True},
+        ]
 
         # with a date range as a string
         input_keywords = {"date": "2025-01-01/2025-02-01", "variable": "a"}
         available_values = self.search_plugin.available_values_from_constraints(
-            constraints, input_keywords, form_keywords
+            constraints, input_keywords, form
         )
         available_values = {k: sorted(v) for k, v in available_values.items()}
         self.assertIn("variable", available_values)
@@ -3528,7 +3531,7 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         # with a date range as the first element of a string list
         input_keywords = {"date": ["2025-01-01/2025-02-01"], "variable": "a"}
         available_values = self.search_plugin.available_values_from_constraints(
-            constraints, input_keywords, form_keywords
+            constraints, input_keywords, form
         )
         available_values = {k: sorted(v) for k, v in available_values.items()}
         self.assertIn("variable", available_values)


### PR DESCRIPTION
This PR is fixing how the queryables are calculated from provider [form file](https://eodag.readthedocs.io/en/latest/plugins.html#eodag.config.PluginConfig.DiscoverQueryables.form_url).

# Queryables available values

If no constraint is matching a given parameter, then look at the form file:

- if the keyword is required by the form but does not match any combination with associated parameters, then do not show it as queryable
- if the keyword is _not_ required by form, then any value is accepted for it.
 
In the latter case, there may be no constraint at all containing that keyword because any value is anyway accepted.

# Queryables by form

- the default value is set with the following priority:
  - input default values > form details default value > no default value
- a parameter is not allowed and excluded from the queryables if the following conditions are true:
  - the keyword is required by form;
  - the keyword is used by some constraint;
  - the list of available values is empty.

# Test

```python
from eodag import EODataAccessGateway
from eodag.utils.exceptions import ValidationError
from typing import get_args

dag = EODataAccessGateway()

# --------------------------------------------------------------------------------------------------
# 1. Parameter is required but does not match allowed combinations with given associated parameters

# parameter 'level' should be required for given collection
queryables = dag.list_queryables(
    provider="cop_cds", collection="CMIP6_CLIMATE_PROJECTIONS"
)
assert get_args(queryables["ecmwf_level"])[1].is_required(), "'level' should be required"

# check that 'level' is not queryable with these parameters
params = {
    "provider": "cop_cds",
    "collection": "CMIP6_CLIMATE_PROJECTIONS",
    "experiment": "ssp2_4_5",
    "model": "access_cm2",
    "month": ["01"],
    "temporal_resolution": "monthly",
    "variable": "near_surface_air_temperature",
    "year": ["2023"],
}
queryables = dag.list_queryables(**params)
assert "ecmwf_level" not in queryables, "'level' should not be queryable"

# validatation should fail if we search with 'level' parameter
try:
    dag.search(**params, level=["1"], raise_errors=True)
except ValidationError as e:
    # expected because 'level' is not queryable
    assert "cannot be used with this combination of parameters" in str(
        e
    ), "Unexpected error message: {}".format(e)
else:
    raise AssertionError("Search should have failed because 'level' is not queryable")

# must succeed without 'level' parameter
dag.search(**params, raise_errors=True)

# --------------------------------------------------------------------------------------------------
# 2. Parameters are not required, so any value should be accepted

# must succeed: `pressure_level` and `model_level` are not required by form: any value is accepted
# note: the constraint file doesn't contain any constraint matching *all* these parameters,
# but this is fine cause any value is accepted
params = {
    "provider": "cop_ads",
    "collection": "CAMS_GAC_FORECAST",
    "variable": ["ammonium_aerosol_mass_mixing_ratio"],
    "pressure_level": ["1"],
    "model_level": ["1"],
    "date": "2025-12-11/2025-12-11",
    "time": ["00:00"],
    "leadtime_hour": ["0"],
    "type": ["forecast"],
    "data_format": "grib",
    "area": [42, 10, 40, 12],
}
dag.search(**params, raise_errors=True)

```