### PR TITLE
fix(plugins): cop_marine asset urls

### DIFF
--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -192,7 +192,11 @@ class CopMarineSearch(StaticStacSearch):
         item_id = os.path.splitext(item_key.split("/")[-1])[0]
         if product_id and product_id != item_id:
             return None
-        download_url = s3_url + "/" + item_key
+        s3_url_parts = s3_url.split("/")
+        item_key_parts = [
+            part for part in item_key.split("/") if part not in s3_url_parts
+        ]
+        download_url = s3_url + "/" + "/".join(item_key_parts)
         geometry = (
             get_geometry_from_various(**dataset_item)
             or self.config.metadata_mapping["eodag:default_geometry"]

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -193,6 +193,8 @@ class CopMarineSearch(StaticStacSearch):
         if product_id and product_id != item_id:
             return None
         s3_url_parts = s3_url.split("/")
+        # create download url from s3_url and item_key,
+        # there are situations where the 2 overlap -> remove parts included in s3_url from item_key
         item_key_parts = [
             part for part in item_key.split("/") if part not in s3_url_parts
         ]

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -1311,10 +1311,7 @@ class QueryStringSearch(Search):
                 self.get_metadata_mapping(kwargs.get("collection")),
                 discovery_config=getattr(self.config, "discover_metadata", {}),
             )
-            # collection alias (required by opentelemetry-instrumentation-eodag)
-            if alias := getattr(self.config, "collection_config", {}).get("alias"):
-                kwargs["collection"] = alias
-            product = EOProduct(self.provider, properties, **kwargs)
+            product = EOProduct(self.provider, properties, **product_kwargs)
 
             additional_assets = self.get_assets_from_mapping(result)
             product.assets.update(additional_assets)

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -4583,7 +4583,74 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
         self.assertEqual(asset.get("cop_marine:owner_id"), "data-access")
         self.assertEqual(asset.get("cop_marine:owner_name"), "Data Access")
 
-    def test_plugins_search_postjsonsearch_discover_queryables(self):
+    def test_plugins_search_cop_marine_create_product(self):
+        """Test creation of EOProduct from input data"""
+        search_plugin = self.get_search_plugin("PRODUCT_A", self.provider)
+        s3_url = "https://s3.test.com/bucket1/native/PRODUCT_A/dataset-number-one"
+        item_key = "PRODUCT_A/dataset-number-one/item1_20010501"
+        collection_dict = {
+            "id": "PRODUCT_A",
+            "properties": {"a": "a", "b": "b"},
+            "assets": {"thumbnail": {"href": "https://www.abc.com/thumbnailA"}},
+        }
+        dataset_dict = {
+            "id": "dataset-number-one",
+            "properties": {
+                "c": "c",
+                "start_datetime": "2000-01-01T00:00:00Z",
+                "end_datetime": "2010-01-01T00:00:00Z",
+            },
+        }
+        product = search_plugin._create_product(
+            "PRODUCT_A", item_key, s3_url, dataset_dict, collection_dict
+        )
+        self.assertEqual("item1_20010501", product.properties["id"])
+        self.assertEqual("PRODUCT_A", product.collection)
+        self.assertEqual(
+            "2001-05-01T00:00:00.000Z", product.properties["start_datetime"]
+        )
+        self.assertEqual("2001-05-01T00:00:00.000Z", product.properties["end_datetime"])
+        self.assertEqual(
+            "https://www.abc.com/thumbnailA", product.properties["eodag:thumbnail"]
+        )
+        self.assertEqual("dataset-number-one", product.properties["dataset"])
+        self.assertEqual("a", product.properties["a"])
+        self.assertEqual("b", product.properties["b"])
+        self.assertEqual("c", product.properties["c"])
+        self.assertIn("native", product.assets)
+        self.assertEqual(
+            "https://s3.test.com/bucket1/native/PRODUCT_A/dataset-number-one/item1_20010501",
+            product.assets["native"]["href"],
+        )
+
+        # with use of dataset dates
+        product = search_plugin._create_product(
+            "PRODUCT_A", item_key, s3_url, dataset_dict, collection_dict, True
+        )
+        self.assertEqual("item1_20010501", product.properties["id"])
+        self.assertEqual("PRODUCT_A", product.collection)
+        self.assertEqual("2000-01-01T00:00:00Z", product.properties["start_datetime"])
+        self.assertEqual("2010-01-01T00:00:00Z", product.properties["end_datetime"])
+
+        # with asset properties
+        product = search_plugin._create_product(
+            "PRODUCT_A",
+            item_key,
+            s3_url,
+            dataset_dict,
+            collection_dict,
+            asset_properties={"z": "z"},
+        )
+        self.assertEqual("item1_20010501", product.properties["id"])
+        self.assertIn("native", product.assets)
+        self.assertEqual(
+            "https://s3.test.com/bucket1/native/PRODUCT_A/dataset-number-one/item1_20010501",
+            product.assets["native"]["href"],
+        )
+        self.assertIn("z", product.assets["native"])
+        self.assertEqual("z", product.assets["native"]["z"])
+
+    def test_plugins_search_cop_marine_discover_queryables(self):
         """Queryables discovery with a CopMarineSearch must return static queryables with an adaptative default value"""  # noqa
         search_plugin = self.get_search_plugin("PRODUCT_A", self.provider)
         kwargs = {"collection": "PRODUCT_A", "provider": self.provider}


### PR DESCRIPTION
- fix for incorrect download urls for `cop_marine` items 
- also removes some superfluous code (maybe came in due to merge error)