### PR TITLE
fix(collections): normalize internal collections STAC processing levels

### DIFF
--- a/eodag/resources/collections.yml
+++ b/eodag/resources/collections.yml
@@ -2203,7 +2203,7 @@ S3_SY_V10:
   providers: [{"url":"https://earth.esa.int","name":"European Space Agency (ESA)","roles":["producer","processor","licensor"]}]
   constellation: SENTINEL3
   platform: S3A,S3B
-  processing:level: LEVEL-2W
+  processing:level: L2W
   keywords: ["SYNERGY", "SY", "SENTINEL", "SENTINEL3", "S3", "S3A", "S3B", "L2", "V10"]
   eodag:sensor_type: OPTICAL,RADAR
   license: other
@@ -2220,7 +2220,7 @@ S3_SY_VG1:
   providers: [{"url":"https://earth.esa.int","name":"European Space Agency (ESA)","roles":["producer","processor","licensor"]}]
   constellation: SENTINEL3
   platform: S3A,S3B
-  processing:level: LEVEL-2
+  processing:level: L2
   keywords: ["SYNERGY", "SY", "SENTINEL", "SENTINEL3", "S3", "S3A", "S3B", "L2", "VG1"]
   eodag:sensor_type: OPTICAL,RADAR
   license: other
@@ -2237,7 +2237,7 @@ S3_SY_VGP:
   providers: [{"url":"https://earth.esa.int","name":"European Space Agency (ESA)","roles":["producer","processor","licensor"]}]
   constellation: SENTINEL3
   platform: S3A,S3B
-  processing:level: LEVEL-2
+  processing:level: L2
   keywords: ["SYNERGY", "SY", "SENTINEL", "SENTINEL3", "S3", "S3A", "S3B", "L2", "VGP"]
   eodag:sensor_type: OPTICAL,RADAR
   license: other
@@ -7172,7 +7172,7 @@ MO_INSITU_GLO_PHY_UV_DISCRETE_NRT_013_048:
   instruments: []
   constellation:
   platform:
-  processing:level: Level 2
+  processing:level: L2
   keywords: ["CMEMS", "Mercator", "ocean", "insitu", "NRT", "currents", "global", "L2"]
   eodag:sensor_type:
   license: other
@@ -7274,7 +7274,7 @@ MO_MULTIOBS_GLO_BGC_NUTRIENTS_CARBON_PROFILES_MYNRT_015_009:
   instruments: []
   constellation:
   platform:
-  processing:level: Level 3
+  processing:level: L3
   keywords: ["CMEMS", "Mercator", "ocean", "global", "vertical", "nutrients", "carbon", "carbonate", "L3"]
   eodag:sensor_type:
   license: other
@@ -7473,7 +7473,7 @@ MO_SST_GLO_SST_L3S_NRT_OBSERVATIONS_010_010:
   instruments: []
   constellation:
   platform:
-  processing:level: Level 3
+  processing:level: L3
   keywords: ["CMEMS", "Mercator", "ocean", "global", "surface", "temperature", "L3", "PIR", "PMW", "GIR"]
   eodag:sensor_type:
   license: other
@@ -7569,7 +7569,7 @@ MO_WAVE_GLO_PHY_SPC_FWK_L3_NRT_014_002:
   instruments: []
   constellation:
   platform:
-  processing:level: Level 3
+  processing:level: L3
   keywords: ["CMEMS", "Mercator", "ocean", "global", "NRT", "wave", "L3", "WAVE-TAC", "SAR", "spectral", "mono-mission"]
   eodag:sensor_type:
   license: other
@@ -7595,7 +7595,7 @@ MO_WAVE_GLO_PHY_SWH_L3_NRT_014_001:
   instruments: []
   constellation:
   platform:
-  processing:level: Level 3
+  processing:level: L3
   keywords: ["CMEMS", "Mercator", "ocean", "global", "NRT", "wave", "height", "L3", "wind", "speed", "WAVE-TAC", "mono-mission"]
   eodag:sensor_type:
   license: other
@@ -7654,7 +7654,7 @@ MO_WIND_GLO_PHY_L3_NRT_012_002:
   instruments: []
   constellation:
   platform:
-  processing:level: Level 3
+  processing:level: L3
   keywords: ["CMEMS", "Mercator", "ocean", "global", "L3", "surface", "wind", "daily", "gridded", "NRT", "Scatterometer"]
   eodag:sensor_type:
   license: other
@@ -7675,7 +7675,7 @@ MO_WIND_GLO_PHY_L3_MY_012_005:
   instruments: []
   constellation:
   platform:
-  processing:level: Level 3
+  processing:level: L3
   keywords: ["CMEMS", "Mercator", "ocean", "global", "L3", "surface", "wind", "daily", "gridded", "reprocessed", "REP", "Scatterometer"]
   eodag:sensor_type:
   license: other
@@ -7733,7 +7733,7 @@ MO_OCEANCOLOUR_GLO_BGC_L3_MY_009_107:
   instruments: []
   constellation:
   platform:
-  processing:level: Level 3
+  processing:level: L3
   keywords: ["CMEMS", "Mercator", "ocean", "global", "L3", "bio-geo-chemical", "BGC", "chlorophyll", "phytoplankton", "reflectance"]
   eodag:sensor_type: multi
   license: other
@@ -7754,7 +7754,7 @@ MO_OCEANCOLOUR_GLO_BGC_L3_NRT_009_101:
   instruments: []
   constellation:
   platform:
