### PR TITLE
feat(plugins): usgs advanced search for geom and scene_filter

### DIFF
--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -31,6 +31,7 @@ from usgs import USGSAuthExpiredError, USGSError, api
 
 from eodag.api.product import EOProduct
 from eodag.api.product.metadata_mapping import (
+    format_query_params,
     mtd_cfg_as_conversion_and_querypath,
     properties_from_json,
 )
@@ -48,6 +49,7 @@ from eodag.utils import (
     format_dict_items,
     path_to_uri,
 )
+from eodag.utils.dates import to_iso_utc_string
 from eodag.utils.exceptions import (
     AuthenticationError,
     NoMatchingCollection,
@@ -165,40 +167,24 @@ class UsgsApi(Api):
         usgs_collection = format_dict_items(collection_def_params, **kwargs)[
             "_collection"
         ]
-        start_date = kwargs.pop("start_datetime", None)
-        end_date = kwargs.pop("end_datetime", None)
-        geom = kwargs.pop("geometry", None)
-        footprint: dict[str, str] = {}
-        if hasattr(geom, "bounds"):
-            (
-                footprint["lonmin"],
-                footprint["latmin"],
-                footprint["lonmax"],
-                footprint["latmax"],
-            ) = geom.bounds
-        else:
-            footprint = geom
+        if start_date := kwargs.pop("start_datetime", None):
+            start_date = to_iso_utc_string(start_date)
+        if end_date := kwargs.pop("end_datetime", None):
+            end_date = to_iso_utc_string(end_date)
+
+        # format query args to get scene_filter
+        formatted_kwargs = format_query_params(collection, self.config, kwargs)
+        scene_filter = formatted_kwargs.get("scene_filter")
 
         final: list[EOProduct] = []
-        if footprint and len(footprint.keys()) == 4:  # a rectangle (or bbox)
-            lower_left = {
-                "longitude": footprint["lonmin"],
-                "latitude": footprint["latmin"],
-            }
-            upper_right = {
-                "longitude": footprint["lonmax"],
-                "latitude": footprint["latmax"],
-            }
-        else:
-            lower_left, upper_right = None, None
+
         try:
             api_search_kwargs = dict(
                 start_date=start_date,
                 end_date=end_date,
-                ll=lower_left,
-                ur=upper_right,
                 max_results=limit,
                 starting_number=token,
+                scene_filter=scene_filter,
             )
 
             # search by id
@@ -277,7 +263,6 @@ class UsgsApi(Api):
                         collection=collection,
                         provider=self.provider,
                         properties=product_properties,
-                        geometry=footprint,
                     )
                 )
         except USGSError as e:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -33,13 +33,24 @@
       id:
         - '_ID'
         - '$.displayId'
-      geometry: '$.spatialBounds'
+      geometry:
+        - '{{"scene_filter": {{"spatialFilter": {{"filterType": "geojson", "geoJson": {geometry#to_geojson} }} }} }}'
+        - '$.spatialBounds'
       title: '$.displayId'
       description: '$.summary'
       eo:cloud_cover: '$.cloudCover'
       start_datetime: '{$.temporalCoverage.startDate#to_iso_utc_datetime}'
       end_datetime: '{$.temporalCoverage.endDate#to_iso_utc_datetime}'
       published: '{$.publishDate#to_iso_utc_datetime}'
