### PR TITLE
fix: datetime interval parsing and normalize UTC output format

### DIFF
--- a/eodag/utils/dates.py
+++ b/eodag/utils/dates.py
@@ -146,15 +146,15 @@ def get_datetime(arguments: dict[str, Any]) -> tuple[Optional[str], Optional[str
 
     Examples:
         >>> get_datetime({"datetime": "2023-03-01/2023-03-31"})
-        ('2023-03-01T00:00:00', '2023-03-31T00:00:00')
+        ('2023-03-01T00:00:00Z', '2023-03-31T00:00:00Z')
         >>> get_datetime({"datetime": "2023-03-01"})
-        ('2023-03-01T00:00:00', '2023-03-01T00:00:00')
+        ('2023-03-01T00:00:00Z', '2023-03-01T00:00:00Z')
         >>> get_datetime({"datetime": "../2023-03-31"})
-        (None, '2023-03-31T00:00:00')
+        (None, '2023-03-31T00:00:00Z')
         >>> get_datetime({"datetime": "2023-03-01/.."})
-        ('2023-03-01T00:00:00', None)
+        ('2023-03-01T00:00:00Z', None)
         >>> get_datetime({"dtstart": "2023-03-01", "dtend": "2023-03-31"})
-        ('2023-03-01T00:00:00', '2023-03-31T00:00:00')
+        ('2023-03-01T00:00:00Z', '2023-03-31T00:00:00Z')
         >>> get_datetime({})
         (None, None)
     """
@@ -190,7 +190,7 @@ def get_date(date: Optional[str]) -> Optional[str]:
     Examples:
         >>> from eodag.utils.exceptions import ValidationError
         >>> get_date("2023-09-23")
-        '2023-09-23T00:00:00'
+        '2023-09-23T00:00:00Z'
         >>> get_date(None) is None
         True
         >>> get_date("invalid-date")  # doctest: +IGNORE_EXCEPTION_DETAIL
@@ -206,7 +206,7 @@ def get_date(date: Optional[str]) -> Optional[str]:
             dateutil.parser.parse(date)
             .replace(tzinfo=tz.UTC)
             .isoformat()
-            .replace("+00:00", "")
+            .replace("+00:00", "Z")
         )
     except ValueError as e:
         exc = ValidationError("invalid input date: %s" % e)

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -2705,8 +2705,8 @@ class TestCoreSearch(TestCoreBase):
         # with datetime
         base = {"datetime": "2021-01-01T00:00:00Z/2021-01-02T00:00:00Z"}
         _, prepared_search = self.dag._prepare_search(**base)
-        self.assertEqual(prepared_search["start_datetime"], "2021-01-01T00:00:00")
-        self.assertEqual(prepared_search["end_datetime"], "2021-01-02T00:00:00")
+        self.assertEqual(prepared_search["start_datetime"], "2021-01-01T00:00:00Z")
+        self.assertEqual(prepared_search["end_datetime"], "2021-01-02T00:00:00Z")
         # with both, start/end overwrites datetime
         base = {
             "start": "2020-01-01",


### PR DESCRIPTION
An issue occurred when using datetime intervals such as:
http://localhost:8000/collections/S1_SAR_GRD/items?datetime=2023-01-01T00:00:00Z/2023-02-01T00:00:00Z&filter=federation:backends=%27planetary_computer%27

This PR fixes the parsing of `/`-separated datetime ranges and normalizes all outputs to ISO 8601 format using the `Z` suffix for UTC.