### PR TITLE
fix(mapping): remove arbitrary download_link for STAC providers

### DIFF
--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -590,11 +590,12 @@ class EOProduct:
             self.remote_location,
             self.location,
         )
-        logger.info(
-            "Remote location of the product is still available through its "
-            "'remote_location' property: %s",
-            self.remote_location,
-        )
+        if self.remote_location != NOT_AVAILABLE:
+            logger.info(
+                "Remote location of the product is still available through its "
+                "'remote_location' property: %s",
+                self.remote_location,
+            )
 
         return fs_path
 

--- a/eodag/resources/stac_provider.yml
+++ b/eodag/resources/stac_provider.yml
@@ -114,7 +114,7 @@ search:
       - '{{"query":{{"eo:cloud_cover":{{"lte":{eo:cloud_cover}}}}}}}'
       - '$.properties."eo:cloud_cover"'
     # eodag metadata
-    eodag:download_link: '$.links[?(@.rel="self")].href'
+    eodag:download_link: '$.null'
     eodag:quicklook: '$.assets.quicklook.href'
     eodag:thumbnail: '$.assets.thumbnail.href'
     # order:status set to succeeded for consistency between providers

--- a/tests/integration/test_core_search_results.py
+++ b/tests/integration/test_core_search_results.py
@@ -29,6 +29,7 @@ from stac_validator import stac_validator
 from tests import TEST_RESOURCES_PATH, EODagTestCase
 from tests.context import (
     GENERIC_STAC_PROVIDER,
+    NOT_AVAILABLE,
     Download,
     EODataAccessGateway,
     EOProduct,
@@ -753,7 +754,7 @@ class TestCoreSearchResults(EODagTestCase):
         self.assertEqual(results[0].properties["id"], "stac-fastapi-eodag-id")
         self.assertEqual(results[0].collection, "foo-collection")
         self.assertEqual(len(results[0].assets), 0)
-        self.assertEqual(results[0].location, "https://provider-url/origin-link")
+        self.assertEqual(results[0].location, NOT_AVAILABLE)
         self.assertIsInstance(results[0].downloader, Download)
 
         self.assertEqual(results[1].provider, "earth_search")


### PR DESCRIPTION
Stop using arbitrary download_link for STAC providers.

`eodag:download_link` property mapped to `Not Available` instead.