### PR TITLE
test: update OIDC discovery response as expected by pyjwt

### DIFF
--- a/tests/integration/test_core_search.py
+++ b/tests/integration/test_core_search.py
@@ -37,6 +37,14 @@ from tests.context import (
     mock,
 )
 
+# Mocked OIDC discovery response as expected by pyjwt.
+_OIDC_CONFIG = {
+    "jwks_uri": "https://example.com/jwks",
+    "token_endpoint": "https://example.com/token",
+    "authorization_endpoint": "https://example.com/authorize",
+    "id_token_signing_alg_values_supported": ["RS256"],
+}
+
 
 class TestCoreSearch(unittest.TestCase):
     def setUp(self):
@@ -277,6 +285,7 @@ class TestCoreSearch(unittest.TestCase):
         self, mock_get, mock_post, mock_request, mock_auth_token, mock_auth_oidc
     ):
         """Core search must loop over providers until finding a non empty result"""
+        mock_auth_oidc.return_value.json.return_value = _OIDC_CONFIG
         collection = "S1_SAR_SLC"
         available_providers = self.dag.providers.filter(collection).names
         self.assertListEqual(
@@ -395,6 +404,7 @@ class TestCoreSearch(unittest.TestCase):
         self, mock_request, mock_urlopen, mock_httpadapter, mock_get, mock_auth_get
     ):
         """Core search must loop over providers until finding a non empty result"""
+        mock_auth_get.return_value.json.return_value = _OIDC_CONFIG
         collection = "S1_SAR_SLC"
         available_providers = self.dag.providers.filter(collection).names
         self.assertListEqual(
@@ -773,6 +783,7 @@ class TestCoreSearch(unittest.TestCase):
         self, mock_request, mock_auth, mock_auth_config_request
     ):
         """search by id should return properties based on status response"""
+        mock_auth_config_request.return_value.json.return_value = _OIDC_CONFIG
         product_id = "123-456"
         auth = CodeAuthorizedAuth(token="123", where="header")
         mock_auth.return_value = auth

--- a/tests/integration/test_core_search_results.py
+++ b/tests/integration/test_core_search_results.py
@@ -67,6 +67,19 @@ class TestCoreSearchResults(EODagTestCase):
             "os.path.expanduser", autospec=True, return_value=self.tmp_home_dir.name
         )
         self.expanduser_mock.start()
