### PR TITLE
fix(providers): dedl pagination

### DIFF
--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -5086,6 +5086,7 @@
         extent: '$.extent'
     pagination:
       max_limit: 100
+      next_page_token_key: token
     sort:
       sort_param_mapping:
         id: id

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -5086,7 +5086,6 @@
         extent: '$.extent'
     pagination:
       max_limit: 100
-      next_page_token_key: page
     sort:
       sort_param_mapping:
         id: id


### PR DESCRIPTION
When we do a search for an item on the dedl providers i got : {"code":"400","ticket":"d3c480e6","description":"1 error(s). page: Extra inputs are not permitted"}')

How to locally reproduce using `stac-fastapi-eodag`:
http://127.0.0.1:8000/collections/METOP_IASSND02/items?filter=federation:backends=%27dedl%27

This Pull request fix that issue