### PR TITLE
docs: add Docker quickstart

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,17 @@ And with ``conda`` from the `conda-forge channel <https://anaconda.org/conda-for
 
    conda install -c conda-forge eodag
 
+EODAG is also published as a container image on GitHub Container Registry:
+
+.. code-block:: bash
+
+   docker pull ghcr.io/cs-si/eodag:<version>
+   docker run --rm ghcr.io/cs-si/eodag:<version> --help
+
+Replace ``<version>`` with the EODAG release tag you want to run. See the
+`Docker quickstart <https://eodag.readthedocs.io/en/latest/getting_started_guide/docker.html>`_
+for configuration and credentials examples.
+
 ..
 
   [!NOTE]

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ EODAG is also published as a container image on GitHub Container Registry:
 
 Replace ``<version>`` with the EODAG release tag you want to run. See the
 `Docker quickstart <https://eodag.readthedocs.io/en/latest/getting_started_guide/docker.html>`_
-for configuration and credentials examples.
+for configuration and examples.
 
 ..
 

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,8 @@ And with ``conda`` from the `conda-forge channel <https://anaconda.org/conda-for
 
    conda install -c conda-forge eodag
 
-EODAG is also published as a container image on GitHub Container Registry:
+EODAG is also published as a container image on
+`GitHub Container Registry <https://github.com/orgs/CS-SI/packages/container/package/eodag>`_:
 
 .. code-block:: bash
 

--- a/docs/getting_started_guide/docker.rst
+++ b/docs/getting_started_guide/docker.rst
@@ -21,7 +21,9 @@ directly after the image name:
 
 .. code-block:: bash
 
-   docker run --rm ghcr.io/cs-si/eodag:<version> list
+   docker run --rm ghcr.io/cs-si/eodag:latest list
+
+See :ref:`cli_user_guide` for the full list of available commands and options.
 
 Use a persistent configuration directory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -35,7 +37,7 @@ directory to the default EODAG configuration directory:
    mkdir -p "$HOME/.config/eodag"
    docker run --rm \
       -v "$HOME/.config/eodag:/home/eodag/.config/eodag" \
-      ghcr.io/cs-si/eodag:<version> list
+      ghcr.io/cs-si/eodag:latest list
 
 This lets EODAG create or reuse the same ``eodag.yml`` configuration file
 across container runs. See :ref:`configure` for the full configuration
@@ -52,7 +54,7 @@ set ``EODAG_CFG_FILE``:
    docker run --rm \
       -v "$PWD/eodag.yml:/config/eodag.yml:ro" \
       -e EODAG_CFG_FILE=/config/eodag.yml \
-      ghcr.io/cs-si/eodag:<version> list
+      ghcr.io/cs-si/eodag:latest list
 
 Provide credentials safely
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -72,7 +74,7 @@ For example, to pass a provider username and password at runtime:
    docker run --rm \
       -e EODAG__CREODIAS__AUTH__CREDENTIALS__USERNAME="$CREODIAS_USERNAME" \
       -e EODAG__CREODIAS__AUTH__CREDENTIALS__PASSWORD="$CREODIAS_PASSWORD" \
-      ghcr.io/cs-si/eodag:<version> list
+      ghcr.io/cs-si/eodag:latest list
 
 Persist downloaded products
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,7 +90,7 @@ download configuration to it:
       -v "$PWD/eodag-downloads:/data" \
       -v "$HOME/.config/eodag:/home/eodag/.config/eodag" \
       -e EODAG__CREODIAS__DOWNLOAD__OUTPUT_DIR=/data \
-      ghcr.io/cs-si/eodag:<version> download \
+      ghcr.io/cs-si/eodag:latest download \
          --search-results /work/search_results.geojson
 
 If ``search_results.geojson`` is in another host directory, mount that

--- a/docs/getting_started_guide/docker.rst
+++ b/docs/getting_started_guide/docker.rst
@@ -4,7 +4,8 @@ Docker quickstart
 =================
 
 EODAG container images are published on GitHub Container Registry at
