### PR TITLE
fix(mapping): timestamps extension and eocat title mapping

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -6463,7 +6463,7 @@
     metadata_mapping:
       assets: '{$.assets#dict_with_roles(["data", "thumbnail", "overview"])}'
       eodag:download_link: '$.assets.enclosure.href'
-      instrument: '{$.properties.instruments#csv_list}'
+      title: '{$.properties.title#remove_extension}'
   products:
     GENERIC_COLLECTION:
       _collection: '{collection}'

--- a/eodag/resources/stac_provider.yml
+++ b/eodag/resources/stac_provider.yml
@@ -90,6 +90,9 @@ search:
     datetime: '$.properties.datetime'
     created: '$.properties.created'
     updated: '$.properties.updated'
+    published: '$.properties.published'
+    unpublished: '$.properties.unpublished'
+    expires: '$.properties.expires'
     start_datetime: '$.properties.start_datetime'
     end_datetime:
       - '{{"datetime":"{start_datetime#to_iso_utc_datetime}/{end_datetime#to_iso_utc_datetime}"}}'


### PR DESCRIPTION
Metadata mapping fixes:
- add [timestamps extension](https://github.com/stac-extensions/timestamps) fields to STAC provider base config
- remove extension from `eocat` `title` property mapping
- remove duplicate mapping of instruments for `eocat` into an inappropriate property