### PR TITLE
build: update pydantic minimal required version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "jsonpath-ng < 1.8.0",
     "lxml",
     "orjson",
-    "pydantic >= 2.1.0, != 2.10.0",
+    "pydantic >= 2.12.3",
     "pydantic_core",
     "PyJWT[crypto] >= 2.5.0",
     "pyproj >= 2.1.0",


### PR DESCRIPTION
qssearch.py:2303 calls FieldInfo.asdict(), which was introduced in Pydantic 2.12.3. However, the current pyproject.toml allows Pydantic >= 2.1.0, which can lead to runtime errors when installing older versions that do not include this method.

This PR raises the minimum required Pydantic version to 2.12.3 to ensure compatibility.

fix: https://github.com/CS-SI/eodag/issues/2207#issuecomment-4576056287