### PR TITLE
fix(queryables): check duplicates in queryables AliasChoices

### DIFF
--- a/eodag/types/stac_metadata.py
+++ b/eodag/types/stac_metadata.py
@@ -314,14 +314,17 @@ def create_stac_metadata_model(
     models = base_models + extension_models
 
     # check for duplicate field aliases (e.g., start_datetime and start in Queryables)
-    aliases: dict[str, Optional[str]] = dict()
-    duplicates = set()
+    alias_strings: set[str] = set()
+    duplicates: set[str] = set()
     for bm in base_models:
         for key, field in bm.model_fields.items():
-            if key not in aliases.keys() and key in aliases.values():
+            if key in alias_strings:
                 duplicates.add(key)
-            else:
-                aliases[key] = field.alias
+                continue
+            if isinstance(field.alias, AliasChoices):
+                alias_strings.update(str(c) for c in field.alias.choices)
+            elif field.alias:
+                alias_strings.add(field.alias)
 
     model = create_model(
         class_name,

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1913,6 +1913,14 @@ class TestCore(TestCoreBase):
         )
         self.assertTrue(item_sara_queryables.additional_properties)
 
+        # `start`/`end` from Queryables (aliased to `start_datetime`/`end_datetime`)
+        # must shadow `start_datetime`/`end_datetime` from CommonStacMetadata so that
+        # only the canonical short names are exposed as queryables.
+        self.assertIn("start", item_sara_queryables)
+        self.assertIn("end", item_sara_queryables)
+        self.assertNotIn("start_datetime", item_sara_queryables)
+        self.assertNotIn("end_datetime", item_sara_queryables)
+
         # additional_properties set to False for EcmwfSearch plugin
         cop_cds_queryables = self.dag.list_queryables(provider="cop_cds")
         self.assertFalse(cop_cds_queryables.additional_properties)


### PR DESCRIPTION
Removes duplicate queryables sharing the same alias.

e.g. for `start` and `start_datetime`, only keep `start` as it has `alias=AliasChoices("start_datetime","datetime")`