+      ingest_after:
+        - '{{"scene_filter": {{"ingestFilter":{{"start":"{ingest_after#to_iso_utc_datetime}" }} }} }}'
+        - $.null
+      ingest_before:
+        - '{{"scene_filter": {{"ingestFilter":{{"end":"{ingest_before#to_iso_utc_datetime}" }} }} }}'
+        - $.null
+      scene_filter:
+        - '{{"scene_filter": {scene_filter#to_geojson} }}'
+        - $.null
       eodag:thumbnail: '$.browse[0].thumbnailPath'
       eodag:quicklook: '$.browse[0].browsePath'
       order:status: '{$.available#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ ecmwf = [
     "ecmwf-api-client",
 ]
 usgs = [
-    "usgs @ git+https://github.com/sbrunato/usgs.git@scene_filter"
+    "usgs >= 0.3.7",
 ]
 notebook = [
     "tqdm[notebook]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ ecmwf = [
     "ecmwf-api-client",
 ]
 usgs = [
-    "usgs >= 0.3.6",
+    "usgs @ git+https://github.com/sbrunato/usgs.git@scene_filter"
 ]
 notebook = [
     "tqdm[notebook]",

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -533,10 +533,25 @@ class TestApisPluginUsgsApi(BaseApisPluginTest):
         search_results = self.api_plugin.query(**search_kwargs)
         mock_api_scene_search.assert_called_once_with(
             "landsat_ot_c2_l1",
-            start_date="2020-02-01",
-            end_date="2020-02-10",
-            ll={"longitude": 10.0, "latitude": 20.0},
-            ur={"longitude": 30.0, "latitude": 40.0},
+            start_date="2020-02-01T00:00:00.000Z",
+            end_date="2020-02-10T00:00:00.000Z",
+            scene_filter={
+                "spatialFilter": {
+                    "filterType": "geojson",
+                    "geoJson": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [10.0, 20.0],
+                                [10.0, 40.0],
+                                [30.0, 40.0],
+                                [30.0, 20.0],
+                                [10.0, 20.0],
+                            ]
+                        ],
+                    },
+                }
+            },
             max_results=5,
             starting_number=6,
         )
@@ -614,14 +629,128 @@ class TestApisPluginUsgsApi(BaseApisPluginTest):
             where={"filter_id": "bar_id", "value": "SOME_PRODUCT_ID"},
             start_date=None,
             end_date=None,
-            ll=None,
-            ur=None,
+            scene_filter=None,
             max_results=500,
             starting_number=1,
         )
         self.assertEqual(search_results.data[0].provider, "usgs")
         self.assertEqual(search_results.data[0].collection, "LANDSAT_C2L1")
         self.assertEqual(len(search_results.data), 1)
