### PR TITLE
ci: benchmark for perf regression check

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,65 @@
+name: Run benchmark
+
+on:
+  pull_request:
+    branches: [develop, v5_download_link_asset]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  benchmark:
+    name: Performance regression check
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the repo
+      uses: actions/checkout@v4
+      with:
+        # Get history and tags for SCM versioning to work
+        fetch-depth: 0
+    - name: Install the latest version of uv with cache enabled
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: "latest"
+        enable-cache: true
+        cache-dependency-glob: ""
+    - name: Run benchmark on develop and current ref, then compare
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        CURRENT_SHA="$(git rev-parse HEAD)"
+
+        echo "Running benchmark on develop"
+        git checkout --detach origin/develop
+        uvx --python 3.14 --with tox-uv tox -e benchmark -- --benchmark-json baseline.json
+
+        echo "Running benchmark on current ref"
+        git checkout --detach "${CURRENT_SHA}"
+        uvx --python 3.14 --with tox-uv tox -e benchmark -- --benchmark-json candidate.json
+
+        echo "Comparing benchmark results"
+        uvx --python 3.14 \
+          --with "pytest-benchmark @ git+https://github.com/ionelmc/pytest-benchmark.git@master" \
+          pytest-benchmark compare --between=min \
+          baseline.json candidate.json \
+          | tee benchmark-compare.txt
+
+        {
+          echo "## Benchmark comparison"
+          echo
+          echo "Compared baseline: \`origin/develop\`"
+          echo "Compared candidate: ${CURRENT_SHA}"
+          echo
+          echo '```text'
+          cat benchmark-compare.txt
+          echo '```'
+        } > benchmark-comment.md
+
+    - name: Publish benchmark comparison comment
+      if: github.event.pull_request.head.repo.full_name == github.repository
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: benchmark-comparison
+        path: benchmark-comment.md

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026, CS GROUP - France, https://www.csgroup.eu/
+#
+# This file is part of EODAG project
+#     https://www.github.com/CS-SI/EODAG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tests import test_cli
+from tests.integration import test_core_search_results
+
+
+def _run_unittest_method(test_case_cls, method_name):
+    """Run one unittest test method with isolated setup/teardown."""
+    test_case = test_case_cls(methodName=method_name)
+    test_case.setUp()
+    try:
+        getattr(test_case, method_name)()
+    finally:
+        test_case.tearDown()
+
+
+def test_benchmark_cli_without_args(benchmark):
+    benchmark(
+        lambda: _run_unittest_method(test_cli.TestEodagCli, "test_eodag_without_args")
+    )
+
+
+def test_benchmark_cli_list_collections(benchmark):
+    benchmark(
+        lambda: _run_unittest_method(
+            test_cli.TestEodagCli, "test_eodag_list_collection_ok"
+        )
+    )
+
+
+def test_benchmark_core_search_with_provider(benchmark):
+    benchmark(
+        lambda: _run_unittest_method(
+            test_core_search_results.TestCoreSearchResults,
+            "test_core_search_with_provider",
+        )
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 [tox]
-envlist = py39, py310, py311, py312, py313, py314, docs, pypi, linters
+envlist = py39, py310, py311, py312, py313, py314, benchmark, docs, pypi, linters
 skipdist = true
 
 # Mapping required by tox-gh-actions, only used in CI
@@ -42,7 +42,7 @@ commands =
 		--cov-report=xml:test-reports/coverage.xml \
 		--junitxml=test-reports/junit-report.xml \
 		--html=test-reports/tests/report.html \
-  	    --self-contained-html {posargs: --ignore=tests/test_end_to_end.py}
+        --self-contained-html {posargs: --ignore=tests/test_end_to_end.py --ignore=tests/test_benchmark.py}
 
 extras = dev
 
@@ -75,6 +75,13 @@ commands =
     # build doc
     make html SPHINXOPTS="-W --keep-going"
 passenv = HOME
+
+[testenv:benchmark]
+basepython = python3.14
+deps =
+    pytest-benchmark[histogram] @ git+https://github.com/ionelmc/pytest-benchmark.git@master
+commands =
+    pytest -v tests/test_benchmark.py --benchmark-disable-gc {posargs}
 
 [testenv:pypi]
 skip_install = true


### PR DESCRIPTION
Add performance regression check in PRs, using `pytest-benchmark` to compare results between `develop` branch and current branch, then post output in a new PR comment:

## Benchmark comparison

Compared baseline: `origin/develop`
Compared candidate: `<sha>`

```text

------------------------- benchmark: 3 tests, 2 sources --------------------------
Name (time in ms)                            baseline Min  candidate Min      ΔMin
----------------------------------------------------------------------------------
test_benchmark_cli_without_args                   17.8418        17.6096     -1.3%
test_benchmark_core_search_with_provider         153.8813       152.2730     -1.0%
test_benchmark_cli_list_collections              148.0923       143.4795     -3.1%
----------------------------------------------------------------------------------

Legend:
  Cyan: reference source for comparison. Green: improvement, Red: regression.
  Δ: percentage change from reference source.
```

<!-- Sticky Pull Request Commentbenchmark-comparison -->