### PR TITLE
refactor: dates parsing and handling harmonization

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,9 +19,9 @@
 #
 from __future__ import annotations
 
+import datetime as dt
 import os
 import re
-from datetime import datetime
 from importlib.metadata import metadata
 from typing import Any
 
@@ -108,7 +108,9 @@ try:
     )
 except (KeyError, IndexError):
     author = "CS GROUP - France"
-copyright = f"2018-{datetime.now().year}, CS GROUP - France, https://www.csgroup.eu"
+copyright = (
+    f"2018-{dt.dt.datetime.now().year}, CS GROUP - France, https://www.csgroup.eu"
+)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,9 +108,7 @@ try:
     )
 except (KeyError, IndexError):
     author = "CS GROUP - France"
-copyright = (
-    f"2018-{dt.dt.datetime.now().year}, CS GROUP - France, https://www.csgroup.eu"
-)
+copyright = f"2018-{dt.datetime.now().year}, CS GROUP - France, https://www.csgroup.eu"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-import datetime
+import datetime as dt
 import itertools
 import logging
 import os
@@ -1039,8 +1039,8 @@ class EODataAccessGateway:
 
             # datetime filtering
             if start_date or end_date:
-                min_aware = datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
-                max_aware = datetime.datetime.max.replace(tzinfo=datetime.timezone.utc)
+                min_aware = dt.datetime.min.replace(tzinfo=dt.timezone.utc)
+                max_aware = dt.datetime.max.replace(tzinfo=dt.timezone.utc)
 
                 col_start_str = col_f.extent.temporal.interval[0][0]
                 if col_start_str and isinstance(col_start_str, str):

--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -18,11 +18,11 @@
 from __future__ import annotations
 
 import base64
+import datetime as dt
 import logging
 import os
 import re
 import tempfile
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, Iterable, Literal, Optional, Union, cast
 
 import geojson
@@ -139,7 +139,7 @@ class EOProduct:
     #: Product search keyword arguments, stored during search
     search_kwargs: Any
     #: Datetime for download next try
-    next_try: datetime
+    next_try: dt.datetime
     #: Stream for requests
     _stream: requests.Response
 

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -29,9 +29,8 @@ import geojson
 import orjson
 import pyproj
 import shapely
-from dateutil.parser import isoparse
 from dateutil.relativedelta import relativedelta
-from dateutil.tz import UTC, tzutc
+from dateutil.tz import tzutc
 from jsonpath_ng.jsonpath import Child, JSONPath
 from lxml import etree
 from lxml.etree import XPathEvalError
@@ -55,7 +54,7 @@ from eodag.utils import (
     string_to_jsonpath,
     update_nested_dict,
 )
-from eodag.utils.dates import get_timestamp
+from eodag.utils.dates import get_timestamp, parse_to_utc, to_iso_utc_string
 from eodag.utils.exceptions import ValidationError
 
 if TYPE_CHECKING:
@@ -302,10 +301,9 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             1619029639123 => "2021-04-21T18:27:19.123Z"
             """
             try:
-                return (
-                    datetime.fromtimestamp(timestamp / 1e3, tzutc())
-                    .isoformat(timespec="milliseconds")
-                    .replace("+00:00", "Z")
+                return cast(
+                    str,
+                    to_iso_utc_string(datetime.fromtimestamp(timestamp / 1e3, tzutc())),
                 )
             except TypeError:
                 return timestamp
@@ -324,13 +322,9 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             'minutes', 'seconds', 'milliseconds' and 'microseconds'.
             """
             try:
-                dt = isoparse(date_time)
-            except ValueError:
+                dt = parse_to_utc(date_time)
+            except (ValidationError, ValueError):
                 return date_time
-            if not dt.tzinfo:
-                dt = dt.replace(tzinfo=UTC)
-            elif dt.tzinfo is not UTC:
-                dt = dt.astimezone(UTC)
             return dt.isoformat(timespec=timespec).replace("+00:00", "Z")
 
         @staticmethod
@@ -343,11 +337,7 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             "2021-04-21" => "2021-04-21"
             "2021-04-21T00:00:00+06:00" => "2021-04-20" !
             """
-            dt = isoparse(datetime_string)
-            if not dt.tzinfo:
-                dt = dt.replace(tzinfo=UTC)
-            elif dt.tzinfo is not UTC:
-                dt = dt.astimezone(UTC)
+            dt = parse_to_utc(datetime_string)
             time_delta_args = ast.literal_eval(time_delta_args_str)
             dt += timedelta(*time_delta_args)
             return dt.isoformat()[:10]
@@ -872,11 +862,11 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             start_date = datetime.strptime(dates[0], "%Y%m%dT%H%M%S") - timedelta(
                 seconds=1
             )
-            params["startDate"] = start_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+            params["startDate"] = cast(str, to_iso_utc_string(start_date))
             end_date = datetime.strptime(dates[1], "%Y%m%dT%H%M%S") + timedelta(
                 seconds=1
             )
-            params["endDate"] = end_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+            params["endDate"] = cast(str, to_iso_utc_string(end_date))
             params["timeliness"] = parts[-2]
             params["sat"] = "Sentinel-" + parts[0][1:]
             return params
@@ -896,10 +886,8 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             else:
                 date_time = datetime.strptime(dates[0], "%Y%m%d")
             return {
-                "min_date": date_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "max_date": (date_time + timedelta(days=1)).strftime(
-                    "%Y-%m-%dT%H:%M:%SZ"
-                ),
+                "min_date": to_iso_utc_string(date_time),
+                "max_date": to_iso_utc_string(date_time + timedelta(days=1)),
             }
 
         @staticmethod
@@ -934,7 +922,7 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             }
             """
             utc_date = MetadataFormatter.convert_to_iso_utc_datetime(date)
