### PR TITLE
fix(queryables): do not use provider pattern on known queryable

### DIFF
--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -2279,15 +2279,25 @@ class StacSearch(PostJsonSearch):
                             eodag_queryable_type,
                             eodag_queryable_fieldinfo,
                         ) = eodag_queryable_args
-                        if ".Literal[" not in str(provider_queryable_type):
+                        provider_has_literal_type = ".Literal[" in str(
+                            provider_queryable_type
+                        )
+                        if not provider_has_literal_type:
                             # use eodag queryable type if provider one has no constraints
                             field_definition = eodag_queryable_type, field_definition[1]
 
-                        # merge provider and eodag queryables FieldInfo metadata
-                        merged_metadata = (
-                            field_definition[1].metadata
-                            + eodag_queryable_fieldinfo.metadata
-                        )
+                        # merge provider and eodag queryables FieldInfo metadata.
+                        # When the provider type has no Literal constraints we keep only eodag's metadata,
+                        # to avoid propagating provider-side constraints that target a different shape than
+                        # the eodag queryable type (patterns do not apply on parameters that
+                        # are parsed/formatted later).
+                        if provider_has_literal_type:
+                            merged_metadata = (
+                                field_definition[1].metadata
+                                + eodag_queryable_fieldinfo.metadata
+                            )
+                        else:
+                            merged_metadata = list(eodag_queryable_fieldinfo.metadata)
                         # build merged attributes: use provider value if set, otherwise fall back to eodag value
                         merged_attrs = {
                             attr_k: (

--- a/tests/context.py
+++ b/tests/context.py
@@ -75,7 +75,7 @@ from eodag.plugins.search.base import Search
 from eodag.plugins.search.build_search_result import ecmwf_temporal_to_eodag
 from eodag.plugins.search.qssearch import QueryStringSearch
 from eodag.types import model_fields_to_annotated
-from eodag.types.queryables import CommonQueryables, Queryables
+from eodag.types.queryables import CommonQueryables, Queryables, QueryablesDict
 from eodag.utils import (
     DEFAULT_MISSION_START_DATE,
     DEFAULT_SHAPELY_GEOMETRY,

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -69,6 +69,7 @@ from tests.context import (
     NotAvailableError,
     PluginManager,
     PreparedSearch,
+    QueryablesDict,
     QueryStringSearch,
     RequestError,
     TimeOutError,
@@ -2535,6 +2536,67 @@ class TestSearchPluginStacSearch(BaseSearchPluginTest):
         # non-empty attributes from provider
         self.assertEqual(sp_fi.description, "provider-only param")
         self.assertEqual(sp_fi.title, "Some param")
+
+    @mock.patch(
+        "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True
+    )
+    def test_plugins_search_stacsearch_discover_queryables_no_pattern_propagation(
+        self, mock_request
+    ):
+        """discover_queryables must not propagate provider `pattern` or other
+        constraints onto eodag queryables, which are parsed/formatted later.
+        """
+        provider_queryables = {
+            "type": "object",
+            "properties": {
+                # mimics planetary-computer strict ISO UTC pattern
+                "start_datetime": {
+                    "title": "Start datetime",
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "(\\+00:00|Z)$",
+                },
+                "end_datetime": {
+                    "title": "End datetime",
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "(\\+00:00|Z)$",
+                },
+            },
+        }
+        mock_request.return_value = mock.Mock()
+        mock_request.return_value.json.side_effect = [provider_queryables]
+        plugin = self.get_search_plugin(provider="dedl")
+        queryables = plugin.discover_queryables(
+            collection="CAMS_GAC_FORECAST", provider="dedl"
+        )
+
+        # "start" / "end" must be present and carry no `pattern` metadata
+        for key in ("start", "end"):
+            self.assertIn(key, queryables)
+            field_type, field_info = get_args(queryables[key])[:2]
+            self.assertEqual(field_type, str)
+            patterns = [
+                getattr(m, "pattern", None)
+                for m in field_info.metadata
+                if getattr(m, "pattern", None)
+                and getattr(m, "pattern", None) is not PydanticUndefined
+            ]
+            self.assertEqual(
+                patterns,
+                [],
+                f"unexpected pattern metadata propagated to `{key}`: {patterns}",
+            )
+
+        # build the pydantic model from these queryables and validate
+        model = QueryablesDict(**queryables).get_model()
+        model.model_validate(
+            {
+                "collection": "CAMS_GAC_FORECAST",
+                "start_datetime": "2024-01-01",
+                "end_datetime": "2024-01-31",
+            }
+        )
 
     @mock.patch(
         "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True


### PR DESCRIPTION
Fixes https://github.com/CS-SI/eodag/issues/2170

Do not use provider queryable constraint pattern on known queryable (e.g. `(\+00:00|Z)$` on `start`/`end` datetimes)