### PR TITLE
fix(plugins): EcmwfSearch custom geometries handling

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -478,18 +478,17 @@ class ECMWFSearch(PostJsonSearch):
         # geometry
         if "geometry" in params:
             params["geometry"] = get_geometry_from_various(geometry=params["geometry"])
+
+        # check ecmwf geom format if given
         # ECMWF Polytope uses non-geojson structure for features
         if "feature" in params:
-            params["geometry"] = get_geometry_from_ecmwf_feature(params["feature"])
-            params.pop("feature")
+            get_geometry_from_ecmwf_feature(params["feature"])
         # bounding box in area format
         if "area" in params:
-            params["geometry"] = get_geometry_from_ecmwf_area(params["area"])
-            params.pop("area")
+            get_geometry_from_ecmwf_area(params["area"])
         # single location
         if "location" in params:
-            params["geometry"] = get_geometry_from_ecmwf_location(params["location"])
-            params.pop("location")
+            get_geometry_from_ecmwf_location(params["location"])
 
         return params
 
@@ -1163,6 +1162,26 @@ class ECMWFSearch(PostJsonSearch):
             # collection alias (required by opentelemetry-instrumentation-eodag)
             if alias := getattr(self.config, "collection_config", {}).get("alias"):
                 kwargs["collection"] = alias
+
+        # Convert ecmwf geometries for properties but keep original in qs
+        # ECMWF Polytope uses non-geojson structure for features
+        if "feature" in sorted_unpaginated_qp:
+            properties["geometry"] = get_geometry_from_ecmwf_feature(
+                sorted_unpaginated_qp["feature"]
+            )
+            properties.pop("feature", None)
+        # bounding box in area format
+        if "area" in sorted_unpaginated_qp:
+            properties["geometry"] = get_geometry_from_ecmwf_area(
+                sorted_unpaginated_qp["area"]
+            )
+            properties.pop("area", None)
+        # single location
+        if "location" in sorted_unpaginated_qp:
+            properties["geometry"] = get_geometry_from_ecmwf_location(
+                sorted_unpaginated_qp["location"]
+            )
+            properties.pop("location", None)
 
         qs = geojson.dumps(sorted_unpaginated_qp)
 

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -1292,15 +1292,19 @@ def get_geometry_from_ecmwf_feature(geom: dict[str, Any]) -> Optional[BaseGeomet
     )
 
 
-def get_geometry_from_ecmwf_area(area: list[float]) -> Optional[BaseGeometry]:
+def get_geometry_from_ecmwf_area(
+    area: Union[str, list[float]]
+) -> Optional[BaseGeometry]:
     """
     Creates a ``shapely.geometry`` from bounding box in area format.
 
-    area format: [max_lat,min_lon,min_lat,max_lon]
+    area format: [max_lat,min_lon,min_lat,max_lon] or "max_lat/min_lon/min_lat/max_lon"
 
     :param area: bounding box in area format.
     :returns: A Shapely polygon.
     """
+    if isinstance(area, str):
+        area = [float(x) for x in area.split("/")]
     if len(area) != 4:
         raise ValueError("The area must be a list of 4 values")
     max_lat, min_lon, min_lat, max_lon = area

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -3307,7 +3307,8 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         )
         eoproduct = results.data[0]
         assert eoproduct.properties["title"].startswith(self.collection)
-        assert eoproduct.geometry.bounds == (1.0, 2.0, 3.0, 4.0)
+        # geom converted using to_nwse_bounds
+        assert eoproduct.geometry.bounds == (2.0, 1.0, 4.0, 3.0)
         # check if collection_params is a subset of eoproduct.properties
         assert self.collection_params.items() <= eoproduct.properties.items()
 
@@ -3318,6 +3319,59 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         )
         eoproduct = results.data[0]
         assert eoproduct.properties["ecmwf:variable"] == "temperature"