-  processing:level: Level 3
+  processing:level: L3
   keywords: ["CMEMS", "Mercator", "ocean", "global", "colour", "L3", "bio-geo-chemical", "BGC", "Copernicus-GlobColour", "NRT"]
   eodag:sensor_type:
   license: other
@@ -7774,7 +7774,7 @@ MO_OCEANCOLOUR_GLO_BGC_L3_MY_009_103:
   instruments: []
   constellation:
   platform:
-  processing:level: Level 3
+  processing:level: L3
   keywords: ["CMEMS", "Mercator", "ocean", "global", "colour", "L3", "bio-geo-chemical", "BGC", "Copernicus-GlobColour", "MY", "multi-years"]
   eodag:sensor_type:
   license: other

--- a/eodag/resources/collections.yml
+++ b/eodag/resources/collections.yml
@@ -666,7 +666,7 @@ S1_SAR_RAW:
   providers: [{"url":"https://earth.esa.int","name":"European Space Agency (ESA)","roles":["producer","processor","licensor"]}]
   constellation: SENTINEL1
   platform: S1A,S1B,S1C
-  processing:level: L0
+  processing:level: RAW
   keywords: ["SAR", "SENTINEL", "SENTINEL1", "S1", "S1A", "S1B", "S1C", "L0", "RAW", "SAFE"]
   eodag:sensor_type: RADAR
   license: other

--- a/tests/units/test_collections_config.py
+++ b/tests/units/test_collections_config.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026, CS GROUP - France, https://www.csgroup.eu/
+#
+# This file is part of EODAG project
+#     https://www.github.com/CS-SI/EODAG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import yaml
+
+
+def test_collection_processing_levels_use_stac_short_names():
+    """Default collection processing levels should use STAC short names."""
+    collections_path = (
+        Path(__file__).parents[2] / "eodag" / "resources" / "collections.yml"
+    )
+
+    with open(collections_path) as fh:
+        collections = yaml.safe_load(fh)
+
+    long_processing_levels = {
+        collection_id: collection["processing:level"]
+        for collection_id, collection in collections.items()
+        if isinstance(collection, dict)
+        and isinstance(collection.get("processing:level"), str)
+        and collection["processing:level"].lower().startswith("level")
+    }
+
+    assert long_processing_levels == {}

--- a/tests/units/test_collections_config.py
+++ b/tests/units/test_collections_config.py
@@ -27,7 +27,7 @@ def test_collection_processing_levels_use_stac_short_names():
         Path(__file__).parents[2] / "eodag" / "resources" / "collections.yml"
     )
 
-    with open(collections_path) as fh:
+    with open(collections_path, encoding="utf-8") as fh:
         collections = yaml.safe_load(fh)
 
     long_processing_levels = {

--- a/tests/units/test_collections_config.py
+++ b/tests/units/test_collections_config.py
@@ -15,27 +15,42 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import unittest
 from pathlib import Path
 
 import yaml
 
 
-def test_collection_processing_levels_use_stac_short_names():
-    """Default collection processing levels should use STAC short names."""
-    collections_path = (
-        Path(__file__).parents[2] / "eodag" / "resources" / "collections.yml"
-    )
+class TestCollectionsConfig(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestCollectionsConfig, cls).setUpClass()
+        collections_path = (
+            Path(__file__).parents[2] / "eodag" / "resources" / "collections.yml"
+        )
+        with open(collections_path, encoding="utf-8") as fh:
+            cls.collections = yaml.safe_load(fh)
 
-    with open(collections_path, encoding="utf-8") as fh:
-        collections = yaml.safe_load(fh)
+    def test_collection_processing_levels_use_stac_short_names(self):
+        """Default collection processing levels must use STAC short names"""
+        long_processing_levels = {
+            collection_id: collection["processing:level"]
+            for collection_id, collection in self.collections.items()
+            if isinstance(collection, dict)
+            and isinstance(collection.get("processing:level"), str)
+            and collection["processing:level"].lower().startswith("level")
+        }
 
-    long_processing_levels = {
-        collection_id: collection["processing:level"]
-        for collection_id, collection in collections.items()
-        if isinstance(collection, dict)
-        and isinstance(collection.get("processing:level"), str)
-        and collection["processing:level"].lower().startswith("level")
-    }
+        self.assertEqual(long_processing_levels, {})
 
-    assert long_processing_levels == {}
+    def test_collection_processing_levels_are_not_number_only(self):
+        """Default collection processing levels must not be number-only values"""
+        number_only_processing_levels = {
+            collection_id: collection["processing:level"]
+            for collection_id, collection in self.collections.items()
+            if isinstance(collection, dict)
+            and isinstance(collection.get("processing:level"), str)
+            and collection["processing:level"].strip().isdigit()
+        }
+
+        self.assertEqual(number_only_processing_levels, {})


### PR DESCRIPTION
## Summary
- normalize long `processing:level` values in `collections.yml` to STAC short names (`L2`, `L2W`, `L3`)
- add a focused regression test so default collection levels do not regress to `Level...` forms

Fixes #2195.

## Tests
- `uv run --with pytest --with pytest-socket --with responses --with OWSLib pytest tests/units/test_collections_config.py -q`
- `uv run --with pytest --with pytest-socket --with responses --with OWSLib --with ecmwf-api-client --with usgs pytest tests/units/test_collections_config.py tests/units/test_collection.py::TestCollection::test_collection_enable_validation -q`
- `uv run --with ruff ruff check tests/units/test_collections_config.py`
- `python3 -m py_compile tests/units/test_collections_config.py`
- `git diff --check`