-``ghcr.io/cs-si/eodag``. Images are built for EODAG releases.
+`ghcr.io/cs-si/eodag <https://github.com/orgs/CS-SI/packages/container/package/eodag>`_. Images are built for EODAG
+releases.
 
 Pull and run an image
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/getting_started_guide/docker.rst
+++ b/docs/getting_started_guide/docker.rst
@@ -1,0 +1,95 @@
+.. _docker:
+
+Docker quickstart
+=================
+
+EODAG container images are published on GitHub Container Registry at
+``ghcr.io/cs-si/eodag``. Images are built for EODAG releases.
+
+Pull and run an image
+^^^^^^^^^^^^^^^^^^^^^
+
+Replace ``<version>`` with the EODAG release tag you want to use:
+
+.. code-block:: bash
+
+   docker pull ghcr.io/cs-si/eodag:<version>
+   docker run --rm ghcr.io/cs-si/eodag:<version> --help
+
+The image entry point is the ``eodag`` command, so CLI arguments can be passed
+directly after the image name:
+
+.. code-block:: bash
+
+   docker run --rm ghcr.io/cs-si/eodag:<version> list
+
+Use a persistent configuration directory
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The container runs as the ``eodag`` user and its home directory is
+``/home/eodag``. To keep user configuration outside the container, mount a host
+directory to the default EODAG configuration directory:
+
+.. code-block:: bash
+
+   mkdir -p "$HOME/.config/eodag"
+   docker run --rm \
+      -v "$HOME/.config/eodag:/home/eodag/.config/eodag" \
+      ghcr.io/cs-si/eodag:<version> list
+
+This lets EODAG create or reuse the same ``eodag.yml`` configuration file
+across container runs. See :ref:`configure` for the full configuration
+reference.
+
+Use a specific configuration file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If your configuration file is stored elsewhere, mount it in the container and
+set ``EODAG_CFG_FILE``:
+
+.. code-block:: bash
+
+   docker run --rm \
+      -v "$PWD/eodag.yml:/config/eodag.yml:ro" \
+      -e EODAG_CFG_FILE=/config/eodag.yml \
+      ghcr.io/cs-si/eodag:<version> list
+
+Provide credentials safely
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Do not bake credentials into a custom image. Prefer one of the runtime
+configuration methods documented in :ref:`configure`:
+
+* Mount a user configuration file or directory, as shown above.
+* Pass provider credentials through environment variables, using the
+  ``EODAG__<PROVIDER>__AUTH__CREDENTIALS__<KEY>`` or
+  ``EODAG__<PROVIDER>__API__CREDENTIALS__<KEY>`` naming patterns.
+
+For example, to pass a provider username and password at runtime:
+
+.. code-block:: bash
+
+   docker run --rm \
+      -e EODAG__CREODIAS__AUTH__CREDENTIALS__USERNAME="$CREODIAS_USERNAME" \
+      -e EODAG__CREODIAS__AUTH__CREDENTIALS__PASSWORD="$CREODIAS_PASSWORD" \
+      ghcr.io/cs-si/eodag:<version> list
+
+Persist downloaded products
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When downloading products, mount a host output directory and point the provider
+download configuration to it:
+
+.. code-block:: bash
+
+   mkdir -p "$PWD/eodag-downloads"
+   docker run --rm \
+      -v "$PWD:/work" \
+      -v "$PWD/eodag-downloads:/data" \
+      -v "$HOME/.config/eodag:/home/eodag/.config/eodag" \
+      -e EODAG__CREODIAS__DOWNLOAD__OUTPUT_DIR=/data \
+      ghcr.io/cs-si/eodag:<version> download \
+         --search-results /work/search_results.geojson
+
+If ``search_results.geojson`` is in another host directory, mount that
+directory and use the mounted path in the command.

--- a/docs/getting_started_guide/index.rst
+++ b/docs/getting_started_guide/index.rst
@@ -66,6 +66,7 @@ Each section below gives you a focused entry point with explanations and example
    overview
    features_overview
    install
+   docker
    collections
    product_storage_status
    configure
@@ -93,6 +94,13 @@ Each section below gives you a focused entry point with explanations and example
       :text-align: center
 
       Get ``eodag`` installed and ready to use in minutes.
+
+   .. grid-item-card:: |icon-download| Docker
+      :link: docker
+      :link-type: doc
+      :text-align: center
+
+      Run ``eodag`` with Docker and keep configuration outside the image.
 
    .. grid-item-card:: |icon-layers| Collections
       :link: collections

--- a/docs/getting_started_guide/index.rst
+++ b/docs/getting_started_guide/index.rst
@@ -59,6 +59,10 @@ Each section below gives you a focused entry point with explanations and example
       <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z"/>
    </svg>
 
+.. |icon-docker| raw:: html
+
+   <i class="fa-brands fa-docker" aria-hidden="true" style="vertical-align:middle; margin-right:6px;"></i>
+
 .. toctree::
    :hidden:
    :maxdepth: 2
@@ -95,7 +99,7 @@ Each section below gives you a focused entry point with explanations and example
 
       Get ``eodag`` installed and ready to use in minutes.
 
-   .. grid-item-card:: |icon-download| Docker
+   .. grid-item-card:: |icon-docker| Docker
       :link: docker
       :link-type: doc
       :text-align: center


### PR DESCRIPTION
## Summary
- add a Docker quickstart page to the getting started guide
- document GHCR image usage, persistent config mounts, EODAG_CFG_FILE, runtime credentials, and download output mounts
- add a short README entry linking to the Docker quickstart

Closes #2185

## Validation
- git diff --check
- local content assertions for the new docs page and getting started toctree

Note: I could not run the full Sphinx docs build locally because Sphinx is not installed in this Windows environment.