+        # Mocked OIDC discovery response as expected by pyjwt.
+        self.oidc_endpoints_mock = mock.patch(
+            "eodag.plugins.authentication.openid_connect."
+            "OIDCRefreshTokenBase._get_oidc_endpoints",
+            autospec=True,
+            return_value={
+                "jwks_uri": "https://example.com/jwks",
+                "token_endpoint": "https://example.com/token",
+                "authorization_endpoint": "https://example.com/authorize",
+                "id_token_signing_alg_values_supported": ["RS256"],
+            },
+        )
+        self.oidc_endpoints_mock.start()
         self.dag = EODataAccessGateway()
         self.maxDiff = None
         self.geojson_repr = {
@@ -129,6 +142,7 @@ class TestCoreSearchResults(EODagTestCase):
     def tearDown(self):
         super(TestCoreSearchResults, self).tearDown()
         # stop Mock and remove tmp config dir
+        self.oidc_endpoints_mock.stop()
         self.expanduser_mock.stop()
         self.tmp_home_dir.cleanup()
 

--- a/tests/integration/test_download_auth.py
+++ b/tests/integration/test_download_auth.py
@@ -25,6 +25,14 @@ from unittest import mock
 from tests import TEST_RESOURCES_PATH
 from tests.context import EODataAccessGateway, MisconfiguredError
 
+# Mocked OIDC discovery response as expected by pyjwt.
+_OIDC_CONFIG = {
+    "jwks_uri": "https://example.com/jwks",
+    "token_endpoint": "https://example.com/token",
+    "authorization_endpoint": "https://example.com/authorize",
+    "id_token_signing_alg_values_supported": ["RS256"],
+}
+
 
 class TestEODagDownloadCredentialsNotSet(unittest.TestCase):
     """MisconfiguredError must be raised when downloading one or several products
@@ -64,6 +72,8 @@ class TestEODagDownloadCredentialsNotSet(unittest.TestCase):
         "eodag.plugins.authentication.openid_connect.requests.get", autospec=True
     )
     def test_eodag_download_missing_credentials_cop_dataspace(self, mock_requests):
+        # mocked OIDC discovery response as expected by pyjwt
+        mock_requests.return_value.json.return_value = _OIDC_CONFIG
         search_resuls = os.path.join(
             TEST_RESOURCES_PATH, "eodag_search_result_cop_dataspace.geojson"
         )
@@ -77,6 +87,8 @@ class TestEODagDownloadCredentialsNotSet(unittest.TestCase):
         "eodag.plugins.authentication.openid_connect.requests.get", autospec=True
     )
     def test_eodag_download_missing_credentials_creodias(self, mock_requests):
+        # mocked OIDC discovery response as expected by pyjwt
+        mock_requests.return_value.json.return_value = _OIDC_CONFIG
         search_resuls = os.path.join(
             TEST_RESOURCES_PATH, "eodag_search_result_creodias.geojson"
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1061,6 +1061,13 @@ class TestEodagCli(unittest.TestCase):
     )
     def test_eodag_download_missingcredentials(self, oidc_request):
         """Calling eodag download with missing credentials must raise MisconfiguredError"""
+        # mocked OIDC discovery response as expected by pyjwt
+        oidc_request.return_value.json.return_value = {
+            "jwks_uri": "https://example.com/jwks",
+            "token_endpoint": "https://example.com/token",
+            "authorization_endpoint": "https://example.com/authorize",
+            "id_token_signing_alg_values_supported": ["RS256"],
+        }
         search_results_path = os.path.join(
             TEST_RESOURCES_PATH, "eodag_search_result.geojson"
         )
@@ -1088,6 +1095,8 @@ class TestEodagCli(unittest.TestCase):
         """Calling eodag download with wrong credentials must raise AuthenticationError"""
         oidc_endpoints = defaultdict(mock.Mock())
         oidc_endpoints["token_endpoint"] = "http://fake_token_endpoint"
+        # mocked OIDC discovery response as expected by pyjwt
+        oidc_endpoints["jwks_uri"] = "https://example.com/jwks"
         mock_req_oidc_endpoints.return_value = oidc_endpoints
         responses.add(
             responses.POST,
@@ -1116,6 +1125,13 @@ class TestEodagCli(unittest.TestCase):
     @mock.patch("eodag.api.product._product.EOProduct.get_quicklook", autospec=True)
     def test_eodag_download_quicklooks(self, mock_get_quicklook, mock_oidc_get):
         """Calling eodag download with --quicklooks argument"""
+        # mocked OIDC discovery response as expected by pyjwt
+        mock_oidc_get.return_value.json.return_value = {
+            "jwks_uri": "https://example.com/jwks",
+            "token_endpoint": "https://example.com/token",
+            "authorization_endpoint": "https://example.com/authorize",
+            "id_token_signing_alg_values_supported": ["RS256"],
+        }
         search_results_path = os.path.join(
             TEST_RESOURCES_PATH, "eodag_search_result_cop_dataspace.geojson"
         )

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -2776,12 +2776,18 @@ class TestCoreSearch(TestCoreBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # Mock OIDC auth requests.get to prevent socket calls during auth plugin init
+        # Mocked OIDC discovery response as expected by pyjwt.
         cls.oidc_mock = mock.patch(
             "eodag.plugins.authentication.openid_connect.requests.get",
             autospec=True,
         )
-        cls.oidc_mock.start()
+        oidc_mock_started = cls.oidc_mock.start()
+        oidc_mock_started.return_value.json.return_value = {
+            "jwks_uri": "https://example.com/jwks",
+            "token_endpoint": "https://example.com/token",
+            "authorization_endpoint": "https://example.com/authorize",
+            "id_token_signing_alg_values_supported": ["RS256"],
+        }
         cls.dag = EODataAccessGateway()
         # Get a SearchResult obj with 2 S2_MSI_L1C cop_dataspace products
         search_results_file = os.path.join(

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -385,7 +385,7 @@ class TestUtils(unittest.TestCase):
 
         # distant error
         with unittest.mock.patch(
-            "eodag.utils.requests.requests.get",
+            "eodag.utils.requests.requests.sessions.Session.get",
             autospec=True,
             side_effect=RequestException,
         ) as mock_get:


### PR DESCRIPTION
Following [pyjwt 2.13.0](https://github.com/jpadilla/pyjwt/releases/tag/2.13.0), update mocked OIDC discovery response in tests to an appropriate object.