### PR TITLE
fix(typing): avoid eodag-cube EOProduct type mismatch in plugins

### DIFF
--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from mypy_boto3_s3 import S3ServiceResource
     from requests.auth import AuthBase
 
-    from eodag.api.product import EOProduct
+    from eodag.api.product._product import EOProduct
     from eodag.api.search_result import SearchResult
     from eodag.config import PluginConfig
     from eodag.types.download_args import DownloadConf

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from mypy_boto3_s3 import S3ServiceResource
     from requests.auth import AuthBase
 
-    from eodag.api.product import EOProduct
+    from eodag.api.product._product import EOProduct
     from eodag.api.provider import ProviderConfig
     from eodag.config import PluginConfig
     from eodag.plugins.base import PluginTopic


### PR DESCRIPTION
Avoids eodag-cube `EOProduct` type mismatch in plugins.
Align plugin type hints with base `EOProduct` so both base and eodag-cube subclasses are accepted by static checkers.