### PR TITLE
fix(core): check plugin conf tag in providers.yml

### DIFF
--- a/eodag/api/provider.py
+++ b/eodag/api/provider.py
@@ -52,6 +52,7 @@ from eodag.utils import (
     update_nested_dict,
 )
 from eodag.utils.exceptions import (
+    MisconfiguredError,
     UnsupportedCollection,
     UnsupportedProvider,
     ValidationError,
@@ -123,7 +124,13 @@ class ProviderConfig(yaml.YAMLObject):
         for node_key, node_value in node.value:
             if node_key.value == "name":
                 node_value.value = slugify(node_value.value).replace("-", "_")
-                break
+            elif node_key.value in PLUGINS_TOPICS_KEYS:
+                if node_value.tag != PluginConfig.yaml_tag:
+                    msg = "Provider plugin topic '%s' must be tagged with '%s'" % (
+                        node_key.value,
+                        PluginConfig.yaml_tag,
+                    )
+                    raise MisconfiguredError(msg)
         return loader.construct_yaml_object(node, cls)
 
     @classmethod

--- a/tests/units/test_provider.py
+++ b/tests/units/test_provider.py
@@ -258,7 +258,9 @@ class TestProviderConfig(unittest.TestCase):
 
     def test_provider_config_from_yaml_requires_plugin_tag(self):
         """ProviderConfig.from_yaml must reject untagged plugin topics."""
-        with self.assertRaisesRegex(MisconfiguredError, "plugin topic 'search'"):
+        with self.assertRaisesRegex(
+            MisconfiguredError, "plugin topic 'search' must be tagged with '!plugin'"
+        ):
             yaml.load(
                 """
 !provider

--- a/tests/units/test_provider.py
+++ b/tests/units/test_provider.py
@@ -20,8 +20,11 @@ import unittest
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
+import yaml
+
 from tests.context import (
     EODataAccessGateway,
+    MisconfiguredError,
     PluginConfig,
     Provider,
     ProviderConfig,
@@ -252,6 +255,19 @@ class TestProviderConfig(unittest.TestCase):
         # Verify they are separate objects (deep copy)
         self.assertIsNot(new_config, original_config)
         self.assertIsNot(new_config.search, original_config.search)
+
+    def test_provider_config_from_yaml_requires_plugin_tag(self):
+        """ProviderConfig.from_yaml must reject untagged plugin topics."""
+        with self.assertRaisesRegex(MisconfiguredError, "plugin topic 'search'"):
+            yaml.load(
+                """
+!provider
+name: test-provider
+search:
+  type: StacSearch
+""",
+                Loader=yaml.Loader,
+            )
 
 
 class TestProvidersDict(unittest.TestCase):


### PR DESCRIPTION
Add a check for missing `!plugin` tags during provider config validation 