-            date_object = datetime.strptime(utc_date, "%Y-%m-%dT%H:%M:%S.%fZ")
+            date_object = parse_to_utc(utc_date)
             if format == "list":
                 return {
                     "year": [date_object.strftime("%Y")],
@@ -973,12 +961,10 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             start, end = date.split(separator)
             start_utc_date = MetadataFormatter.convert_to_iso_utc_datetime(start)
             end_utc_date = MetadataFormatter.convert_to_iso_utc_datetime(end)
-            start_date_object = datetime.strptime(
-                start_utc_date, "%Y-%m-%dT%H:%M:%S.%fZ"
-            )
+            start_date_object = parse_to_utc(start_utc_date)
             if end_utc_date == "None":
                 end_utc_date = start_utc_date
-            end_date_object = datetime.strptime(end_utc_date, "%Y-%m-%dT%H:%M:%S.%fZ")
+            end_date_object = parse_to_utc(end_utc_date)
 
             delta_utc_date = end_date_object - start_date_object
 
@@ -1026,14 +1012,14 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             start_date = datetime.strptime(dates[0], "%Y%m%d")
             end_date = datetime.strptime(dates[1], "%Y%m%d")
             return {
-                "startDate": start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "endDate": end_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "startDate": to_iso_utc_string(start_date),
+                "endDate": to_iso_utc_string(end_date),
             }
 
         @staticmethod
         def convert_get_hydrological_year(date: str):
             utc_date = MetadataFormatter.convert_to_iso_utc_datetime(date)
-            date_object = datetime.strptime(utc_date, "%Y-%m-%dT%H:%M:%S.%fZ")
+            date_object = parse_to_utc(utc_date)
             date_object_second_year = date_object + relativedelta(years=1)
             return [
                 f"{date_object.strftime('%Y')}_{date_object_second_year.strftime('%y')}"

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -864,6 +864,7 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             start_date = dt.datetime.strptime(dates[0], "%Y%m%dT%H%M%S") - dt.timedelta(
                 seconds=1
             )
+            # cast to tell the type checker that value won't be None here
             params["startDate"] = cast(str, to_iso_utc_string(start_date))
             end_date = dt.datetime.strptime(dates[1], "%Y%m%dT%H%M%S") + dt.timedelta(
                 seconds=1

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -325,7 +325,7 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             """
             try:
                 parsed_dt = parse_to_utc(date_time)
-            except (ValidationError, ValueError):
+            except ValidationError:
                 return date_time
             return parsed_dt.isoformat(timespec=timespec).replace("+00:00", "Z")
 

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -18,10 +18,10 @@
 from __future__ import annotations
 
 import ast
+import datetime as dt
 import json
 import logging
 import re
-from datetime import datetime, timedelta
 from string import Formatter
 from typing import TYPE_CHECKING, Any, AnyStr, Callable, Iterator, Optional, Union, cast
 
@@ -303,7 +303,9 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             try:
                 return cast(
                     str,
-                    to_iso_utc_string(datetime.fromtimestamp(timestamp / 1e3, tzutc())),
+                    to_iso_utc_string(
+                        dt.datetime.fromtimestamp(timestamp / 1e3, tzutc())
+                    ),
                 )
             except TypeError:
                 return timestamp
@@ -322,10 +324,10 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             'minutes', 'seconds', 'milliseconds' and 'microseconds'.
             """
             try:
-                dt = parse_to_utc(date_time)
+                parsed_dt = parse_to_utc(date_time)
             except (ValidationError, ValueError):
                 return date_time
-            return dt.isoformat(timespec=timespec).replace("+00:00", "Z")
+            return parsed_dt.isoformat(timespec=timespec).replace("+00:00", "Z")
 
         @staticmethod
         def convert_to_iso_date(
@@ -337,10 +339,10 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             "2021-04-21" => "2021-04-21"
             "2021-04-21T00:00:00+06:00" => "2021-04-20" !
             """
-            dt = parse_to_utc(datetime_string)
+            parsed_dt = parse_to_utc(datetime_string)
             time_delta_args = ast.literal_eval(time_delta_args_str)
-            dt += timedelta(*time_delta_args)
-            return dt.isoformat()[:10]
+            parsed_dt += dt.timedelta(*time_delta_args)
+            return parsed_dt.isoformat()[:10]
 
         @staticmethod
         def convert_to_non_separated_date(datetime_string):
@@ -859,11 +861,11 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             parts: list[str] = re.split(r"_(?!_)", product_id)
             params = {"collection": product_id[4:15]}
             dates = re.findall("[0-9]{8}T[0-9]{6}", product_id)
-            start_date = datetime.strptime(dates[0], "%Y%m%dT%H%M%S") - timedelta(
+            start_date = dt.datetime.strptime(dates[0], "%Y%m%dT%H%M%S") - dt.timedelta(
                 seconds=1
             )
             params["startDate"] = cast(str, to_iso_utc_string(start_date))
-            end_date = datetime.strptime(dates[1], "%Y%m%dT%H%M%S") + timedelta(
+            end_date = dt.datetime.strptime(dates[1], "%Y%m%dT%H%M%S") + dt.timedelta(
                 seconds=1
             )
             params["endDate"] = cast(str, to_iso_utc_string(end_date))
@@ -882,12 +884,12 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
                 dates = re.findall(date_format_2, product_id)
                 date = dates[0]
             if len(date) == 10:
-                date_time = datetime.strptime(dates[0], "%Y%m%d%H")
+                date_time = dt.datetime.strptime(dates[0], "%Y%m%d%H")
             else:
-                date_time = datetime.strptime(dates[0], "%Y%m%d")
+                date_time = dt.datetime.strptime(dates[0], "%Y%m%d")
             return {
                 "min_date": to_iso_utc_string(date_time),
-                "max_date": to_iso_utc_string(date_time + timedelta(days=1)),
+                "max_date": to_iso_utc_string(date_time + dt.timedelta(days=1)),
             }
 
         @staticmethod
@@ -973,7 +975,7 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
             days = set()
 
             for i in range(delta_utc_date.days + 1):
-                date_object = start_date_object + timedelta(days=i)
+                date_object = start_date_object + dt.timedelta(days=i)
                 years.add(date_object.strftime("%Y"))
                 months.add(date_object.strftime("%m"))
                 days.add(date_object.strftime("%d"))
@@ -1009,8 +1011,8 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
                 return NOT_AVAILABLE
             dates_str = match.group()
             dates = dates_str.split(split_param)
-            start_date = datetime.strptime(dates[0], "%Y%m%d")
-            end_date = datetime.strptime(dates[1], "%Y%m%d")
+            start_date = dt.datetime.strptime(dates[0], "%Y%m%d")
+            end_date = dt.datetime.strptime(dates[1], "%Y%m%d")
             return {
                 "startDate": to_iso_utc_string(start_date),
                 "endDate": to_iso_utc_string(end_date),

--- a/eodag/cli.py
+++ b/eodag/cli.py
@@ -53,6 +53,7 @@ from concurrent.futures import ThreadPoolExecutor
 from eodag.api.collection import CollectionsList
 from eodag.api.core import EODataAccessGateway, SearchResult
 from eodag.utils import DEFAULT_LIMIT, DEFAULT_PAGE
+from eodag.utils.dates import to_iso_utc_string
 from eodag.utils.exceptions import NoMatchingCollection, UnsupportedProvider
 from eodag.utils.logging import setup_logging
 
@@ -352,9 +353,9 @@ def search_crunch(ctx: Context, **kwargs: Any) -> None:
         locations = None
     criteria["locations"] = locations
     if start_date:
-        criteria["start_datetime"] = start_date.isoformat()
+        criteria["start_datetime"] = to_iso_utc_string(start_date)
     if stop_date:
-        criteria["end_datetime"] = stop_date.isoformat()
+        criteria["end_datetime"] = to_iso_utc_string(stop_date)
     conf_file = kwargs.pop("conf")
     if conf_file:
         conf_file = click.format_filename(conf_file)

--- a/eodag/plugins/authentication/openid_connect.py
+++ b/eodag/plugins/authentication/openid_connect.py
@@ -17,10 +17,10 @@
 # limitations under the License.
 from __future__ import annotations
 
+import datetime as dt
 import logging
 import re
 import string
-from datetime import datetime, timedelta, timezone
 from random import SystemRandom
 from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import parse_qs, urlparse
@@ -66,10 +66,10 @@ class OIDCRefreshTokenBase(Authentication):
     jwks_client: jwt.PyJWKClient
 
     access_token: str
-    access_token_expiration: datetime
+    access_token_expiration: dt.datetime
 
     refresh_token: str
-    refresh_token_expiration: datetime
+    refresh_token_expiration: dt.datetime
 
     token_endpoint: str
     authorization_endpoint: str
@@ -78,9 +78,9 @@ class OIDCRefreshTokenBase(Authentication):
         super(OIDCRefreshTokenBase, self).__init__(provider, config)
 
         self.access_token = ""
-        self.access_token_expiration = datetime.min.replace(tzinfo=timezone.utc)
+        self.access_token_expiration = dt.datetime.min.replace(tzinfo=dt.timezone.utc)
         self.refresh_token = ""
-        self.refresh_token_expiration = datetime.min.replace(tzinfo=timezone.utc)
+        self.refresh_token_expiration = dt.datetime.min.replace(tzinfo=dt.timezone.utc)
         self.session = requests.Session()
 
         auth_config = self._get_oidc_endpoints()
@@ -125,8 +125,8 @@ class OIDCRefreshTokenBase(Authentication):
             raise AuthenticationError(e)
 
     def _get_access_token(self) -> str:
-        now = datetime.now(timezone.utc)
-        expiration_margin = timedelta(
+        now = dt.datetime.now(dt.timezone.utc)
+        expiration_margin = dt.timedelta(
             seconds=getattr(
                 self.config, "token_expiration_margin", DEFAULT_TOKEN_EXPIRATION_MARGIN
             )
@@ -151,19 +151,19 @@ class OIDCRefreshTokenBase(Authentication):
             response = self._request_new_token()
 
         self.access_token = response[getattr(self.config, "token_key", "access_token")]
-        self.access_token_expiration = datetime.fromtimestamp(
-            self.decode_jwt_token(self.access_token)["exp"], timezone.utc
+        self.access_token_expiration = dt.datetime.fromtimestamp(
+            self.decode_jwt_token(self.access_token)["exp"], dt.timezone.utc
         )
         self.refresh_token = response.get(
             getattr(self.config, "refresh_token_key", "refresh_token"), ""
         )
         if self.refresh_token and response.get("refresh_expires_in", "0"):
-            self.refresh_token_expiration = now + timedelta(
+            self.refresh_token_expiration = now + dt.timedelta(
                 seconds=int(response["refresh_expires_in"])
             )
         else:
             # refresh token does not expire but will be changed at each request
-            self.refresh_token_expiration = now + timedelta(days=1000)
+            self.refresh_token_expiration = now + dt.timedelta(days=1000)
 
         return self.access_token
 

--- a/eodag/plugins/authentication/token.py
+++ b/eodag/plugins/authentication/token.py
@@ -17,8 +17,8 @@
 # limitations under the License.
 from __future__ import annotations
 
+import datetime as dt
 import logging
-from datetime import datetime, timedelta
 from threading import Lock
 from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
@@ -104,7 +104,7 @@ class TokenAuth(Authentication):
         super(TokenAuth, self).__init__(provider, config)
         self.token = ""
         self.refresh_token = ""
-        self.token_expiration = datetime.now()
+        self.token_expiration = dt.datetime.now()
         self.auth_lock = Lock()
         self._unformatted_auth_uri: Optional[str] = None
 
@@ -166,7 +166,7 @@ class TokenAuth(Authentication):
 
         # Use a thread lock to avoid several threads requesting the token at the same time
         with self.auth_lock:
-            expiration_margin = timedelta(
+            expiration_margin = dt.timedelta(
                 seconds=getattr(
                     self.config,
                     "token_expiration_margin",
@@ -177,7 +177,7 @@ class TokenAuth(Authentication):
                 self.validate_config_credentials()
             if (
                 self.token
-                and self.token_expiration - datetime.now() > expiration_margin
+                and self.token_expiration - dt.datetime.now() > expiration_margin
             ):
                 logger.debug("using existing access token")
                 return RequestsTokenAuth(
@@ -221,7 +221,7 @@ class TokenAuth(Authentication):
                     self.refresh_token = response.json()[self.config.refresh_token_key]
                 if getattr(self.config, "token_expiration_key", None):
                     expiration_time = response.json()[self.config.token_expiration_key]
-                    self.token_expiration = datetime.now() + timedelta(
+                    self.token_expiration = dt.datetime.now() + dt.timedelta(
                         seconds=expiration_time
                     )
 

--- a/eodag/plugins/crunch/filter_date.py
+++ b/eodag/plugins/crunch/filter_date.py
@@ -23,13 +23,11 @@ import time
 from datetime import datetime as dt
 from typing import TYPE_CHECKING, Any
 
-import dateutil.parser
-from dateutil import tz
-
 if TYPE_CHECKING:
     from eodag.api.product import EOProduct
 
 from eodag.plugins.crunch.base import Crunch
+from eodag.utils.dates import parse_to_utc
 
 logger = logging.getLogger("eodag.crunch.date")
 
@@ -54,7 +52,7 @@ class FilterDate(Crunch):
             # Retrieve year, month, day, hour, minute, second of EPOCH start
             epoch = time.gmtime(0)[:-3]
             start_date = datetime.datetime(*epoch).isoformat()
-        return dateutil.parser.parse(start_date)
+        return parse_to_utc(start_date)
 
     def proceed(
         self, products: list[EOProduct], **search_params: Any
@@ -71,18 +69,14 @@ class FilterDate(Crunch):
         # filter start date
         filter_start_str = self.config.__dict__.get("start")
         if filter_start_str:
-            filter_start = dateutil.parser.parse(filter_start_str)
-            if not filter_start.tzinfo:
-                filter_start = filter_start.replace(tzinfo=tz.UTC)
+            filter_start = parse_to_utc(filter_start_str)
         else:
             filter_start = None
 
         # filter end date
         filter_end_str = self.config.__dict__.get("end")
         if filter_end_str:
-            filter_end = dateutil.parser.parse(filter_end_str)
-            if not filter_end.tzinfo:
-                filter_end = filter_end.replace(tzinfo=tz.UTC)
+            filter_end = parse_to_utc(filter_end_str)
         else:
             filter_end = None
 
@@ -95,18 +89,14 @@ class FilterDate(Crunch):
             # product start date
             product_start_str = product.properties.get("start_datetime")
             if product_start_str:
-                product_start = dateutil.parser.parse(product_start_str)
-                if not product_start.tzinfo:
-                    product_start = product_start.replace(tzinfo=tz.UTC)
+                product_start = parse_to_utc(product_start_str)
             else:
                 product_start = None
 
             # product end date
             product_end_str = product.properties.get("end_datetime")
             if product_end_str:
-                product_end = dateutil.parser.parse(product_end_str)
-                if not product_end.tzinfo:
-                    product_end = product_end.replace(tzinfo=tz.UTC)
+                product_end = parse_to_utc(product_end_str)
             else:
                 product_end = None
 

--- a/eodag/plugins/crunch/filter_date.py
+++ b/eodag/plugins/crunch/filter_date.py
@@ -17,10 +17,8 @@
 # limitations under the License.
 from __future__ import annotations
 
-import datetime
+import datetime as dt
 import logging
-import time
-from datetime import datetime as dt
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -45,13 +43,11 @@ class FilterDate(Crunch):
     """
 
     @staticmethod
-    def sort_product_by_start_date(product: EOProduct) -> dt:
+    def sort_product_by_start_date(product: EOProduct) -> dt.datetime:
         """Get product start date"""
         start_date = product.properties.get("start_datetime")
         if not start_date:
-            # Retrieve year, month, day, hour, minute, second of EPOCH start
-            epoch = time.gmtime(0)[:-3]
-            start_date = datetime.datetime(*epoch).isoformat()
+            return dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
         return parse_to_utc(start_date)
 
     def proceed(

--- a/eodag/plugins/crunch/filter_latest_intersect.py
+++ b/eodag/plugins/crunch/filter_latest_intersect.py
@@ -22,12 +22,12 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-import dateutil.parser
 from shapely.errors import ShapelyError
 from shapely.geometry.base import BaseGeometry
 
 from eodag.plugins.crunch.base import Crunch
 from eodag.utils import get_geometry_from_various
+from eodag.utils.dates import parse_to_utc
 
 if TYPE_CHECKING:
     from datetime import datetime as dt
@@ -52,7 +52,7 @@ class FilterLatestIntersect(Crunch):
             # Retrieve year, month, day, hour, minute, second of EPOCH start
             epoch = time.gmtime(0)[:-3]
             start_date = datetime.datetime(*epoch).isoformat()
-        return dateutil.parser.parse(start_date)
+        return parse_to_utc(start_date)
 
     def proceed(
         self, products: list[EOProduct], **search_params: dict[str, Any]

--- a/eodag/plugins/crunch/filter_latest_intersect.py
+++ b/eodag/plugins/crunch/filter_latest_intersect.py
@@ -17,9 +17,8 @@
 # limitations under the License.
 from __future__ import annotations
 
-import datetime
+import datetime as dt
 import logging
-import time
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from shapely.errors import ShapelyError
@@ -30,8 +29,6 @@ from eodag.utils import get_geometry_from_various
 from eodag.utils.dates import parse_to_utc
 
 if TYPE_CHECKING:
-    from datetime import datetime as dt
-
     from eodag.api.product import EOProduct
 
 logger = logging.getLogger("eodag.crunch.latest_intersect")
@@ -45,13 +42,11 @@ class FilterLatestIntersect(Crunch):
     """
 
     @staticmethod
-    def sort_product_by_start_date(product: EOProduct) -> dt:
+    def sort_product_by_start_date(product: EOProduct) -> dt.datetime:
         """Get product start date"""
         start_date = product.properties.get("start_datetime")
         if not start_date:
-            # Retrieve year, month, day, hour, minute, second of EPOCH start
-            epoch = time.gmtime(0)[:-3]
-            start_date = datetime.datetime(*epoch).isoformat()
+            return dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
         return parse_to_utc(start_date)
 
     def proceed(

--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import datetime as dt
 import hashlib
 import logging
 import os
@@ -25,7 +26,6 @@ import tarfile
 import tempfile
 import zipfile
 from abc import abstractmethod
-from datetime import datetime, timedelta
 from pathlib import Path
 from time import sleep
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, TypeVar, Union
@@ -498,8 +498,8 @@ class Download(PluginTopic):
         products = products[:]
         paths: list[str] = []
         # initiate retry loop
-        start_time = datetime.now()
-        stop_time = start_time + timedelta(minutes=timeout)
+        start_time = dt.datetime.now()
+        stop_time = start_time + dt.timedelta(minutes=timeout)
         nb_products = len(products)
         retry_count = 0
         # another output for notebooks
@@ -564,8 +564,8 @@ class Download(PluginTopic):
                 futures = {}
 
                 for idx, product in enumerate(products_batch):
-                    if datetime.now() >= product.next_try:
-                        products[idx].next_try += timedelta(minutes=wait)
+                    if dt.datetime.now() >= product.next_try:
+                        products[idx].next_try += dt.timedelta(minutes=wait)
                         future = executor.submit(
                             product.download,
                             progress_callback=product_progress_callback,
@@ -590,7 +590,7 @@ class Download(PluginTopic):
                         bar(1)
 
                         # reset stop time for next product
-                        stop_time = datetime.now() + timedelta(minutes=timeout)
+                        stop_time = dt.datetime.now() + dt.timedelta(minutes=timeout)
 
                     except NotAvailableError as e:
                         logger.info(e)
@@ -616,10 +616,10 @@ class Download(PluginTopic):
 
                 if (
                     len(products) > 0
-                    and datetime.now() < products[0].next_try
-                    and datetime.now() < stop_time
+                    and dt.datetime.now() < products[0].next_try
+                    and dt.datetime.now() < stop_time
                 ):
-                    wait_seconds = (products[0].next_try - datetime.now()).seconds
+                    wait_seconds = (products[0].next_try - dt.datetime.now()).seconds
                     retry_count += 1
                     info_message = (
                         f"[Retry #{retry_count}, {nb_products - len(products)}/{nb_products} D/L] "
@@ -629,7 +629,7 @@ class Download(PluginTopic):
                     logger.info(info_message)
                     nb_info.display_html(info_message)
                     sleep(wait_seconds + 1)
-                elif len(products) > 0 and datetime.now() >= stop_time:
+                elif len(products) > 0 and dt.datetime.now() >= stop_time:
                     logger.warning(
                         f"{len(products)} products could not be downloaded: "
                         + str([prod.properties["title"] for prod in products])
@@ -662,8 +662,8 @@ class Download(PluginTopic):
         def decorator(order_download: Callable[..., T]) -> Callable[..., T]:
             def download_and_retry(*args: Any, **kwargs: Unpack[DownloadConf]) -> T:
                 # initiate retry loop
-                start_time = datetime.now()
-                stop_time = start_time + timedelta(minutes=timeout)
+                start_time = dt.datetime.now()
+                stop_time = start_time + dt.timedelta(minutes=timeout)
                 product.next_try = start_time
                 retry_count = 0
                 not_available_info = "The product could not be downloaded"
@@ -671,10 +671,10 @@ class Download(PluginTopic):
                 nb_info = NotebookWidgets()
 
                 while "Loop until products download succeeds or timeout is reached":
-                    datetime_now = datetime.now()
+                    datetime_now = dt.datetime.now()
 
                     if datetime_now >= product.next_try:
-                        product.next_try += timedelta(minutes=wait)
+                        product.next_try += dt.timedelta(minutes=wait)
                         try:
                             download = order_download(*args, **kwargs)
                         except NotAvailableError as e:
@@ -694,7 +694,7 @@ class Download(PluginTopic):
 
                     if datetime_now >= product.next_try and datetime_now < stop_time:
                         wait_seconds: Union[float, int] = (
-                            datetime_now - product.next_try + timedelta(minutes=wait)
+                            datetime_now - product.next_try + dt.timedelta(minutes=wait)
                         ).seconds
                         retry_count += 1
                         retry_info = (

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -21,15 +21,13 @@ import hashlib
 import logging
 import re
 from collections import OrderedDict
-from datetime import datetime, timedelta
+from datetime import timedelta
 from types import MethodType
 from typing import TYPE_CHECKING, Annotated, Any, Optional
 from urllib.parse import quote_plus, unquote_plus
 
 import geojson
 import orjson
-from dateutil.parser import isoparse
-from dateutil.tz import tzutc
 from pydantic import AliasChoices
 from pydantic.fields import FieldInfo
 from requests.auth import AuthBase
@@ -69,8 +67,10 @@ from eodag.utils.dates import (
     format_date,
     is_range_in_range,
     parse_date,
+    parse_to_utc,
     parse_year_month_day,
     time_values_to_hhmm,
+    to_iso_utc_string,
     validate_datetime_param,
 )
 from eodag.utils.exceptions import (
@@ -253,7 +253,7 @@ def ecmwf_temporal_to_eodag(
         start, end = parse_year_month_day(year, month, day, time)
 
     if start and end:
-        return start.strftime("%Y-%m-%dT%H:%M:%SZ"), end.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return to_iso_utc_string(start), to_iso_utc_string(end)
     else:
         return None, None
 
@@ -450,21 +450,9 @@ class ECMWFSearch(PostJsonSearch):
         # adapt end date if it is midnight
         if END in params:
             end_date_excluded = getattr(self.config, "end_date_excluded", True)
-            is_datetime = True
-            try:
-                end_date = datetime.strptime(params[END], "%Y-%m-%dT%H:%M:%SZ")
-                end_date = end_date.replace(tzinfo=tzutc())
-            except ValueError:
-                try:
-                    end_date = datetime.strptime(
-                        params[END],
-                        "%Y-%m-%dT%H:%M:%S.%fZ",
-                    )
-                    end_date = end_date.replace(tzinfo=tzutc())
-                except ValueError:
-                    end_date = isoparse(params[END])
-                    is_datetime = False
-            start_date = isoparse(params[START])
+            is_datetime = "T" in str(params[END])
+            end_date = parse_to_utc(params[END])
+            start_date = parse_to_utc(params[START])
             if (
                 not end_date_excluded
                 and is_datetime
@@ -473,7 +461,7 @@ class ECMWFSearch(PostJsonSearch):
                 == end_date.replace(hour=0, minute=0, second=0, microsecond=0)
             ):
                 end_date += timedelta(days=-1)
-                params[END] = end_date.isoformat()
+                params[END] = to_iso_utc_string(end_date)
 
         # geometry
         if "geometry" in params:

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -17,11 +17,11 @@
 # limitations under the License.
 from __future__ import annotations
 
+import datetime as dt
 import hashlib
 import logging
 import re
 from collections import OrderedDict
-from datetime import timedelta
 from types import MethodType
 from typing import TYPE_CHECKING, Annotated, Any, Optional
 from urllib.parse import quote_plus, unquote_plus
@@ -460,7 +460,7 @@ class ECMWFSearch(PostJsonSearch):
                 and end_date
                 == end_date.replace(hour=0, minute=0, second=0, microsecond=0)
             ):
-                end_date += timedelta(days=-1)
+                end_date += dt.timedelta(days=-1)
                 params[END] = to_iso_utc_string(end_date)
 
         # geometry

--- a/eodag/plugins/search/cop_ghsl.py
+++ b/eodag/plugins/search/cop_ghsl.py
@@ -265,6 +265,7 @@ class CopGhslSearch(Search):
             return {"start_date": start_date_str, "end_date": end_date_str}
 
         result: dict[str, str] = {}
+        # cast to tell the type checker that value won't be None here
         result["start_date"] = cast(str, to_iso_utc_string(start_date))
         result["end_date"] = cast(str, to_iso_utc_string(end_date))
         return result

--- a/eodag/plugins/search/cop_ghsl.py
+++ b/eodag/plugins/search/cop_ghsl.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-import datetime
+import datetime as dt
 import logging
 import math
 from calendar import monthrange
@@ -229,7 +229,7 @@ class CopGhslSearch(Search):
     ) -> dict[str, str]:
         """get the start and end time from year/month in the properties or missionStart/EndDate"""
         if "month" in properties:
-            start_date = datetime.datetime(
+            start_date = dt.datetime(
                 year=int(properties["year"]),
                 month=int(properties["month"]),
                 day=1,
@@ -238,7 +238,7 @@ class CopGhslSearch(Search):
                 second=0,
             )
             end_day = monthrange(int(properties["year"]), int(properties["month"]))[1]
-            end_date = datetime.datetime(
+            end_date = dt.datetime(
                 year=int(properties["year"]),
                 month=int(properties["month"]),
                 day=end_day,
@@ -247,10 +247,10 @@ class CopGhslSearch(Search):
                 second=59,
             )
         elif "year" in properties:
-            start_date = datetime.datetime(
+            start_date = dt.datetime(
                 year=int(properties["year"]), month=1, day=1, hour=0, minute=0, second=0
             )
-            end_date = datetime.datetime(
+            end_date = dt.datetime(
                 year=int(properties["year"]),
                 month=12,
                 day=31,
@@ -322,10 +322,10 @@ class CopGhslSearch(Search):
             properties = deepcopy(params)
             properties["order:status"] = "succeeded"
             properties["start_datetime"] = to_iso_utc_string(
-                datetime.datetime(year=int(year), month=1, day=1)
+                dt.datetime(year=int(year), month=1, day=1)
             )
             properties["end_datetime"] = to_iso_utc_string(
-                datetime.datetime(
+                dt.datetime(
                     year=int(year), month=12, day=31, hour=23, minute=59, second=59
                 )
             )

--- a/eodag/plugins/search/cop_ghsl.py
+++ b/eodag/plugins/search/cop_ghsl.py
@@ -23,7 +23,6 @@ import math
 from calendar import monthrange
 from typing import Annotated, Any, Optional, cast
 
-import dateutil
 import requests
 from pydantic.fields import FieldInfo
 from pyproj import CRS, Transformer
@@ -42,7 +41,7 @@ from eodag.types import json_field_definition_to_python
 from eodag.types.queryables import Queryables
 from eodag.utils import DEFAULT_LIMIT, HTTP_REQ_TIMEOUT, USER_AGENT, deepcopy
 from eodag.utils.cache import instance_cached_method
-from eodag.utils.dates import to_iso_utc_string
+from eodag.utils.dates import parse_to_utc, to_iso_utc_string
 from eodag.utils.exceptions import (
     MisconfiguredError,
     RequestError,
@@ -179,8 +178,8 @@ def _replace_datetimes(params: dict[str, Any]):
     if not start_date_str:
         return
 
-    start_date = dateutil.parser.isoparse(start_date_str)
-    end_date = dateutil.parser.isoparse(end_date_str)
+    start_date = parse_to_utc(start_date_str)
+    end_date = parse_to_utc(end_date_str)
     start_year = start_date.year
     end_year = end_date.year
     years = [str(y) for y in range(start_year, end_year + 1)]

--- a/eodag/plugins/search/cop_ghsl.py
+++ b/eodag/plugins/search/cop_ghsl.py
@@ -21,7 +21,7 @@ import datetime
 import logging
 import math
 from calendar import monthrange
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any, Optional, cast
 
 import dateutil
 import requests
@@ -42,6 +42,7 @@ from eodag.types import json_field_definition_to_python
 from eodag.types.queryables import Queryables
 from eodag.utils import DEFAULT_LIMIT, HTTP_REQ_TIMEOUT, USER_AGENT, deepcopy
 from eodag.utils.cache import instance_cached_method
+from eodag.utils.dates import to_iso_utc_string
 from eodag.utils.exceptions import (
     MisconfiguredError,
     RequestError,
@@ -263,9 +264,9 @@ class CopGhslSearch(Search):
             end_date_str = interval[0][1]
             return {"start_date": start_date_str, "end_date": end_date_str}
 
-        result = {}
-        result["start_date"] = start_date.strftime("%Y-%m-%dT%H:%M:%SZ")
-        result["end_date"] = end_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+        result: dict[str, str] = {}
+        result["start_date"] = cast(str, to_iso_utc_string(start_date))
+        result["end_date"] = cast(str, to_iso_utc_string(end_date))
         return result
 
     def _create_products_from_tiles(
@@ -320,12 +321,14 @@ class CopGhslSearch(Search):
         for year in list_years:
             properties = deepcopy(params)
             properties["order:status"] = "succeeded"
-            properties["start_datetime"] = datetime.datetime(
-                year=int(year), month=1, day=1
-            ).strftime("%Y-%m-%dT%H:%M:%SZ")
-            properties["end_datetime"] = datetime.datetime(
-                year=int(year), month=12, day=31, hour=23, minute=59, second=59
-            ).strftime("%Y-%m-%dT%H:%M:%SZ")
+            properties["start_datetime"] = to_iso_utc_string(
+                datetime.datetime(year=int(year), month=1, day=1)
+            )
+            properties["end_datetime"] = to_iso_utc_string(
+                datetime.datetime(
+                    year=int(year), month=12, day=31, hour=23, minute=59, second=59
+                )
+            )
             properties["year"] = year
 
             # information for id and download path

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -28,7 +28,6 @@ from urllib.parse import urlsplit
 import boto3
 import botocore
 import requests
-from dateutil.parser import parse as dateutil_parse
 from dateutil.tz import tzutc
 from dateutil.utils import today
 
@@ -39,6 +38,7 @@ from eodag.config import PluginConfig
 from eodag.plugins.search import PreparedSearch
 from eodag.plugins.search.static_stac_search import StaticStacSearch
 from eodag.utils import get_bucket_name_and_prefix, get_geometry_from_various
+from eodag.utils.dates import parse_to_utc, to_iso_utc_string
 from eodag.utils.exceptions import RequestError, UnsupportedCollection, ValidationError
 
 if TYPE_CHECKING:
@@ -226,10 +226,8 @@ class CopMarineSearch(StaticStacSearch):
                 item_end = _get_date_from_yyyymmdd(item_dates[1], item_key)
             else:  # only date and created_at timestamps
                 item_end = item_start
-            properties["start_datetime"] = item_start.strftime("%Y-%m-%dT%H:%M:%SZ")
-            properties["end_datetime"] = (item_end or item_start).strftime(
-                "%Y-%m-%dT%H:%M:%SZ"
-            )
+            properties["start_datetime"] = to_iso_utc_string(item_start)
+            properties["end_datetime"] = to_iso_utc_string(item_end or item_start)
 
         for key, value in collection_dict["properties"].items():
             if key not in ["id", "title", "start_datetime", "end_datetime", "datetime"]:
@@ -319,25 +317,19 @@ class CopMarineSearch(StaticStacSearch):
 
                 # date bounds
                 if "start_datetime" in kwargs:
-                    start_date = dateutil_parse(kwargs["start_datetime"])
+                    start_date = parse_to_utc(kwargs["start_datetime"])
                 elif "start_datetime" in dataset_item["properties"]:
-                    start_date = dateutil_parse(
+                    start_date = parse_to_utc(
                         dataset_item["properties"]["start_datetime"]
                     )
                 else:
-                    start_date = dateutil_parse(dataset_item["properties"]["datetime"])
-                if not start_date.tzinfo:
-                    start_date = start_date.replace(tzinfo=tzutc())
+                    start_date = parse_to_utc(dataset_item["properties"]["datetime"])
                 if "end_datetime" in kwargs:
-                    end_date = dateutil_parse(kwargs["end_datetime"])
+                    end_date = parse_to_utc(kwargs["end_datetime"])
                 elif "end_datetime" in dataset_item["properties"]:
-                    end_date = dateutil_parse(
-                        dataset_item["properties"]["end_datetime"]
-                    )
+                    end_date = parse_to_utc(dataset_item["properties"]["end_datetime"])
                 else:
                     end_date = today(tzinfo=tzutc())
-                if not end_date.tzinfo:
-                    end_date = end_date.replace(tzinfo=tzutc())
 
                 # retrieve information about s3 from collection data
                 s3_url = dataset_item["assets"]["native"]["href"]
@@ -391,10 +383,7 @@ class CopMarineSearch(StaticStacSearch):
                                 last_modified := headers.get("last-modified")
                             ) is not None:
                                 try:
-                                    updated = dateutil_parse(last_modified)
-                                    asset_properties["updated"] = updated.strftime(
-                                        "%Y-%m-%dT%H:%I:%SZ"
-                                    )
+                                    asset_properties["updated"] = to_iso_utc_string(last_modified)
                                 except Exception:
                                     pass
                     except Exception:
@@ -479,22 +468,8 @@ class CopMarineSearch(StaticStacSearch):
                         use_dataset_dates = True
                         dates = _get_dates_from_dataset_data(dataset_item)
                         if dates:
-                            item_start_str = dates["start"].replace("Z", "+0000")
-                            item_end_str = dates["end"].replace("Z", "+0000")
-                            try:
-                                item_start = datetime.datetime.strptime(
-                                    item_start_str, "%Y-%m-%dT%H:%M:%S.%f%z"
-                                )
-                                item_end = datetime.datetime.strptime(
-                                    item_end_str, "%Y-%m-%dT%H:%M:%S.%f%z"
-                                )
-                            except ValueError:
-                                item_start = datetime.datetime.strptime(
-                                    item_start_str, "%Y-%m-%dT%H:%M:%S%z"
-                                )
-                                item_end = datetime.datetime.strptime(
-                                    item_end_str, "%Y-%m-%dT%H:%M:%S%z"
-                                )
+                            item_start = parse_to_utc(dates["start"])
+                            item_end = parse_to_utc(dates["end"])
                     if not item_start:
                         # no valid datetime in id and dataset data
                         continue

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -381,7 +381,9 @@ class CopMarineSearch(StaticStacSearch):
                                 last_modified := headers.get("last-modified")
                             ) is not None:
                                 try:
-                                    asset_properties["updated"] = to_iso_utc_string(last_modified)
+                                    asset_properties["updated"] = to_iso_utc_string(
+                                        last_modified
+                                    )
                                 except Exception:
                                     pass
                     except Exception:
@@ -491,9 +493,9 @@ class CopMarineSearch(StaticStacSearch):
 
                             last_modified_date = obj.get("LastModified")
                             if isinstance(last_modified_date, dt.datetime):
-                                asset_properties[
-                                    "updated"
-                                ] = last_modified_date.strftime("%Y-%m-%dT%H:%I:%SZ")
+                                asset_properties["updated"] = to_iso_utc_string(
+                                    last_modified_date
+                                )
 
                             etag_obj: Any = obj.get("ETag")
                             if isinstance(etag_obj, str) and "-" not in etag_obj:

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import copy
-import datetime
+import datetime as dt
 import logging
 import os
 import re
@@ -47,9 +47,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("eodag.search.cop_marine")
 
 
-def _get_date_from_yyyymmdd(
-    date_str: str, item_key: str
-) -> Optional[datetime.datetime]:
+def _get_date_from_yyyymmdd(date_str: str, item_key: str) -> Optional[dt.datetime]:
     year = date_str[:4]
     month = date_str[4:6]
     if len(date_str) > 6:
@@ -57,7 +55,7 @@ def _get_date_from_yyyymmdd(
     else:
         day = "1"
     try:
-        date = datetime.datetime(
+        date = dt.datetime(
             int(year),
             int(month),
             int(day),
@@ -492,7 +490,7 @@ class CopMarineSearch(StaticStacSearch):
                             asset_properties = {}
 
                             last_modified_date = obj.get("LastModified")
-                            if isinstance(last_modified_date, datetime.datetime):
+                            if isinstance(last_modified_date, dt.datetime):
                                 asset_properties[
                                     "updated"
                                 ] = last_modified_date.strftime("%Y-%m-%dT%H:%I:%SZ")

--- a/eodag/types/queryables.py
+++ b/eodag/types/queryables.py
@@ -47,6 +47,7 @@ from eodag.utils.dates import (
     is_range_in_range,
     parse_date,
 )
+from eodag.utils.exceptions import ValidationError as EodagValidationError
 from eodag.utils.repr import remove_class_repr, shorter_type_repr
 
 if TYPE_CHECKING:
@@ -171,7 +172,7 @@ class Queryables(CommonQueryables):
             )
         try:
             start, end = parse_date(v)
-        except ValueError as e:
+        except EodagValidationError as e:
             raise ValueError("date must follow 'yyyy-mm-dd' format") from e
         if end < start:
             raise ValueError("date range end must be after start")

--- a/eodag/types/search_args.py
+++ b/eodag/types/search_args.py
@@ -15,8 +15,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime as dt
 import re
-from datetime import datetime
 from typing import Annotated, Any, Optional, Union, cast
 
 from annotated_types import MinLen
@@ -58,7 +58,7 @@ class SearchArgs(BaseModel):
     def check_date_format(cls, v: str) -> str:
         """Validate dates"""
         try:
-            datetime.fromisoformat(v)
+            dt.datetime.fromisoformat(v)
         except ValueError as e:
             raise ValueError("start_date and end must follow ISO8601 format") from e
         return v

--- a/eodag/types/stac_metadata.py
+++ b/eodag/types/stac_metadata.py
@@ -39,6 +39,7 @@ from stac_pydantic.shared import Provider
 from typing_extensions import Self
 
 from eodag.types.stac_extensions import STAC_EXTENSIONS, BaseStacExtension
+from eodag.utils.dates import to_iso_utc_string
 
 logger = logging.getLogger("eodag.types.stac_metadata")
 
@@ -77,7 +78,7 @@ class CommonStacMetadata(ItemProperties):
         """format datetime properties"""
         if not value:
             return None
-        return value.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        return to_iso_utc_string(value)
 
     @model_validator(mode="before")
     @classmethod

--- a/eodag/types/stac_metadata.py
+++ b/eodag/types/stac_metadata.py
@@ -17,9 +17,9 @@
 # limitations under the License.
 """property fields."""
 
+import datetime as dt
 import logging
 from collections.abc import Callable
-from datetime import datetime as dt
 from typing import Annotated, Any, ClassVar, Optional, Type, TypeVar, Union, cast
 
 from pydantic import (
@@ -52,11 +52,13 @@ class CommonStacMetadata(ItemProperties):
     # TODO: replace dt by stac_pydantic.shared.UtcDatetime.
     # Requires timezone to be set in EODAG datetime properties
     # Tested with EFAS FORECAST
-    datetime: Annotated[dt, Field(None, validation_alias="start_datetime")]
-    start_datetime: Annotated[dt, Field(None)]  # TODO do not set if start = end
-    end_datetime: Annotated[dt, Field(None)]  # TODO do not set if start = end
-    created: Annotated[dt, Field(None)]
-    updated: Annotated[dt, Field(None)]
+    datetime: Annotated[dt.datetime, Field(None, validation_alias="start_datetime")]
+    start_datetime: Annotated[
+        dt.datetime, Field(None)
+    ]  # TODO do not set if start = end
+    end_datetime: Annotated[dt.datetime, Field(None)]  # TODO do not set if start = end
+    created: Annotated[dt.datetime, Field(None)]
+    updated: Annotated[dt.datetime, Field(None)]
     platform: Annotated[str, Field(None)]
     instruments: Annotated[list[str], Field(None)]
     constellation: Annotated[str, Field(None)]
@@ -74,7 +76,7 @@ class CommonStacMetadata(ItemProperties):
     @field_serializer(
         "datetime", "start_datetime", "end_datetime", "created", "updated"
     )
-    def format_datetime(self, value: dt):
+    def format_datetime(self, value: dt.datetime):
         """format datetime properties"""
         if not value:
             return None

--- a/eodag/utils/dates.py
+++ b/eodag/utils/dates.py
@@ -32,6 +32,8 @@ from dateutil.tz import UTC
 
 from eodag.utils.exceptions import ValidationError
 
+STAC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
 RFC3339_PATTERN = (
     r"^(\d{4})-(\d{2})-(\d{2})"
     r"(?:T(\d{2}):(\d{2}):(\d{2})(\.\d+)?"
@@ -58,6 +60,7 @@ def get_timestamp(date_time: str) -> float:
 
     :param date_time: The datetime string to return as timestamp
     :returns: The timestamp corresponding to the ``date_time`` string in seconds
+    :raises ValueError: If ``date_time`` cannot be parsed as ISO8601
 
     Examples:
         >>> get_timestamp("2023-09-23T12:34:56Z")  # doctest: +ELLIPSIS
@@ -108,6 +111,7 @@ def is_range_in_range(valid_range: str, check_range: str) -> bool:
     :param valid_range: The valid date range in the format 'YYYY-MM-DD/YYYY-MM-DD'.
     :param check_range: The date range to check in the format 'YYYY-MM-DD/YYYY-MM-DD'.
     :returns: True if check_range is within valid_range, otherwise False.
+    :raises ValueError: If date parts cannot be parsed as ISO8601
 
     Examples:
         >>> is_range_in_range("2023-01-01/2023-12-31", "2023-03-01/2023-03-31")
@@ -128,11 +132,11 @@ def is_range_in_range(valid_range: str, check_range: str) -> bool:
     start_valid, end_valid = valid_range.split("/")
     start_check, end_check = check_range.split("/")
 
-    # Convert the strings to datetime objects using fromisoformat
-    start_valid_dt = datetime.datetime.fromisoformat(start_valid)
-    end_valid_dt = datetime.datetime.fromisoformat(end_valid)
-    start_check_dt = datetime.datetime.fromisoformat(start_check)
-    end_check_dt = datetime.datetime.fromisoformat(end_check)
+    # Convert the strings to datetime objects
+    start_valid_dt = isoparse(start_valid)
+    end_valid_dt = isoparse(end_valid)
+    start_check_dt = isoparse(start_check)
+    end_check_dt = isoparse(end_check)
 
     # Check if check_range is within valid_range
     return start_valid_dt <= start_check_dt and end_valid_dt >= end_check_dt
@@ -143,18 +147,19 @@ def get_datetime(arguments: dict[str, Any]) -> tuple[Optional[str], Optional[str
 
     :param arguments: dict containing a single date or `/` separated dates in `datetime` item
     :returns: Start date and end date from datetime string (duplicate value if only one date as input)
+    :raises ValidationError: If a date string cannot be parsed
 
     Examples:
         >>> get_datetime({"datetime": "2023-03-01/2023-03-31"})
-        ('2023-03-01T00:00:00', '2023-03-31T00:00:00')
+        ('2023-03-01T00:00:00.000Z', '2023-03-31T00:00:00.000Z')
         >>> get_datetime({"datetime": "2023-03-01"})
-        ('2023-03-01T00:00:00', '2023-03-01T00:00:00')
+        ('2023-03-01T00:00:00.000Z', '2023-03-01T00:00:00.000Z')
         >>> get_datetime({"datetime": "../2023-03-31"})
-        (None, '2023-03-31T00:00:00')
+        (None, '2023-03-31T00:00:00.000Z')
         >>> get_datetime({"datetime": "2023-03-01/.."})
-        ('2023-03-01T00:00:00', None)
+        ('2023-03-01T00:00:00.000Z', None)
         >>> get_datetime({"dtstart": "2023-03-01", "dtend": "2023-03-31"})
-        ('2023-03-01T00:00:00', '2023-03-31T00:00:00')
+        ('2023-03-01T00:00:00.000Z', '2023-03-31T00:00:00.000Z')
         >>> get_datetime({})
         (None, None)
     """
@@ -185,12 +190,13 @@ def get_date(date: Optional[str]) -> Optional[str]:
     Check if the input date can be parsed as a date
 
     :param date: The date to parse
-    :returns: The datetime represented with ISO format
+    :returns: The datetime represented with ISO 8601 UTC format
+    :raises ValidationError: If the date string cannot be parsed
 
     Examples:
         >>> from eodag.utils.exceptions import ValidationError
         >>> get_date("2023-09-23")
-        '2023-09-23T00:00:00'
+        '2023-09-23T00:00:00.000Z'
         >>> get_date(None) is None
         True
         >>> get_date("invalid-date")  # doctest: +IGNORE_EXCEPTION_DETAIL
@@ -201,16 +207,10 @@ def get_date(date: Optional[str]) -> Optional[str]:
 
     if not date:
         return None
-    try:
-        return (
-            dateutil.parser.parse(date)
-            .replace(tzinfo=tz.UTC)
-            .isoformat()
-            .replace("+00:00", "")
-        )
-    except ValueError as e:
-        exc = ValidationError("invalid input date: %s" % e)
-        raise exc
+    result = to_iso_utc_string(date)
+    if result is None:
+        raise ValidationError("invalid input date: %s" % date)
+    return result
 
 
 def rfc3339_str_to_datetime(s: str) -> datetime.datetime:
@@ -218,7 +218,7 @@ def rfc3339_str_to_datetime(s: str) -> datetime.datetime:
 
     :param s: The string to convert to :class:`datetime.datetime`
     :returns: The datetime represented by the ISO8601 (RFC 3339) formatted string
-    :raises: :class:`ValidationError`
+    :raises ValidationError: If the string does not conform to RFC 3339
 
     Examples:
         >>> from eodag.utils.exceptions import ValidationError
@@ -299,12 +299,13 @@ def parse_date(
 
     :param date: Single or interval date string
     :returns: A tuple with the start and end datetime
+    :raises ValidationError: If a date string cannot be parsed
 
     Examples:
         >>> parse_date("2020-12-15")
-        (datetime.datetime(2020, 12, 15, 0, 0), datetime.datetime(2020, 12, 15, 0, 0))
+        (datetime.datetime(2020, 12, 15, 0, 0, tzinfo=tzutc()), datetime.datetime(2020, 12, 15, 0, 0, tzinfo=tzutc()))
         >>> parse_date("2020-12-15/to/20201230")
-        (datetime.datetime(2020, 12, 15, 0, 0), datetime.datetime(2020, 12, 30, 0, 0))
+        (datetime.datetime(2020, 12, 15, 0, 0, tzinfo=tzutc()), datetime.datetime(2020, 12, 30, 0, 0, tzinfo=tzutc()))
     """
     if "to" in date:
         start_date_str, end_date_str = date.split("/to/")
@@ -323,8 +324,8 @@ def parse_date(
     if re.match(r"^\d{8}$", end_date_str):
         end_date_str = f"{end_date_str[:4]}-{end_date_str[4:6]}-{end_date_str[6:]}"
 
-    start_date = dt.fromisoformat(start_date_str.rstrip("Z"))
-    end_date = dt.fromisoformat(end_date_str.rstrip("Z"))
+    start_date = parse_to_utc(start_date_str)
+    end_date = parse_to_utc(end_date_str)
 
     if time:
         start_t, end_t = get_min_max(time)
@@ -490,37 +491,85 @@ def time_values_to_hhmm(time_values: list[str]) -> list[str]:
     return buffer
 
 
+def _ensure_utc(value: dt) -> dt:
+    """Ensure a datetime is UTC-aware.
+
+    If the datetime is naive, it is assumed to be UTC.
+    If it already has a timezone, it is converted to UTC.
+
+    :param value: A datetime object
+    :returns: A timezone-aware datetime in UTC
+
+    Examples:
+        >>> from datetime import datetime, timezone
+        >>> _ensure_utc(datetime(2020, 1, 1, 12, 0))
+        datetime.datetime(2020, 1, 1, 12, 0, tzinfo=tzutc())
+        >>> _ensure_utc(datetime(2021, 4, 21, 0, 0, tzinfo=timezone.utc))
+        datetime.datetime(2021, 4, 21, 0, 0, tzinfo=tzutc())
+    """
+    if not value.tzinfo:
+        return value.replace(tzinfo=tz.UTC)
+    return value.astimezone(tz.UTC)
+
+
+def parse_to_utc(raw: str) -> dt:
+    """Parse a date string to a UTC-aware datetime.
+
+    Uses ``dateutil.parser.isoparse`` for ISO strings. Falls back to
+    ``dateutil.parser.parse`` for non-ISO formats. Always returns a
+    timezone-aware datetime in UTC.
+
+    :param raw: A date string
+    :returns: A timezone-aware datetime in UTC
+    :raises ValidationError: If the string cannot be parsed
+
+    Examples:
+        >>> parse_to_utc("2020-01-01")
+        datetime.datetime(2020, 1, 1, 0, 0, tzinfo=tzutc())
+        >>> parse_to_utc("2021-04-21T00:00:00+02:00")
+        datetime.datetime(2021, 4, 20, 22, 0, tzinfo=tzutc())
+        >>> parse_to_utc("invalid")  # doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+            ...
+        ValidationError
+    """
+    try:
+        parsed = isoparse(raw)
+    except (ValueError, TypeError):
+        try:
+            parsed = dateutil.parser.parse(raw)
+        except (ValueError, TypeError) as e:
+            raise ValidationError(f"Cannot parse date: {raw!r}") from e
+    if not parsed.tzinfo:
+        parsed = parsed.replace(tzinfo=tz.UTC)
+    return parsed.astimezone(tz.UTC)
+
+
 def to_iso_utc_string(
     raw: Optional[Union[dt, str]],
 ) -> Optional[str]:
-    """Convert a datetime or date string to an ISO 8601 UTC string.
+    """Convert a datetime or date string to an ISO 8601 UTC string with millisecond precision.
 
     :param raw: A datetime object or date string to convert
-    :returns: ISO 8601 formatted UTC string (``YYYY-MM-DDTHH:MM:SSZ``), or ``None``
+    :returns: ISO 8601 formatted UTC string (``YYYY-MM-DDTHH:MM:SS.sssZ``), or ``None``
 
     Examples:
         >>> from datetime import datetime
         >>> to_iso_utc_string(datetime(2020, 1, 1, 12, 0))
-        '2020-01-01T12:00:00Z'
+        '2020-01-01T12:00:00.000Z'
         >>> to_iso_utc_string("2020-01-01")
-        '2020-01-01T00:00:00Z'
+        '2020-01-01T00:00:00.000Z'
+        >>> to_iso_utc_string("2021-04-21T00:00:00+02:00")
+        '2021-04-20T22:00:00.000Z'
         >>> to_iso_utc_string(None) is None
         True
     """
     if raw is None:
         return None
-    if isinstance(raw, dt):
-        raw = raw.replace(tzinfo=tz.UTC)
-        return raw.strftime("%Y-%m-%dT%H:%M:%SZ")
-    if not isinstance(raw, str):
-        return None
-
     try:
-        parsed_datetime = isoparse(raw)
-        if parsed_datetime.tzinfo is None:
-            parsed_datetime = parsed_datetime.replace(tzinfo=tz.UTC)
-        return parsed_datetime.strftime("%Y-%m-%dT%H:%M:%SZ")
-    except (ValueError, OverflowError):
+        utc_dt = _ensure_utc(raw) if isinstance(raw, dt) else parse_to_utc(raw)
+        return utc_dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    except (ValidationError, OverflowError):
         return None
 
 
@@ -548,16 +597,17 @@ def compute_date_range_from_params(
     :param month: List of month strings (zero-padded)
     :param day: List of day strings (zero-padded)
     :returns: Tuple of (start_datetime, end_datetime) as ISO UTC strings
+    :raises ValidationError: If a date string cannot be parsed
 
     Examples:
         >>> compute_date_range_from_params(date="2020-12-15")
-        ('2020-12-15T00:00:00Z', '2020-12-15T00:00:00Z')
+        ('2020-12-15T00:00:00.000Z', '2020-12-15T00:00:00.000Z')
         >>> compute_date_range_from_params(date="2020-12-15", time=["0600", "1800"])
-        ('2020-12-15T06:00:00Z', '2020-12-15T18:00:00Z')
+        ('2020-12-15T06:00:00.000Z', '2020-12-15T18:00:00.000Z')
         >>> compute_date_range_from_params(year=["2020", "2021"])
-        ('2020-01-01T00:00:00Z', '2021-12-31T23:59:59Z')
+        ('2020-01-01T00:00:00.000Z', '2021-12-31T23:59:59.000Z')
         >>> compute_date_range_from_params(year=["2020"], month=["03"], day=["15"])
-        ('2020-03-15T00:00:00Z', '2020-03-15T23:59:59Z')
+        ('2020-03-15T00:00:00.000Z', '2020-03-15T23:59:59.000Z')
         >>> compute_date_range_from_params()
         (None, None)
     """
@@ -584,10 +634,10 @@ def compute_date_range_from_params(
                 max_day = day[-1]
 
         if time:
-            min_time = f"{time[0][0:2]}:{time[0][2:4]}:00"
-            max_time = f"{time[-1][0:2]}:{time[-1][2:4]}:00"
+            min_time = f"{time[0][0:2]}:{time[0][2:4]}:00.000"
+            max_time = f"{time[-1][0:2]}:{time[-1][2:4]}:00.000"
         else:
-            min_time, max_time = "00:00:00", "23:59:59"
+            min_time, max_time = "00:00:00.000", "23:59:59.000"
 
         start_str = f"{min_year}-{min_month}-{min_day}T{min_time}Z"
         end_str = f"{max_year}-{max_month}-{max_day}T{max_time}Z"

--- a/eodag/utils/dates.py
+++ b/eodag/utils/dates.py
@@ -491,7 +491,7 @@ def time_values_to_hhmm(time_values: list[str]) -> list[str]:
     return buffer
 
 
-def _ensure_utc(value: dt) -> dt:
+def ensure_utc(value: dt) -> dt:
     """Ensure a datetime is UTC-aware.
 
     If the datetime is naive, it is assumed to be UTC.
@@ -502,9 +502,9 @@ def _ensure_utc(value: dt) -> dt:
 
     Examples:
         >>> from datetime import datetime, timezone
-        >>> _ensure_utc(datetime(2020, 1, 1, 12, 0))
+        >>> ensure_utc(datetime(2020, 1, 1, 12, 0))
         datetime.datetime(2020, 1, 1, 12, 0, tzinfo=tzutc())
-        >>> _ensure_utc(datetime(2021, 4, 21, 0, 0, tzinfo=timezone.utc))
+        >>> ensure_utc(datetime(2021, 4, 21, 0, 0, tzinfo=timezone.utc))
         datetime.datetime(2021, 4, 21, 0, 0, tzinfo=tzutc())
     """
     if not value.tzinfo:
@@ -567,7 +567,7 @@ def to_iso_utc_string(
     if raw is None:
         return None
     try:
-        utc_dt = _ensure_utc(raw) if isinstance(raw, dt) else parse_to_utc(raw)
+        utc_dt = ensure_utc(raw) if isinstance(raw, dt) else parse_to_utc(raw)
         return utc_dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
     except (ValidationError, OverflowError):
         return None

--- a/eodag/utils/dates.py
+++ b/eodag/utils/dates.py
@@ -18,11 +18,8 @@
 """eodag.rest.dates methods that must be importable without eodag[server] installeds"""
 
 import calendar
-import datetime
+import datetime as dt
 import re
-from datetime import date
-from datetime import datetime as dt
-from datetime import timezone
 from typing import Any, Iterator, Optional, Union
 
 import dateutil.parser
@@ -76,7 +73,7 @@ def get_timestamp(date_time: str) -> float:
     return dt.timestamp()
 
 
-def datetime_range(start: dt, end: dt) -> Iterator[dt]:
+def datetime_range(start: dt.datetime, end: dt.datetime) -> Iterator[dt.datetime]:
     """Generator function for all dates in-between ``start`` and ``end`` date.
 
     :param start: Start date
@@ -99,7 +96,7 @@ def datetime_range(start: dt, end: dt) -> Iterator[dt]:
     """
     delta = end - start
     for nday in range(delta.days + 1):
-        yield start + datetime.timedelta(days=nday)
+        yield start + dt.timedelta(days=nday)
 
 
 def is_range_in_range(valid_range: str, check_range: str) -> bool:
@@ -213,7 +210,7 @@ def get_date(date: Optional[str]) -> Optional[str]:
     return result
 
 
-def rfc3339_str_to_datetime(s: str) -> datetime.datetime:
+def rfc3339_str_to_datetime(s: str) -> dt.datetime:
     """Convert a string conforming to RFC 3339 to a :class:`datetime.datetime`.
 
     :param s: The string to convert to :class:`datetime.datetime`
@@ -238,7 +235,7 @@ def rfc3339_str_to_datetime(s: str) -> datetime.datetime:
     if not result:
         raise ValidationError("Invalid RFC3339 datetime.")
 
-    return dateutil.parser.isoparse(s).replace(tzinfo=datetime.timezone.utc)
+    return dateutil.parser.isoparse(s).replace(tzinfo=dt.timezone.utc)
 
 
 def get_min_max(
@@ -263,7 +260,7 @@ def get_min_max(
     return value, value
 
 
-def append_time(input_date: date, time: Optional[str] = None) -> dt:
+def append_time(input_date: dt.date, time: Optional[str] = None) -> dt.datetime:
     """Appends a string-formatted time to a date.
 
     :param input_date: Date to combine with the time
@@ -287,14 +284,16 @@ def append_time(input_date: date, time: Optional[str] = None) -> dt:
     time = re.sub(":|_", "", time)
     if time == "2400":
         time = "0000"
-    combined_dt = dt.combine(input_date, dt.strptime(time, "%H%M").time())
-    combined_dt.replace(tzinfo=timezone.utc)
+    combined_dt = dt.datetime.combine(
+        input_date, dt.datetime.strptime(time, "%H%M").time()
+    )
+    combined_dt.replace(tzinfo=dt.timezone.utc)
     return combined_dt
 
 
 def parse_date(
     date: str, time: Optional[Union[str, list[str]]] = None
-) -> tuple[dt, dt]:
+) -> tuple[dt.datetime, dt.datetime]:
     """Parses a date string in formats YYYY-MM-DD, YYYMMDD, solo or in start/end or start/to/end intervals.
 
     :param date: Single or interval date string
@@ -340,7 +339,7 @@ def parse_year_month_day(
     month: Optional[Union[str, list[str]]] = None,
     day: Optional[Union[str, list[str]]] = None,
     time: Optional[Union[str, list[str]]] = None,
-) -> tuple[dt, dt]:
+) -> tuple[dt.datetime, dt.datetime]:
     """Returns minimum and maximum datetimes from given lists of years, months, days, times.
 
     :param year: List of years or a single one
@@ -354,9 +353,9 @@ def parse_year_month_day(
         (datetime.datetime(2020, 1, 1, 0, 0), datetime.datetime(2022, 5, 1, 12, 0))
     """
 
-    def build_date(year, month=None, day=None, time=None) -> dt:
+    def build_date(year, month=None, day=None, time=None) -> dt.datetime:
         """Datetime from default_date with updated year, month, day and time."""
-        updated_date = dt(int(year), 1, 1).replace(
+        updated_date = dt.datetime(int(year), 1, 1).replace(
             month=int(month) if month is not None else 1,
             day=int(day) if day is not None else 1,
         )
@@ -375,7 +374,7 @@ def parse_year_month_day(
     return start_date, end_date
 
 
-def format_date(date: dt) -> str:
+def format_date(date: dt.datetime) -> str:
     """Format a ``datetime`` with the format 'YYYY-MM-DD'.
 
     :param date: Datetime to format
@@ -391,7 +390,7 @@ def format_date(date: dt) -> str:
     return date.isoformat()[:10]
 
 
-def format_date_range(start: dt, end: dt) -> str:
+def format_date_range(start: dt.datetime, end: dt.datetime) -> str:
     """Format a range with the format 'YYYY-MM-DD/YYYY-MM-DD'.
 
     :param start: Start datetime
@@ -448,9 +447,9 @@ def validate_datetime_param(
                 # Prepend a dummy year when format contains %d without %Y
                 # to avoid ambiguity (deprecated in 3.14, error in 3.15+)
                 if "%d" in formatter and "%Y" not in formatter:
-                    dt.strptime(f"2000 {item}", f"%Y {formatter}")
+                    dt.datetime.strptime(f"2000 {item}", f"%Y {formatter}")
                 else:
-                    dt.strptime(item, formatter)
+                    dt.datetime.strptime(item, formatter)
                 buffer.append(item)
             except Exception as e:
                 has_error = e
@@ -491,7 +490,7 @@ def time_values_to_hhmm(time_values: list[str]) -> list[str]:
     return buffer
 
 
-def ensure_utc(value: dt) -> dt:
+def ensure_utc(value: dt.datetime) -> dt.datetime:
     """Ensure a datetime is UTC-aware.
 
     If the datetime is naive, it is assumed to be UTC.
@@ -512,7 +511,7 @@ def ensure_utc(value: dt) -> dt:
     return value.astimezone(tz.UTC)
 
 
-def parse_to_utc(raw: str) -> dt:
+def parse_to_utc(raw: str) -> dt.datetime:
     """Parse a date string to a UTC-aware datetime.
 
     Uses ``dateutil.parser.isoparse`` for ISO strings. Falls back to
@@ -546,7 +545,7 @@ def parse_to_utc(raw: str) -> dt:
 
 
 def to_iso_utc_string(
-    raw: Optional[Union[dt, str]],
+    raw: Optional[Union[dt.datetime, str]],
 ) -> Optional[str]:
     """Convert a datetime or date string to an ISO 8601 UTC string with millisecond precision.
 
@@ -567,7 +566,7 @@ def to_iso_utc_string(
     if raw is None:
         return None
     try:
-        utc_dt = ensure_utc(raw) if isinstance(raw, dt) else parse_to_utc(raw)
+        utc_dt = ensure_utc(raw) if isinstance(raw, dt.datetime) else parse_to_utc(raw)
         return utc_dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
     except (ValidationError, OverflowError):
         return None

--- a/eodag/utils/s3.py
+++ b/eodag/utils/s3.py
@@ -17,7 +17,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import datetime
 import io
 import logging
 import os
@@ -40,6 +39,7 @@ from eodag.utils import (
     parse_le_uint16,
     parse_le_uint32,
 )
+from eodag.utils.dates import to_iso_utc_string
 from eodag.utils.exceptions import (
     AuthenticationError,
     InvalidDataError,
@@ -583,14 +583,8 @@ def update_assets_from_s3(
                     if size is not None:
                         asset_data["file:size"] = size
 
-                    last_modified = item_s3.get("LastModified")
-                    if isinstance(last_modified, datetime.datetime):
-                        try:
-                            asset_data["updated"] = last_modified.strftime(
-                                "%Y-%m-%dT%H:%M:%SZ"
-                            )
-                        except Exception:
-                            pass
+                    if last_modified := to_iso_utc_string(item_s3.get("LastModified")):
+                        asset_data["updated"] = last_modified
 
                     assets_data[key] = asset_data
 

--- a/tests/context.py
+++ b/tests/context.py
@@ -104,7 +104,7 @@ from eodag.utils import (
     StreamResponse,
     MockResponse,
 )
-from eodag.utils.dates import get_timestamp
+from eodag.utils.dates import get_timestamp, to_iso_utc_string
 from eodag.utils.env import is_env_var_true
 from eodag.utils.requests import fetch_json
 from eodag.utils.s3 import (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,7 @@ from packaging import version
 from eodag.api.collection import Collection, CollectionsList
 from eodag.api.search_result import SearchResult
 from eodag.utils import GENERIC_COLLECTION
+from eodag.utils.dates import to_iso_utc_string
 from eodag.utils.exceptions import UnsupportedProvider
 from tests import TEST_RESOURCES_PATH
 from tests.context import (
@@ -614,9 +615,9 @@ class TestEodagCli(unittest.TestCase):
         with self.user_conf() as conf_file:
             collection = "whatever"
             start_date_str = "2022-01-01"
-            start_date_datetime = datetime.strptime(
-                start_date_str, "%Y-%m-%d"
-            ).isoformat()
+            start_date_datetime = to_iso_utc_string(
+                datetime.strptime(start_date_str, "%Y-%m-%d")
+            )
             exit_code, output, error = self.eodag_command(
                 [
                     "search",
@@ -660,9 +661,9 @@ class TestEodagCli(unittest.TestCase):
         with self.user_conf() as conf_file:
             collection = "whatever"
             stop_date_str = "2022-01-01"
-            stop_date_datetime = datetime.strptime(
-                stop_date_str, "%Y-%m-%d"
-            ).isoformat()
+            stop_date_datetime = to_iso_utc_string(
+                datetime.strptime(stop_date_str, "%Y-%m-%d")
+            )
             exit_code, output, error = self.eodag_command(
                 [
                     "search",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,13 +15,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime as dt
 import logging
 import os
 import re
 import unittest
 from collections import defaultdict
 from contextlib import contextmanager
-from datetime import datetime
 from importlib.resources import files as res_files
 from tempfile import TemporaryDirectory
 from typing import Optional, Tuple
@@ -616,7 +616,7 @@ class TestEodagCli(unittest.TestCase):
             collection = "whatever"
             start_date_str = "2022-01-01"
             start_date_datetime = to_iso_utc_string(
-                datetime.strptime(start_date_str, "%Y-%m-%d")
+                dt.datetime.strptime(start_date_str, "%Y-%m-%d")
             )
             exit_code, output, error = self.eodag_command(
                 [
@@ -662,7 +662,7 @@ class TestEodagCli(unittest.TestCase):
             collection = "whatever"
             stop_date_str = "2022-01-01"
             stop_date_datetime = to_iso_utc_string(
-                datetime.strptime(stop_date_str, "%Y-%m-%d")
+                dt.datetime.strptime(stop_date_str, "%Y-%m-%d")
             )
             exit_code, output, error = self.eodag_command(
                 [

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
+import datetime as dt
 import hashlib
 import os
 import re
@@ -113,9 +113,9 @@ HYDROWBEB_NEXT_SEARCH_ARGS = [
 ]
 # As of 2021-01-14 the products previously required in 2020-08 were offline.
 # Trying here to retrieve the most recent products which are more likely to be online.
-today = datetime.date.today()
-week_span = datetime.timedelta(days=7)
-day_span = datetime.timedelta(days=1)
+today = dt.date.today()
+week_span = dt.timedelta(days=7)
+day_span = dt.timedelta(days=1)
 USGS_RECENT_SEARCH_ARGS = [
     "usgs",
     "LANDSAT_C2L1",
@@ -765,8 +765,8 @@ class TestEODagEndToEndComplete(EndToEndBase):
         ].download.output_dir = self.tmp_download_path
 
         # Search for products that are online and as small as possible (smallest area first)
-        today = datetime.date.today()
-        month_span = datetime.timedelta(weeks=4)
+        today = dt.date.today()
+        month_span = dt.timedelta(weeks=4)
         search_results = self.eodag.search(
             collection="S2_MSI_L1C",
             start=(today - month_span).isoformat(),

--- a/tests/units/test_auth_plugins.py
+++ b/tests/units/test_auth_plugins.py
@@ -16,9 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime as dt
 import pickle
 import unittest
-from datetime import datetime, timedelta
 from unittest import mock
 
 import boto3
@@ -382,7 +382,7 @@ class TestAuthPluginTokenAuth(BaseAuthPluginTest):
         self.assertTrue(isinstance(auth, AuthBase))
         mock_requests_post.assert_not_called()
         # reset expiration -> token should be fetched again
-        auth_plugin.token_expiration = datetime.now()
+        auth_plugin.token_expiration = dt.datetime.now()
         mock_requests_post.return_value.json.return_value = {
             "not_token": "this_is_not_test_token",
             "token_is_here": "this_is_a_new_token",
@@ -458,7 +458,7 @@ class TestAuthPluginTokenAuth(BaseAuthPluginTest):
 
         # reset expiration -> token should be fetched again
         # The refresh token mechanism will be used.
-        auth_plugin.token_expiration = datetime.now()
+        auth_plugin.token_expiration = dt.datetime.now()
         mock_requests_post.return_value.json.return_value = {
             "not_token": "this_is_not_test_token",
             "token_is_here": "this_is_a_refreshed_token",
@@ -1852,7 +1852,7 @@ class TestAuthPluginKeycloakOIDCPasswordAuth(BaseAuthPluginTest):
         auth_plugin = self.auth_plugin
         auth_plugin.config.credentials = {"username": "john"}
         mock_decode.return_value = {
-            "exp": (now_in_utc() + timedelta(seconds=3600)).timestamp()
+            "exp": (now_in_utc() + dt.timedelta(seconds=3600)).timestamp()
         }
 
         with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
@@ -1898,7 +1898,7 @@ class TestAuthPluginKeycloakOIDCPasswordAuth(BaseAuthPluginTest):
         auth_plugin = self.auth_plugin
         auth_plugin.config.credentials = {"username": "john"}
         mock_decode.return_value = {
-            "exp": (now_in_utc() + timedelta(seconds=3600)).timestamp()
+            "exp": (now_in_utc() + dt.timedelta(seconds=3600)).timestamp()
         }
 
         with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
@@ -1935,7 +1935,7 @@ class TestAuthPluginKeycloakOIDCPasswordAuth(BaseAuthPluginTest):
         auth_plugin = self.auth_plugin
         auth_plugin.config.credentials = {"username": "john"}
         mock_decode.return_value = {
-            "exp": (now_in_utc() + timedelta(seconds=3600)).timestamp()
+            "exp": (now_in_utc() + dt.timedelta(seconds=3600)).timestamp()
         }
 
         # backup token_provision and change it to header mode
@@ -2257,7 +2257,7 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         }
         mock_request_new_token.return_value = json_response
         mock_get_token_with_refresh_token.return_value = json_response
-        expiration = current_time + timedelta(
+        expiration = current_time + dt.timedelta(
             seconds=float(json_response["expires_in"])
         )
         mock_decode.return_value = {"exp": expiration.timestamp()}
@@ -2297,9 +2297,9 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
 
         # Refresh token available but expired and access token expired-> new auth
         auth_plugin.refresh_token = "old-refresh-token"
-        auth_plugin.refresh_token_expiration = current_time - timedelta(hours=3)
+        auth_plugin.refresh_token_expiration = current_time - dt.timedelta(hours=3)
         auth_plugin.access_token = "old-access-token"
-        auth_plugin.access_token_expiration = current_time - timedelta(hours=4)
+        auth_plugin.access_token_expiration = current_time - dt.timedelta(hours=4)
         _authenticate(
             mock_request_new_token,
             mock_get_token_with_refresh_token,
@@ -2309,9 +2309,9 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         # Refresh token available but expires in a minute (60s) and access token expired-> new auth
         # 60s = the default time for the config parameter "token_expiration_margin"
         auth_plugin.refresh_token = "old-refresh-token"
-        auth_plugin.refresh_token_expiration = current_time + timedelta(seconds=60)
+        auth_plugin.refresh_token_expiration = current_time + dt.timedelta(seconds=60)
         auth_plugin.access_token = "old-access-token"
-        auth_plugin.access_token_expiration = current_time - timedelta(hours=4)
+        auth_plugin.access_token_expiration = current_time - dt.timedelta(hours=4)
         _authenticate(
             mock_request_new_token,
             mock_get_token_with_refresh_token,
@@ -2321,7 +2321,7 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         # Refresh token *not* available and access token expired - new auth
         auth_plugin.access_token = "old-access-token"
         auth_plugin.refresh_token = ""
-        auth_plugin.access_token_expiration = current_time - timedelta(hours=4)
+        auth_plugin.access_token_expiration = current_time - dt.timedelta(hours=4)
 
         _authenticate(
             mock_request_new_token,
@@ -2333,7 +2333,7 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         # 60s = the default time for the config parameter "token_expiration_margin"
         auth_plugin.access_token = "old-access-token"
         auth_plugin.refresh_token = ""
-        auth_plugin.access_token_expiration = current_time + timedelta(seconds=60)
+        auth_plugin.access_token_expiration = current_time + dt.timedelta(seconds=60)
 
         _authenticate(
             mock_request_new_token,
@@ -2343,9 +2343,9 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
 
         # Refresh token available and access token expired -> refresh
         auth_plugin.refresh_token = "old-refresh-token"
-        auth_plugin.refresh_token_expiration = current_time + timedelta(hours=3)
+        auth_plugin.refresh_token_expiration = current_time + dt.timedelta(hours=3)
         auth_plugin.access_token = "old-access-token"
-        auth_plugin.access_token_expiration = current_time - timedelta(hours=4)
+        auth_plugin.access_token_expiration = current_time - dt.timedelta(hours=4)
         _authenticate(
             mock_get_token_with_refresh_token,
             mock_request_new_token,
@@ -2355,9 +2355,9 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         # Refresh token available and access token expires in a minute (60s)-> refresh
         # 60s = the default time for the config parameter "token_expiration_margin"
         auth_plugin.refresh_token = "old-refresh-token"
-        auth_plugin.refresh_token_expiration = current_time + timedelta(hours=3)
+        auth_plugin.refresh_token_expiration = current_time + dt.timedelta(hours=3)
         auth_plugin.access_token = "old-access-token"
-        auth_plugin.access_token_expiration = current_time + timedelta(seconds=60)
+        auth_plugin.access_token_expiration = current_time + dt.timedelta(seconds=60)
         _authenticate(
             mock_get_token_with_refresh_token,
             mock_request_new_token,
@@ -2367,9 +2367,9 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         # Both Refresh token and access token expire in a minute (60s)-> new auth
         # 60s = the default time for the config parameter "token_expiration_margin"
         auth_plugin.refresh_token = "old-refresh-token"
-        auth_plugin.refresh_token_expiration = current_time + timedelta(seconds=60)
+        auth_plugin.refresh_token_expiration = current_time + dt.timedelta(seconds=60)
         auth_plugin.access_token = "old-access-token"
-        auth_plugin.access_token_expiration = current_time + timedelta(seconds=60)
+        auth_plugin.access_token_expiration = current_time + dt.timedelta(seconds=60)
         _authenticate(
             mock_request_new_token,
             mock_get_token_with_refresh_token,
@@ -2378,9 +2378,9 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
 
         # Access token not expired -> use already retrieved token
         auth_plugin.refresh_token = "old-refresh-token"
-        auth_plugin.refresh_token_expiration = current_time + timedelta(hours=3)
+        auth_plugin.refresh_token_expiration = current_time + dt.timedelta(hours=3)
         auth_plugin.access_token = "old-access-token"
-        auth_plugin.access_token_expiration = current_time + timedelta(hours=2)
+        auth_plugin.access_token_expiration = current_time + dt.timedelta(hours=2)
         auth = auth_plugin.authenticate()
         mock_request_new_token.assert_not_called()
         mock_get_token_with_refresh_token.assert_not_called()
@@ -2424,7 +2424,7 @@ class TestAuthPluginOIDCAuthorizationCodeFlowAuth(BaseAuthPluginTest):
         mock_compute_state.return_value = state
         mock_exchange_code_for_token.return_value = MockResponse(json_response, 200)
         mock_decode.return_value = {
-            "exp": (now_in_utc() + timedelta(seconds=3600)).timestamp()
+            "exp": (now_in_utc() + dt.timedelta(seconds=3600)).timestamp()
         }
 
         auth = auth_plugin.authenticate()

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 import copy
+import datetime as dt
 import glob
 import json
 import logging
@@ -24,7 +25,6 @@ import os
 import shutil
 import tempfile
 import unittest
-from datetime import datetime, timezone
 from importlib.resources import files as res_files
 from tempfile import TemporaryDirectory
 
@@ -2832,7 +2832,7 @@ class TestCoreSearch(TestCoreBase):
         # with dates
         self.assertEqual(
             self.dag.collections_config["S2_MSI_L1C"].extent.temporal.interval[0][0],
-            datetime(2015, 6, 23, 0, 0, tzinfo=timezone.utc),
+            dt.datetime(2015, 6, 23, 0, 0, tzinfo=dt.timezone.utc),
         )
         self.assertNotIn(
             "S2_MSI_L1C",

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -2916,8 +2916,8 @@ class TestCoreSearch(TestCoreBase):
         # with datetime
         base = {"datetime": "2021-01-01T00:00:00Z/2021-01-02T00:00:00Z"}
         _, prepared_search = self.dag._prepare_search(**base)
-        self.assertEqual(prepared_search["start_datetime"], "2021-01-01T00:00:00")
-        self.assertEqual(prepared_search["end_datetime"], "2021-01-02T00:00:00")
+        self.assertEqual(prepared_search["start_datetime"], "2021-01-01T00:00:00.000Z")
+        self.assertEqual(prepared_search["end_datetime"], "2021-01-02T00:00:00.000Z")
         # with both, start/end overwrites datetime
         base = {
             "start": "2020-01-01",

--- a/tests/units/test_crunch.py
+++ b/tests/units/test_crunch.py
@@ -20,7 +20,6 @@ from collections import UserList
 from typing import Any
 from unittest import mock
 
-import dateutil
 import shapely
 from shapely import Polygon, geometry
 from shapely.errors import ShapelyError
@@ -44,7 +43,7 @@ class TestPluginCrunch(unittest.TestCase):
     __product_id: int = 0
 
     def __fake_search_result(
-        self, products_properties: list[dict[str:Any]]
+        self, products_properties: list[dict[str, Any]]
     ) -> SearchResult:
         """Mock search result"""
         search_results = []
@@ -156,7 +155,7 @@ class TestPluginCrunch(unittest.TestCase):
                 FilterDate(dict(start="invalid_date", end="2025-01-18"))
             )
             self.fail("Must not let pass invalid date format")
-        except dateutil.parser._parser.ParserError:
+        except ValidationError:
             pass
 
         try:
@@ -164,7 +163,7 @@ class TestPluginCrunch(unittest.TestCase):
                 FilterDate(dict(start="2025-01-16", end="wrong_date"))
             )
             self.fail("Must not let pass invalid date format")
-        except dateutil.parser._parser.ParserError:
+        except ValidationError:
             pass
 
         # Uncomplete products

--- a/tests/units/test_metadata_mapping.py
+++ b/tests/units/test_metadata_mapping.py
@@ -675,8 +675,8 @@ class TestMetadataFormatter(unittest.TestCase):
         to_format = "{id#split_id_into_s3_params}"
         expected = {
             "collection": "OL_2_LRR___",
-            "startDate": "2021-06-01T22:38:21Z",
-            "endDate": "2021-06-01T23:22:48Z",
+            "startDate": "2021-06-01T22:38:21.000Z",
+            "endDate": "2021-06-01T23:22:48.000Z",
             "timeliness": "NT",
             "sat": "Sentinel-3B",
         }
@@ -747,8 +747,8 @@ class TestMetadataFormatter(unittest.TestCase):
             format_metadata(to_format, text="20231019-20231020"),
             str(
                 {
-                    "startDate": "2023-10-19T00:00:00Z",
-                    "endDate": "2023-10-20T00:00:00Z",
+                    "startDate": "2023-10-19T00:00:00.000Z",
+                    "endDate": "2023-10-20T00:00:00.000Z",
                 }
             ),
         )
@@ -757,8 +757,8 @@ class TestMetadataFormatter(unittest.TestCase):
             format_metadata(to_format, text="20231019_20231020"),
             str(
                 {
-                    "startDate": "2023-10-19T00:00:00Z",
-                    "endDate": "2023-10-20T00:00:00Z",
+                    "startDate": "2023-10-19T00:00:00.000Z",
+                    "endDate": "2023-10-20T00:00:00.000Z",
                 }
             ),
         )
@@ -805,8 +805,8 @@ class TestMetadataFormatter(unittest.TestCase):
             ),
             str(
                 {
-                    "min_date": "2021-12-11T02:00:00Z",
-                    "max_date": "2021-12-12T02:00:00Z",
+                    "min_date": "2021-12-11T02:00:00.000Z",
+                    "max_date": "2021-12-12T02:00:00.000Z",
                 }
             ),
         )
@@ -817,8 +817,8 @@ class TestMetadataFormatter(unittest.TestCase):
             ),
             str(
                 {
-                    "min_date": "2022-06-01T00:00:00Z",
-                    "max_date": "2022-06-02T00:00:00Z",
+                    "min_date": "2022-06-01T00:00:00.000Z",
+                    "max_date": "2022-06-02T00:00:00.000Z",
                 }
             ),
         )

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -3399,34 +3399,34 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
             ecmwf_temporal_to_eodag(
                 dict(day="15", month="02", year="2022", time="0600")
             ),
-            ("2022-02-15T06:00:00Z", "2022-02-15T06:00:00Z"),
+            ("2022-02-15T06:00:00.000Z", "2022-02-15T06:00:00.000Z"),
         )
         self.assertEqual(
             ecmwf_temporal_to_eodag(dict(hday="15", hmonth="02", hyear="2022")),
-            ("2022-02-15T00:00:00Z", "2022-02-15T00:00:00Z"),
+            ("2022-02-15T00:00:00.000Z", "2022-02-15T00:00:00.000Z"),
         )
         self.assertEqual(
             ecmwf_temporal_to_eodag(dict(date="2022-02-15")),
-            ("2022-02-15T00:00:00Z", "2022-02-15T00:00:00Z"),
+            ("2022-02-15T00:00:00.000Z", "2022-02-15T00:00:00.000Z"),
         )
         self.assertEqual(
             ecmwf_temporal_to_eodag(
                 dict(date="2022-02-15T00:00:00Z/2022-02-16T00:00:00Z")
             ),
-            ("2022-02-15T00:00:00Z", "2022-02-16T00:00:00Z"),
+            ("2022-02-15T00:00:00.000Z", "2022-02-16T00:00:00.000Z"),
         )
         self.assertEqual(
             ecmwf_temporal_to_eodag(dict(date="20220215/to/20220216")),
-            ("2022-02-15T00:00:00Z", "2022-02-16T00:00:00Z"),
+            ("2022-02-15T00:00:00.000Z", "2022-02-16T00:00:00.000Z"),
         )
         # List of dates
         self.assertEqual(
             ecmwf_temporal_to_eodag(dict(date=["20220215", "20220216"])),
-            ("2022-02-15T00:00:00Z", "2022-02-16T00:00:00Z"),
+            ("2022-02-15T00:00:00.000Z", "2022-02-16T00:00:00.000Z"),
         )
         self.assertEqual(
             ecmwf_temporal_to_eodag(dict(date=["20220215"])),
-            ("2022-02-15T00:00:00Z", "2022-02-15T00:00:00Z"),
+            ("2022-02-15T00:00:00.000Z", "2022-02-15T00:00:00.000Z"),
         )
 
     def test_plugins_search_ecmwfsearch_get_available_values_from_contraints(self):
@@ -4224,11 +4224,11 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
             self.assertEqual(2, len(products_dataset1))
             self.assertEqual(1, len(products_dataset2))
             self.assertEqual(
-                "2020-01-02T00:00:00Z",
+                "2020-01-02T00:00:00.000Z",
                 products_dataset2[0].properties["start_datetime"],
             )
             self.assertEqual(
-                "2020-01-03T00:00:00Z",
+                "2020-01-03T00:00:00.000Z",
                 products_dataset2[0].properties["end_datetime"],
             )
 
@@ -5219,8 +5219,8 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
         self.assertEqual(8, count)
         self.assertEqual(5, len(products))
         properties = products[0].properties
-        self.assertEqual("2000-01-01T00:00:00Z", properties["start_datetime"])
-        self.assertEqual("2000-12-31T23:59:59Z", properties["end_datetime"])
+        self.assertEqual("2000-01-01T00:00:00.000Z", properties["start_datetime"])
+        self.assertEqual("2000-12-31T23:59:59.000Z", properties["end_datetime"])
         self.assertEqual("2000", properties["year"])
         self.assertEqual("EPSG:4326", properties["proj:code"])
         self.assertEqual(
@@ -5315,8 +5315,8 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
         self.assertEqual(1, count)
         self.assertEqual(1, len(products))
         properties = products[0].properties
-        self.assertEqual("2011-02-01T00:00:00Z", properties["start_datetime"])
-        self.assertEqual("2011-02-28T23:59:59Z", properties["end_datetime"])
+        self.assertEqual("2011-02-01T00:00:00.000Z", properties["start_datetime"])
+        self.assertEqual("2011-02-28T23:59:59.000Z", properties["end_datetime"])
         self.assertEqual("2011", properties["year"])
         self.assertEqual("02", properties["month"])
         assets = products[0].assets

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import ast
-import datetime
+import datetime as dt
 import json
 import os
 import re
@@ -4544,8 +4544,8 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
                 contents = [
                     {
                         "Key": f"{prefix}/{asset_filename}",
-                        "LastModified": datetime.datetime(
-                            2020, 1, 15, tzinfo=datetime.timezone.utc
+                        "LastModified": dt.datetime(
+                            2020, 1, 15, tzinfo=dt.timezone.utc
                         ),
                         "ETag": '"d41d8cd98f00b204e9800998ecf8427e"',
                         "Size": 666,

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -17,13 +17,13 @@
 # limitations under the License.
 
 import copy
+import datetime as dt
 import logging
 import os
 import ssl
 import sys
 import unittest
 from contextlib import closing
-from datetime import datetime, timezone
 from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -75,8 +75,10 @@ class TestUtils(unittest.TestCase):
         # Date to timestamp to date, this assumes the date is in UTC
         requested_date = "2020-08-08"  # Considered as 2020-08-08T00:00:00Z
         ts_in_secs = get_timestamp(requested_date)
-        expected_dt = dateutil_parser.parse(requested_date).replace(tzinfo=timezone.utc)
-        actual_utc_dt = datetime.fromtimestamp(ts_in_secs, timezone.utc)
+        expected_dt = dateutil_parser.parse(requested_date).replace(
+            tzinfo=dt.timezone.utc
+        )
+        actual_utc_dt = dt.datetime.fromtimestamp(ts_in_secs, dt.timezone.utc)
         self.assertEqual(actual_utc_dt, expected_dt)
 
         # Handle UTC datetime

--- a/tests/units/test_utils_s3.py
+++ b/tests/units/test_utils_s3.py
@@ -24,6 +24,7 @@ from tests.context import (
     list_files_in_s3_zipped_object,
     open_s3_zipped_object,
     stream_download_from_s3,
+    to_iso_utc_string,
     update_assets_from_s3,
 )
 
@@ -220,9 +221,9 @@ class TestUtilsS3(TestCase):
         self.assertEqual(len(self.prod.assets), 3)
 
         def s3_updated(key):
-            return self.s3_client.head_object(Bucket="mybucket", Key=key)[
-                "LastModified"
-            ].strftime("%Y-%m-%dT%H:%M:%SZ")
+            return to_iso_utc_string(
+                self.s3_client.head_object(Bucket="mybucket", Key=key)["LastModified"]
+            )
 
         expected_assets = {
             "MTD_MSIL1C.xml": {


### PR DESCRIPTION
Harmonizes dates parsing and handling, and uses common methods from [eodag.utils.dates](https://eodag.readthedocs.io/en/latest/api_reference/utils.html#module-eodag.utils.dates)