### PR TITLE
fix(plugins): GHS_ESM download_link in CopGhslSearch

### DIFF
--- a/eodag/plugins/search/cop_ghsl.py
+++ b/eodag/plugins/search/cop_ghsl.py
@@ -346,6 +346,13 @@ class CopGhslSearch(Search):
             dataset = dataset.replace(
                 "__", "_"
             )  # in case additional filter value is empty
+            # adapt dataset if necessary for specific dataset and parameters
+            if "_dataset_modified" in parsed_metadata_mapping:
+                dataset_modified = properties_from_json(
+                    {"dataset": dataset},
+                    {"_dataset_modified": parsed_metadata_mapping["_dataset_modified"]},
+                )["_dataset_modified"]
+                dataset = dataset_modified
 
             # create items from tiles
             for tile in tiles[year]:

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -6918,8 +6918,9 @@
       metadata_mapping:
         tile_size: '{$.tile_size#replace_str("2m", "02")}'
         dataset: ESM_BUILT_VHR2015_EUROPE_R2019_3035_{tile_size}
+        _dataset_modified: '{$.dataset#replace_str("VHR2015_EUROPE_R2019_3035_10m","VHR2015CLASS_EUROPE_R2019_3035_10")}'  # modify dataset if tile_size is 10m
         eodag:download_link: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/ESM_BUILT_VHR2015_Europe_R2019/{dataset}/V1-0/tiles/{tile_id}.zip'
-    # produc types with one file
+    # collections with one file
     GHS_DUC:
       _collection: DUC
       metadata_mapping:

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -5378,6 +5378,59 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
         )
         self.assertEqual(geometry, products[0].geometry)
 
+    def test_plugins_search_cop_ghsl_create_products_from_tiles_modified_dataset(self):
+        """test the creation of products based on tiles returned by the provider"""
+        tiles = {
+            "2015": [
+                {
+                    "tileID": "R3_C3",
+                    "BBox": ["-160.008", "69.100", "-150.008", "59.100"],
+                },
+                {
+                    "tileID": "R3_C4",
+                    "BBox": ["-150.008", "69.100", "-140.008", "59.100"],
+                },
+                {
+                    "tileID": "R3_C5",
+                    "BBox": ["-140.008", "69.100", "-130.008", "59.100"],
+                },
+                {
+                    "tileID": "R3_C6",
+                    "BBox": ["-130.008", "69.100", "-120.008", "59.100"],
+                },
+            ],
+        }
+        collection = "GHS_ESM"
+        plugin = next(
+            self.plugins_manager.get_search_plugins(
+                collection=collection, provider="cop_ghsl"
+            )
+        )
+        product_type_config = deepcopy(plugin.config.products.get(collection, {}))
+        params = product_type_config
+        params["tile_size"] = "10m"
+        params["per_page"] = 5
+        params["page"] = 1
+        products, count = plugin._create_products_from_tiles(
+            tiles, "lat/lon", collection, params, need_count=True
+        )
+        self.assertEqual(4, count)
+        self.assertEqual(4, len(products))
+        properties = products[0].properties
+        self.assertEqual("2015-01-01T00:00:00.000Z", properties["start_datetime"])
+        self.assertEqual("2015-12-31T23:59:59.000Z", properties["end_datetime"])
+        self.assertEqual("2015", properties["year"])
+        self.assertEqual("EPSG:3035", properties["proj:code"])
+        self.assertEqual(
+            "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/ESM_BUILT_VHR2015_Europe_R2019/"
+            "ESM_BUILT_VHR2015CLASS_EUROPE_R2019_3035_10/V1-0/tiles/R3_C3.zip",
+            properties["eodag:download_link"],
+        )
+        geometry = get_geometry_from_various(
+            geometry=["-160.008", "69.100", "-150.008", "59.100"]
+        )
+        self.assertEqual(geometry, products[0].geometry)
+
     def test_plugins_search_cop_ghsl_create_products_without_tiles(self):
         """test if products are created correctly for product types without tiles"""
 


### PR DESCRIPTION
For `cop_ghsl` provider (`CopGhslSearch` search plugin) and collection `GHS_ESM` the download url is different for the 10m tile size than for the 2m tile size. This PR adds the possibility to modify the dataset parameter used in the download_link in specific cases by using a mapping `_dataset_modified`.
