### PR TITLE
fix(providers): constraints url for DT_CLIMATE_ADAPTATION and DT_EXTREMES

### DIFF
--- a/eodag/resources/providers/dedt_lumi.yml
+++ b/eodag/resources/providers/dedt_lumi.yml
@@ -34,11 +34,11 @@
   products:
     DT_CLIMATE_ADAPTATION:
       discover_queryables:
-        constraints_url: "https://s3.central.data.destination-earth.eu/swift/v1/dedt-lumi-constraints/{dataset}.json"
+        constraints_url: "https://s3.central.data.destination-earth.eu/swift/v1/constraints/dedt_lumi/{dataset}.json"
       dataset: climate-dt
     DT_EXTREMES:
       discover_queryables:
-        constraints_url: "https://s3.central.data.destination-earth.eu/swift/v1/dedt-lumi-constraints/{dataset}.json"
+        constraints_url: "https://s3.central.data.destination-earth.eu/swift/v1/constraints/dedt_lumi/{dataset}.json"
       dataset: extremes-dt
       class: d1
       expver: "0001"


### PR DESCRIPTION
Update the path of the DT_CLIMATE_ADAPTATION and DT_EXTREMES constraint. 
We are using :
https://s3.central.data.destination-earth.eu/swift/v1/constraints/dedt_lumi/extremes-dt.json
https://s3.central.data.destination-earth.eu/swift/v1/constraints/dedt_lumi/climate-dt.json
