### PR TITLE
fix(plugins): check already downloaded in sanitized paths

### DIFF
--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -207,8 +207,6 @@ class Download(PluginTopic):
             self.config, "output_extension", ""
         )
 
-        # Strong asumption made here: all products downloaded will be zip files
-        # If they are not, the '.zip' extension will be removed when they are downloaded and returned as is
         prefix = os.path.abspath(output_dir)
         sanitized_title = sanitize(product.properties["title"])
         if sanitized_title == product.properties["title"]:
@@ -222,6 +220,16 @@ class Download(PluginTopic):
         fs_dir_path = (
             fs_path.replace(output_extension, "") if output_extension else fs_path
         )
+        # check also path without collision suffix that may be used as path dir
+        fs_path_without_suffix = os.path.join(
+            prefix, f"{sanitize(product.properties['title'])}{output_extension}"
+        )
+        fs_dir_path_without_suffix = (
+            fs_path_without_suffix.replace(output_extension, "")
+            if output_extension
+            else fs_path_without_suffix
+        )
+
         download_records_dir = os.path.join(prefix, ".downloaded")
         try:
             os.makedirs(download_records_dir)
@@ -260,7 +268,9 @@ class Download(PluginTopic):
                 ),
                 None,
             )
-        elif os.path.isfile(record_filename) and os.path.isdir(fs_dir_path):
+        elif os.path.isfile(record_filename) and (
+            os.path.isdir(fs_dir_path) or os.path.isdir(fs_dir_path_without_suffix)
+        ):
             logger.info(
                 f"Product already downloaded: {fs_dir_path}",
             )

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -186,6 +186,38 @@ class TestDownloadPluginBase(BaseDownloadPluginTest):
                 plugin._prepare_download(self.product, **download_kwargs)
                 self.assertIn("Product already downloaded", str(cm.output))
 
+    def test_plugins_download_base_prepare_download_record_file_collision_dir(self):
+        """Download._prepare_download must detect already-downloaded dir without collision suffix"""
+
+        self.product.properties["title"] = "title to sanitïze"
+        self.product.properties["id"] = "id alsô"
+        self.product.location = self.product.remote_location = "http://foo.bar"
+        self.product.collection = "foo"
+
+        with TemporaryDirectory() as output_dir:
+            download_kwargs = dict(output_dir=output_dir)
+            # directory created without the collision-avoidance suffix
+            # (e.g. extracted archive containing just the sanitized title)
+            product_path_dir = Path(output_dir) / "title_to_sanitize"
+            product_path_dir.mkdir()
+            (product_path_dir / "foo").touch()
+
+            recordfile_dir = Path(output_dir) / ".downloaded"
+            recordfile_dir.mkdir()
+            recordfile_path = (
+                recordfile_dir / hashlib.md5("foo-id alsô".encode("utf-8")).hexdigest()
+            )
+            recordfile_path.touch()
+
+            plugin = self.get_download_plugin(self.product)
+
+            with self.assertLogs(level="INFO") as cm:
+                fs_path, _ = plugin._prepare_download(self.product, **download_kwargs)
+                self.assertIn("Product already downloaded", str(cm.output))
+                self.assertEqual(
+                    fs_path, str(Path(output_dir) / "title_to_sanitize-id_also")
+                )
+
     def test_plugins_download_base_prepare_download_no_url(self):
         """Download._prepare_download must return None when no download url"""
 


### PR DESCRIPTION
Fixes the check for already downloaded products that have special characters in their `title` property and need to be sanitized.
There was an issue in the checked downloaded path, causing check miss.