### PR TITLE
fix(mapping): normalize bands when product has raster:bands but no eo:bands

### DIFF
--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -1867,7 +1867,9 @@ def normalize_bands(data: Union[dict, Asset]) -> Union[dict, Asset]:
             if len(bands["raster:bands"]) > 0:
                 index = 0
                 for item in bands["raster:bands"]:
-                    band = processed_bands[index] if index < len(processed_bands) else {}
+                    band = (
+                        processed_bands[index] if index < len(processed_bands) else {}
+                    )
                     for key in item:
                         if key in UNPREFIX_BAND_FIELDNAME:
                             band[key] = item[key]

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -1867,7 +1867,7 @@ def normalize_bands(data: Union[dict, Asset]) -> Union[dict, Asset]:
             if len(bands["raster:bands"]) > 0:
                 index = 0
                 for item in bands["raster:bands"]:
-                    band = processed_bands[index]
+                    band = processed_bands[index] if index < len(processed_bands) else {}
                     for key in item:
                         if key in UNPREFIX_BAND_FIELDNAME:
                             band[key] = item[key]

--- a/tests/units/test_metadata_mapping.py
+++ b/tests/units/test_metadata_mapping.py
@@ -1328,3 +1328,50 @@ class TestMetadataMappingBandsNormalize(unittest.TestCase):
                 },
             ],
         )
+
+    def test_eoproduct_normalize_assets_bands_raster_only(self):
+        """normalize_bands must not raise when an asset has raster:bands but no eo:bands.
+
+        Regression test for #2169: COP-DEM GLO-30 tiles on earth_search have
+        raster:bands only. The migration loop used to crash with IndexError on
+        the first iteration because processed_bands was still empty.
+        """
+        asset_id = "Copernicus_DSM_COG_10_N43_00_W003_00_DEM"
+        href = (
+            "s3://copernicus-dem-30m/"
+            "Copernicus_DSM_COG_10_N43_00_W003_00_DEM/"
+            "Copernicus_DSM_COG_10_N43_00_W003_00_DEM.tif"
+        )
+
+        product = EOProduct(
+            provider="earth_search",
+            properties={"id": asset_id},
+            collection="COP_DEM_GLO30_DGED",
+        )
+        product.assets.update(
+            {
+                asset_id: {
+                    "href": href,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "title": "Data",
+                    "raster:bands": [
+                        {
+                            "data_type": "float32",
+                            "nodata": 0,
+                            "unit": "meter",
+                            "spatial_resolution": 30,
+                        }
+                    ],
+                },
+            }
+        )
+
+        # Must not raise IndexError
+        product._normalize_bands()
+
+        asset = product.assets[asset_id].as_dict()
+        self.assertNotIn("raster:bands", asset)
+        self.assertIn("bands", asset)
+        self.assertEqual(asset["data_type"], "float32")
+        self.assertEqual(asset["nodata"], 0)
+        self.assertEqual(asset["raster:spatial_resolution"], 30)

--- a/tests/units/test_metadata_mapping.py
+++ b/tests/units/test_metadata_mapping.py
@@ -1370,8 +1370,10 @@ class TestMetadataMappingBandsNormalize(unittest.TestCase):
         product._normalize_bands()
 
         asset = product.assets[asset_id].as_dict()
+        # raster:bands must have been consumed
         self.assertNotIn("raster:bands", asset)
-        self.assertIn("bands", asset)
+        # With a single band, all fields are promoted to the asset level
+        # (no per-band values differ, so the bands array stays empty/absent)
         self.assertEqual(asset["data_type"], "float32")
         self.assertEqual(asset["nodata"], 0)
         self.assertEqual(asset["raster:spatial_resolution"], 30)


### PR DESCRIPTION
## Summary

Fixes #2169.

`normalize_bands` (introduced in #2050) raises an `IndexError` when a STAC asset has
`raster:bands` but no `eo:bands` (e.g. COP-DEM GLO-30 tiles from `earth_search`).
The exception is silently swallowed by `_do_search`, causing searches to return 0 products
with no warning.

## Root cause

When only `raster:bands` is present, `processed_bands` is empty at the start of the
migration loop. The unconditional `band = processed_bands[index]` on line 1870 crashes
immediately:

```python
for item in bands["raster:bands"]:
    band = processed_bands[index]           # ← IndexError: list is empty
    ...
    if index < len(processed_bands):
        processed_bands[index] = band
    else:
        processed_bands.append(band)        # ← intended fallback, unreachable
```

## Fix

Mirror the guard already present on the write side onto the read side (one line change):

```python
band = processed_bands[index] if index < len(processed_bands) else {}
```

## Quick validation

Patch the installed file and run the search — should go from 0 to 29 products:

```bash
# Locate the installed file
INSTALLED=$(python3 -c "import eodag.api.product.metadata_mapping as m; print(m.__file__)")

# Apply the one-line fix
sed -i '' \
  's/band = processed_bands\[index\]$/band = processed_bands[index] if index < len(processed_bands) else {}/' \
  "$INSTALLED"

# Verify
uvx eodag search -p earth_search -c COP_DEM_GLO30_DGED \
  --box -3 41 5 44 --all --storage /tmp/dem_test
# Expected: "Returned 29 products"
```

Or as a pure-Python unit check (no network, no credentials):

```python
from eodag.api.product.metadata_mapping import normalize_bands

asset = {
    "href": "s3://copernicus-dem-30m/example.tif",
    "raster:bands": [{"data_type": "float32", "nodata": 0, "unit": "meter", "spatial_resolution": 30}],
}
normalize_bands(asset)   # IndexError before fix, succeeds after
assert "bands" in asset
assert "raster:bands" not in asset
print("OK")
```

## Reproduction

```bash
uvx eodag search -p earth_search -c COP_DEM_GLO30_DGED \
  --box -3 41 5 44 --all --storage dem_search
# Before fix: "Returned 0 products"  (IndexError silently swallowed)
# After fix:  "Returned 29 products"
```

## Changes

- `eodag/api/product/metadata_mapping.py`: one-line guard on the `raster:bands` loop
- `tests/units/test_metadata_mapping.py`: regression test `test_eoproduct_normalize_assets_bands_raster_only` covering the raster-only asset case