### PR TITLE
fix(plugins): add datetime to queryables

### DIFF
--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -47,6 +47,7 @@ from eodag.utils import (
     string_to_jsonpath,
     update_nested_dict,
 )
+from eodag.utils.dates import get_datetime
 from eodag.utils.exceptions import ValidationError
 
 if TYPE_CHECKING:
@@ -442,6 +443,13 @@ class Search(PluginTopic):
         )
         discover_metadata = getattr(self.config, "discover_metadata", {})
         auto_discovery = discover_metadata.get("auto_discovery", False)
+
+        if "datetime" in filters:
+            datetimes = get_datetime(filters)
+            if "start_datetime" not in filters:
+                filters["start_datetime"] = datetimes[0]
+            if "end_datetime" not in filters:
+                filters["end_datetime"] = datetimes[1]
 
         if collection or getattr(self.config, "discover_queryables", {}).get(
             "fetch_url", ""

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -65,7 +65,6 @@ from eodag.utils.dates import (
     DATE_RANGE_PATTERN,
     compute_date_range_from_params,
     format_date,
-    get_datetime,
     is_range_in_range,
     parse_date,
     parse_to_utc,
@@ -603,12 +602,6 @@ class ECMWFSearch(PostJsonSearch):
         default_values.pop("metadata_mapping_from_product", None)
         default_values.pop("discover_queryables", None)
         kwargs.pop("discover_queryables", None)
-        if "datetime" in kwargs:
-            datetimes = get_datetime(kwargs)
-            if START not in kwargs:
-                kwargs[START] = datetimes[0]
-            if END not in kwargs:
-                kwargs[END] = datetimes[1]
         filters = {**default_values, **kwargs}
 
         if "start" in filters:

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -641,6 +641,7 @@ class ECMWFSearch(PostJsonSearch):
             if key not in ALLOWED_KEYWORDS | {
                 START,
                 END,
+                "datetime",
                 "geometry",
             } and not self._is_discoverable_metadata_key(key):
                 raise ValidationError(
@@ -697,6 +698,7 @@ class ECMWFSearch(PostJsonSearch):
                 | {
                     START,
                     END,
+                    "datetime",
                     "geometry",
                 }
                 and keyword not in [f["name"] for f in form]

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -65,6 +65,7 @@ from eodag.utils.dates import (
     DATE_RANGE_PATTERN,
     compute_date_range_from_params,
     format_date,
+    get_datetime,
     is_range_in_range,
     parse_date,
     parse_to_utc,
@@ -603,9 +604,11 @@ class ECMWFSearch(PostJsonSearch):
         default_values.pop("discover_queryables", None)
         kwargs.pop("discover_queryables", None)
         if "datetime" in kwargs:
-            start = kwargs.pop("datetime").split("T")[0]
-            if start and START not in kwargs:
-                kwargs[START] = start
+            datetimes = get_datetime(kwargs)
+            if START not in kwargs:
+                kwargs[START] = datetimes[0]
+            if END not in kwargs:
+                kwargs[END] = datetimes[1]
         filters = {**default_values, **kwargs}
 
         if "start" in filters:

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -602,6 +602,10 @@ class ECMWFSearch(PostJsonSearch):
         default_values.pop("metadata_mapping_from_product", None)
         default_values.pop("discover_queryables", None)
         kwargs.pop("discover_queryables", None)
+        if "datetime" in kwargs:
+            start = kwargs.pop("datetime").split("T")[0]
+            if start and START not in kwargs:
+                kwargs[START] = start
         filters = {**default_values, **kwargs}
 
         if "start" in filters:
@@ -641,7 +645,6 @@ class ECMWFSearch(PostJsonSearch):
             if key not in ALLOWED_KEYWORDS | {
                 START,
                 END,
-                "datetime",
                 "geometry",
             } and not self._is_discoverable_metadata_key(key):
                 raise ValidationError(
@@ -698,7 +701,6 @@ class ECMWFSearch(PostJsonSearch):
                 | {
                     START,
                     END,
-                    "datetime",
                     "geometry",
                 }
                 and keyword not in [f["name"] for f in form]

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -3907,6 +3907,65 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         "eodag.plugins.search.build_search_result.ECMWFSearch._fetch_data",
         autospec=True,
     )
+    def test_plugins_search_ecmwfsearch_discover_queryables_datetime(
+        self, mock__fetch_data
+    ):
+        """ECMWFSearch.discover_queryables must convert `datetime` into `start` and `end`."""
+        constraints_path = os.path.join(TEST_RESOURCES_PATH, "constraints.json")
+        with open(constraints_path) as f:
+            constraints = json.load(f)
+        form_path = os.path.join(TEST_RESOURCES_PATH, "form.json")
+        with open(form_path) as f:
+            form = json.load(f)
+        mock__fetch_data.side_effect = [constraints, form]
+
+        default_values = deepcopy(
+            getattr(self.search_plugin.config, "products", {}).get(
+                "CAMS_EU_AIR_QUALITY_RE", {}
+            )
+        )
+        default_values.pop("metadata_mapping", None)
+        params = deepcopy(default_values)
+        params["collection"] = "CAMS_EU_AIR_QUALITY_RE"
+        params["datetime"] = "2001-06-01/2001-06-01"
+        params["variable"] = "e"
+
+        queryables = self.search_plugin.discover_queryables(**params)
+
+        self.assertNotIn("datetime", queryables)
+        self.assertIn("start", queryables)
+        self.assertIn("end", queryables)
+
+        start_args = get_args(queryables["start"])
+        end_args = get_args(queryables["end"])
+        self.assertEqual(
+            "2001-06-01T00:00:00.000Z",
+            start_args[1].default,
+        )
+        self.assertEqual(
+            "2001-06-01T00:00:00.000Z",
+            end_args[1].default,
+        )
+
+        mock__fetch_data.assert_has_calls(
+            [
+                call(
+                    mock.ANY,
+                    "https://ads.atmosphere.copernicus.eu/api/catalogue/v1/collections/"
+                    "cams-europe-air-quality-reanalyses/constraints.json",
+                ),
+                call(
+                    mock.ANY,
+                    "https://ads.atmosphere.copernicus.eu/api/catalogue/v1/collections/"
+                    "cams-europe-air-quality-reanalyses/form.json",
+                ),
+            ]
+        )
+
+    @mock.patch(
+        "eodag.plugins.search.build_search_result.ECMWFSearch._fetch_data",
+        autospec=True,
+    )
     def test_plugins_search_ecmwfsearch_discover_queryables_ko(self, mock__fetch_data):
         constraints_path = os.path.join(TEST_RESOURCES_PATH, "constraints.json")
         with open(constraints_path) as f:

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -3919,18 +3919,19 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
             form = json.load(f)
         mock__fetch_data.side_effect = [constraints, form]
 
-        default_values = deepcopy(
-            getattr(self.search_plugin.config, "products", {}).get(
-                "CAMS_EU_AIR_QUALITY_RE", {}
-            )
+        queryables = self.search_plugin.list_queryables(
+            filters={
+                "datetime": "2001-06-01/2001-06-01",
+                "variable": "e",
+            },
+            collection="CAMS_EU_AIR_QUALITY_RE",
+            available_collections=["CAMS_EU_AIR_QUALITY_RE"],
+            collection_configs={
+                "CAMS_EU_AIR_QUALITY_RE": self.search_plugin.config.products[
+                    "CAMS_EU_AIR_QUALITY_RE"
+                ]
+            },
         )
-        default_values.pop("metadata_mapping", None)
-        params = deepcopy(default_values)
-        params["collection"] = "CAMS_EU_AIR_QUALITY_RE"
-        params["datetime"] = "2001-06-01/2001-06-01"
-        params["variable"] = "e"
-
-        queryables = self.search_plugin.discover_queryables(**params)
 
         self.assertNotIn("datetime", queryables)
         self.assertIn("start", queryables)
@@ -3946,6 +3947,9 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
             "2001-06-01T00:00:00.000Z",
             end_args[1].default,
         )
+
+        self.assertIn("ecmwf_variable", queryables)
+        self.assertEqual("e", get_args(queryables["ecmwf_variable"])[1].default)
 
         mock__fetch_data.assert_has_calls(
             [


### PR DESCRIPTION
Since EODAG v4 `datetime` is accepted in the search but it is not accepted as a filter in the queryables.

This fix translates `datetime` into a start/end parameters when appropriate. The conversion is only performed if start or end are not already present, preventing any override of existing temporal query parameters defined by the provider.

This ensures compatibility with the STAC parameters while preserving existing query behavior.
