### PR TITLE
fix(plugins): EcmwfSearch pre-processing of date parameters

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -635,9 +635,9 @@ class ECMWFSearch(PostJsonSearch):
         if year is not None:
             indirects["year"] = year
         if month is not None:
-            indirects["month"] = ["{:02d}".format(int(m)) for m in month]
+            indirects["month"] = [f"{int(m):02d}" for m in month]
         if day is not None:
-            indirects["day"] = ["{:02d}".format(int(d)) for d in day]
+            indirects["day"] = [f"{int(d):02d}" for d in day]
 
         # Compute date range from "date" param (takes precedence)
         date = params.get("date", None)
@@ -657,8 +657,8 @@ class ECMWFSearch(PostJsonSearch):
         # Compute date range from year/month/day/time params
         start, end = compute_date_range_from_params(
             year=year,
-            month=(indirects["month"] if month else None),
-            day=(indirects["day"] if day else None),
+            month=indirects.get("month"),
+            day=indirects.get("day"),
             time=time,
         )
         if start is not None:
@@ -1251,14 +1251,9 @@ class ECMWFSearch(PostJsonSearch):
 
             # start_datetime /  computed from "date", "time", "year", "month", "day"
             indirects = self._preprocess_indirect_date_parameters(result_data)
-            if result_data.get(START) is None:
-                value = indirects.get("start_datetime", None)
-                if value is not None:
-                    result_data[START] = value
-            if result_data.get(END) is None:
-                value = indirects.get("end_datetime", None)
-                if value is not None:
-                    result_data[END] = value
+            for key in (START, END):
+                if result_data.get(key) is None and indirects.get(key) is not None:
+                    result_data[key] = indirects[key]
 
             properties = properties_from_json(
                 result_data,

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -495,7 +495,7 @@ class ECMWFSearch(PostJsonSearch):
         collection = prep.collection
         if not collection:
             collection = kwargs.get("collection")
-        kwargs = self._preprocess_search_params(kwargs, collection)
+        kwargs = self._preprocess_search_params(kwargs)
         result = super().query(prep, **kwargs)
         if prep.count and not result.number_matched:
             result.number_matched = 1
@@ -529,9 +529,7 @@ class ECMWFSearch(PostJsonSearch):
             collection=collection, query_dict=ordered_kwargs
         )
 
-    def _preprocess_search_params(
-        self, params: dict[str, Any], collection: Optional[str]
-    ) -> dict[str, Any]:
+    def _preprocess_search_params(self, params: dict[str, Any]) -> dict[str, Any]:
         """Preprocess search parameters before making a request to the CDS API.
 
         This method is responsible for checking and updating the provided search parameters
@@ -540,7 +538,6 @@ class ECMWFSearch(PostJsonSearch):
         in the input parameters, default values or values from the configuration are used.
 
         :param params: Search parameters to be preprocessed.
-        :param collection: (optional) collection id
         """
 
         _dc_qs = params.get("_dc_qs")
@@ -571,17 +568,6 @@ class ECMWFSearch(PostJsonSearch):
             start_date, end_date = parse_date(params["date"])
             params[START] = format_date(start_date)
             params[END] = format_date(end_date)
-
-        # start_datetime /  computed from "date", "time", "year", "month", "day"
-        indirects = self._preprocess_indirect_date_parameters(params)
-        if params.get(START) is None:
-            value = indirects.get("start_datetime", None)
-            if value is not None:
-                params[START] = value
-        if params.get(END) is None:
-            value = indirects.get("end_datetime", None)
-            if value is not None:
-                params[END] = value
 
         # adapt end date if it is midnight
         if END in params:
@@ -649,9 +635,9 @@ class ECMWFSearch(PostJsonSearch):
         if year is not None:
             indirects["year"] = year
         if month is not None:
-            indirects["month"] = month
+            indirects["month"] = ["{:02d}".format(int(m)) for m in month]
         if day is not None:
-            indirects["day"] = day
+            indirects["day"] = ["{:02d}".format(int(d)) for d in day]
 
         # Compute date range from "date" param (takes precedence)
         date = params.get("date", None)
@@ -670,7 +656,10 @@ class ECMWFSearch(PostJsonSearch):
 
         # Compute date range from year/month/day/time params
         start, end = compute_date_range_from_params(
-            year=year, month=month, day=day, time=time
+            year=year,
+            month=(indirects["month"] if month else None),
+            day=(indirects["day"] if day else None),
+            time=time,
         )
         if start is not None:
             indirects["start_datetime"] = start
@@ -738,9 +727,7 @@ class ECMWFSearch(PostJsonSearch):
 
         # extract default datetime and convert geometry
         try:
-            processed_filters = self._preprocess_search_params(
-                deepcopy(filters), collection
-            )
+            processed_filters = self._preprocess_search_params(deepcopy(filters))
         except Exception as e:
             raise ValidationError(e.args[0]) from e
 
@@ -1261,6 +1248,17 @@ class ECMWFSearch(PostJsonSearch):
                 **result_data,
                 **{k: v for k, v in kwargs.items() if v is not None},
             }
+
+            # start_datetime /  computed from "date", "time", "year", "month", "day"
+            indirects = self._preprocess_indirect_date_parameters(result_data)
+            if result_data.get(START) is None:
+                value = indirects.get("start_datetime", None)
+                if value is not None:
+                    result_data[START] = value
+            if result_data.get(END) is None:
+                value = indirects.get("end_datetime", None)
+                if value is not None:
+                    result_data[END] = value
 
             properties = properties_from_json(
                 result_data,

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2823,6 +2823,12 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
             eoproduct.properties["ecmwf:month"],
             ["2"],
         )
+        # qs (used for order request) should contain year/month/day but not date
+        self.assertIn("qs", eoproduct.properties)
+        self.assertIn("day", eoproduct.properties["qs"])
+        self.assertIn("month", eoproduct.properties["qs"])
+        self.assertIn("year", eoproduct.properties["qs"])
+        self.assertNotIn("date", eoproduct.properties["qs"])
 
     def test_plugins_search_ecmwfsearch_collection_with_alias(self):
         """alias of collection must be used in search result"""

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2799,6 +2799,30 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
             eoproduct.properties["ecmwf:day"],
             ["20", "21"],
         )
+        # month with one digit
+        results = self.search_plugin.query(
+            prep=PreparedSearch(),
+            collection="ERA5_SL",
+            **{
+                "ecmwf:year": "2020",
+                "ecmwf:month": ["2"],
+                "ecmwf:day": ["20", "21"],
+                "ecmwf:time": ["01:00"],
+            },
+        )
+        eoproduct = results.data[0]
+        self.assertEqual(
+            eoproduct.properties["start_datetime"],
+            "2020-02-20T01:00:00.000Z",
+        )
+        self.assertEqual(
+            eoproduct.properties["end_datetime"],
+            "2020-02-21T01:00:00.000Z",
+        )
+        self.assertEqual(
+            eoproduct.properties["ecmwf:month"],
+            ["2"],
+        )
 
     def test_plugins_search_ecmwfsearch_collection_with_alias(self):
         """alias of collection must be used in search result"""


### PR DESCRIPTION
fixes for the pre-processing of date parameters in EcmwfSearch plugin
- move the creation of start/end_datetime from year/month/day to `normalize_results` to avoid having date and year/month(/day) in order_request
- accept month and day values with one digit