+
+    def test_plugins_search_ecmwfsearch_with_area_keeps_qs(self):
+        """ECMWFSearch.query with ``area`` must expose geometry in properties and keep ``area`` in qs."""
+        # string format: "max_lat/min_lon/min_lat/max_lon"
+        area_str = "44.0/1.0/43.0/2.0"
+        results = self.search_plugin.query(
+            **self.query_dates, collection=self.collection, area=area_str
+        )
+        eoproduct = results.data[0]
+        # geometry on the EOProduct is the converted polygon
+        self.assertEqual(eoproduct.geometry.bounds, (1.0, 43.0, 2.0, 44.0))
+        # original ``area`` is preserved in qs (used for download/order request)
+        self.assertIn("qs", eoproduct.properties)
+        self.assertEqual(eoproduct.properties["qs"]["area"], area_str)
+        # ``area`` must not leak as a top-level property on the EOProduct
+        for key in ("area", "ecmwf:area", "ecmwf_area"):
+            self.assertNotIn(key, eoproduct.properties)
+
+    def test_plugins_search_ecmwfsearch_with_feature_keeps_qs(self):
+        """ECMWFSearch.query with ``feature`` must expose geometry in properties and keep ``feature`` in qs."""
+        feature = {
+            "shape": [
+                [43.0, 1.0],
+                [44.0, 1.0],
+                [44.0, 2.0],
+                [43.0, 2.0],
+                [43.0, 1.0],
+            ],
+            "type": "polygon",
+        }
+        results = self.search_plugin.query(
+            **self.query_dates, collection=self.collection, feature=feature
+        )
+        eoproduct = results.data[0]
+        self.assertEqual(eoproduct.geometry.bounds, (1.0, 43.0, 2.0, 44.0))
+        self.assertIn("qs", eoproduct.properties)
+        self.assertEqual(eoproduct.properties["qs"]["feature"], feature)
+        for key in ("feature", "ecmwf:feature", "ecmwf_feature"):
+            self.assertNotIn(key, eoproduct.properties)
+
+    def test_plugins_search_ecmwfsearch_with_location_keeps_qs(self):
+        """ECMWFSearch.query with ``location`` must expose geometry in properties and keep ``location`` in qs."""
+        location = {"latitude": 43.5, "longitude": 1.5}
+        results = self.search_plugin.query(
+            **self.query_dates, collection=self.collection, location=location
+        )
+        eoproduct = results.data[0]
+        # single location -> point-like polygon (bbox of a point)
+        self.assertEqual(eoproduct.geometry.bounds, (1.5, 43.5, 1.5, 43.5))
+        self.assertIn("qs", eoproduct.properties)
+        self.assertEqual(eoproduct.properties["qs"]["location"], location)
+        for key in ("location", "ecmwf:location", "ecmwf_location"):
+            self.assertNotIn(key, eoproduct.properties)
 
     def test_plugins_search_ecmwfsearch_with_custom_collection(self):
         """ECMWFSearch.query must build a EOProduct from input parameters with custom collection"""
@@ -3738,7 +3792,7 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
                 "collection": "CAMS_EU_AIR_QUALITY_RE",
                 "area": area,
             }
-            with self.assertRaises(ValidationError):
+            with self.assertRaises(ValidationError, msg=area):
                 self.search_plugin.discover_queryables(**params)
 
         # feature
@@ -3758,7 +3812,7 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
                 "collection": "CAMS_EU_AIR_QUALITY_RE",
                 "feature": feature,
             }
-            with self.assertRaises(ValidationError):
+            with self.assertRaises(ValidationError, msg=feature):
                 self.search_plugin.discover_queryables(**params)
 
         # location
@@ -3773,7 +3827,7 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
                 "collection": "CAMS_EU_AIR_QUALITY_RE",
                 "location": location,
             }
-            with self.assertRaises(ValidationError):
+            with self.assertRaises(ValidationError, msg=location):
                 self.search_plugin.discover_queryables(**params)
 
     @mock.patch("eodag.utils.requests.requests.sessions.Session.get", autospec=True)
@@ -4754,7 +4808,7 @@ class TestSearchPluginDedtLumi(BaseSearchPluginTest):
         )
         eoproduct = results.data[0]
 
-        self.assertDictEqual(_expected_feature, eoproduct.properties["ecmwf:feature"])
+        self.assertDictEqual(_expected_feature, eoproduct.properties["qs"]["feature"])
 
         # Unsupported multi-polygon
         with self.assertRaises(ValidationError):

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -33,7 +33,7 @@ from dateutil import parser as dateutil_parser
 from requests.exceptions import RequestException
 from shapely.geometry import Point, Polygon
 
-from eodag.utils import get_geometry_from_ecmwf_feature
+from eodag.utils import get_geometry_from_ecmwf_area, get_geometry_from_ecmwf_feature
 from tests.context import (
     HTTP_REQ_TIMEOUT,
     USER_AGENT,
@@ -446,3 +446,26 @@ class TestUtils(unittest.TestCase):
                 {"type": "circle", "center": [43.5, 1.5], "radius": 1.0}
             )
         )
+
+    def test_get_geometry_from_ecmwf_area_accepts_list_and_string(self):
+        """``get_geometry_from_ecmwf_area`` must accept both list and slash-separated string formats."""
+        # list format: [max_lat, min_lon, min_lat, max_lon]
+        geom_from_list = get_geometry_from_ecmwf_area([44.0, 1.0, 43.0, 2.0])
+        self.assertIsInstance(geom_from_list, Polygon)
+        self.assertEqual(geom_from_list.bounds, (1.0, 43.0, 2.0, 44.0))
+
+        # equivalent string format: "max_lat/min_lon/min_lat/max_lon"
+        geom_from_str = get_geometry_from_ecmwf_area("44.0/1.0/43.0/2.0")
+        self.assertIsInstance(geom_from_str, Polygon)
+        self.assertEqual(geom_from_str.bounds, (1.0, 43.0, 2.0, 44.0))
+
+        # both formats should produce equivalent geometries
+        self.assertTrue(geom_from_list.equals(geom_from_str))
+
+        # invalid string: wrong number of components
+        with self.assertRaises(ValueError):
+            get_geometry_from_ecmwf_area("44.0/1.0/43.0")
+
+        # invalid string: non-numeric content
+        with self.assertRaises(ValueError):
+            get_geometry_from_ecmwf_area("a/b/c/d")


### PR DESCRIPTION
Following https://github.com/CS-SI/eodag/pull/2149, fixes custom geometries handling in `EcmwfSearch`:

check custom geometry on search validation, build a shapely geometry for `EOProduct` attributes, and keep it as is in `qs` property used in order mechanism