### PR TITLE
fix(providers): add missing usgs queryables

### DIFF
--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -49,7 +49,6 @@ from eodag.utils import (
     format_dict_items,
     path_to_uri,
 )
-from eodag.utils.dates import to_iso_utc_string
 from eodag.utils.exceptions import (
     AuthenticationError,
     NoMatchingCollection,
@@ -167,13 +166,11 @@ class UsgsApi(Api):
         usgs_collection = format_dict_items(collection_def_params, **kwargs)[
             "_collection"
         ]
-        if start_date := kwargs.pop("start_datetime", None):
-            start_date = to_iso_utc_string(start_date)
-        if end_date := kwargs.pop("end_datetime", None):
-            end_date = to_iso_utc_string(end_date)
 
         # format query args to get scene_filter
         formatted_kwargs = format_query_params(collection, self.config, kwargs)
+        start_date = formatted_kwargs.get("start_date")
+        end_date = formatted_kwargs.get("end_date")
         scene_filter = formatted_kwargs.get("scene_filter")
 
         final: list[EOProduct] = []

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING, Annotated, get_args
 
 import orjson
@@ -485,6 +486,9 @@ class Search(PluginTopic):
                 str, Field(default=collection_or_alias)
             ]
 
+        # provider prefix regex
+        prefix_re = re.compile(r"^" + re.escape(self.provider) + r"[_:]")
+
         for k, v in eodag_queryables.items():
             eodag_queryable_field_info = (
                 get_args(v)[1] if len(get_args(v)) > 1 else None
@@ -492,18 +496,22 @@ class Search(PluginTopic):
             if not isinstance(eodag_queryable_field_info, FieldInfo):
                 continue
             queryable_alias = eodag_queryable_field_info.alias
-            if isinstance(queryable_alias, AliasChoices):
-                in_metadata = (
-                    any(
-                        [
-                            a[0] in metadata_mapping
-                            for a in queryable_alias.convert_to_aliases()
-                        ]
-                    )
-                    or k in metadata_mapping
-                )
-            else:
-                in_metadata = (queryable_alias or k) in metadata_mapping
+            # Collect every alias under which the queryable could appear in the
+            # metadata_mapping (model field name + declared alias(es)).
+            candidates = (
+                [a[0] for a in queryable_alias.convert_to_aliases()]
+                if isinstance(queryable_alias, AliasChoices)
+                else [queryable_alias]
+            )
+            candidates.append(k)
+            # Core search strips the ``<provider>:`` / ``<provider>_`` prefix
+            # from user-supplied keys before sending them to the plugin, so the
+            # metadata_mapping may store the queryable under its unprefixed name.
+            in_metadata = any(
+                c in metadata_mapping or prefix_re.sub("", c) in metadata_mapping
+                for c in candidates
+                if c
+            )
             if eodag_queryable_field_info.is_required() or in_metadata:
                 queryables[k] = v
         return queryables

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -38,9 +38,15 @@
         - '$.spatialBounds'
       title: '$.displayId'
       description: '$.summary'
-      eo:cloud_cover: '$.cloudCover'
-      start_datetime: '{$.temporalCoverage.startDate#to_iso_utc_datetime}'
-      end_datetime: '{$.temporalCoverage.endDate#to_iso_utc_datetime}'
+      eo:cloud_cover:
+        - '{{"scene_filter": {{"cloudCoverFilter":{{"max":{eo:cloud_cover}, "includeUnknown": false }} }} }}'
+        - '$.cloudCover'
+      start_datetime:
+        - '{{"start_date": "{start_datetime#to_iso_utc_datetime}" }}'
+        - '{$.temporalCoverage.startDate#to_iso_utc_datetime}'
+      end_datetime:
+        - '{{"end_date": "{end_datetime#to_iso_utc_datetime}" }}'
+        - '{$.temporalCoverage.endDate#to_iso_utc_datetime}'
       published: '{$.publishDate#to_iso_utc_datetime}'
       ingest_after:
         - '{{"scene_filter": {{"ingestFilter":{{"start":"{ingest_after#to_iso_utc_datetime}" }} }} }}'

--- a/eodag/types/stac_extensions.py
+++ b/eodag/types/stac_extensions.py
@@ -654,6 +654,22 @@ class EcmwfExtension(BaseStacExtension):
         return self
 
 
+class UsgsFields(BaseModel):
+    """Custom fields for usgs provider."""
+
+    usgs_ingest_after: Annotated[str, Field(None)]
+    usgs_ingest_before: Annotated[str, Field(None)]
+    usgs_scene_filter: Annotated[dict[str, Any], Field(None)]
+
+
+class UsgsExtension(BaseStacExtension):
+    """Custom extension for provider usgs."""
+
+    FIELDS: type[BaseModel] = UsgsFields
+
+    field_name_prefix: Optional[str] = "usgs"
+
+
 STAC_EXTENSIONS = [
     SarExtension(),
     SatelliteExtension(),
@@ -673,4 +689,5 @@ STAC_EXTENSIONS = [
     LabelExtension(),
     FederationExtension(),
     EcmwfExtension(),
+    UsgsExtension(),
 ]

--- a/eodag/types/stac_extensions.py
+++ b/eodag/types/stac_extensions.py
@@ -509,7 +509,7 @@ class EcmwfItemProperties(BaseModel):
     ecmwf_area: Annotated[Union[str, list[float]], Field(None)]
     ecmwf_block: Annotated[str, Field(None)]
     ecmwf_channel: Annotated[str, Field(None)]
-    ecmwf_class: Optional[str] = Field(default=None, alias="class")
+    ecmwf_class: Optional[str] = Field(default=None)
     ecmwf_dataset: Annotated[str, Field(None)]
     ecmwf_date: Annotated[str, Field(None)]
     ecmwf_diagnostic: Annotated[str, Field(None)]
@@ -625,19 +625,17 @@ class EcmwfItemProperties(BaseModel):
     ecmwf_location: Annotated[dict[str, int], Field(None)]
 
 
-class EcmwfExtension(BaseStacExtension):
-    """STAC SAR extension."""
+class ProviderStacExtension(BaseStacExtension):
+    """Base class for provider-specific STAC extensions.
 
-    FIELDS: type[BaseModel] = EcmwfItemProperties
-
-    field_name_prefix: Optional[str] = "ecmwf"
+    Sets up field aliases so each field accepts both the stac-prefixed
+    (e.g. ``usgs:scene_filter``) and the no-prefix (e.g. ``scene_filter``)
+    forms as input, while serializing as the stac-prefixed form.
+    """
 
     @model_validator(mode="after")
-    def setup_field_aliases(self) -> "EcmwfExtension":
-        """Set up aliases for ECMWF fields, accepting both stac-prefixed and
-        no-prefix forms (e.g. 'ecmwf:data_format' and 'data_format') as input,
-        while serializing as the stac-prefixed form.
-        """
+    def setup_field_aliases(self) -> "ProviderStacExtension":
+        """Set up dual (prefixed/unprefixed) aliases on extension fields."""
         if self.field_name_prefix is None:
             return self
 
@@ -654,6 +652,14 @@ class EcmwfExtension(BaseStacExtension):
         return self
 
 
+class EcmwfExtension(ProviderStacExtension):
+    """STAC ECMWF extension."""
+
+    FIELDS: type[BaseModel] = EcmwfItemProperties
+
+    field_name_prefix: Optional[str] = "ecmwf"
+
+
 class UsgsFields(BaseModel):
     """Custom fields for usgs provider."""
 
@@ -662,7 +668,7 @@ class UsgsFields(BaseModel):
     usgs_scene_filter: Annotated[dict[str, Any], Field(None)]
 
 
-class UsgsExtension(BaseStacExtension):
+class UsgsExtension(ProviderStacExtension):
     """Custom extension for provider usgs."""
 
     FIELDS: type[BaseModel] = UsgsFields

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -649,14 +649,14 @@ class TestApisPluginUsgsApi(BaseApisPluginTest):
         autospec=True,
         return_value=DOWNLOAD_OPTION_RETURN,
     )
-    def test_plugins_apis_usgs_query_with_custom_scene_filter(
+    def test_plugins_apis_usgs_query_with_filters(
         self,
         mock_api_download_options,
         mock_api_scene_search,
         mock_api_logout,
         mock_api_login,
     ):
-        """UsgsApi.query must forward a user-provided scene_filter to the usgs api"""
+        """UsgsApi.query must translate filter kwargs into the proper scene_filter"""
 
         custom_scene_filter = {
             "cloudCoverFilter": {"min": 0, "max": 20, "includeUnknown": False},
@@ -666,91 +666,130 @@ class TestApisPluginUsgsApi(BaseApisPluginTest):
                 "value": "some_value",
             },
         }
-
-        search_kwargs = {
-            "collection": "LANDSAT_C2L1",
-            "start_datetime": "2020-02-01",
-            "end_datetime": "2020-02-10",
-            "scene_filter": custom_scene_filter,
-            "prep": PreparedSearch(
-                limit=5,
-            ),
-        }
-        search_kwargs["prep"].next_page_token = "6"
-        search_results = self.api_plugin.query(**search_kwargs)
-        mock_api_scene_search.assert_called_once_with(
-            "landsat_ot_c2_l1",
-            start_date="2020-02-01T00:00:00.000Z",
-            end_date="2020-02-10T00:00:00.000Z",
-            scene_filter=custom_scene_filter,
-            max_results=5,
-            starting_number=6,
-        )
-        self.assertEqual(search_results.data[0].provider, "usgs")
-        self.assertEqual(search_results.data[0].collection, "LANDSAT_C2L1")
-
-    @mock.patch("usgs.api.login", autospec=True)
-    @mock.patch("usgs.api.logout", autospec=True)
-    @mock.patch(
-        "usgs.api.scene_search",
-        autospec=True,
-        return_value=SCENE_SEARCH_RETURN,
-    )
-    @mock.patch(
-        "usgs.api.download_options",
-        autospec=True,
-        return_value=DOWNLOAD_OPTION_RETURN,
-    )
-    def test_plugins_apis_usgs_query_with_custom_scene_filter_and_geometry(
-        self,
-        mock_api_download_options,
-        mock_api_scene_search,
-        mock_api_logout,
-        mock_api_login,
-    ):
-        """UsgsApi.query must merge a user-provided scene_filter with the geometry-based one"""
-
-        custom_scene_filter = {
-            "cloudCoverFilter": {"min": 0, "max": 20, "includeUnknown": False},
+        geometry_scene_filter = {
+            "spatialFilter": {
+                "filterType": "geojson",
+                "geoJson": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [10.0, 20.0],
+                            [10.0, 40.0],
+                            [30.0, 40.0],
+                            [30.0, 20.0],
+                            [10.0, 20.0],
+                        ]
+                    ],
+                },
+            },
         }
 
