### PR TITLE
fix(plugins): dedl required queryables

### DIFF
--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -2268,7 +2268,9 @@ class StacSearch(PostJsonSearch):
                 # convert provider json field definition to python
                 default = kwargs.get(param, json_mtd.get("default"))
                 annotated_def = json_field_definition_to_python(
-                    json_mtd, default_value=default
+                    json_mtd,
+                    default_value=default,
+                    required=json_param in resp_as_json.get("required", []),
                 )
                 field_definition = get_args(annotated_def)
 

--- a/eodag/types/__init__.py
+++ b/eodag/types/__init__.py
@@ -258,7 +258,7 @@ def json_field_definition_to_python(
     ]
 
     if required:
-        metadata.append("json_schema_required")
+        metadata[1].metadata.append("json_schema_required")
 
     return Annotated[tuple(metadata)]
 

--- a/eodag/types/__init__.py
+++ b/eodag/types/__init__.py
@@ -252,15 +252,10 @@ def json_field_definition_to_python(
     else:
         field_default = default_value
 
-    metadata = [
-        python_type,
-        Field(field_default, **field_type_kwargs),
-    ]
-
+    field = Field(field_default, **field_type_kwargs)
     if required:
-        metadata[1].metadata.append("json_schema_required")
-
-    return Annotated[tuple(metadata)]
+        field.metadata.append("json_schema_required")
+    return Annotated[python_type, field]
 
 
 def python_field_definition_to_json(

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2436,12 +2436,14 @@ class TestSearchPluginStacSearch(BaseSearchPluginTest):
         self.assertEqual(get_origin(base_type), list)
         literal_args = get_args(base_type)
         self.assertEqual(literal_args, (Literal["00:00"],))
+        self.assertIn("json_schema_required", args[1].metadata)
 
         # Check that "start" has type Annotated[str, ...]
         self.assertIn("start", queryables_dedl)
         annotated_type = queryables_dedl["start"]
         args = get_args(annotated_type)
         self.assertEqual(args[0], str)
+        self.assertNotIn("json_schema_required", args[1].metadata)
 
         # Check that "geom" has type Annotated[Union[str, dict[str, float], BaseGeometry], ...]
         self.assertIn("geom", queryables_dedl)
@@ -2459,6 +2461,14 @@ class TestSearchPluginStacSearch(BaseSearchPluginTest):
                 if isinstance(arg, type)
             )
         )
+        self.assertTrue(args[1].is_required())
+
+        # Check that "bbox" has type fieldInfo with "required": "True" and json_schema_required in metadata
+        self.assertIn("bbox", queryables_dedl)
+        annotated_type = queryables_dedl["bbox"]
+        args = get_args(annotated_type)
+        self.assertTrue(args[1].is_required())
+        self.assertIn("json_schema_required", args[1].metadata)
 
     @mock.patch(
         "eodag.plugins.search.qssearch.QueryStringSearch._request", autospec=True


### PR DESCRIPTION
The DEDL provider exposes a required field in the queryables endpoint to indicate which queryable parameters are mandatory. However, this field was ignored by EODAG, causing all parameters to be marked with "required": false.

To fix this issue, I updated the discover_metadata method to correctly propagate the required information when calling json_field_definition_to_python. I also updated json_field_definition_to_python to store the "json_schema_required" metadata directly in field_info.metadata.

fixes https://github.com/CS-SI/eodag/issues/2214