### PR TITLE
test: fixed tests and stac-validator warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ dev = [
     "pytest-xdist",
     "pytest",
     "responses != 0.24.0",
-    "stac-validator",
+    "stac-valid",
     "stdlib-list",
     "tomli; python_version < '3.11'",
     "tox-uv",

--- a/tests/integration/test_core_search_results.py
+++ b/tests/integration/test_core_search_results.py
@@ -594,7 +594,9 @@ class TestCoreSearchResults(EODagTestCase):
 
         mock_query.return_value = (products.data, len(products))
 
-        search_results = self.dag.search(collection="S2_MSI_L1C")
+        search_results = self.dag.search(
+            collection="S2_MSI_L1C", provider="cop_dataspace"
+        )
 
         for search_result in search_results:
             self.assertIsInstance(search_result.downloader, PluginTopic)

--- a/tests/integration/test_search_stac_static.py
+++ b/tests/integration/test_search_stac_static.py
@@ -157,6 +157,11 @@ class TestSearchStacStatic(unittest.TestCase):
         self, mock_fetch_collections_list, mock_auth_session_request
     ):
         """Use StaticStacSearch plugin to search by cloud cover"""
-        search_result = self.dag.search(cloudCover=10, count=True, validate=False)
+        search_result = self.dag.search(
+            provider=self.static_stac_provider,
+            count=True,
+            validate=False,
+            **{"eo:cloud_cover": 10},
+        )
         self.assertEqual(len(search_result), 1)
         self.assertEqual(search_result.number_matched, 1)


### PR DESCRIPTION
Fixed warnings in tests:
- Updated `stac-validator` dependency in `dev`  extra to `stac-valid`
- Fixed some tests that needed to be updated