### PR TITLE
ci: do not fetch collections on every PR merge

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -2,8 +2,6 @@ name: Fetch collections
 
 on:
   workflow_dispatch:
-  push:
-    branches: [develop]
   schedule:
     - cron: "0 6 * * *"
 


### PR DESCRIPTION
Do not run github action that fetches collections on every PR merge, just do it once per day or on-demand