-        search_kwargs = {
-            "collection": "LANDSAT_C2L1",
-            "start_datetime": "2020-02-01",
-            "end_datetime": "2020-02-10",
-            "geometry": get_geometry_from_various(geometry=[10, 20, 30, 40]),
-            "scene_filter": custom_scene_filter,
-            "prep": PreparedSearch(
-                limit=5,
-            ),
-        }
-        search_kwargs["prep"].next_page_token = "6"
-        self.api_plugin.query(**search_kwargs)
-        mock_api_scene_search.assert_called_once_with(
-            "landsat_ot_c2_l1",
-            start_date="2020-02-01T00:00:00.000Z",
-            end_date="2020-02-10T00:00:00.000Z",
-            scene_filter={
-                "spatialFilter": {
-                    "filterType": "geojson",
-                    "geoJson": {
-                        "type": "Polygon",
-                        "coordinates": [
-                            [
-                                [10.0, 20.0],
-                                [10.0, 40.0],
-                                [30.0, 40.0],
-                                [30.0, 20.0],
-                                [10.0, 20.0],
-                            ]
-                        ],
+        cases = [
+            {
+                "description": "user-provided scene_filter is forwarded as-is",
+                "kwargs": {
+                    "start_datetime": "2020-02-01",
+                    "end_datetime": "2020-02-10",
+                    "scene_filter": custom_scene_filter,
+                },
+                "expected_kwargs": {
+                    "start_date": "2020-02-01T00:00:00.000Z",
+                    "end_date": "2020-02-10T00:00:00.000Z",
+                    "scene_filter": custom_scene_filter,
+                },
+            },
+            {
+                "description": "user-provided scene_filter is merged with geometry",
+                "kwargs": {
+                    "start_datetime": "2020-02-01",
+                    "end_datetime": "2020-02-10",
+                    "geometry": get_geometry_from_various(geometry=[10, 20, 30, 40]),
+                    "scene_filter": {
+                        "cloudCoverFilter": {
+                            "min": 0,
+                            "max": 20,
+                            "includeUnknown": False,
+                        },
                     },
                 },
-                "cloudCoverFilter": {"min": 0, "max": 20, "includeUnknown": False},
+                "expected_kwargs": {
+                    "start_date": "2020-02-01T00:00:00.000Z",
+                    "end_date": "2020-02-10T00:00:00.000Z",
+                    "scene_filter": {
+                        **geometry_scene_filter,
+                        "cloudCoverFilter": {
+                            "min": 0,
+                            "max": 20,
+                            "includeUnknown": False,
+                        },
+                    },
+                },
             },
-            max_results=5,
-            starting_number=6,
+            {
+                "description": "eo:cloud_cover is translated into cloudCoverFilter",
+                "kwargs": {
+                    "start_datetime": "2020-02-01",
+                    "end_datetime": "2020-02-10",
+                    "eo:cloud_cover": 20,
+                },
+                "expected_kwargs": {
+                    "start_date": "2020-02-01T00:00:00.000Z",
+                    "end_date": "2020-02-10T00:00:00.000Z",
+                    "scene_filter": {
+                        "cloudCoverFilter": {"max": 20, "includeUnknown": False}
+                    },
+                },
+            },
+            {
+                "description": "ingest_after/ingest_before are translated into ingestFilter",
+                "kwargs": {
+                    "ingest_after": "2020-02-01",
+                    "ingest_before": "2020-02-10",
+                },
+                "expected_kwargs": {
+                    "start_date": None,
+                    "end_date": None,
+                    "scene_filter": {
+                        "ingestFilter": {
+                            "start": "2020-02-01T00:00:00.000Z",
+                            "end": "2020-02-10T00:00:00.000Z",
+                        },
+                    },
+                },
+            },
+        ]
+
+        for case in cases:
+            with self.subTest(case["description"]):
+                mock_api_scene_search.reset_mock()
+                search_kwargs = {
+                    "collection": "LANDSAT_C2L1",
+                    "prep": PreparedSearch(limit=5),
+                    **case["kwargs"],
+                }
+                search_kwargs["prep"].next_page_token = "1"
+                self.api_plugin.query(**search_kwargs)
+                mock_api_scene_search.assert_called_once_with(
+                    "landsat_ot_c2_l1",
+                    max_results=5,
+                    starting_number=1,
+                    **case["expected_kwargs"],
+                )
+
+    def test_plugins_apis_usgs_queryables_from_metadata_mapping(self):
+        """USGS plugin must expose usgs-prefixed STAC extension fields as queryables"""
+        queryables = self.api_plugin.queryables_from_metadata_mapping(
+            collection="LANDSAT_C2L1"
         )
+        # Custom UsgsExtension fields (prefixed) must be present despite the
+        # metadata_mapping storing them under their unprefixed names.
+        self.assertIn("usgs_scene_filter", queryables)
+        self.assertIn("usgs_ingest_after", queryables)
+        self.assertIn("usgs_ingest_before", queryables)
+        # Standard STAC fields backed by metadata_mapping entries must remain.
+        self.assertIn("eo_cloud_cover", queryables)
+        self.assertIn("start", queryables)
+        self.assertIn("end", queryables)
 
     @mock.patch("usgs.api.login", autospec=True)
     @mock.patch("usgs.api.logout", autospec=True)

--- a/tests/units/test_search_types.py
+++ b/tests/units/test_search_types.py
@@ -238,6 +238,19 @@ class TestQueryables(unittest.TestCase):
             field.validation_alias.choices, ["ecmwf:data_format", "data_format"]
         )
 
+    def test_usgs_extension_dual_aliases(self):
+        """UsgsFields must expose both stac-prefixed and unprefixed aliases via
+        the shared ProviderStacExtension base class."""
+        from eodag.types.stac_extensions import UsgsFields
+
+        for unprefixed in ("scene_filter", "ingest_after", "ingest_before"):
+            field = UsgsFields.model_fields[f"usgs_{unprefixed}"]
+            prefixed = f"usgs:{unprefixed}"
+            self.assertEqual(field.alias, prefixed)
+            self.assertEqual(field.serialization_alias, prefixed)
+            self.assertIsInstance(field.validation_alias, AliasChoices)
+            self.assertEqual(field.validation_alias.choices, [prefixed, unprefixed])
+
 
 class TestFieldDefinition(unittest.TestCase):
     def test_json_field_definition_to_python(self):


### PR DESCRIPTION
Adds missing queryables for `usgs` provider. 
```py
>>> dag.list_queryables("usgs")
{
  'collection': typing.Annotated[str, FieldInfo(annotation=NoneType, required=True)],
  'end': typing.Annotated[str, FieldInfo(annotation=NoneType, required=False, default=None, alias='end_datetime', alias_priority=2, description="Date/time as string in ISO 8601 format (e.g. '2024-06-10T12:00:00Z')")], 
  'geom': typing.Annotated[str | dict[str, float] | shapely.geometry.base.BaseGeometry, FieldInfo(annotation=NoneType, required=False, default=None, alias=AliasChoices(choices=['geometry', 'intersects']), alias_priority=2, description='Read EODAG documentation for all supported geometry format.')],
  'id': typing.Annotated[str, FieldInfo(annotation=NoneType, required=False, default=None)],
  'start': typing.Annotated[str, FieldInfo(annotation=NoneType, required=False, default=None, alias=AliasChoices(choices=['start_datetime', 'datetime']), alias_priority=2, description="Date/time as string in ISO 8601 format (e.g. '2024-06-10T12:00:00Z')")],
  'eo_cloud_cover': typing.Annotated[float, FieldInfo(annotation=NoneType, required=False, default=None, alias='eo:cloud_cover', metadata=[{'extension': 'ElectroOpticalExtension'}, Ge(ge=0), Le(le=100)])],
  'usgs_ingest_after': typing.Annotated[str, FieldInfo(annotation=NoneType, required=False, default=None, alias='usgs:ingest_after', validation_alias=AliasChoices(choices=['usgs:ingest_after', 'ingest_after']), metadata=[{'extension': 'UsgsExtension'}])],
  'usgs_ingest_before': typing.Annotated[str, FieldInfo(annotation=NoneType, required=False, default=None, alias='usgs:ingest_before', validation_alias=AliasChoices(choices=['usgs:ingest_before', 'ingest_before']), metadata=[{'extension': 'UsgsExtension'}])],
  'usgs_scene_filter': typing.Annotated[dict[str, typing.Any], FieldInfo(annotation=NoneType, required=False, default=None, alias='usgs:scene_filter', validation_alias=AliasChoices(choices=['usgs:scene_filter', 'scene_filter']), metadata=[{'extension': 'UsgsExtension'}])]
}
```

`EcmwfExtension` and `UsgsExtension` refactored using new `ProviderStacExtension` to handle queryables prefixes.