### PR TITLE
fix: do not pop feature

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -481,7 +481,6 @@ class ECMWFSearch(PostJsonSearch):
         # ECMWF Polytope uses non-geojson structure for features
         if "feature" in params:
             params["geometry"] = get_geometry_from_ecmwf_feature(params["feature"])
-            params.pop("feature")
         # bounding box in area format
         if "area" in params:
             params["geometry"] = get_geometry_from_ecmwf_area(params["area"])


### PR DESCRIPTION
When doing a search on dedt_lumi or dedt_mn5 with feature, some parameters were mising. 
for exemple if we search with:
```
feature={
        "type": "timeseries",
        "points": [
                    [
                        -9.10,
                        38.78
                    ]
                ],
                "time_axis": "step",
                "range": {
                    "start": 0,
                    "end": 360
                },
                "axes": [
                    "latitude",
                    "longitude"
                ]
	}
```

We got this in the order: 
```
"feature": {
        "points": [
            [
                -9.1,
                38.78
            ]
        ],
        "type": "position"
    }
```
the parameter time_axis, range and axes were missing. 
By removing the params.pop("feature") we keep all the parameters.