### PR TITLE
feat(providers): geodes order status

### DIFF
--- a/eodag/plugins/search/geodes.py
+++ b/eodag/plugins/search/geodes.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026, CS GROUP - France, https://www.csgroup.eu/
+#
+# This file is part of EODAG project
+#     https://www.github.com/CS-SI/EODAG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from typing import Any, List
+
+from eodag.api.product import EOProduct  # type: ignore
+from eodag.api.product.metadata_mapping import OFFLINE_STATUS, ONLINE_STATUS
+from eodag.api.search_result import RawSearchResult
+from eodag.plugins.search import PreparedSearch
+from eodag.plugins.search.qssearch import StacSearch
+
+logger = logging.getLogger("eodag.search.geodes")
+
+
+class GeodesSearch(StacSearch):
+    """``GeodesSearch`` is an extension of :class:`~eodag.plugins.search.qssearch.StacSearch`.
+
+    It executes a Search on given STAC API endpoint and updates assets with content listed by the plugin using
+    ``eodag:download_link`` :class:`~eodag.api.product._product.EOProduct` property.
+
+    :param provider: provider name
+    :param config: It has the same Search plugin configuration as :class:`~eodag.plugins.search.qssearch.StacSearch` and
+                   one additional parameter:
+
+        * :attr:`~eodag.config.PluginConfig.s3_endpoint` (``str``): s3 endpoint if not hosted on AWS
+    """
+
+    def __init__(self, provider, config):
+        super(GeodesSearch, self).__init__(provider, config)
+
+    def _get_availability(self, products: list[EOProduct]) -> dict[str, Any]:
+        """Get availability information for the products from the provider's 'fastavailability' endpoint."""
+        body: dict[str, list] = {"availability": []}
+        for product in products:
+            download_link = product.properties.get("eodag:download_link")
+            endpoint_url = product.properties.get("geodes:endpoint_url")
+            if download_link and endpoint_url:
+                body["availability"].append(
+                    {"href": download_link, "endpointURL": endpoint_url}
+                )
+
+        url = self.config.api_endpoint.replace("api/stac/search", "fastavailability")
+        prep = PreparedSearch(url=url)
+        prep.query_params = body
+
+        logger.debug("Get products availability information from %s", url)
+        resp = self._request(prep)
+
+        return resp.json()
+
+    def _set_availability(self, products: list[EOProduct]) -> None:
+        """Set availability information on the products."""
+        availability_dict = self._get_availability(products)
+        updated = 0
+
+        for product in products:
+            download_link = product.properties.get("eodag:download_link")
+
+            # find matching product
+            product_availability_list = [
+                a
+                for a in availability_dict.get("products", [])
+                if a.get("id") in download_link
+            ]
+            if len(product_availability_list) != 1:
+                continue
+            product_availability = product_availability_list[0]
+
+            # find matching asset
+            asset_availability_list = [
+                a.get("available")
+                for a in product_availability.get("files", {})
+                if a.get("checksum") in download_link
+            ]
+            if len(asset_availability_list) != 1:
+                continue
+            asset_availability = asset_availability_list[0]
+
+            # set status
+            product.properties["order:status"] = (
+                ONLINE_STATUS if asset_availability else OFFLINE_STATUS
+            )
+
+            updated += 1
+
+        if updated < len(products):
+            logger.warning(
+                "Could not update availability for %d out of %d products",
+                len(products) - updated,
+                len(products),
+            )
+
+    def normalize_results(
+        self, results: RawSearchResult, **kwargs: Any
+    ) -> List[EOProduct]:
+        """Build EOProducts from provider results"""
+
+        products = super(GeodesSearch, self).normalize_results(results, **kwargs)
+
+        self._set_availability(products)
+
+        return products

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -85,6 +85,7 @@ from eodag.utils import (
     REQ_RETRY_BACKOFF_FACTOR,
     REQ_RETRY_STATUS_FORCELIST,
     REQ_RETRY_TOTAL,
+    STAC_SEARCH_PLUGINS,
     USER_AGENT,
     copy_deepcopy,
     deepcopy,
@@ -2102,8 +2103,19 @@ class StacSearch(PostJsonSearch):
     """
 
     def __init__(self, provider: str, config: PluginConfig) -> None:
-        # backup results_entry overwritten by init
-        results_entry = config.results_entry
+        try:
+            # backup results_entry overwritten by init
+            results_entry = config.results_entry
+        except AttributeError:
+            plugin_name = self.__class__.__name__
+            if plugin_name not in STAC_SEARCH_PLUGINS:
+                raise MisconfiguredError(
+                    "Missing results_entry in %s configuration. If %s is expected to be used as "
+                    "a STAC plugin, it must be referenced in STAC_SEARCH_PLUGINS."
+                    % (provider, plugin_name)
+                )
+            else:
+                raise
 
         super(StacSearch, self).__init__(provider, config)
 

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -5934,7 +5934,7 @@
   description: French National Space Agency (CNES) Earth Observation portal
   url: https://geodes.cnes.fr
   search: !plugin
-    type: StacSearch
+    type: GeodesSearch
     api_endpoint: https://geodes-portal.cnes.fr/api/stac/search
     need_auth: false
     asset_key_from_href: false
@@ -6017,8 +6017,8 @@
       eodag:download_link: '$.assets[?(@.roles[0] == "data") & (@.type != "application/xml")].href'
       eodag:quicklook: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
       eodag:thumbnail: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
-      # order:status set to succeeded for consistency between providers
-      order:status: '{$.null#replace_str("Not Available","succeeded")}'
+      # order:status set to orderable by default and then updated from plugin
+      order:status: '{$.null#replace_str("Not Available","orderable")}'
   products:
     S1_SAR_OCN:
       product:type: OCN

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -97,6 +97,7 @@ GENERIC_STAC_PROVIDER = "generic_stac_provider"
 
 #: List of known STAC search plugins. Required to complete plugin configuration with STAC plugins specific features.
 STAC_SEARCH_PLUGINS = [
+    "GeodesSearch",
     "StacSearch",
     "StacListAssets",
     "StaticStacSearch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,7 @@ CreodiasS3Search = "eodag.plugins.search.creodias_s3:CreodiasS3Search"
 CopMarineSearch = "eodag.plugins.search.cop_marine:CopMarineSearch"
 StacListAssets = "eodag.plugins.search.stac_list_assets:StacListAssets"
 CopGhslSearch = "eodag.plugins.search.cop_ghsl:CopGhslSearch"
+GeodesSearch = "eodag.plugins.search.geodes:GeodesSearch"
 
 [tool.setuptools]
 include-package-data = true

--- a/tests/integration/test_core_search_results.py
+++ b/tests/integration/test_core_search_results.py
@@ -389,9 +389,8 @@ class TestCoreSearchResults(EODagTestCase):
         )
         mock__request.return_value = mock.Mock()
         with open(geodes_resp_file) as f:
-            mock__request.return_value.json.side_effect = [
-                json.load(f),
-            ]
+            # mock search result, then availability
+            mock__request.return_value.json.side_effect = [json.load(f), {}]
         prods = self.dag.search(
             provider="geodes", collection="S2_MSI_L1C", raise_errors=True
         )

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2584,6 +2584,249 @@ class TestSearchPluginStacSearch(BaseSearchPluginTest):
         # provider-only param still present
         self.assertIn("some_param", queryables)
 
+    def test_plugins_search_stacsearch_missing_results_entry_misconfigured(self):
+        """StacSearch must raise MisconfiguredError when results_entry is missing
+        for a subclass not referenced in STAC_SEARCH_PLUGINS"""
+        from eodag.config import PluginConfig
+        from eodag.plugins.search.qssearch import StacSearch
+
+        class _UnregisteredStacSearch(StacSearch):
+            pass
+
+        config = PluginConfig()
+        # do not set results_entry on purpose
+        with self.assertRaises(MisconfiguredError) as ctx:
+            _UnregisteredStacSearch("some_provider", config)
+        self.assertIn("results_entry", str(ctx.exception))
+        self.assertIn("_UnregisteredStacSearch", str(ctx.exception))
+        self.assertIn("STAC_SEARCH_PLUGINS", str(ctx.exception))
+
+    def test_plugins_search_stacsearch_missing_results_entry_reraises_for_known_plugin(
+        self,
+    ):
+        """StacSearch must re-raise AttributeError when results_entry is missing
+        for a subclass referenced in STAC_SEARCH_PLUGINS"""
+        from eodag.config import PluginConfig
+        from eodag.plugins.search.geodes import GeodesSearch
+
+        config = PluginConfig()
+        # GeodesSearch is in STAC_SEARCH_PLUGINS so AttributeError must be re-raised
+        with self.assertRaises(AttributeError):
+            GeodesSearch("geodes", config)
+
+
+class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
+    def setUp(self):
+        super(TestSearchPluginGeodesSearch, self).setUp()
+        self.provider = "geodes"
+        self.search_plugin = self.get_search_plugin(provider=self.provider)
+
+    def test_plugins_search_geodes_plugin_class(self):
+        """The geodes provider must use the GeodesSearch plugin"""
+        from eodag.plugins.search.geodes import GeodesSearch
+
+        self.assertIsInstance(self.search_plugin, GeodesSearch)
+
+    def _build_product(
+        self, identifier, checksum, endpoint_url="https://geodes.example/data"
+    ):
+        download_link = f"https://geodes.example/data/{identifier}/file_{checksum}.tif"
+        return EOProduct(
+            self.provider,
+            {
+                "id": identifier,
+                "geometry": "POINT (0 0)",
+                "eodag:download_link": download_link,
+                "geodes:endpoint_url": endpoint_url,
+            },
+        )
+
+    @mock.patch("eodag.plugins.search.geodes.GeodesSearch._request", autospec=True)
+    def test_plugins_search_geodes_get_availability(self, mock__request):
+        """_get_availability must POST to the fastavailability endpoint with the
+        download_link and endpoint_url for each product"""
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {"products": []}
+        mock__request.return_value = mock_response
+
+        p1 = self._build_product("PROD1", "abc")
+        p2 = self._build_product("PROD2", "def")
+
+        result = self.search_plugin._get_availability([p1, p2])
+
+        self.assertEqual(result, {"products": []})
+        self.assertEqual(mock__request.call_count, 1)
+        prep = mock__request.call_args.args[1]
+        # url must be derived from api_endpoint (replacing api/stac/search by fastavailability)
+        self.assertEqual(
+            prep.url,
+            self.search_plugin.config.api_endpoint.replace(
+                "api/stac/search", "fastavailability"
+            ),
+        )
+        self.assertEqual(
+            prep.query_params,
+            {
+                "availability": [
+                    {
+                        "href": p1.properties["eodag:download_link"],
+                        "endpointURL": "https://geodes.example/data",
+                    },
+                    {
+                        "href": p2.properties["eodag:download_link"],
+                        "endpointURL": "https://geodes.example/data",
+                    },
+                ]
+            },
+        )
+
+    @mock.patch("eodag.plugins.search.geodes.GeodesSearch._request", autospec=True)
+    def test_plugins_search_geodes_get_availability_skips_missing_fields(
+        self, mock__request
+    ):
+        """Products without eodag:download_link or geodes:endpoint_url must be skipped
+        in the availability request body"""
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {"products": []}
+        mock__request.return_value = mock_response
+
+        p_ok = self._build_product("PROD1", "abc")
+        p_no_url = EOProduct(
+            self.provider,
+            {
+                "id": "PROD2",
+                "geometry": "POINT (0 0)",
+                "eodag:download_link": "https://geodes.example/data/PROD2/file.tif",
+            },
+        )
+        p_no_link = EOProduct(
+            self.provider,
+            {
+                "id": "PROD3",
+                "geometry": "POINT (0 0)",
+                "geodes:endpoint_url": "https://geodes.example/data",
+            },
+        )
+
+        self.search_plugin._get_availability([p_ok, p_no_url, p_no_link])
+
+        prep = mock__request.call_args.args[1]
+        self.assertEqual(len(prep.query_params["availability"]), 1)
+        self.assertEqual(
+            prep.query_params["availability"][0]["href"],
+            p_ok.properties["eodag:download_link"],
+        )
+
+    @mock.patch(
+        "eodag.plugins.search.geodes.GeodesSearch._get_availability", autospec=True
+    )
+    def test_plugins_search_geodes_set_availability_online(self, mock_get_availability):
+        """_set_availability must set order:status to ONLINE when asset is available"""
+        from eodag.api.product.metadata_mapping import ONLINE_STATUS
+
+        product = self._build_product("PROD1", "abc")
+        mock_get_availability.return_value = {
+            "products": [
+                {
+                    "id": "PROD1",
+                    "files": [{"checksum": "abc", "available": True}],
+                }
+            ]
+        }
+
+        self.search_plugin._set_availability([product])
+
+        self.assertEqual(product.properties["order:status"], ONLINE_STATUS)
+
+    @mock.patch(
+        "eodag.plugins.search.geodes.GeodesSearch._get_availability", autospec=True
+    )
+    def test_plugins_search_geodes_set_availability_offline(
+        self, mock_get_availability
+    ):
+        """_set_availability must set order:status to OFFLINE when asset is not available"""
+        from eodag.api.product.metadata_mapping import OFFLINE_STATUS
+
+        product = self._build_product("PROD1", "abc")
+        mock_get_availability.return_value = {
+            "products": [
+                {
+                    "id": "PROD1",
+                    "files": [{"checksum": "abc", "available": False}],
+                }
+            ]
+        }
+
+        self.search_plugin._set_availability([product])
+
+        self.assertEqual(product.properties["order:status"], OFFLINE_STATUS)
+
+    @mock.patch(
+        "eodag.plugins.search.geodes.GeodesSearch._get_availability", autospec=True
+    )
+    def test_plugins_search_geodes_set_availability_no_match(
+        self, mock_get_availability
+    ):
+        """When no matching product/asset is found in the availability response,
+        order:status must be left unchanged and a warning must be logged"""
+        product = self._build_product("PROD1", "abc")
+        product.properties["order:status"] = "untouched"
+        # no matching id in response
+        mock_get_availability.return_value = {"products": []}
+
+        with self.assertLogs("eodag.search.geodes", level="WARNING") as log_ctx:
+            self.search_plugin._set_availability([product])
+
+        self.assertEqual(product.properties["order:status"], "untouched")
+        self.assertTrue(
+            any("Could not update availability" in m for m in log_ctx.output)
+        )
+
+    @mock.patch(
+        "eodag.plugins.search.geodes.GeodesSearch._get_availability", autospec=True
+    )
+    def test_plugins_search_geodes_set_availability_ambiguous_asset(
+        self, mock_get_availability
+    ):
+        """Products whose checksum matches more than one file must be skipped"""
+        product = self._build_product("PROD1", "abc")
+        product.properties["order:status"] = "untouched"
+        mock_get_availability.return_value = {
+            "products": [
+                {
+                    "id": "PROD1",
+                    "files": [
+                        {"checksum": "abc", "available": True},
+                        {"checksum": "abc", "available": False},
+                    ],
+                }
+            ]
+        }
+
+        with self.assertLogs("eodag.search.geodes", level="WARNING"):
+            self.search_plugin._set_availability([product])
+
+        self.assertEqual(product.properties["order:status"], "untouched")
+
+    @mock.patch(
+        "eodag.plugins.search.geodes.GeodesSearch._set_availability", autospec=True
+    )
+    @mock.patch(
+        "eodag.plugins.search.qssearch.StacSearch.normalize_results", autospec=True
+    )
+    def test_plugins_search_geodes_normalize_results_calls_set_availability(
+        self, mock_super_normalize, mock_set_availability
+    ):
+        """normalize_results must delegate to StacSearch.normalize_results and
+        then call _set_availability with the resulting products"""
+        product = self._build_product("PROD1", "abc")
+        mock_super_normalize.return_value = [product]
+
+        results = self.search_plugin.normalize_results([{}])
+
+        self.assertEqual(results, [product])
+        mock_set_availability.assert_called_once_with(self.search_plugin, [product])
+
 
 class TestSearchPluginMeteoblueSearch(BaseSearchPluginTest):
     @mock.patch("eodag.plugins.authentication.qsauth.requests.get", autospec=True)

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2040,13 +2040,14 @@ class TestSearchPluginStacSearch(BaseSearchPluginTest):
         )
         self.assertEqual(products[1].geometry.bounds, (-180.0, -90.0, 180.0, 90.0))
 
+    @mock.patch("eodag.plugins.search.geodes.GeodesSearch._request", autospec=True)
     @mock.patch(
         "eodag.api.product.drivers.base.DatasetDriver.guess_asset_key_and_roles",
         autospec=True,
     )
     @mock.patch.dict(QueryStringSearch.extract_properties, {"json": mock.MagicMock()})
     def test_plugins_search_stacsearch_normalize_asset_key_from_href(
-        self, mock_guess_asset_key_and_roles
+        self, mock_guess_asset_key_and_roles, mock_geodes_search_request
     ):
         """normalize_results must guess asset key from href if asset_key_from_href is set to True"""
 


### PR DESCRIPTION
closes https://github.com/CS-SI/eodag/issues/1777
closes #1861 (duplicate)

Updates `order:status` property in `geodes` search results using a new `GeodesSearch` plugin.

Order mechanism is not available in the current provider API, so it cannot be implemented for the moment.