### PR TITLE
fix(stream): explicit signal handler registration

### DIFF
--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -75,7 +75,7 @@ from tqdm.auto import tqdm
 from .exceptions import MisconfiguredError
 from .logging import get_disable_tqdm
 from .logging import logging as eodag_logging
-from .streamresponse import StreamResponse
+from .streamresponse import StreamResponse, StreamResponseContent
 
 if TYPE_CHECKING:
     from jsonpath_ng import JSONPath
@@ -1829,6 +1829,7 @@ __all__ = [
     "ARRAY_FIELD_MATCH",
     "FloatRange",
     "StreamResponse",
+    "StreamResponseContent",
     "DownloadedCallback",
     "ProgressCallback",
     "MockResponse",

--- a/eodag/utils/streamresponse.py
+++ b/eodag/utils/streamresponse.py
@@ -1,5 +1,6 @@
 import os
 import signal
+import threading
 from dataclasses import dataclass, field
 from typing import Iterable, Iterator, Mapping, Optional, Union
 
@@ -14,19 +15,32 @@ class StreamResponseContent(Iterable[bytes]):
     __instances: list["StreamResponseContent"] = []
 
     @staticmethod
-    def init():
-        """Main static initializer"""
-        if not StreamResponseContent.__initialized:
-            StreamResponseContent.__initialized = True
+    def install_signal_handlers() -> bool:
+        """Register SIGINT/SIGTERM handlers that interrupt any live stream.
 
-            # Catch end of main process to internal status
-            def signal_handler(sig, frame):
-                for stream in StreamResponseContent.__instances:
-                    stream.interrupt()
-                StreamResponseContent.__instances = []
+        This must be called explicitly from the main thread (typically during a
+        server's startup) because :func:`signal.signal` only works there. It is
+        a no-op if the handlers are already installed or if it is called outside
+        of the main thread.
 
-            signal.signal(signal.SIGINT, signal_handler)
-            signal.signal(signal.SIGTERM, signal_handler)
+        :returns: ``True`` if the handlers were installed, ``False`` otherwise.
+        """
+        if StreamResponseContent.__initialized:
+            return False
+        if threading.current_thread() is not threading.main_thread():
+            return False
+
+        StreamResponseContent.__initialized = True
+
+        # Catch end of main process to internal status
+        def signal_handler(sig, frame):
+            for stream in StreamResponseContent.__instances:
+                stream.interrupt()
+            StreamResponseContent.__instances = []
+
+        signal.signal(signal.SIGINT, signal_handler)
+        signal.signal(signal.SIGTERM, signal_handler)
+        return True
 
     def __init__(self, content: Union[Iterable[bytes], bytes]):
         self.buffer: bytes = b""
@@ -63,9 +77,6 @@ class StreamResponseContent(Iterable[bytes]):
             result, self.buffer = self.buffer[:size], self.buffer[size:]
 
         return bytes(result)
-
-
-StreamResponseContent.init()
 
 
 @dataclass

--- a/tests/units/test_utils_streamingresponse.py
+++ b/tests/units/test_utils_streamingresponse.py
@@ -1,9 +1,11 @@
 import os
 import shutil
+import signal
 import tempfile
+import threading
 import unittest
 
-from eodag.utils import StreamResponse
+from eodag.utils import StreamResponse, StreamResponseContent
 
 
 class StreamResponseTest(unittest.TestCase):
@@ -112,3 +114,75 @@ class StreamResponseTest(unittest.TestCase):
             )
         except InterruptedError:
             pass
+
+
+class StreamResponseSignalHandlersTest(unittest.TestCase):
+    """Signal handlers must only be installed explicitly, on the main thread."""
+
+    def setUp(self):
+        # Preserve handlers possibly set by other tests/the runtime.
+        self._sigint = signal.getsignal(signal.SIGINT)
+        self._sigterm = signal.getsignal(signal.SIGTERM)
+        # Reset the one-shot installation flag so each test starts clean.
+        StreamResponseContent._StreamResponseContent__initialized = False
+
+    def tearDown(self):
+        signal.signal(signal.SIGINT, self._sigint)
+        signal.signal(signal.SIGTERM, self._sigterm)
+        StreamResponseContent._StreamResponseContent__initialized = False
+
+    def test_importing_streamresponse_does_not_register_handlers(self):
+        """Importing streamresponse must not modify process signal handlers."""
+        # Importing the module must not override the default SIGINT handler.
+        self.assertIs(signal.getsignal(signal.SIGINT), signal.default_int_handler)
+
+    def test_install_signal_handlers_on_main_thread(self):
+        """Main-thread installation must register handlers once and be idempotent."""
+        self.assertTrue(StreamResponseContent.install_signal_handlers())
+        self.assertIsNot(signal.getsignal(signal.SIGINT), signal.default_int_handler)
+        self.assertIsNot(signal.getsignal(signal.SIGTERM), signal.SIG_DFL)
+        # Idempotent: a second call is a no-op.
+        self.assertFalse(StreamResponseContent.install_signal_handlers())
+
+    def test_install_signal_handlers_off_main_thread_is_noop(self):
+        """Background-thread installation must be a no-op."""
+        results = {}
+
+        def worker():
+            results["installed"] = StreamResponseContent.install_signal_handlers()
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+
+        self.assertFalse(results["installed"])
+        # Default handler untouched when called from a background thread.
+        self.assertIs(signal.getsignal(signal.SIGINT), signal.default_int_handler)
+
+    def test_construct_streamresponse_off_main_thread_does_not_raise(self):
+        """Creating stream content in worker threads must not raise."""
+        errors = []
+
+        def worker():
+            try:
+                StreamResponseContent.install_signal_handlers()
+                StreamResponseContent(iter([b"abc"]))
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(exc)
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+
+        self.assertEqual(errors, [])
+
+    def test_handler_interrupts_live_stream(self):
+        """Installed signal handler must interrupt active stream reads."""
+        StreamResponseContent.install_signal_handlers()
+        stream = StreamResponseContent(iter([b"abc", b"def"]))
+
+        # Simulate receiving SIGINT by invoking the installed handler.
+        signal.getsignal(signal.SIGINT)(signal.SIGINT, None)
+
+        with self.assertRaises(InterruptedError):
+            stream.read(1)


### PR DESCRIPTION
Fixes https://github.com/CS-SI/eodag/issues/2232

Makes signal handler registration explicit and main-thread only.

Replaces import-time signal setup with explicit `StreamResponseContent.install_signal_handlers()` to be called from `stac-fastapi-eodag`.