+
+    @mock.patch("usgs.api.login", autospec=True)
+    @mock.patch("usgs.api.logout", autospec=True)
+    @mock.patch(
+        "usgs.api.scene_search",
+        autospec=True,
+        return_value=SCENE_SEARCH_RETURN,
+    )
+    @mock.patch(
+        "usgs.api.download_options",
+        autospec=True,
+        return_value=DOWNLOAD_OPTION_RETURN,
+    )
+    def test_plugins_apis_usgs_query_with_custom_scene_filter(
+        self,
+        mock_api_download_options,
+        mock_api_scene_search,
+        mock_api_logout,
+        mock_api_login,
+    ):
+        """UsgsApi.query must forward a user-provided scene_filter to the usgs api"""
+
+        custom_scene_filter = {
+            "cloudCoverFilter": {"min": 0, "max": 20, "includeUnknown": False},
+            "metadataFilter": {
+                "filterType": "value",
+                "filterId": "some_filter_id",
+                "value": "some_value",
+            },
+        }
+
+        search_kwargs = {
+            "collection": "LANDSAT_C2L1",
+            "start_datetime": "2020-02-01",
+            "end_datetime": "2020-02-10",
+            "scene_filter": custom_scene_filter,
+            "prep": PreparedSearch(
+                limit=5,
+            ),
+        }
+        search_kwargs["prep"].next_page_token = "6"
+        search_results = self.api_plugin.query(**search_kwargs)
+        mock_api_scene_search.assert_called_once_with(
+            "landsat_ot_c2_l1",
+            start_date="2020-02-01T00:00:00.000Z",
+            end_date="2020-02-10T00:00:00.000Z",
+            scene_filter=custom_scene_filter,
+            max_results=5,
+            starting_number=6,
+        )
+        self.assertEqual(search_results.data[0].provider, "usgs")
+        self.assertEqual(search_results.data[0].collection, "LANDSAT_C2L1")
+
+    @mock.patch("usgs.api.login", autospec=True)
+    @mock.patch("usgs.api.logout", autospec=True)
+    @mock.patch(
+        "usgs.api.scene_search",
+        autospec=True,
+        return_value=SCENE_SEARCH_RETURN,
+    )
+    @mock.patch(
+        "usgs.api.download_options",
+        autospec=True,
+        return_value=DOWNLOAD_OPTION_RETURN,
+    )
+    def test_plugins_apis_usgs_query_with_custom_scene_filter_and_geometry(
+        self,
+        mock_api_download_options,
+        mock_api_scene_search,
+        mock_api_logout,
+        mock_api_login,
+    ):
+        """UsgsApi.query must merge a user-provided scene_filter with the geometry-based one"""
+
+        custom_scene_filter = {
+            "cloudCoverFilter": {"min": 0, "max": 20, "includeUnknown": False},
+        }
+
+        search_kwargs = {
+            "collection": "LANDSAT_C2L1",
+            "start_datetime": "2020-02-01",
+            "end_datetime": "2020-02-10",
+            "geometry": get_geometry_from_various(geometry=[10, 20, 30, 40]),
+            "scene_filter": custom_scene_filter,
+            "prep": PreparedSearch(
+                limit=5,
+            ),
+        }
+        search_kwargs["prep"].next_page_token = "6"
+        self.api_plugin.query(**search_kwargs)
+        mock_api_scene_search.assert_called_once_with(
+            "landsat_ot_c2_l1",
+            start_date="2020-02-01T00:00:00.000Z",
+            end_date="2020-02-10T00:00:00.000Z",
+            scene_filter={
+                "spatialFilter": {
+                    "filterType": "geojson",
+                    "geoJson": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [10.0, 20.0],
+                                [10.0, 40.0],
+                                [30.0, 40.0],
+                                [30.0, 20.0],
+                                [10.0, 20.0],
+                            ]
+                        ],
+                    },
+                },
+                "cloudCoverFilter": {"min": 0, "max": 20, "includeUnknown": False},
+            },
+            max_results=5,
+            starting_number=6,
+        )
 
     @mock.patch("usgs.api.login", autospec=True)
     @mock.patch("usgs.api.logout", autospec=True)


### PR DESCRIPTION
Updates `UsgsApi` plugin and `usgs` provider configuration to support advanced search using polygon geometries (instead of bounding boxes), `ingest_after`/`ingest_before` parameters, and [scene_filter](https://m2m.cr.usgs.gov/api/docs/datatypes/#sceneFilter) filtering.

Example:
```py
results = dag.search(
    collection="LANDSAT_C2L1",
    start="2021-01-01", end_="2021-05-15",
    geom="POLYGON ((1.23 43.42, 1.23 43.76, 1.68 43.76, 1.68 43.42, 1.23 43.42))",
    scene_filter={"cloudCoverFilter": {"min": 20, "max": 30, "includeUnknown": False}},
    ingest_after="2022-06-01", ingest_before="2022-06-30"
)
```
Performs the following request for `landsat_ot_c2_l2` on `usgs` :
```
{
    'start_date': '2021-01-01T00:00:00.000Z', 
    'end_date': '2021-05-15T00:00:00.000Z',
    'max_results': 20,
    'starting_number': 1,
    'scene_filter': {
        'cloudCoverFilter': {'min': 10, 'max': 20, 'includeUnknown': False},
        'ingestFilter': {'start': '2022-06-01T00:00:00.000Z', 'end': '2022-06-30T00:00:00.000Z'},
        'spatialFilter': {'filterType': 'geojson', 'geoJson': {'type': 'Polygon', 'coordinates': [[[1.23, 43.42], [1.23, 43.76], [1.68, 43.76], [1.68, 43.42], [1.23, 43.42]]]}}
    }
}
```

Requires https://github.com/kapadia/usgs/pull/79