### PR TITLE
fix(core): download link to asset

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Run Tests
 
 on:
   push:
-    branches: [master, develop, v3.10.x]
+    branches: [master, develop, v5_download_link_asset]
   pull_request:
-    branches: [master, develop, v3.10.x]
+    branches: [master, develop, v5_download_link_asset]
   schedule:
     - cron: "0 7 * * 1"
   workflow_dispatch:

--- a/eodag/api/product/_assets.py
+++ b/eodag/api/product/_assets.py
@@ -73,6 +73,12 @@ class AssetsDict(UserDict):
     def __setitem__(self, key: str, value: dict[str, Any]) -> None:
         if not self._check(key, value):
             return
+        # Merge with an already existing asset so that values seeded earlier
+        # (e.g. ``href`` / ``eodag:order_link``) are not lost when an incoming
+        # mapping only provides a subset of the keys.
+        existing = self.data.get(key)
+        if existing is not None:
+            value = {**existing.data, **value}
         super().__setitem__(key, Asset(self.product, key, value))
         self.sort()
         self._update_product_location()
@@ -109,32 +115,36 @@ class AssetsDict(UserDict):
     def _check(self, asset_key: str, asset_value: dict[str, Any]) -> bool:
         """Validate an asset before insertion.
 
-        Checks that the asset has a valid ``href`` or ``order_link`` and that its
-        URL is not already used by another (non-technical) asset.  Mutates
-        *asset_value* in place by stripping empty/unavailable href/order_link entries.
+        Checks that the asset has a valid ``href`` or ``eodag:order_link`` and that
+        its URL is not already used by another (non-technical) asset.  Mutates
+        *asset_value* in place by stripping empty/unavailable href/order_link entries
+        and normalizing the legacy ``order_link`` key to ``eodag:order_link``.
 
         :param asset_key: Key under which the asset will be stored
         :param asset_value: Mutable asset dictionary (modified in place)
         :returns: ``True`` if the asset is valid and can be inserted, ``False`` otherwise
         """
-        # Asset must have href or order_link
+        # Asset must have href or eodag:order_link
         href = asset_value.pop("href", None)
         if href not in [None, "", NOT_AVAILABLE]:
             asset_value["href"] = href
-        order_link = asset_value.pop("order_link", None)
+        # accept the legacy ``order_link`` key, normalizing it to ``eodag:order_link``
+        order_link = asset_value.pop("eodag:order_link", None) or asset_value.pop(
+            "order_link", None
+        )
         if order_link not in [None, "", NOT_AVAILABLE]:
-            asset_value["order_link"] = order_link
+            asset_value["eodag:order_link"] = order_link
 
-        if "href" not in asset_value and "order_link" not in asset_value:
+        if "href" not in asset_value and "eodag:order_link" not in asset_value:
             logger.warning(
-                "asset '{}' skipped ignored because neither href nor order_link is available".format(
+                "asset '{}' skipped ignored because neither href nor eodag:order_link is available".format(
                     asset_key
                 ),
             )
             return False
 
         def target_url(asset: dict[str, Any]) -> Optional[str]:
-            return asset.get("href") or asset.get("order_link")
+            return asset.get("href") or asset.get("eodag:order_link")
 
         assets = self.as_dict()
         used_urls = [
@@ -179,7 +189,11 @@ class AssetsDict(UserDict):
         :return: list of assets
         """
         if not asset_filter:
-            return [a for a in self.values() if "href" in a]
+            return [
+                a
+                for k, a in self.items()
+                if k not in TECHNICAL_ASSET_KEYS and "href" in a
+            ]
 
         if regex:
             filter_regex = re.compile(asset_filter)
@@ -302,7 +316,7 @@ class Asset(UserDict):
             super().__setitem__("title", self.key)
 
         # Order link behaviour require order:status state
-        orderlink = self.get("order_link")
+        orderlink = self.get("eodag:order_link") or self.get("order_link")
         orderstatus = self.get("order:status")
         if orderlink is not None and orderstatus is None:
             super().__setitem__("order:status", OFFLINE_STATUS)

--- a/eodag/api/product/_assets.py
+++ b/eodag/api/product/_assets.py
@@ -17,10 +17,15 @@
 # limitations under the License.
 from __future__ import annotations
 
+import logging
 import re
 from collections import UserDict
 from typing import TYPE_CHECKING, Any, Optional
 
+from typing_extensions import override
+
+from eodag.api.product.metadata_mapping import NOT_AVAILABLE, OFFLINE_STATUS
+from eodag.utils import guess_file_type
 from eodag.utils.exceptions import NotAvailableError
 from eodag.utils.repr import dict_to_html_table
 
@@ -28,6 +33,10 @@ if TYPE_CHECKING:
     from eodag.api.product import EOProduct
     from eodag.types.download_args import DownloadConf
     from eodag.utils import StreamResponse, Unpack
+
+logger = logging.getLogger("eodag.api.product.assets")
+
+TECHNICAL_ASSET_KEYS: tuple[str, ...] = ("download_link", "quicklook", "thumbnail")
 
 
 class AssetsDict(UserDict):
@@ -47,11 +56,12 @@ class AssetsDict(UserDict):
     ...     provider="foo",
     ...     properties={"id": "bar", "geometry": "POINT (0 0)"}
     ... )
-    >>> type(product.assets)
-    <class 'eodag.api.product._assets.AssetsDict'>
+    >>> from eodag.api.product._assets import AssetsDict
+    >>> isinstance(product.assets, AssetsDict)
+    True
     >>> product.assets.update({"foo": {"href": "http://somewhere/something"}})
     >>> product.assets
-    {'foo': {'href': 'http://somewhere/something'}}
+    {'foo': {'href': 'http://somewhere/something', 'title': 'foo', 'type': 'application/octet-stream'}}
     """
 
     product: EOProduct
@@ -60,12 +70,97 @@ class AssetsDict(UserDict):
         self.product = product
         super(AssetsDict, self).__init__(*args, **kwargs)
 
-    def update(self, data: dict[str, Any]) -> None:  # type: ignore
-        """Update assets"""
-        super().update(data)
-
     def __setitem__(self, key: str, value: dict[str, Any]) -> None:
+        if not self._check(key, value):
+            return
         super().__setitem__(key, Asset(self.product, key, value))
+        self.sort()
+        self._update_product_location()
+
+    @override
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        """Used to self update with external value"""
+        incoming = {k: v for k, v in dict(*args, **kwargs).items() if self._check(k, v)}
+
+        if not incoming:
+            return
+
+        super().update(incoming)
+        self.sort()
+        self._update_product_location()
+
+    def _update_product_location(self) -> None:
+        """Backward-compat: propagate ``download_link`` asset to product location.
+
+        ``EOProduct.location`` / ``EOProduct.remote_location`` are still expected to
+        carry the download URL by downstream code (download plugins, server-mode, ...).
+        Technical assets are NOT written back to ``EOProduct.properties``.
+        """
+        dl = self.data.get("download_link")
+        if dl is None:
+            return
+        href = dl.get("href") or ""
+        if href:
+            if not self.product.location:
+                self.product.location = href
+            if not self.product.remote_location:
+                self.product.remote_location = href
+
+    def _check(self, asset_key: str, asset_value: dict[str, Any]) -> bool:
+        """Validate an asset before insertion.
+
+        Checks that the asset has a valid ``href`` or ``order_link`` and that its
+        URL is not already used by another (non-technical) asset.  Mutates
+        *asset_value* in place by stripping empty/unavailable href/order_link entries.
+
+        :param asset_key: Key under which the asset will be stored
+        :param asset_value: Mutable asset dictionary (modified in place)
+        :returns: ``True`` if the asset is valid and can be inserted, ``False`` otherwise
+        """
+        # Asset must have href or order_link
+        href = asset_value.pop("href", None)
+        if href not in [None, "", NOT_AVAILABLE]:
+            asset_value["href"] = href
+        order_link = asset_value.pop("order_link", None)
+        if order_link not in [None, "", NOT_AVAILABLE]:
+            asset_value["order_link"] = order_link
+
+        if "href" not in asset_value and "order_link" not in asset_value:
+            logger.warning(
+                "asset '{}' skipped ignored because neither href nor order_link is available".format(
+                    asset_key
+                ),
+            )
+            return False
+
+        def target_url(asset: dict[str, Any]) -> Optional[str]:
+            return asset.get("href") or asset.get("order_link")
+
+        assets = self.as_dict()
+        used_urls = [
+            target_url(asset) for key, asset in assets.items() if key != asset_key
+        ]
+
+        # Prevent asset key / asset target url replication (out from technical ones)
+        # thumbnail and quicklook can share same url
+        url = target_url(asset_value)
+        if asset_key not in TECHNICAL_ASSET_KEYS and (url in used_urls):
+            # Duplicated url
+            return False
+
+        return True
+
+    def sort(self):
+        """Used to self sort"""
+        sorted_assets = {}
+        # Keep technical assets first
+        for key in TECHNICAL_ASSET_KEYS:
+            if key in self.data:
+                sorted_assets[key] = self.data.pop(key)
+        # Sort and add others
+        for key in sorted(self.data):
+            sorted_assets[key] = self.data[key]
+        self.data = sorted_assets
 
     def as_dict(self) -> dict[str, Any]:
         """Builds a representation of AssetsDict to enable its serialization
@@ -83,28 +178,30 @@ class AssetsDict(UserDict):
         :param regex: Uses regex to match the asset key or simply compare strings
         :return: list of assets
         """
-        if asset_filter:
-            if regex:
-                filter_regex = re.compile(asset_filter)
-                assets_keys = list(self.keys())
-                assets_keys = list(filter(filter_regex.fullmatch, assets_keys))
-            else:
-                assets_keys = [a for a in self.keys() if a == asset_filter]
-            filtered_assets = {}
-            if len(assets_keys) > 0:
-                filtered_assets = {a_key: self.get(a_key) for a_key in assets_keys}
-            assets_values = [a for a in filtered_assets.values() if a and "href" in a]
-            if not assets_values and regex:
-                # retry without regex
-                return self.get_values(asset_filter, regex=False)
-            elif not assets_values:
-                raise NotAvailableError(
-                    rf"No asset key matching re.fullmatch(r'{asset_filter}') was found in {self.product}"
-                )
-            else:
-                return assets_values
-        else:
+        if not asset_filter:
             return [a for a in self.values() if "href" in a]
+
+        if regex:
+            filter_regex = re.compile(asset_filter)
+            assets_keys = [k for k in self.keys() if filter_regex.fullmatch(k)]
+        else:
+            assets_keys = [k for k in self.keys() if k == asset_filter]
+
+        assets_values = [
+            a
+            for k in assets_keys
+            for a in [self.get(k)]
+            if isinstance(a, Asset) and "href" in a
+        ]
+
+        if assets_values:
+            return assets_values
+        if regex:
+            # retry without regex
+            return self.get_values(asset_filter, regex=False)
+        raise NotAvailableError(
+            rf"No asset key matching re.fullmatch(r'{asset_filter}') was found in {self.product}"
+        )
 
     def _repr_html_(self, embeded=False):
         thead = (
@@ -162,13 +259,20 @@ class Asset(UserDict):
     ...     properties={"id": "bar", "geometry": "POINT (0 0)"}
     ... )
     >>> product.assets.update({"foo": {"href": "http://somewhere/something"}})
-    >>> type(product.assets["foo"])
-    <class 'eodag.api.product._assets.Asset'>
+    >>> from eodag.api.product._assets import Asset
+    >>> isinstance(product.assets["foo"], Asset)
+    True
     >>> product.assets["foo"]
-    {'href': 'http://somewhere/something'}
+    {'href': 'http://somewhere/something', 'title': 'foo', 'type': 'application/octet-stream'}
     """
 
     product: EOProduct
+
+    # Location
+    location: Optional[str]
+    remote_location: Optional[str]
+
+    # File
     size: int
     filename: Optional[str]
     rel_path: str
@@ -176,7 +280,48 @@ class Asset(UserDict):
     def __init__(self, product: EOProduct, key: str, *args: Any, **kwargs: Any) -> None:
         self.product = product
         self.key = key
+        self.location = None
+        self.remote_location = None
         super(Asset, self).__init__(*args, **kwargs)
+        self._update()
+
+    def __setitem__(self, key, item):
+        super().__setitem__(key, item)
+        self._update()
+
+    def _update(self):
+        """Normalize asset fields and sync ``location``/``remote_location`` from ``href``.
+
+        Fills in default ``title``, ``href``, ``order:status`` and ``type`` entries
+        when missing, and mirrors a non-empty ``href`` into the asset's
+        ``location`` / ``remote_location`` attributes.
+        """
+
+        title = self.get("title")
+        if title is None:
+            super().__setitem__("title", self.key)
+
+        # Order link behaviour require order:status state
+        orderlink = self.get("order_link")
+        orderstatus = self.get("order:status")
+        if orderlink is not None and orderstatus is None:
+            super().__setitem__("order:status", OFFLINE_STATUS)
+
+        href = self.get("href")
+        if href is None:
+            super().__setitem__("href", "")
+            href = ""
+
+        if href != "":
+            # Provide location and remote_location when undefined and href updated
+            if self.location is None:
+                self.location = href
+            if self.remote_location is None:
+                self.remote_location = href
+            # With order behaviour, href can be fill later
+            content_type = self.get("type")
+            if content_type is None:
+                super().__setitem__("type", guess_file_type(href))
 
     def as_dict(self) -> dict[str, Any]:
         """Builds a representation of Asset to enable its serialization

--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -470,12 +470,15 @@ class EOProduct:
                                 the download and authentication plugins.
         """
         download_plugin = plugins_manager.get_download_plugin(self)
-        if len(self.assets) > 0:
-            matching_url = next(iter(self.assets.values()))["href"]
-        elif self.properties.get("order:status") != ONLINE_STATUS:
+        if (
+            self.assets.get("download_link", {}).get("order:status", ONLINE_STATUS)
+            != ONLINE_STATUS
+        ):
             matching_url = self.properties.get(
                 "eodag:order_link"
             ) or self.properties.get("eodag:download_link")
+        elif len(self.assets) > 0:
+            matching_url = next(iter(self.assets.values()))["href"]
         else:
             matching_url = self.properties.get("eodag:download_link")
 

--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -470,17 +470,15 @@ class EOProduct:
                                 the download and authentication plugins.
         """
         download_plugin = plugins_manager.get_download_plugin(self)
-        if (
-            self.assets.get("download_link", {}).get("order:status", ONLINE_STATUS)
-            != ONLINE_STATUS
-        ):
-            matching_url = self.properties.get(
-                "eodag:order_link"
-            ) or self.properties.get("eodag:download_link")
+        download_asset = self.assets.get("download_link", {})
+        if download_asset.get("order:status", ONLINE_STATUS) != ONLINE_STATUS:
+            matching_url = download_asset.get("eodag:order_link") or download_asset.get(
+                "href"
+            )
         elif len(self.assets) > 0:
-            matching_url = next(iter(self.assets.values()))["href"]
+            matching_url = next(iter(self.assets.values())).get("href")
         else:
-            matching_url = self.properties.get("eodag:download_link")
+            matching_url = download_asset.get("href")
 
         try:
             auth_plugin = next(
@@ -531,6 +529,19 @@ class EOProduct:
                 except (TypeError, ValueError) as e:
                     logger.debug(
                         f"Could not resolve {k} property ({v}) in register_downloader: {str(e)}"
+                    )
+
+        # keep the download_link asset href in sync with the resolved location
+        download_asset = self.assets.get("download_link")
+        if download_asset is not None:
+            asset_href = download_asset.get("href")
+            if isinstance(asset_href, str) and "%(" in asset_href:
+                try:
+                    download_asset["href"] = asset_href % vars(self.downloader.config)
+                except (TypeError, ValueError) as e:
+                    logger.debug(
+                        f"Could not resolve download_link asset href ({asset_href})"
+                        f" in register_downloader: {str(e)}"
                     )
 
     def download(

--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -687,6 +687,7 @@ class EOProduct:
     def _download_quicklook(
         self,
         quicklook_file: str,
+        quicklook_url: str,
         progress_callback: ProgressCallback,
         ssl_verify: Optional[bool] = None,
         auth: Optional[AuthBase] = None,
@@ -698,6 +699,7 @@ class EOProduct:
         authentication, and can display a download progress if a callback is provided.
 
         :param quicklook_file: The full path (including filename) where the quicklook will be saved.
+        :param quicklook_url: The quicklook URL to fetch.
         :param progress_callback: A callable that accepts the current and total download sizes
                                 to display or log the download progress. It must support `reset(total)`
                                 and be callable with downloaded chunk sizes.
@@ -707,7 +709,7 @@ class EOProduct:
         :raises HTTPError: If the HTTP request to the quicklook URL fails.
         """
         with requests.get(
-            self.properties["eodag:quicklook"],
+            quicklook_url,
             stream=True,
             auth=auth,
             headers=USER_AGENT,
@@ -748,29 +750,33 @@ class EOProduct:
         :returns: The absolute path of the downloaded quicklook
         """
 
-        def format_quicklook_address() -> None:
+        quicklook_asset = self.assets.get("quicklook")
+        quicklook_url = quicklook_asset.get("href") if quicklook_asset else None
+
+        def format_quicklook_address(url: str) -> str:
             """If the quicklook address is a Python format string, resolve the
             formatting with the properties of the product."""
-            fstrmatch = re.match(r".*{.+}*.*", self.properties["eodag:quicklook"])
+            fstrmatch = re.match(r".*{.+}*.*", url)
             if fstrmatch:
-                self.properties["eodag:quicklook"] = format_string(
+                return format_string(
                     None,
-                    self.properties["eodag:quicklook"],
+                    url,
                     **{
                         prop_key: prop_val
                         for prop_key, prop_val in self.properties.items()
                         if prop_key != "eodag:quicklook"
                     },
                 )
+            return url
 
-        if self.properties.get("eodag:quicklook") is None:
+        if quicklook_url is None:
             logger.warning(
                 "Missing information to retrieve quicklook for EO product: %s",
                 self.properties["id"],
             )
             return ""
 
-        format_quicklook_address()
+        quicklook_url = format_quicklook_address(quicklook_url)
 
         if output_dir is not None:
             quicklooks_output_dir = os.path.abspath(os.path.realpath(output_dir))
@@ -805,11 +811,10 @@ class EOProduct:
             # it is a HTTP URL. If not, we assume it is a base64 string, in which case
             # we just decode the content, write it into the quicklook_file and return it.
             if not (
-                self.properties["eodag:quicklook"].startswith("http")
-                or self.properties["eodag:quicklook"].startswith("https")
+                quicklook_url.startswith("http") or quicklook_url.startswith("https")
             ):
                 with open(quicklook_file, "wb") as fd:
-                    img = self.properties["eodag:quicklook"].encode("ascii")
+                    img = quicklook_url.encode("ascii")
                     fd.write(base64.b64decode(img))
                 return quicklook_file
 
@@ -829,7 +834,7 @@ class EOProduct:
             )
             try:
                 self._download_quicklook(
-                    quicklook_file, progress_callback, ssl_verify, auth
+                    quicklook_file, quicklook_url, progress_callback, ssl_verify, auth
                 )
             except RequestException as e:
                 logger.debug(
@@ -837,7 +842,11 @@ class EOProduct:
                 )
                 try:
                     self._download_quicklook(
-                        quicklook_file, progress_callback, ssl_verify, None
+                        quicklook_file,
+                        quicklook_url,
+                        progress_callback,
+                        ssl_verify,
+                        None,
                     )
                 except RequestException as e_no_auth:
                     logger.error(

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -24,6 +24,7 @@ import logging
 import re
 from string import Formatter
 from typing import TYPE_CHECKING, Any, AnyStr, Callable, Iterator, Optional, Union, cast
+from urllib.parse import unquote
 
 import geojson
 import orjson
@@ -39,7 +40,6 @@ from shapely import wkt
 from shapely.geometry import LineString, MultiPolygon, Point, Polygon
 from shapely.ops import transform
 
-from eodag.api.product._assets import Asset
 from eodag.types.queryables import Queryables
 from eodag.utils import (
     DEFAULT_PROJ,
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
 
     from shapely.geometry.base import BaseGeometry
 
+    from eodag.api.product._assets import Asset
     from eodag.config import PluginConfig
 
 logger = logging.getLogger("eodag.product.metadata_mapping")
@@ -211,6 +212,8 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
         - ``to_rounded_wkt``: simplify the WKT of a geometry
         - ``to_title``: Convert a string to title case
         - ``to_upper``: Convert a string to uppercase
+        - ``url_decode``: Convert a string url_encoded to decoded ones
+        - ``round``: Convert a string number to another one without decimal part
 
     :param search_param: The string to be formatted
     :param args: (optional) Additional arguments to use in the formatting process
@@ -831,6 +834,28 @@ def format_metadata(search_param: str, *args: Any, **kwargs: Any) -> str:
         def convert_to_upper(string: str) -> str:
             """Convert a string to uppercase."""
             return string.upper()
+
+        @staticmethod
+        def convert_url_decode(string: str):
+            return unquote(string)
+
+        @staticmethod
+        def convert_round(string: Any) -> str:
+            """Convert a number string to integer string"""
+            if isinstance(string, float):
+                return str(int(string))
+            elif isinstance(string, int):
+                return str(string)
+            elif isinstance(string, str):
+                formatted = ""
+                for i in range(0, len(string)):
+                    char = string[i]
+                    if char == ".":
+                        break
+                    if "0123456789".find(char) >= 0:
+                        formatted += char
+                return formatted
+            return string
 
         @staticmethod
         def convert_to_title(string: str) -> str:
@@ -1607,10 +1632,18 @@ def format_query_params(
 
         if COMPLEX_QS_REGEX.match(provider_search_param):
             parts = provider_search_param.split("=")
+
             if len(parts) == 1:
-                formatted_query_param = format_metadata(
-                    provider_search_param, collection, **query_dict
-                )
+
+                # If part contains something to interprete (nested braces or a converter)
+                inner = parts[0].strip("{}")
+                if inner.find("{") >= 0 or "#" in inner:
+                    formatted_query_param = format_metadata(
+                        provider_search_param, collection, **query_dict
+                    )
+                else:
+                    formatted_query_param = "{" + inner + "}"
+
                 formatted_query_param = formatted_query_param.replace("'", '"')
                 if "{{" in provider_search_param:
                     # retrieve values from hashes where keys are given in the param
@@ -2049,6 +2082,7 @@ def normalize_bands(data: Union[dict, Asset]) -> Union[dict, Asset]:
         "statistics",
     ]
     EXCLUDE_MOVE_TO_PARENT_BAND_FIELDNAME = ["name", "eo:common_name"]
+    from eodag.api.product._assets import Asset
 
     # https://github.com/radiantearth/stac-spec/blob/v1.1.0/best-practices.md#bands
     # Migrate band STAC 1.0 to 1.1

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -1173,6 +1173,7 @@ def properties_from_json(
     json: dict[str, Any],
     mapping: dict[str, Any],
     discovery_config: Optional[dict[str, Any]] = None,
+    existing_properties: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     """Extract properties from a provider json result.
 
@@ -1184,6 +1185,8 @@ def properties_from_json(
     :param discovery_config: (optional) metadata discovery configuration dict, accepting among other items
                              `discovery_pattern` (Regex pattern for metadata key discovery, e.g. "^[a-zA-Z]+$"),
                              `discovery_path` (String representation of jsonpath)
+    :param existing_properties: (optional) already parsed properties made available (in addition to the
+                                properties extracted from ``json``) when resolving templates
     :returns: The metadata of the :class:`~eodag.api.product._product.EOProduct`
     """
     extracted_value: Any
@@ -1261,14 +1264,20 @@ def properties_from_json(
             pass
 
     # Resolve templates
+    # already parsed properties are made available to resolve templates, without
+    # leaking into the returned properties
+    available_properties: dict[str, Any] = {**(existing_properties or {}), **properties}
     for metadata, template in templates.items():
         try:
-            properties[metadata] = format_string(metadata, template, **properties)
+            properties[metadata] = format_string(
+                metadata, template, **available_properties
+            )
+            available_properties[metadata] = properties[metadata]
         except ValueError:
             logger.warning(
                 f"Could not parse {metadata} ({template}) using product properties"
             )
-            logger.debug(f"available properties: {properties}")
+            logger.debug(f"available properties: {available_properties}")
             properties[metadata] = NOT_AVAILABLE
 
     # adds missing discovered properties

--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -1349,6 +1349,7 @@ def properties_from_xml(
     mapping: Any,
     empty_ns_prefix: str = "ns",
     discovery_config: Optional[dict[str, Any]] = None,
+    existing_properties: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     """Extract properties from a provider xml result.
 
@@ -1365,6 +1366,8 @@ def properties_from_xml(
     :param discovery_config: (optional) metadata discovery configuration dict, accepting among other items
                              `discovery_pattern` (Regex pattern for metadata key discovery, e.g. "^[a-zA-Z]+$"),
                              `discovery_path` (String representation of xpath)
+    :param existing_properties: (optional) already parsed properties made available (in addition to the
+                                properties extracted from ``xml_as_text``) when resolving templates
     :returns: the metadata of the :class:`~eodag.api.product._product.EOProduct`
     """
     properties: dict[str, Any] = {}
@@ -1469,8 +1472,21 @@ def properties_from_xml(
             else:
                 properties[metadata] = path_or_text
     # Resolve templates
+    # already parsed properties are made available to resolve templates, without
+    # leaking into the returned properties
+    available_properties: dict[str, Any] = {**(existing_properties or {}), **properties}
     for metadata, template in templates.items():
-        properties[metadata] = template.format(**properties)
+        try:
+            properties[metadata] = format_string(
+                metadata, template, **available_properties
+            )
+            available_properties[metadata] = properties[metadata]
+        except ValueError:
+            logger.warning(
+                f"Could not parse {metadata} ({template}) using product properties"
+            )
+            logger.debug(f"available properties: {available_properties}")
+            properties[metadata] = NOT_AVAILABLE
 
     # adds missing discovered properties
     if not discovery_config:

--- a/eodag/api/search_result.py
+++ b/eodag/api/search_result.py
@@ -34,7 +34,7 @@ from eodag.plugins.crunch.filter_latest_intersect import FilterLatestIntersect
 from eodag.plugins.crunch.filter_latest_tpl_name import FilterLatestByName
 from eodag.plugins.crunch.filter_overlap import FilterOverlap
 from eodag.plugins.crunch.filter_property import FilterProperty
-from eodag.utils import STAC_VERSION, _deprecated
+from eodag.utils import ONLINE_STATUS, STAC_VERSION, _deprecated
 
 if TYPE_CHECKING:
     from shapely.geometry.base import BaseGeometry
@@ -178,11 +178,23 @@ class SearchResult(UserList[EOProduct]):
     def filter_online(self) -> SearchResult:
         """Filter to only keep online products.
 
-        Applies :class:`~eodag.plugins.crunch.filter_property.FilterProperty` crunch for ``order:status == succeeded``.
+        Keeps products whose ``download_link`` asset ``order:status`` is online
+        (``succeeded``). Products without a ``download_link`` asset are considered
+        online.
 
         :returns: The result of the application of the crunching method to the EO products
         """
-        return self.filter_property(**{"order:status": "succeeded"})
+        return SearchResult(
+            [
+                product
+                for product in self.data
+                if product.assets.get("download_link", {}).get(
+                    "order:status", ONLINE_STATUS
+                )
+                == ONLINE_STATUS
+            ],
+            self.number_matched,
+        )
 
     @classmethod
     def from_dict(

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -584,7 +584,7 @@ class PluginConfig(yaml.YAMLObject):
 
     def __or__(self, other: Union[Self, dict[str, Any]]) -> Self:
         """Return a new PluginConfig with merged values."""
-        new_config = self.__class__.from_mapping(self.__dict__)
+        new_config: Self = self.__class__.from_mapping(self.__dict__)
         new_config.update(other)
         return new_config
 

--- a/eodag/plugins/apis/ecmwf.py
+++ b/eodag/plugins/apis/ecmwf.py
@@ -242,7 +242,7 @@ class EcmwfApi(Api, ECMWFSearch):
             raise DownloadError(e)
 
         with open(record_filename, "w") as fh:
-            fh.write(product.properties["eodag:download_link"])
+            fh.write(product.remote_location)
         logger.debug("Download recorded in %s", record_filename)
 
         # do not try to extract a directory

--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -135,6 +135,8 @@ class UsgsApi(Api):
                     os.remove(api.TMPFILE)
                     continue
                 raise AuthenticationError("Please check your USGS credentials.") from e
+            except Exception as e:
+                raise AuthenticationError("Authentication failure") from e
 
     def query(
         self,
@@ -255,13 +257,13 @@ class UsgsApi(Api):
                     result, self.config.metadata_mapping
                 )
 
-                final.append(
-                    EOProduct(
-                        collection=collection,
-                        provider=self.provider,
-                        properties=product_properties,
-                    )
+                product = EOProduct(
+                    collection=collection,
+                    provider=self.provider,
+                    properties=product_properties,
                 )
+                product.assets.update(self.build_assets_from_mapping(result, product))
+                final.append(product)
         except USGSError as e:
             logger.warning(
                 f"Collection {usgs_collection} may not exist on USGS EE catalog"

--- a/eodag/plugins/apis/usgs.py
+++ b/eodag/plugins/apis/usgs.py
@@ -420,7 +420,7 @@ class UsgsApi(Api):
         download_request(product, fs_path, progress_callback, **kwargs)
 
         with open(record_filename, "w") as fh:
-            fh.write(product.properties["eodag:download_link"])
+            fh.write(product.remote_location)
         logger.debug(f"Download recorded in {record_filename}")
 
         api.logout()

--- a/eodag/plugins/download/aws.py
+++ b/eodag/plugins/download/aws.py
@@ -31,6 +31,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from lxml import etree
 from requests.auth import AuthBase
 
+from eodag.api.product._assets import TECHNICAL_ASSET_KEYS
 from eodag.api.product.metadata_mapping import (
     mtd_cfg_as_conversion_and_querypath,
     properties_from_json,
@@ -588,22 +589,22 @@ class AwsDownload(Download):
         :return: tuples of bucket names and prefixes
         """
         # if assets are defined, use them instead of scanning product.location
-        if len(product.assets) > 0 and not ignore_assets:
+        # technical assets (e.g. download_link) are product-level links, not files
+        real_assets = {
+            k: v for k, v in product.assets.items() if k not in TECHNICAL_ASSET_KEYS
+        }
+        if real_assets and not ignore_assets:
             if asset_filter:
                 filter_regex = re.compile(asset_filter)
-                assets_keys = getattr(product, "assets", {}).keys()
-                assets_keys = list(filter(filter_regex.fullmatch, assets_keys))
-                filtered_assets = {
-                    a_key: getattr(product, "assets", {})[a_key]
-                    for a_key in assets_keys
-                }
+                assets_keys = list(filter(filter_regex.fullmatch, real_assets.keys()))
+                filtered_assets = {a_key: real_assets[a_key] for a_key in assets_keys}
                 assets_values = [a for a in filtered_assets.values() if "href" in a]
                 if not assets_values:
                     raise NotAvailableError(
                         rf"No asset key matching re.fullmatch(r'{asset_filter}') was found in {product}"
                     )
             else:
-                assets_values = list(product.assets.values())
+                assets_values = list(real_assets.values())
 
             bucket_names_and_prefixes = []
             for complementary_url in assets_values:

--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -548,7 +548,7 @@ class Download(PluginTopic):
             if (
                 product.downloader
                 and product.downloader.config.type == "AwsDownload"
-                or len(product.assets) > 0
+                or len(product.assets.get_values()) > 0
                 and (
                     not getattr(self.config, "ignore_assets", False)
                     or kwargs.get("asset") is not None

--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -691,7 +691,9 @@ class Download(PluginTopic):
                             not_available_info = str(e)
                         else:
                             if (
-                                product.properties.get("order:status", ONLINE_STATUS)
+                                product.assets.get("download_link", {}).get(
+                                    "order:status", ONLINE_STATUS
+                                )
                                 == ONLINE_STATUS
                             ) or timeout <= 0:
                                 return download
@@ -747,11 +749,12 @@ class Download(PluginTopic):
                         nb_info.display_html(retry_info)
                         sleep(wait_seconds)
                     elif datetime_now >= stop_time and timeout > 0:
-                        if "order:status" not in product.properties:
-                            product.properties["order:status"] = "N/A status"
+                        order_status = product.assets.get("download_link", {}).get(
+                            "order:status", "N/A status"
+                        )
                         logger.info(not_available_info)
                         raise NotAvailableError(
-                            f"{product.properties['title']} is not available ({product.properties['order:status']})"
+                            f"{product.properties['title']} is not available ({order_status})"
                             f" and order was not successfull, timeout reached"
                         )
                     elif datetime_now >= stop_time:

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -180,7 +180,8 @@ class HTTPDownload(Download):
         :param kwargs: download additional kwargs
         :returns: the returned json status response
         """
-        product.properties["order:status"] = STAGING_STATUS
+        if "download_link" in product.assets:
+            product.assets["download_link"]["order:status"] = STAGING_STATUS
 
         order_method = getattr(self.config, "order_method", "GET").upper()
         ssl_verify = getattr(self.config, "ssl_verify", True)
@@ -227,7 +228,8 @@ class HTTPDownload(Download):
                     response.raise_for_status()
                     ordered_message = response.text
                     logger.debug(ordered_message)
-                    product.properties["order:status"] = STAGING_STATUS
+                    if "download_link" in product.assets:
+                        product.assets["download_link"]["order:status"] = STAGING_STATUS
                 except RequestException as e:
                     self._check_auth_exception(e)
                     QuotaExceededError.raise_if_quota_exceeded(e, self.provider)
@@ -473,7 +475,8 @@ class HTTPDownload(Download):
                     f"Provider {product.provider} returned: {status_dict.get('error_message', status_message)}"
                 )
 
-        product.properties["order:status"] = STAGING_STATUS
+        if "download_link" in product.assets:
+            product.assets["download_link"]["order:status"] = STAGING_STATUS
 
         success_status: dict[str, Any] = status_config.get("success", {}).get(
             "eodag:order_status"
@@ -486,7 +489,8 @@ class HTTPDownload(Download):
             product.properties.pop("eodag:download_link", None)
             return None
 
-        product.properties["order:status"] = ONLINE_STATUS
+        if "download_link" in product.assets:
+            product.assets["download_link"]["order:status"] = ONLINE_STATUS
 
         if not config_on_success:
             # Nothing left to do
@@ -691,7 +695,8 @@ class HTTPDownload(Download):
                     raise DownloadError(f"product {product.properties['id']} is empty")
                 else:
                     # make sure storage status is online
-                    product.properties["order:status"] = ONLINE_STATUS
+                    if "download_link" in product.assets:
+                        product.assets["download_link"]["order:status"] = ONLINE_STATUS
 
                 return path
             else:
@@ -732,16 +737,15 @@ class HTTPDownload(Download):
 
     def _check_stream_size(self, product: EOProduct) -> int:
         stream_size = int(product._stream.headers.get("content-length", 0))
-        if (
-            stream_size == 0
-            and "order:status" in product.properties
-            and product.properties["order:status"] != ONLINE_STATUS
-        ):
+        order_status = product.assets.get("download_link", {}).get(
+            "order:status", ONLINE_STATUS
+        )
+        if stream_size == 0 and order_status != ONLINE_STATUS:
             raise NotAvailableError(
                 "%s(initially %s) ordered, got: %s"
                 % (
                     product.properties["title"],
-                    product.properties["order:status"],
+                    order_status,
                     product._stream.reason,
                 )
             )
@@ -907,7 +911,10 @@ class HTTPDownload(Download):
             e.response.text.strip() if e is not None and e.response is not None else ""
         )
         # product not available
-        if product.properties.get("order:status", ONLINE_STATUS) != ONLINE_STATUS:
+        order_status = product.assets.get("download_link", {}).get(
+            "order:status", ONLINE_STATUS
+        )
+        if order_status != ONLINE_STATUS:
             msg = (
                 ordered_message
                 if ordered_message and not response_text
@@ -918,7 +925,7 @@ class HTTPDownload(Download):
                 "%s(initially %s) requested, returned: %s"
                 % (
                     product.properties["title"],
-                    product.properties["order:status"],
+                    order_status,
                     msg,
                 )
             )
@@ -939,16 +946,19 @@ class HTTPDownload(Download):
         product: EOProduct,
         auth: Optional[AuthBase],
     ) -> None:
+        order_status = product.assets.get("download_link", {}).get(
+            "order:status", ONLINE_STATUS
+        )
         if (
             "eodag:order_link" in product.properties
-            and product.properties.get("order:status") == OFFLINE_STATUS
+            and order_status == OFFLINE_STATUS
             and not product.properties.get("eodag:order_status")
         ):
             self._order(product=product, auth=auth)
 
         if (
             product.properties.get("eodag:status_link")
-            and product.properties.get("order:status") != ONLINE_STATUS
+            and order_status != ONLINE_STATUS
         ):
             self._order_status(product=product, auth=auth)
 
@@ -1066,7 +1076,8 @@ class HTTPDownload(Download):
             ).get(
                 "http_code"
             ):
-                product.properties["order:status"] = "ORDERED"
+                if "download_link" in product.assets:
+                    product.assets["download_link"]["order:status"] = "ORDERED"
                 self._process_exception(None, product, ordered_message)
             stream_size = self._check_stream_size(product) or None
 

--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -149,6 +149,16 @@ class HTTPDownload(Download):
             "ignore_assets", getattr(self.config, "ignore_assets", False)
         )
 
+    @staticmethod
+    def _set_download_link_href(product: EOProduct, href: str) -> None:
+        """Update (or create) the product ``download_link`` asset ``href`` and keep
+        ``EOProduct.location`` / ``EOProduct.remote_location`` in sync."""
+        product.remote_location = product.location = href
+        if "download_link" in product.assets:
+            product.assets["download_link"]["href"] = href
+        else:
+            product.assets["download_link"] = {"href": href}
+
     def _order(
         self,
         product: EOProduct,
@@ -158,7 +168,7 @@ class HTTPDownload(Download):
         """Send product order request.
 
         It will be executed once before the download retry loop, if the product is orderable
-        and has ``eodag:order_link`` in its properties.
+        and has ``eodag:order_link`` in its ``download_link`` asset.
         Product ordering can be configured using the following download plugin parameters:
 
             - :attr:`~eodag.config.PluginConfig.order_enabled`: Wether order is enabled or not (may not use this method
@@ -171,7 +181,7 @@ class HTTPDownload(Download):
 
               - *metadata_mapping*: edit or add new product propoerties properties
 
-        Product properties used for order:
+        Product ``download_link`` asset key used for order:
 
             - **eodag:order_link**: order request URL
 
@@ -180,6 +190,7 @@ class HTTPDownload(Download):
         :param kwargs: download additional kwargs
         :returns: the returned json status response
         """
+        order_link = product.assets.get("download_link", {}).get("eodag:order_link")
         if "download_link" in product.assets:
             product.assets["download_link"]["order:status"] = STAGING_STATUS
 
@@ -192,7 +203,7 @@ class HTTPDownload(Download):
         order_kwargs: OrderKwargs = {}
         if order_method == "POST":
             # separate url & parameters
-            parts = urlparse(str(product.properties["eodag:order_link"]))
+            parts = urlparse(str(order_link))
             query_dict = {}
             # `parts.query` may be a JSON with query strings as one of values. If `parse_qs` is executed as first step,
             # the resulting `query_dict` would be erroneous.
@@ -209,7 +220,7 @@ class HTTPDownload(Download):
             if query_dict:
                 order_kwargs["json"] = query_dict
         else:
-            order_url = product.properties["eodag:order_link"]
+            order_url = order_link
             order_kwargs = {}
 
         headers = {**getattr(self.config, "order_headers", {}), **USER_AGENT}
@@ -269,6 +280,9 @@ class HTTPDownload(Download):
             {"json": json_response, "headers": {**response.headers}},
             on_response_mm_jsonpath,
         )
+        # the freshly ordered download link is moved to the download_link asset and
+        # must never end up in product.properties
+        download_link = properties_update.pop("eodag:download_link", None)
         product.properties.update(
             {k: v for k, v in properties_update.items() if v != NOT_AVAILABLE}
         )
@@ -282,10 +296,8 @@ class HTTPDownload(Download):
                 + "_"
                 + product.properties["id"]
             )
-        if "eodag:download_link" in product.properties:
-            product.remote_location = product.location = product.properties[
-                "eodag:download_link"
-            ]
+        if download_link not in (None, NOT_AVAILABLE):
+            self._set_download_link_href(product, download_link)
             logger.debug(f"Product location updated to {product.location}")
 
         return json_response
@@ -485,8 +497,8 @@ class HTTPDownload(Download):
         if (
             success_status and success_status != status_dict.get("eodag:order_status")
         ) or (success_code and success_code != response.status_code):
-            # Remove the download link if the order has not been completed or was not successful
-            product.properties.pop("eodag:download_link", None)
+            # Order has not been completed or was not successful: the download_link
+            # asset order:status (set to STAGING above) prevents the download.
             return None
 
         if "download_link" in product.assets:
@@ -596,12 +608,13 @@ class HTTPDownload(Download):
                 f"Could not parse result after order success. Please search and download {product} again"
             ) from e
 
-        # update product
+        # update product; the freshly ordered download link is moved to the
+        # download_link asset and must never end up in product.properties
+        _missing = object()
+        download_link = properties_update.pop("eodag:download_link", _missing)
         product.properties.update(properties_update)
-        if "eodag:download_link" in properties_update:
-            product.location = product.remote_location = product.properties[
-                "eodag:download_link"
-            ]
+        if download_link is not _missing:
+            self._set_download_link_href(product, download_link)
         else:
             self.order_response_process(response, product)
 
@@ -641,8 +654,9 @@ class HTTPDownload(Download):
             return fs_path
 
         # download assets if exist instead of remote_location
-        if len(product.assets) > 0 and (
-            not self._should_ignore_assets(product) or kwargs.get("asset") is not None
+        if kwargs.get("asset") is not None or (
+            len(product.assets.get_values()) > 0
+            and not self._should_ignore_assets(product)
         ):
             try:
                 fs_path = self._download_assets(
@@ -805,8 +819,9 @@ class HTTPDownload(Download):
             raise MisconfiguredError(f"Incompatible auth plugin: {type(auth)}")
 
         # download assets if exist instead of remote_location
-        if len(product.assets) > 0 and (
-            not self._should_ignore_assets(product) or kwargs.get("asset") is not None
+        if kwargs.get("asset") is not None or (
+            len(product.assets.get_values()) > 0
+            and not self._should_ignore_assets(product)
         ):
             executor = ThreadPoolExecutor(
                 max_workers=getattr(self.config, "max_workers", None)
@@ -950,7 +965,7 @@ class HTTPDownload(Download):
             "order:status", ONLINE_STATUS
         )
         if (
-            "eodag:order_link" in product.properties
+            product.assets.get("download_link", {}).get("eodag:order_link")
             and order_status == OFFLINE_STATUS
             and not product.properties.get("eodag:order_status")
         ):

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -251,11 +251,14 @@ class PluginManager:
         """
         # matching url from product to download
         if product is not None and len(product.assets) > 0:
-            matching_url = next(iter(product.assets.values()))["href"]
+            download_asset = product.assets.get("download_link") or next(
+                iter(product.assets.values())
+            )
+            matching_url = download_asset.get("href") or download_asset.get(
+                "eodag:order_link"
+            )
         elif product is not None:
-            matching_url = product.properties.get(
-                "eodag:download_link"
-            ) or product.properties.get("eodag:order_link")
+            matching_url = None
         else:
             # search auth
             matching_url = getattr(associated_plugin.config, "api_endpoint", None)

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -26,10 +26,11 @@ from pydantic import AliasChoices
 from pydantic import ValidationError as PydanticValidationError
 from pydantic.fields import Field, FieldInfo
 
+from eodag.api.product import AssetsDict
 from eodag.api.product.metadata_mapping import (
-    NOT_AVAILABLE,
     NOT_MAPPED,
     mtd_cfg_as_conversion_and_querypath,
+    properties_from_json,
 )
 from eodag.api.search_result import SearchResult
 from eodag.plugins.base import PluginTopic
@@ -44,7 +45,6 @@ from eodag.utils import (
     format_dict_items,
     format_pydantic_error,
     get_collection_dates,
-    string_to_jsonpath,
     update_nested_dict,
 )
 from eodag.utils.exceptions import ValidationError
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from mypy_boto3_s3 import S3ServiceResource
     from requests.auth import AuthBase
 
+    from eodag import EOProduct
     from eodag.config import PluginConfig
 
 logger = logging.getLogger("eodag.search.base")
@@ -190,12 +191,8 @@ class Search(PluginTopic):
         default value is returned.
 
         :param key: The configuration option key.
-        :type key: str
         :param default: The default value to be returned if the option is not found (default is None).
-        :type default: Any
-
         :return: The value of the specified configuration option or the default value.
-        :rtype: Any
         """
         collection_cfg = getattr(self.config, "collection_config", {})
         non_none_cfg = {k: v for k, v in collection_cfg.items() if v}
@@ -228,11 +225,75 @@ class Search(PluginTopic):
         :param collection: the desired collection
         :returns: The collection specific metadata-mapping
         """
-        if collection:
-            return self.config.products.get(collection, {}).get(
-                "metadata_mapping", self.config.metadata_mapping
-            )
-        return self.config.metadata_mapping
+        # copy to avoid mutating the cached plugin configuration
+        metadata_mapping = dict(getattr(self.config, "metadata_mapping", {}))
+        if collection is not None:
+            # Special overload for collection config
+            # "metadata_mapping_from_product" overloaded by "current"
+            collection_metadata_mapping: dict[str, Union[str, list[str]]] = {}
+            target_collection: Optional[str] = collection
+            visited: set[str] = set()
+            while target_collection is not None and target_collection not in visited:
+                visited.add(target_collection)
+                # Check if collection has a specific configuration
+                collection_config = self.config.products.get(target_collection, {})
+                # Overload imported metadata mapping configuration by current one
+                # (copy to avoid mutating the cached collection configuration)
+                buffer = dict(collection_config.get("metadata_mapping", {}))
+                buffer.update(collection_metadata_mapping)
+                collection_metadata_mapping = buffer
+                # This collection configuration can refer to another collection configuration
+                target_collection = collection_config.get(
+                    "metadata_mapping_from_product"
+                )
+            if target_collection is not None:
+                logger.warning(
+                    "Could not resolve metadata_mapping_from_product for %s, cycle detected at %s",
+                    collection,
+                    target_collection,
+                )
+            metadata_mapping.update(collection_metadata_mapping)
+
+        return metadata_mapping
+
+    def get_assets_mapping(
+        self, collection: Optional[str] = None
+    ) -> Union[Any, dict[str, dict[str, Any]]]:
+        """Get the plugin asset mapping configuration (collection specific if exists)
+
+        :param collection: the desired collection
+        :returns: The collection specific assets-mapping
+        """
+        # copy to avoid mutating the cached plugin configuration
+        assets_mapping = dict(getattr(self.config, "assets_mapping", {}))
+        if collection is not None:
+            # Special overload for collection config
+            # "assets_mapping_from_product" overloaded by "current"
+            collection_asset_mapping: dict[str, Union[str, list[str]]] = {}
+            target_collection: Optional[str] = collection
+            visited: set[str] = set()
+            while target_collection is not None and target_collection not in visited:
+                visited.add(target_collection)
+                # Check if collection has a specific configuration
+                collection_config = self.config.products.get(target_collection, {})
+                # Overload imported asset mapping configuration by current one
+                # (copy to avoid mutating the cached collection configuration)
+                buffer = dict(collection_config.get("assets_mapping", {}))
+                buffer.update(collection_asset_mapping)
+                collection_asset_mapping = buffer
+                # This collection configuration can refer to another collection configuration
+                target_collection = collection_config.get(
+                    "assets_mapping_from_product", None
+                )
+            if target_collection is not None:
+                logger.warning(
+                    "Could not resolve assets_mapping_from_product for %s, cycle detected at %s",
+                    collection,
+                    target_collection,
+                )
+            assets_mapping.update(collection_asset_mapping)
+
+        return assets_mapping
 
     def get_sort_by_arg(self, kwargs: dict[str, Any]) -> Optional[SortByList]:
         """Extract the ``sort_by`` argument from the kwargs or the provider default sort configuration
@@ -510,34 +571,72 @@ class Search(PluginTopic):
                 queryables[k] = v
         return queryables
 
-    def get_assets_from_mapping(self, provider_item: dict[str, Any]) -> dict[str, Any]:
+    def build_assets_from_mapping(
+        self, provider_item: dict[str, Any], product: Optional[EOProduct] = None
+    ) -> Union[AssetsDict, dict[str, Any]]:
         """
         Create assets based on the assets_mapping in the provider's config
         and an item returned by the provider
 
         :param provider_item: dict of item properties returned by the provider
+        :param product: optional product against which assets are computed
         :returns: dict containing the asset metadata
         """
-        assets_mapping = getattr(self.config, "assets_mapping", None)
-        if not assets_mapping:
-            return {}
-        assets = {}
-        for key, values in assets_mapping.items():
-            asset_href = values.get("href")
-            if not asset_href:
-                logger.warning(
-                    "asset mapping %s skipped because no href is available", key
+        collection = getattr(product, "collection", None)
+        properties = getattr(product, "properties", {}) or {}
+
+        assets_mapping = self.get_assets_mapping(collection)
+
+        def resolve_asset_from_mapping(
+            key: str, mapping: dict[str, Any]
+        ) -> dict[str, Any]:
+            try:
+                asset_querypaths = mtd_cfg_as_conversion_and_querypath(mapping, {})
+                return properties_from_json(provider_item, asset_querypaths)
+            except Exception as e:
+                logger.warning("Could not resolve asset mapping '%s': %s", key, e)
+                return dict(mapping)
+
+        if product is None:
+            # Plain mapping container used by unit tests / introspection
+            computed: dict[str, Any] = {}
+            for key, mapping in (assets_mapping or {}).items():
+                computed[key] = resolve_asset_from_mapping(key, mapping)
+            return computed
+
+        assets = AssetsDict(product)
+
+        for key, mapping in (assets_mapping or {}).items():
+            assets.update({key: resolve_asset_from_mapping(key, mapping)})
+
+        # Global imported assets
+        imported_assets: dict[str, Any] = {}
+        if isinstance(properties.get("assets"), dict):
+            imported_assets = product.properties.pop("assets", {})
+
+        # Process local assets through product driver
+        driver = getattr(product, "driver", None)
+        if driver is not None:
+            asset_key_from_href = getattr(self.config, "asset_key_from_href", True)
+            computed_assets = {}
+            for asset_key, asset in imported_assets.items():
+                # Local transformation from driver
+                norm_key, norm_roles = driver.guess_asset_key_and_roles(
+                    asset.get("href", "") if asset_key_from_href else asset_key,
+                    product,
                 )
-                continue
-            json_url_path = string_to_jsonpath(asset_href)
-            if isinstance(json_url_path, str):
-                url_path = json_url_path
-            else:
-                url_match = json_url_path.find(provider_item)
-                if len(url_match) == 1:
-                    url_path = url_match[0].value
-                else:
-                    url_path = NOT_AVAILABLE
-            assets[key] = deepcopy(values)
-            assets[key]["href"] = url_path
+                # If the driver could not normalize the key/roles
+                # (e.g. no extension in href), keep the original key/roles.
+                if norm_key is None:
+                    computed_assets[asset_key] = asset
+                    if "title" not in asset:
+                        asset["title"] = asset_key
+                    continue
+                asset["roles"] = norm_roles
+                asset["title"] = norm_key
+                computed_assets[norm_key] = asset
+            imported_assets = computed_assets
+
+        assets.update(imported_assets)
+
         return assets

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -572,7 +572,10 @@ class Search(PluginTopic):
         return queryables
 
     def build_assets_from_mapping(
-        self, provider_item: dict[str, Any], product: Optional[EOProduct] = None
+        self,
+        provider_item: dict[str, Any],
+        product: Optional[EOProduct] = None,
+        raw_product_properties: Optional[dict[str, Any]] = None,
     ) -> Union[AssetsDict, dict[str, Any]]:
         """
         Create assets based on the assets_mapping in the provider's config
@@ -580,10 +583,12 @@ class Search(PluginTopic):
 
         :param provider_item: dict of item properties returned by the provider
         :param product: optional product against which assets are computed
+        :param raw_product_properties: optional product properties before EOProduct filtering
         :returns: dict containing the asset metadata
         """
         collection = getattr(product, "collection", None)
         properties = getattr(product, "properties", {}) or {}
+        raw_properties = raw_product_properties or {}
 
         assets_mapping = self.get_assets_mapping(collection)
 
@@ -592,7 +597,15 @@ class Search(PluginTopic):
         ) -> dict[str, Any]:
             try:
                 asset_querypaths = mtd_cfg_as_conversion_and_querypath(mapping, {})
-                return properties_from_json(provider_item, asset_querypaths)
+                existing_properties = {
+                    **properties,
+                    **raw_properties,
+                }
+                return properties_from_json(
+                    provider_item,
+                    asset_querypaths,
+                    existing_properties=existing_properties,
+                )
             except Exception as e:
                 logger.warning("Could not resolve asset mapping '%s': %s", key, e)
                 return dict(mapping)

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -37,7 +37,6 @@ from eodag.api.product import EOProduct
 from eodag.api.product.metadata_mapping import (
     DEFAULT_GEOMETRY,
     NOT_AVAILABLE,
-    OFFLINE_STATUS,
     STAGING_STATUS,
     format_metadata,
     mtd_cfg_as_conversion_and_querypath,
@@ -314,8 +313,6 @@ class ECMWFSearch(PostJsonSearch):
             **{
                 "id": "$.id",
                 "title": "$.id",
-                "order:status": OFFLINE_STATUS,
-                "eodag:download_link": "$.null",
                 "geometry": ["feature", "$.geometry"],
                 "eodag:default_geometry": "POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))",
             },
@@ -1110,10 +1107,11 @@ class ECMWFSearch(PostJsonSearch):
             start, end = ecmwf_temporal_to_eodag(properties)
             properties["start_datetime"] = start
             properties["end_datetime"] = end
+            result_data = result
 
         else:
             # use all available query_params to parse properties
-            result_data: dict[str, Any] = {
+            result_data = {
                 **results.collection_def_params,
                 **sorted_unpaginated_qp,
                 **{"qs": sorted_unpaginated_qp},
@@ -1182,6 +1180,9 @@ class ECMWFSearch(PostJsonSearch):
             properties={ecmwf_format(k): v for k, v in properties.items()},
             **kwargs,
         )
+
+        # "Technicals" assets as (downloadlink, quicklook, thumbnail)
+        product.assets.update(self.build_assets_from_mapping(result_data, product))
 
         # backup original register_downloader to register_downloader_only
         product.register_downloader_only = product.register_downloader
@@ -1441,6 +1442,9 @@ class MeteoblueSearch(ECMWFSearch):
             collection=collection,
             properties=properties,
         )
+
+        # "Technicals" assets as (downloadlink, quicklook, thumbnail)
+        product.assets.update(self.build_assets_from_mapping(result, product))
 
         return [
             product,

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -1247,7 +1247,8 @@ def _check_id(product: EOProduct) -> EOProduct:
         product.downloader._order_status(product=product, auth=auth)  # type: ignore
     # when a NotAvailableError is catched, it means the product is not ready and still needs to be polled
     except NotAvailableError:
-        product.properties["order:status"] = STAGING_STATUS
+        if "download_link" in product.assets:
+            product.assets["download_link"]["order:status"] = STAGING_STATUS
     except Exception as e:
         if (
             isinstance(e, DownloadError) or isinstance(e, ValidationError)

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -1182,7 +1182,11 @@ class ECMWFSearch(PostJsonSearch):
         )
 
         # "Technicals" assets as (downloadlink, quicklook, thumbnail)
-        product.assets.update(self.build_assets_from_mapping(result_data, product))
+        product.assets.update(
+            self.build_assets_from_mapping(
+                result_data, product, raw_product_properties=properties
+            )
+        )
 
         # backup original register_downloader to register_downloader_only
         product.register_downloader_only = product.register_downloader
@@ -1444,7 +1448,11 @@ class MeteoblueSearch(ECMWFSearch):
         )
 
         # "Technicals" assets as (downloadlink, quicklook, thumbnail)
-        product.assets.update(self.build_assets_from_mapping(result, product))
+        product.assets.update(
+            self.build_assets_from_mapping(
+                result, product, raw_product_properties=properties
+            )
+        )
 
         return [
             product,

--- a/eodag/plugins/search/cop_ghsl.py
+++ b/eodag/plugins/search/cop_ghsl.py
@@ -372,9 +372,16 @@ class CopGhslSearch(Search):
                 download_link = metadata_mapping.get("eodag:download_link").format(
                     dataset=dataset, tile_id=tile["tileID"]
                 )
-                properties["eodag:download_link"] = download_link
                 product = EOProduct(
                     provider="cop_ghsl", properties=properties, collection=collection
+                )
+                product.assets.update(
+                    {
+                        "download_link": {
+                            "href": download_link,
+                            "order:status": "succeeded",
+                        }
+                    }
                 )
                 if not filter_geometry or filter_geometry.intersects(product.geometry):
                     if current_index >= start_index and current_index <= end_index:
@@ -429,9 +436,7 @@ class CopGhslSearch(Search):
                 properties.update(format_params)
                 if "proj:code" in filter_params:
                     properties["proj:code"] = filter_params["proj:code"]
-                properties["eodag:download_link"] = download_link.format(
-                    **format_params
-                )
+                item_download_link = download_link.format(**format_params)
                 datetimes = self._get_start_and_end_from_properties(format_params)
                 properties["start_datetime"] = datetimes["start_date"]
                 properties["end_datetime"] = datetimes["end_date"]
@@ -443,11 +448,11 @@ class CopGhslSearch(Search):
                     assets = AssetsDict(product=product)
                     for key, mapping in assets_mapping.items():
                         filters = {k.replace(":", "_"): v for k, v in filters.items()}
-                        download_link = mapping["href"].format(**filters)
+                        asset_href = mapping["href"].format(**filters)
                         assets.update(
                             {
                                 key: {
-                                    "href": download_link,
+                                    "href": asset_href,
                                     "title": mapping["title"],
                                     "type": mapping["type"],
                                 }
@@ -456,6 +461,15 @@ class CopGhslSearch(Search):
                     product.assets = assets
                     if "download_link" in product.assets:
                         product.assets["download_link"]["order:status"] = "succeeded"
+                else:
+                    product.assets.update(
+                        {
+                            "download_link": {
+                                "href": item_download_link,
+                                "order:status": "succeeded",
+                            }
+                        }
+                    )
                 products.append(product)
                 if i == end_index:
                     break
@@ -465,9 +479,16 @@ class CopGhslSearch(Search):
             datetimes = self._get_start_and_end_from_properties(properties)
             properties["start_datetime"] = datetimes["start_date"]
             properties["end_datetime"] = datetimes["end_date"]
-            properties["eodag:download_link"] = download_link
             product = EOProduct(
                 provider="cop_ghsl", properties=properties, collection=collection
+            )
+            product.assets.update(
+                {
+                    "download_link": {
+                        "href": download_link,
+                        "order:status": "succeeded",
+                    }
+                }
             )
             products.append(product)
             num_products = 1

--- a/eodag/plugins/search/cop_ghsl.py
+++ b/eodag/plugins/search/cop_ghsl.py
@@ -320,7 +320,6 @@ class CopGhslSearch(Search):
         current_index = 0
         for year in list_years:
             properties = deepcopy(params)
-            properties["order:status"] = "succeeded"
             properties["start_datetime"] = to_iso_utc_string(
                 dt.datetime(year=int(year), month=1, day=1)
             )
@@ -395,7 +394,6 @@ class CopGhslSearch(Search):
         ]
         properties = {}
         properties["geometry"] = default_geometry[1]
-        properties["order:status"] = "succeeded"
         if "proj:code" in filters:
             filters["proj:code"] = filters["proj:code"].replace("EPSG:", "")
         collection_config = self.config.products.get(collection, {})
@@ -456,6 +454,8 @@ class CopGhslSearch(Search):
                             }
                         )
                     product.assets = assets
+                    if "download_link" in product.assets:
+                        product.assets["download_link"]["order:status"] = "succeeded"
                 products.append(product)
                 if i == end_index:
                     break

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -207,8 +207,6 @@ class CopMarineSearch(StaticStacSearch):
             "title": item_id,
             "geometry": geometry,
             "dataset": dataset_item["id"],
-            # order:status set to succeeded for consistency between providers
-            "order:status": "succeeded",
         }
         assets = {
             "download_link": {
@@ -216,6 +214,8 @@ class CopMarineSearch(StaticStacSearch):
                 "href": download_url,
                 "roles": ["archive", "data"],
                 "type": "application/x-netcdf",
+                # order:status set to succeeded for consistency between providers
+                "order:status": "succeeded",
                 **asset_properties,
             }
         }

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -278,7 +278,9 @@ class CopMarineSearch(StaticStacSearch):
 
         # List current asset urls
         product = EOProduct(self.provider, properties, collection=collection)
-        merged_assets = self.build_assets_from_mapping(dataset_item, product)
+        merged_assets = self.build_assets_from_mapping(
+            dataset_item, product, raw_product_properties=properties
+        )
         merged_assets.update(assets)
         product.assets.update(merged_assets)
 

--- a/eodag/plugins/search/cop_marine.py
+++ b/eodag/plugins/search/cop_marine.py
@@ -32,7 +32,6 @@ from dateutil.tz import tzutc
 from dateutil.utils import today
 
 from eodag import EOProduct
-from eodag.api.product import AssetsDict
 from eodag.api.search_result import SearchResult
 from eodag.config import PluginConfig
 from eodag.plugins.search import PreparedSearch
@@ -207,11 +206,20 @@ class CopMarineSearch(StaticStacSearch):
             "id": item_id,
             "title": item_id,
             "geometry": geometry,
-            "eodag:download_link": download_url,
             "dataset": dataset_item["id"],
             # order:status set to succeeded for consistency between providers
             "order:status": "succeeded",
         }
+        assets = {
+            "download_link": {
+                "title": "downloadlink",
+                "href": download_url,
+                "roles": ["archive", "data"],
+                "type": "application/x-netcdf",
+                **asset_properties,
+            }
+        }
+
         if use_dataset_dates:
             dates = _get_dates_from_dataset_data(dataset_item)
             if not dates:
@@ -254,24 +262,26 @@ class CopMarineSearch(StaticStacSearch):
 
         _check_int_values_properties(properties)
 
-        properties["eodag:thumbnail"] = collection_dict["assets"]["thumbnail"]["href"]
-        if "omiFigure" in collection_dict["assets"]:
-            properties["eodag:quicklook"] = collection_dict["assets"]["omiFigure"][
-                "href"
-            ]
-
-        asset_native = {
-            "title": "native",
-            "href": download_url,
-            "type": "application/x-netcdf",
+        assets["thumbnail"] = {
+            "title": "thumbnail",
+            "href": collection_dict["assets"]["thumbnail"]["href"],
+            "roles": ["thumbnail"],
+            "type": "image/jpeg",
         }
-        asset_native.update(asset_properties)
-        assets = {"native": asset_native}
-        additional_assets = self.get_assets_from_mapping(dataset_item)
-        assets.update(additional_assets)
+        if "omiFigure" in collection_dict["assets"]:
+            assets["quicklook"] = {
+                "title": "quicklook",
+                "href": collection_dict["assets"]["omiFigure"]["href"],
+                "roles": ["overview"],
+                "type": "image/jpeg",
+            }
 
+        # List current asset urls
         product = EOProduct(self.provider, properties, collection=collection)
-        product.assets = AssetsDict(product, assets)
+        merged_assets = self.build_assets_from_mapping(dataset_item, product)
+        merged_assets.update(assets)
+        product.assets.update(merged_assets)
+
         product._normalize_bands()
         return product
 

--- a/eodag/plugins/search/eumetsat_ds.py
+++ b/eodag/plugins/search/eumetsat_ds.py
@@ -47,7 +47,7 @@ class EumetsatDsSearch(QueryStringSearch):
         for index in range(0, len(processed_results)):
             result = processed_results[index]
             if hasattr(result, "assets"):
-                for name, asset in result.assets.items():
+                for name, asset in list(result.assets.items()):
                     if "type" in asset:
                         asset["eumesat_ds:type"] = asset["type"]
                         del asset["type"]

--- a/eodag/plugins/search/geodes.py
+++ b/eodag/plugins/search/geodes.py
@@ -112,9 +112,11 @@ class GeodesSearch(StacSearch):
     ) -> List[EOProduct]:
         """Build EOProducts from provider results"""
 
-        # Preprocess parsable description
+        # Parse description fields and build a href -> extra_props mapping
+        href_extra_props: dict[str, dict[str, Any]] = {}
         for result in results:
             for asset in result.get("assets", {}).values():
+                extra_props: dict[str, Any] = {}
                 for segment in asset.get("description", "").split("\n"):
                     key, sep, value = segment.strip("\r\t").partition(":")
                     if not sep:
@@ -126,17 +128,27 @@ class GeodesSearch(StacSearch):
                             value.removesuffix("bytes").removesuffix("byte").strip()
                         )
                         if filesize.isnumeric():
-                            asset["file:size"] = int(filesize)
+                            extra_props["file:size"] = int(filesize)
                     elif key == "Is reference":
-                        asset["geodes:reference"] = value.lower() == "true"
+                        extra_props["geodes:reference"] = value.lower() == "true"
                     elif key == "Is online":
-                        asset["geodes:online"] = value.lower() == "true"
+                        extra_props["geodes:online"] = value.lower() == "true"
                     elif key == "Datatype":
-                        asset["geodes:datatype"] = value
+                        extra_props["geodes:datatype"] = value
                     elif key == "Checksum MD5":
-                        asset["file:checksum"] = value.lower()
+                        extra_props["file:checksum"] = value.lower()
+
+                if extra_props and asset.get("href"):
+                    href_extra_props[asset["href"]] = extra_props
 
         products = super(GeodesSearch, self).normalize_results(results, **kwargs)
+
+        # Apply parsed properties to normalized assets by matching on href
+        for product in products:
+            for asset in product.assets.values():
+                href = asset.get("href", "")
+                if href in href_extra_props:
+                    asset.update(href_extra_props[href])
 
         self._set_availability(products)
 

--- a/eodag/plugins/search/geodes.py
+++ b/eodag/plugins/search/geodes.py
@@ -94,9 +94,10 @@ class GeodesSearch(StacSearch):
             asset_availability = asset_availability_list[0]
 
             # set status
-            product.properties["order:status"] = (
-                ONLINE_STATUS if asset_availability else OFFLINE_STATUS
-            )
+            if "download_link" in product.assets:
+                product.assets["download_link"]["order:status"] = (
+                    ONLINE_STATUS if asset_availability else OFFLINE_STATUS
+                )
 
             updated += 1
 

--- a/eodag/plugins/search/geodes.py
+++ b/eodag/plugins/search/geodes.py
@@ -47,7 +47,7 @@ class GeodesSearch(StacSearch):
         """Get availability information for the products from the provider's 'fastavailability' endpoint."""
         body: dict[str, list] = {"availability": []}
         for product in products:
-            download_link = product.properties.get("eodag:download_link")
+            download_link = product.assets.get("download_link", {}).get("href")
             endpoint_url = product.properties.get("geodes:endpoint_url")
             if download_link and endpoint_url:
                 body["availability"].append(
@@ -69,7 +69,7 @@ class GeodesSearch(StacSearch):
         updated = 0
 
         for product in products:
-            download_link = product.properties.get("eodag:download_link")
+            download_link = product.assets.get("download_link", {}).get("href")
             if download_link is None:
                 continue
 

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -1288,6 +1288,7 @@ class QueryStringSearch(Search):
         self, results: RawSearchResult, **kwargs: Any
     ) -> list[EOProduct]:
         """Build EOProducts from provider results"""
+        collection = kwargs.get("collection")
         normalize_remaining_count = len(results)
         logger.debug(
             "Adapting %s plugin results to eodag product representation"
@@ -1299,16 +1300,25 @@ class QueryStringSearch(Search):
         # collection alias as collection property for product
         if alias := getattr(self.config, "collection_config", {}).get("alias"):
             product_kwargs["collection"] = alias
+        # use collection_def_params as existing properties for parsing
+        existing_properties = (
+            self.get_collection_def_params(collection) if collection else {}
+        )
         for result in results:
             properties = QueryStringSearch.extract_properties[self.config.result_type](
                 result,
-                self.get_metadata_mapping(kwargs.get("collection")),
+                self.get_metadata_mapping(collection),
                 discovery_config=getattr(self.config, "discover_metadata", {}),
+                existing_properties=existing_properties,
             )
             product = EOProduct(self.provider, properties, **product_kwargs)
 
             # "Technicals" assets as (downloadlink, quicklook, thumbnail)
-            product.assets.update(self.build_assets_from_mapping(result, product))
+            product.assets.update(
+                self.build_assets_from_mapping(
+                    result, product, raw_product_properties=properties
+                )
+            )
 
             product._normalize_bands()
             products.append(product)

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -422,9 +422,6 @@ class QueryStringSearch(Search):
                     other_collection_mtd_mapping = mtd_cfg_as_conversion_and_querypath(
                         other_collection_def_params.get("metadata_mapping", {})
                     )
-                else:
-                    msg = f"Cannot reuse empty metadata_mapping from {other_product_for_mapping} for {collection}"
-                    raise MisconfiguredError(msg)
                 # update mapping
                 for metadata, mapping in other_collection_mtd_mapping.items():
                     collection_metadata_mapping.pop(metadata, None)
@@ -1297,7 +1294,6 @@ class QueryStringSearch(Search):
             % normalize_remaining_count
         )
         products: list[EOProduct] = []
-        asset_key_from_href = getattr(self.config, "asset_key_from_href", True)
         product_kwargs = deepcopy(kwargs)
 
         # collection alias as collection property for product
@@ -1311,28 +1307,12 @@ class QueryStringSearch(Search):
             )
             product = EOProduct(self.provider, properties, **product_kwargs)
 
-            additional_assets = self.get_assets_from_mapping(result)
-            product.assets.update(additional_assets)
+            # "Technicals" assets as (downloadlink, quicklook, thumbnail)
+            product.assets.update(self.build_assets_from_mapping(result, product))
 
-            # move assets from properties to product's attr, normalize keys & roles
-            for key, asset in product.properties.pop("assets", {}).items():
-                url = asset.get("href", "")
-                norm_key, roles = product.driver.guess_asset_key_and_roles(
-                    url if asset_key_from_href else key,
-                    product,
-                )
-                if norm_key is not None:
-                    asset["title"] = norm_key
-                    asset["roles"] = roles
-                    product.assets[norm_key] = asset
-                else:
-                    asset["title"] = asset.get("title", key)
-                    product.assets[key] = asset
-
-            # sort assets
-            product.assets.data = dict(sorted(product.assets.data.items()))
             product._normalize_bands()
             products.append(product)
+
         return products
 
     def count_hits(self, count_url: str, result_type: Optional[str] = "json") -> int:

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -1847,8 +1847,10 @@ class PostJsonSearch(QueryStringSearch):
         """Build EOProducts from provider results"""
         normalized = super().normalize_results(results, **kwargs)
         for product in normalized:
-            if "eodag:download_link" in product.properties:
-                decoded_link = unquote(product.properties["eodag:download_link"])
+            download_asset = product.assets.get("download_link")
+            download_href = download_asset.get("href") if download_asset else None
+            if download_href:
+                decoded_link = unquote(download_href)
                 if decoded_link[0] == "{":  # not a url but a dict
                     if product.collection is None:
                         msg = (
@@ -1870,20 +1872,19 @@ class PostJsonSearch(QueryStringSearch):
                     product.properties["_dc_qs"] = quote_plus(_dc_qs)
 
             # workaround to add collection to wekeo cmems order links
-            if (
-                "eodag:order_link" in product.properties
-                and "collection" in product.properties["eodag:order_link"]
-                and "order" not in product.properties["eodag:order_link"]
-            ):
+            order_link = (
+                download_asset.get("eodag:order_link") if download_asset else None
+            )
+            if order_link and "collection" in order_link and "order" not in order_link:
                 if product.collection is None:
                     msg = (
                         f"Cannot build order link for "
                         f"{product}: collection is undefined"
                     )
                     raise MisconfiguredError(msg)
-                product.properties["eodag:order_link"] = product.properties[
-                    "eodag:order_link"
-                ].replace("collection", product.collection)
+                download_asset["eodag:order_link"] = order_link.replace(
+                    "collection", product.collection
+                )
         return normalized
 
     def collect_search_urls(

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -57,13 +57,27 @@
       scene_filter:
         - '{{"scene_filter": {scene_filter#to_geojson} }}'
         - $.null
-      eodag:thumbnail: '$.browse[0].thumbnailPath'
-      eodag:quicklook: '$.browse[0].browsePath'
-      order:status: '{$.available#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
-      eodag:download_link: 'https://earthexplorer.usgs.gov/download/external/options/{_collection}/{entityId}/M2M/'
       # metadata needed for download
       usgs:entityId: '$.entityId'
       usgs:productId: '$.id'
+    assets_mapping:
+      download_link:
+        _collection: '$.collection'
+        _entity_id: '$.entityId'
+        href: 'https://earthexplorer.usgs.gov/download/external/options/{_collection}/{_entity_id}/M2M/'
+        roles: '["archive", "data"]'
+        type: 'application/octet-stream'
+        order:status: '{$.available#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
+      quicklook:
+        href: '$.browse[0].browsePath'
+        title: "quicklook"
+        roles: '["overwiev"]'
+        type: 'image/jpeg'
+      thumbnail:
+        href: '$.browse[0].thumbnailPath'
+        title: "thumbnail"
+        roles: '["thumbnail"]'
+        type: 'image/jpeg'
     extract: True
     order_enabled: true
     max_workers: 2
@@ -127,8 +141,9 @@
       geometry:
         - '{{"search":{{"shape": {geometry#to_geojson} }} }}'
         - '$.dataGeometry'
-      # order:status set to succeeded for consistency between providers
-      order:status: '{$.null#replace_str("Not Available","succeeded")}'
+    assets_mapping:
+      download_link:
+        order:status: 'succeeded'
   products:
     CBERS4_PAN10M_L2:
       instruments: PAN10M
@@ -165,69 +180,72 @@
           - '$.sunElevation'
         # Custom parameters (not defined in the base document referenced above)
         _aws_path: '$.downloadUrl'
-        eodag:download_link: 's3://cbers-pds/{_aws_path}'
         eodag:mtd_download_link: 's3://cbers-meta-pds/{_aws_path}'
-        _preview_basename: '{$.sceneID#replace_str("_L2","")}'
-        eodag:thumbnail: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}_small.jpeg'
-        eodag:quicklook: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}.jpg'
         id:
           - '{{"search":{{"sceneID":"{id}" }} }}'
           - '{title}'
+      assets_mapping:
+        download_link:
+          _download_url: '$.downloadUrl'
+          href: 's3://cbers-pds/{_download_url}'
+          roles: '["archive", "data"]'
+          order:status: 'succeded'
+        quicklook:
+          _download_url: '$.downloadUrl'
+          _scene_id: '{$.sceneID#replace_str("_L[24]$","")}'
+          href: 'https://s3.amazonaws.com/cbers-meta-pds/{_download_url}/{_scene_id}.jpg'
+          title: "quicklook"
+          roles: '["overwiev"]'
+          type: 'image/jpeg'
+        thumbnail:
+          _download_url: '$.downloadUrl'
+          _scene_id: '{$.sceneID#replace_str("_L[24]$","")}'
+          href: 'https://s3.amazonaws.com/cbers-meta-pds/{_download_url}/{_scene_id}_small.jpeg'
+          title: "thumbnail"
+          roles: '["thumbnail"]'
+          type: 'image/jpeg'
     CBERS4_PAN10M_L4:
       instruments: PAN10M
       _collection: cbers4
       processing:level: 4
       metadata_mapping_from_product: CBERS4_PAN10M_L2
-      metadata_mapping:
-        # Custom parameters (not defined in the base document referenced above)
-        _preview_basename: '{$.sceneID#replace_str("_L4","")}'
-        eodag:thumbnail: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}_small.jpeg'
-        eodag:quicklook: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}.jpg'
+      assets_mapping_from_product:   CBERS4_PAN10M_L2
     CBERS4_PAN5M_L2:
       instruments: PAN5M
       _collection: cbers4
       processing:level: 2
       metadata_mapping_from_product: CBERS4_PAN10M_L2
+      assets_mapping_from_product:   CBERS4_PAN10M_L2
     CBERS4_PAN5M_L4:
       instruments: PAN5M
       _collection: cbers4
       processing:level: 4
       metadata_mapping_from_product: CBERS4_PAN10M_L2
-      metadata_mapping:
-        # Custom parameters (not defined in the base document referenced above)
-        _preview_basename: '{$.sceneID#replace_str("_L4","")}'
-        eodag:thumbnail: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}_small.jpeg'
-        eodag:quicklook: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}.jpg'
+      assets_mapping_from_product:   CBERS4_PAN10M_L2
     CBERS4_MUX_L2:
       instruments: MUX
       _collection: cbers4
       processing:level: 2
       metadata_mapping_from_product: CBERS4_PAN10M_L2
+      assets_mapping_from_product:   CBERS4_PAN10M_L2
     CBERS4_MUX_L4:
       instruments: MUX
       _collection: cbers4
       processing:level: 4
       metadata_mapping_from_product: CBERS4_PAN10M_L2
-      metadata_mapping:
-        # Custom parameters (not defined in the base document referenced above)
-        _preview_basename: '{$.sceneID#replace_str("_L4","")}'
-        eodag:thumbnail: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}_small.jpeg'
-        eodag:quicklook: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}.jpg'
+      assets_mapping_from_product:   CBERS4_PAN10M_L2
     CBERS4_AWFI_L2:
       instruments: AWFI
       _collection: cbers4
       processing:level: 2
       metadata_mapping_from_product: CBERS4_PAN10M_L2
+      assets_mapping_from_product:   CBERS4_PAN10M_L2
     CBERS4_AWFI_L4:
       instruments: AWFI
       _collection: cbers4
       processing:level: 4
       metadata_mapping_from_product: CBERS4_PAN10M_L2
-      metadata_mapping:
-        # Custom parameters (not defined in the base document referenced above)
-        _preview_basename: '{$.sceneID#replace_str("_L4","")}'
-        eodag:thumbnail: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}_small.jpeg'
-        eodag:quicklook: 'https://s3.amazonaws.com/cbers-meta-pds/{_aws_path}/{_preview_basename}.jpg'
+      assets_mapping_from_product:   CBERS4_PAN10M_L2
     L8_OLI_TIRS_C1L1:
       _collection: landsat8
       _on_amazon: true
@@ -272,6 +290,21 @@
         id:
           - '{{"search":{{"productID":"{id}" }} }}'
           - '{title}'
+      assets_mapping:
+        download_link:
+          href: 's3://landsat-pds/c1/L8/{_path:03.0f}/{_row:03.0f}/{title}/'
+          roles: '["archive", "data"]'
+          order:status: 'succeded'
+        quicklook:
+          href: 'https://landsat-pds.s3.amazonaws.com/c1/L8/{_path:03.0f}/{_row:03.0f}/{title}/{title}_thumb_large.jpg'
+          title: "quicklook"
+          roles: '["overwiev"]'
+          type: 'image/jpeg'
+        thumbnail:
+          href: '$.thumbnail'
+          title: "thumbnail"
+          roles: '["thumbnail"]'
+          type: 'image/jpeg'
     MODIS_MCD43A4:
       _collection: modis
       metadata_mapping:
@@ -296,15 +329,28 @@
           - '{{"search":{{"date":{{"to":"{end_datetime}"}} }} }}'
           - '$.EndingDateTime'
         # Custom parameters (not defined in the base document referenced above)
-        _vertical_tile_nb: '$.verticalTileNumber'
-        _horizontal_tile_nb: '$.horizontalTileNumber'
-        _doy_date: '{$.sceneID#slice_str(9,16,1)}'
-        eodag:download_link: 's3://modis-pds/MCD43A4.006/{_horizontal_tile_nb:02.0f}/{_vertical_tile_nb:02.0f}/{_doy_date}/'
-        eodag:thumbnail: '$.thumbnail'
-        eodag:quicklook: '$.thumbnail'
         id:
           - '{{"search":{{"sceneID":"{id}" }} }}'
           - '{title}'
+      assets_mapping:
+        download_link:
+          _h_tile: '{$.horizontalTileNumber#round}'
+          _v_tile: '{$.verticalTileNumber#round}'
+          _scene_id: '{$.sceneID#slice_str(9,16,1)}'
+          href: 's3://modis-pds/MCD43A4.006/{_h_tile}/{_v_tile}/{_scene_id}/'
+          roles: '["archive", "data"]'
+          type: 'application/octet-stream'
+          order:status: 'succeded'
+        quicklook:
+          href: '$.thumbnail'
+          title: "quicklook"
+          roles: '["overwiev"]'
+          type: 'image/jpeg'
+        thumbnail:
+          href: '$.thumbnail'
+          title: "thumbnail"
+          roles: '["thumbnail"]'
+          type: 'image/jpeg'
     NAIP:
       _collection: naip
       metadata_mapping:
@@ -325,11 +371,16 @@
           - '{{"search":{{"date":{{"to":"{end_datetime}"}} }} }}'
           - '$.date'
         # Custom parameters (not defined in the base document referenced above)
-        _aws_path: '$.awsPath'
-        eodag:download_link: 's3://naip-analytic/{_aws_path}'
         id:
           - '{{"search":{{"sceneID":"{id}" }} }}'
           - '{title}'
+      assets_mapping:
+        download_link:
+          _aws_path: '$.awsPath'
+          href: 's3://naip-analytic/{_aws_path}'
+          roles: '["archive", "data"]'
+          type: 'application/octet-stream'
+          order:status: 'succeded'
     S1_SAR_GRD:
       product:type: GRD
       _collection: sentinel1
@@ -364,13 +415,26 @@
           - '{{"search":{{"polarization":"{sar:polarizations#replace_tuple(((["HH"],"SH"),(["VV"],"SV"),(["HH","HV"], "DH"),(["VV","VH"],"DV")))}" }} }}'
           - '{$.polarization#replace_tuple((("SH",["HH"]),("SV",["VV"]),("DH",["HH","HV"]),("DV",["VV","VH"])))}'
         # Custom parameters (not defined in the base document referenced above)
-        _aws_path: '$.awsPath'
-        eodag:download_link: 's3://sentinel-s1-l1c/{_aws_path}'
-        eodag:thumbnail: 'https://render.eosda.com/S1/thumb/{title}.png'
-        eodag:quicklook: 'https://render.eosda.com/S1/thumb/{title}.png'
         id:
           - '{{"search":{{"sceneID":"{id}" }} }}'
           - '{title}'
+      assets_mapping:
+        download_link:
+          _aws_path: '$.awsPath'
+          href: 's3://sentinel-s1-l1c/{_aws_path}'
+          roles: '["archive", "data"]'
+          type: 'application/octet-stream'
+          order:status: 'succeded'
+        quicklook:
+          href: 'https://render.eosda.com/S1/thumb/{title}.png'
+          title: "quicklook"
+          roles: '["overwiev"]'
+          type: 'image/png'
+        thumbnail:
+          href: 'https://render.eosda.com/S1/thumb/{title}.png'
+          title: "thumbnail"
+          roles: '["thumbnail"]'
+          type: 'image/png'
     S2_MSI_L1C:
       _collection: sentinel2
       metadata_mapping:
@@ -410,6 +474,23 @@
           - '{title}'
         _processed_l2a: '$.null'
         _aws_path_l2a: '$.null'
+      assets_mapping:
+        download_link:
+          _aws_path: '$.awsPath'
+          href: 's3://sentinel-s2-l1c/{_aws_path}'
+          roles: '["archive", "data"]'
+          type: 'application/octet-stream'
+          order:status: 'succeded'
+        quicklook:
+          href: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
+          title: "quicklook"
+          roles: '["overwiev"]'
+          type: 'image/jpeg'
+        thumbnail:
+          href: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
+          title: "thumbnail"
+          roles: '["thumbnail"]'
+          type: 'image/jpeg'
     S2_MSI_L2A:
       _collection: sentinel2
       _processed_l2a: true
@@ -464,10 +545,6 @@
           - '{{"search":{{"zenithAngle":"{view:incidence_angle}" }} }}'
           - '$.zenithAngle'
         # Custom parameters (not defined in the base document referenced above)
-        eodag:thumbnail: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
-        eodag:quicklook: '{eodag:thumbnail}'
-        eodag:download_link: 's3://sentinel-s2-l2a/{_aws_path_l2a}'
-        _aws_path: '$.null'
         eodag:product_path: '$.null'
         eodag:product_info: 'https://roda.sentinel-hub.com/sentinel-s2-l2a/{_aws_path_l2a}/productInfo.json'
         id:
@@ -477,7 +554,14 @@
           - '{{"search":{{"processedL2A":"{_processed_l2a}" }} }}'
           - '$.processedL2A'
         _aws_path_l2a: '$.awsPathL2A'
-
+      assets_mapping_from_product: S2_MSI_L1C
+      assets_mapping:
+        download_link:
+          _aws_path_l2a: '$.awsPathL2A'
+          href: 's3://sentinel-s2-l2a/{_aws_path_l2a}'
+          roles: '["archive", "data"]'
+          type: 'application/octet-stream'
+          order:status: 'succeded'
   download: !plugin
     type: AwsDownload
     ssl_verify: true
@@ -756,19 +840,30 @@
       geometry:
         - null
         - '{$.Footprint#from_ewkt}'
-      type: "$.ContentType"
-      file:size: "$.ContentLength"
-      file:checksum: '$.Checksum[?Algorithm="MD5"].Value'
-      # The url to download the product "as is" (literal or as a template to be completed either after the search result
-      # is obtained from the provider or during the eodag download phase)
-      eodag:download_link: 'https://zipper.creodias.eu/odata/v1/Products({uid})/$value'
-      # order:status: must be one of succeeded, ordered, orderable
-      order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
       collection:
         - null
         - $.null
-      eodag:quicklook: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
-      eodag:thumbnail: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+      assets: '$.Assets'
+    assets_mapping:
+      download_link:
+        title: 'downloadlink'
+        href: 'https://zipper.creodias.eu/odata/v1/Products({uid})/$value'
+        roles: '["archive", "data"]'
+        type: '$.ContentType'
+        file:checksum: '$.Checksum[?Algorithm="MD5"].Value'
+        file:size: '$.ContentLength'
+        # order:status: must be one of succeeded, ordered, orderable
+        order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
+      quicklook:
+        href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+        title: "quicklook"
+        roles: '["overwiev"]'
+        type: "image/jpeg"
+      thumbnail:
+        href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+        title: "thumbnail"
+        roles: '["thumbnail"]'
+        type: "image/jpeg"
   download: !plugin
     type: HTTPDownload
     extract: true
@@ -1205,6 +1300,17 @@
     # Note: Sorting is intentionally disabled for this provider, as enabling it causes pagination to malfunction.
     metadata_mapping:
       assets: '{$.assets#from_alternate(s3)}'
+    assets_mapping:
+      quicklook:
+        href: '$.assets.reduced_resolution_browse.alternate.s3.href'
+        title: "quicklook"
+        roles: '["overwiev"]'
+        type: '$.assets.reduced_resolution_browse.type'
+      thumbnail:
+        href: '$.assets.thumbnail.alternate.s3.href'
+        title: "thumbnail"
+        roles: '["thumbnail"]'
+        type: '$.assets.thumbnail.type'
   products:
     LANDSAT_C2L1:
       _collection: landsat-c2l1
@@ -1289,6 +1395,14 @@
         - '{{"query":{{"grid:code":{{"eq":"{grid:code}"}}}}}}'
         - '$.properties.grid:code'
       assets: '{$.assets#dict_filter($[?(href=~"^s3.*")])}'
+  assets_mapping:
+    download_link:
+      title: "downloadlink"
+      href: '$.links[?(@.rel="self")].href'
+      roles: '["archive", "data"]'
+      type: 'aplication/json'
+      # order:status set to succeeded for consistency between providers
+      order:status: 'succeeded'
   products:
     S1_SAR_GRD:
       _collection: sentinel-1-grd
@@ -1384,13 +1498,34 @@
         mgrs:utm_zone: '$.properties."sentinel:utm_zone"'
         mgrs:latitude_band: '$.properties."sentinel:latitude_band"'
         mgrs:grid_square: '$.properties."sentinel:grid_square"'
-        eodag:download_link: 's3://gcp-public-data-sentinel-2/tiles/{mgrs:utm_zone}/{mgrs:latitude_band}/{mgrs:grid_square}/{title}.SAFE'
+      assets_mapping:
+        download_link:
+          href: 's3://gcp-public-data-sentinel-2/tiles/{mgrs:utm_zone}/{mgrs:latitude_band}/{mgrs:grid_square}/{title}.SAFE'
+          roles: '["archive", "data"]'
+          type: 'application/octet-stream'
+          order:status: 'succeeded'
+        quicklook:
+          href: '$.assets.thumbnail.href'
+          title: "thumbnail"
+          roles: '["overwiev"]'
+          type: '$.assets.thumbnail.type'
+        thumbnail:
+          href: '$.assets.thumbnail.href'
+          title: "thumbnail"
+          roles: '["thumbnail"]'
+          type: '$.assets.thumbnail.type'
     L8_OLI_TIRS_C1L1:
       _collection: landsat-8-l1-c1
       metadata_mapping:
         wrsPath: '$.properties."landsat:wrs_path"'
         wrsRow: '$.properties."landsat:wrs_row"'
-        eodag:download_link: 's3://gcp-public-data-landsat/LC08/01/{wrsPath:03d}/{wrsRow:03d}/{title}'
+      assets_mapping_from_product: S2_MSI_L1C
+      assets_mapping:
+        download_link:
+          href: 's3://gcp-public-data-landsat/LC08/01/{wrsPath:03d}/{wrsRow:03d}/{title}'
+          roles: '["archive", "data"]'
+          type: 'application/octet-stream'
+          order:status: 'succeeded'
     GENERIC_COLLECTION:
       _collection: '{collection}'
   download: !plugin
@@ -1430,10 +1565,16 @@
         - 'area={geometry#to_nwse_bounds_str(/)}'
         - '$.geometry'
       eodag:default_geometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
-      # order:status set to succeeded for consistency between providers
-      order:status: '{$.null#replace_str("Not Available","succeeded")}'
       qs: $.qs
-      eodag:download_link: 'https://apps.ecmwf.int/datasets/data/{dataset}?{qs#to_geojson}'
+    assets_mapping:
+      download_link:
+        _dataset: '$.dataset'
+        _qs: '$.qs'
+        href: 'https://apps.ecmwf.int/datasets/data/{_dataset}?{_qs#to_geojson}'
+        roles: '["archive", "data"]'
+        type: 'application/octet-stream'
+        # order:status set to succeeded for consistency between providers
+        order:status: 'succeeded'
   products:
     # See Archive Catalog in https://apps.ecmwf.int/archive-catalogue/
     # See available Public Datasets in https://apps.ecmwf.int/datasets/
@@ -1517,7 +1658,13 @@
         - '{{"area": {geometry#to_nwse_bounds}}}'
         - $.geometry
       qs: $.qs
-      eodag:order_link: 'https://ads.atmosphere.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{{"inputs": {qs#to_geojson}}}'
+    assets_mapping:
+      download_link:
+        title: "downloadlink"
+        href: ""
+        roles: '["archive", "data"]'
+        type: "application/netcdf"
+        order_link: 'https://ads.atmosphere.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{"inputs": {qs#to_geojson}}'
   products:
     # See available Public Datasets in https://ads.atmosphere.copernicus.eu/cdsapp#!/search?type=dataset
     CAMS_GAC_FORECAST:
@@ -1687,7 +1834,13 @@
         - '{{"area": {geometry#to_nwse_bounds}}}'
         - $.geometry
       qs: $.qs
-      eodag:order_link: 'https://cds.climate.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{{"inputs": {qs#to_geojson}}}'
+    assets_mapping:
+      download_link:
+        title: "downloadlink"
+        href: ""
+        roles: '["archive", "data"]'
+        type: "application/netcdf"
+        order_link: 'https://ads.atmosphere.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{"inputs": {qs#to_geojson}}'
   products:
     # See available Public Datasets in https://cds.climate.copernicus.eu/cdsapp#!/search?type=dataset
     AG_ERA5:
@@ -1907,18 +2060,30 @@
       geometry:
         - 'geometry={geometry#to_rounded_wkt}'
         - '$.geometry'
-      # The url of the quicklook
-      eodag:quicklook: '$.properties.quicklook'
-      # The url to download the product "as is" (literal or as a template to be completed either after the search result
-      # is obtained from the provider or during the eodag download phase)
-      eodag:download_link: '$.properties.services.download.url'
-      type: '{$.properties.services.download.mimeType#replace_str("application/unknown","application/octet-stream")}'
-      file:size: '$.properties.services.download.size'
-      file:checksum: '{$.properties.services.download.checksum#replace_str("md5=","")}'
-      # order:status set to succeeded for consistency between providers
-      order:status: '{$.null#replace_str("Not Available","succeeded")}'
-      # Additional metadata provided by the providers but that don't appear in the reference spec
-      eodag:thumbnail: '$.properties.thumbnail'
+      # Unset field from product
+      sara:quicklook: '$.null'
+      sara:thumbnail: '$.null'
+    assets_mapping:
+      download_link:
+        # The url to download the product "as is" (literal or as a template to be completed either after the search result
+        # is obtained from the provider or during the eodag download phase)
+        href: '$.properties.services.download.url'
+        roles: '["archive", "data"]'
+        type: '{$.properties.services.download.mimeType#replace_str("application/unknown","application/octet-stream")}'
+        file:size: '$.properties.services.download.size'
+        file:checksum: '{$.properties.services.download.checksum#replace_str("md5=","")#to_lower'
+        # order:status set to succeeded for consistency between providers
+        order:status: 'succeeded'
+      quicklook:
+        href: '$.properties.quicklook'
+        title: "quicklook"
+        roles: '["overwiev"]'
+        type: "image/png"
+      thumbnail:
+        href: '$.properties.thumbnail'
+        title: "thumbnail"
+        roles: '["thumbnail"]'
+        type: "image/png"
   products:
     # Sentinel 1
     S1_SAR_OCN:
@@ -2106,9 +2271,7 @@
         - '$.geometry'
       eodag:default_geometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
       collection: '$.queries[0].domain'
-      order:status: '{$.requiresJobQueue#get_group_name((?P<succeeded>False)|(?P<orderable>True))}'
       qs: $.qs
-      eodag:download_link: https://my.meteoblue.com/dataset/query?{qs#to_geojson}
       # Meteoblue specific parameters
       datapoints: '$.datapoints'
       requiresJobQueue: '$.requiresJobQueue'
@@ -2125,7 +2288,14 @@
       timeIntervalsAlignment:
         - '{{"timeIntervalsAlignment": {timeIntervalsAlignment#to_geojson} }}'
         - '$.timeIntervalsAlignment'
-      eodag:order_link: https://my.meteoblue.com/dataset/query?{qs#replace_str(r"^(.*)(\")(queries\")(.)",r"\1\2runOnJobQueue\2\4 true, \2\3\4")}
+    assets_mapping:
+      download_link:
+        qs: '$.qs'
+        href: https://my.meteoblue.com/dataset/query?{qs#to_geojson}
+        roles: '["archive", "data"]'
+        type: 'application/octet-stream'
+        order:status: '{$.requiresJobQueue#get_group_name((?P<succeeded>False)|(?P<orderable>True))}'
+        order_link: https://my.meteoblue.com/dataset/query?{qs#replace_str(r"^(.*)(\")(queries\")(.)",r"\1\2runOnJobQueue\2\4 true, \2\3\4")}
   products:
     NEMSGLOBAL_TCDC:
       product:type: NEMSGLOBAL
@@ -2415,14 +2585,28 @@
         - '{$.Footprint#from_ewkt}'
       # The url to download the product "as is" (literal or as a template to be completed either after the search result
       # is obtained from the provider or during the eodag download phase)
-      eodag:download_link: 'https://catalogue.dataspace.copernicus.eu/odata/v1/Products({uid})/$value'
-      # order:status: must be one of succeeded, ordered, orderable
-      order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
       collection:
         - null
         - $.null
-      eodag:quicklook: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
-      eodag:thumbnail: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+    assets_mapping:
+      download_link:
+        href: 'https://catalogue.dataspace.copernicus.eu/odata/v1/Products({uid})/$value'
+        roles: '["archive", "data"]'
+        type: '$.ContentType'
+        file:checksum: '$.Checksum[?Algorithm="MD5"].Value'
+        file:size: '$.ContentLength'
+        # order:status: must be one of succeeded, ordered, orderable
+        order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
+      quicklook:
+        href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+        title: "quicklook"
+        roles: '["overwiev"]'
+        type: "image/jpeg"
+      thumbnail:
+        href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+        title: "thumbnail"
+        roles: '["thumbnail"]'
+        type: "image/jpeg"
   download: !plugin
     type: HTTPDownload
     extract: true
@@ -2845,6 +3029,18 @@
       grid:code:
         - '{{"query":{{"s2:mgrs_tile":{{"eq":"{grid:code#replace_str("MGRS-","")}"}}}}}}'
         - '{$.properties."s2:mgrs_tile"#replace_str(r"^T?(.*)$",r"MGRS-\1")}'
+      assets: '$.assets'
+    assets_mapping:
+      quicklook:
+        href: '$.assets[?(@.rel == "preview")].href'
+        title: "quicklook"
+        roles: '["overwiev"]'
+        type: '$.assets[?(@.rel == "preview")].type'
+      thumbnail:
+        href: '$.assets[?(@.rel == "preview")].href'
+        title: "thumbnail"
+        roles: '["thumbnail"]'
+        type: '$.assets[?(@.rel == "preview")].type'
   products:
     S1_SAR_GRD:
       _collection: sentinel-1-grd
@@ -2927,6 +3123,7 @@
       spatial:scene_id:
         - '{{"query":{{"spatial:scene_id":{{"eq":{spatial:scene_id}}}}}}}'
         - '$.properties.spatial:scene_id'
+      assets: '$.assets'
   products:
     GENERIC_COLLECTION:
       _collection: '{collection}'
@@ -2949,44 +3146,6 @@
     - host
   description: WEkEO - Sentinel and some various Copernicus data
   url: https://www.wekeo.eu/
-  # anchors to avoid duplications
-  anchor_s1_sar: &s1_sar_params
-    processing:level:
-      - '{{"processingLevel": "{processing:level}"}}'
-      - '$.id.`sub(/^[^_]([^_]+)_([^_]+)_([^_]+)_([0-4]+).*/, LEVEL\\4)`'
-    platform:
-      - '{{"platformSerialIdentifier": "{platform}"}}'
-      - '$.null'
-    instruments:
-      - '{{"instrumentShortName": "{instruments#csv_list}"}}'
-      - '$.null'
-    order:status:
-      - '{{"online": "{order:status#get_group_name((?P<true>succeeded)|(?P<false>orderable))}"}}'
-      - '$.null'
-    sar:polarizations:
-      - '{{"polarisationChannels": "{sar:polarizations#csv_list(%26)}"}}'
-      - '$.null'
-    sat:relative_orbit:
-      - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
-      - '$.null'
-  anchor_orbit_cycle: &orbit_cycle
-    sat:relative_orbit:
-      - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
-      - '$.null'
-    sat:absolute_orbit:
-      - '{{"orbit": "{sat:absolute_orbit}"}}'
-      - '$.null'
-    sat:orbit_cycle:
-      - '{{"cycle": "{sat:orbit_cycle}"}}'
-      - '$.null'
-  anchor_id_from_date: &id_from_date
-    id:
-      - |
-        {{
-          "startdate": "{id#replace_str(r'^.*_([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])_.*$',r'\1-\2-\3T\4%3A\5%3A00Z')}",
-          "enddate": "{id#replace_str(r'^.*_([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])_.*$',r'\1-\2-\3T\4%3A\5%3A00Z')}"
-        }}
-      - '{$.id#remove_extension}'
   search: !plugin
     type: WekeoSearch
     api_endpoint: https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/search
@@ -3031,13 +3190,7 @@
       end_datetime:
         - '{{"enddate": "{end_datetime}"}}'
         - '$.properties.enddate'
-      eodag:download_link: '$.properties.location'
-      file:size: '$.properties.size'
-      file:local_path: '$.properties.localpath'
-      eodag:quicklook: '$.properties.thumbnail'
-      eodag:thumbnail: '$.properties.thumbnail'
       title: '$.id'
-      order:status: 'orderable'
       processing:level:
         - '{{"processingLevel": "{processing:level}"}}'
         - '$.null'
@@ -3085,12 +3238,28 @@
       itemsPerPage: '$.null'
       startIndex: '$.null'
       sortOrder: '$.null'
+    assets_mapping:
+      download_link:
+        href: ''
+        roles: '["archive", "data"]'
+        type: 'application/octet-stream'
+        order:status: 'orderable'
+        order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}'
+      quicklook:
+        href: '$.properties.thumbnail'
+        title: "quicklook"
+        roles: '["overwiev"]'
+        type: 'image/jpeg'
+      thumbnail:
+        href: '$.properties.thumbnail'
+        title: "thumbnail"
+        roles: '["thumbnail"]'
+        type: 'image/jpeg'
   products:
     S1_SAR_GRD:
       _collection: EO:ESA:DAT:SENTINEL-1
       product:type: GRD
       metadata_mapping:
-        <<: *s1_sar_params
         id:
           - |
             {{
@@ -3098,7 +3267,24 @@
               "enddate": "{id#replace_str(r'^.*_([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])T([0-9][0-9])([0-9][0-9])([0-9][0-9])_.*$',r'\1-\2-\3T23%3A59%3A59Z')}"
             }}
           - '{$.id#remove_extension}'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SAFE", "dataset_id": "EO:ESA:DAT:SENTINEL-1"}}'
+        processing:level:
+          - '{{"processingLevel": "{processing:level}"}}'
+          - '$.id.`sub(/^[^_]([^_]+)_([^_]+)_([^_]+)_([0-4]+).*/, LEVEL\\4)`'
+        sar:instrument_mode:
+          - '{{"sensorMode": "{sar:instrument_mode}"}}'
+          - '$.id.`sub(/^[^_]([^_]+)_([^_]+)_.*/, \\2)`'
+        swath:
+          - '{{"swath": "{swath}"}}'
+          - '$.null'
+        polarisation:
+          - '{{"polarisation": "{polarisation}"}}'
+          - '$.null'
+        sat:relative_orbit:
+          - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
+          - '$.null'
+        missionTakeId:
+          - '{{"missionTakeId": "{missionTakeId}"}}'
+          - '$.null'
     S1_SAR_RAW:
       _collection: EO:ESA:DAT:SENTINEL-1
       product:type: RAW
@@ -3131,7 +3317,6 @@
         eo:cloud_cover:
           - '{{"cloudCover": "{eo:cloud_cover}"}}'
           - '$.null'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SAFE", "dataset_id": "EO:ESA:DAT:SENTINEL-2"}}'
     S2_MSI_L2A:
       _collection: EO:ESA:DAT:SENTINEL-2
       product:type: S2MSI2A
@@ -3164,7 +3349,6 @@
         eo:cloud_cover:
           - '{{"cloudCover": "{eo:cloud_cover}"}}'
           - '$.null'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:ESA:DAT:SENTINEL-3"}}'
     S3_LAN_SI:
       _collection: EO:ESA:DAT:SENTINEL-3
       product:type: SR_2_LAN_SI
@@ -3200,38 +3384,33 @@
           - '{{"sat": "{constellation}"}}'
           - '$.id.`sub(/^[^_]([^_]+)_.*/, Sentinel-\\1)`'
         platform: '$.id.`sub(/^[^_]([^_]+)_.*/, S\\1)`'
-        <<: *orbit_cycle
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:OL_1_EFR___"}}'
+        sat:relative_orbit:
+          - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
+          - '$.null'
+        sat:absolute_orbit:
+          - '{{"orbit": "{sat:absolute_orbit}"}}'
+          - '$.null'
+        sat:orbit_cycle:
+          - '{{"cycle": "{sat:orbit_cycle}"}}'
+          - '$.null'
     S3_ERR:
       _collection: EO:EUM:DAT:SENTINEL-3:OL_1_ERR___
       metadata_mapping_from_product: S3_EFR
-      metadata_mapping:
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:OL_1_ERR___"}}'
     S3_OLCI_L2WFR:
       _collection: EO:EUM:DAT:SENTINEL-3:OL_2_WFR___
       metadata_mapping_from_product: S3_EFR
-      metadata_mapping:
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:OL_2_WFR___"}}'
     S3_OLCI_L2WRR:
       _collection: EO:EUM:DAT:SENTINEL-3:OL_2_WRR___
       metadata_mapping_from_product: S3_EFR
-      metadata_mapping:
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:OL_2_WRR___"}}'
     S3_SRA:
       _collection: EO:EUM:DAT:SENTINEL-3:SR_1_SRA___
       metadata_mapping_from_product: S3_EFR
-      metadata_mapping:
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:SR_1_SRA___"}}'
     S3_SRA_A:
       _collection: EO:EUM:DAT:SENTINEL-3:SR_1_SRA_A_
       metadata_mapping_from_product: S3_EFR
-      metadata_mapping:
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:SR_1_SRA_A_"}}'
     S3_SRA_BS:
       _collection: EO:EUM:DAT:SENTINEL-3:SR_1_SRA_BS
       metadata_mapping_from_product: S3_EFR
-      metadata_mapping:
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:SR_1_SRA_BS"}}'
     S3_SLSTR_L1RBT:
       _collection: EO:EUM:DAT:SENTINEL-3:SL_1_RBT___
       product:type: SL_1_RBT___
@@ -3243,15 +3422,21 @@
           - '{{"sat": "{constellation}"}}'
           - '$.id.`sub(/^[^_]([^_]+)_.*/, Sentinel-\\1)`'
         platform: '$.id.`sub(/^[^_]([^_]+)_.*/, S\\1)`'
-        <<: *orbit_cycle
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:SL_1_RBT___"}}'
+        sat:relative_orbit:
+          - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
+          - '$.null'
+        sat:absolute_orbit:
+          - '{{"orbit": "{sat:absolute_orbit}"}}'
+          - '$.null'
+        sat:orbit_cycle:
+          - '{{"cycle": "{sat:orbit_cycle}"}}'
+          - '$.null'
     S3_WAT:
       _collection: EO:EUM:DAT:SENTINEL-3:SR_2_WAT___
       metadata_mapping:
         id:
           - '{{"type": "SR_2_WAT___", "timeliness": {id#split_id_into_s3_params}["timeliness"], "sat": {id#split_id_into_s3_params}["sat"], "startdate": {id#split_id_into_s3_params}["startDate"], "enddate": {id#split_id_into_s3_params}["endDate"]}}'
           - '{$.id#remove_extension}'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.SEN3", "dataset_id": "EO:EUM:DAT:SENTINEL-3:SR_2_WAT___"}}'
     S5P_L1B_IR_ALL:
       _collection: EO:ESA:DAT:SENTINEL-5P
       processing:level: L1b
@@ -3268,7 +3453,6 @@
         sat:absolute_orbit:
           - '{{"orbitNumber": "{sat:absolute_orbit}"}}'
           - '$.null'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}.nc", "dataset_id": "EO:ESA:DAT:SENTINEL-5P"}}'
     S5P_L2_IR_ALL:
       _collection: EO:ESA:DAT:SENTINEL-5P
       processing:level: L2
@@ -3283,7 +3467,6 @@
           resolution:
               - '{{"resolution": "{resolution}"}}'
               - '{$.id#replace_str(r"^.*_R([0-9]+m)_.*$",r"\1")}'
-          eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:EEA:DAT:HRL:TCF"}}'
     COP_DEM_GLO30_DGED:
       _collection: EO:ESA:DAT:COP-DEM
       product:type: DGE_30
@@ -3291,7 +3474,6 @@
         gsd:
           - '{{"spatialResolution": "{gsd}"}}'
           - '$.null'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:ESA:DAT:COP-DEM"}}'
     COP_DEM_GLO30_DTED:
       _collection: EO:ESA:DAT:COP-DEM
       product:type: DTE_30
@@ -3322,7 +3504,6 @@
         format:
           - '{{"fileFormat": "{format}"}}'
           - '$.null'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:JRC:DAT:CLMS"}}'
     CLMS_GLO_NDVI_1KM_LTS:
       _collection: EO:JRC:DAT:CLMS
       product:type: vegetation_indices
@@ -3337,13 +3518,16 @@
         id:
           - '{{"format": "{id#get_group_name((?P<GeoPackage>geoPackage)|(?P<ESRI fgdb>fgdb)|(?P<GeoTiff100mt>raster100m))}"}}'
           - '$.id'
-        start_datetime: '$.properties.startdate'
-        end_datetime: '$.properties.enddate'
+        start_datetime:
+          - $.null
+          - '$.properties.startdate'
+        end_datetime:
+          - $.null
+          - '$.properties.enddate'
         format:
           - '{{"format": "{format}"}}'
           - '{$.id#get_group_name((?P<GeoPackage>geoPackage)|(?P<ESRI fgdb>fgdb)|(?P<GeoTiff100mt>raster100m))}'
         eodag:default_geometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:EEA:DAT:CORINE"}}'
     CLMS_GLO_FCOVER_333M:
       _collection: EO:JRC:DAT:CLMS
       product:type: vegetation_properties
@@ -3375,28 +3559,24 @@
         id:
           - '{{"uid": "{id}"}}'
           - '$.id'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:EEA:DAT:CLMS_HRVPP_ST"}}'
     CLMS_HRVPP_ST_LAEA:
       _collection: EO:EEA:DAT:CLMS_HRVPP_ST-LAEA
       metadata_mapping:
         id:
           - '{{"uid": "{id}"}}'
           - '$.id'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:EEA:DAT:CLMS_HRVPP_ST-LAEA"}}'
     CLMS_HRVPP_VPP:
       _collection: EO:EEA:DAT:CLMS_HRVPP_VPP
       metadata_mapping:
         id:
           - '{{"uid": "{id}"}}'
           - '$.id'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:EEA:DAT:CLMS_HRVPP_VPP"}}'
     CLMS_HRVPP_VPP_LAEA:
       _collection: EO:EEA:DAT:CLMS_HRVPP_VPP-LAEA
       metadata_mapping:
         id:
           - '{{"uid": "{id}"}}'
           - '$.id'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:EEA:DAT:CLMS_HRVPP_VPP-LAEA"}}'
   auth: !plugin
     type: TokenAuth
     matching_url: https://[-\w\.]+.wekeo2.eu
@@ -3539,12 +3719,18 @@
       product:type:
         - dataset_id
         - $.dataset
-      eodag:download_link: $.properties.location
-      file:size: '$.properties.size'
       dataset:
         - dataset_id
         - $.dataset
+      eodag:download_link: $.properties.location
       eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "{dataset}"}}'
+    assets_mapping:
+      download_link:
+        href: ''
+        roles: '["archive", "data"]'
+        type: '$.ContentType'
+        "order_link": 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location#url_decode}","product_id":"{id}", "dataset_id": "{dataset}"}'
+        order:status: 'orderable'
   products:
     SATELLITE_CARBON_DIOXIDE:
       dataset: EO:ECMWF:DAT:SATELLITE_CARBON_DIOXIDE
@@ -3821,10 +4007,14 @@
       variable:
         - '{{"variable": "{variable}"}}'
         - '{$.properties.location#get_variables_from_path}'
-      eodag:download_link: '$.properties.location'
       title: '$.id'
-      order:status: 'orderable'
-      eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "cacheable": "true", "dataset_id": "productType"}}'
+    assets_mapping:
+      download_link:
+        href: '$.properties.location'
+        roles: '["archive", "data"]'
+        type: 'application/octet-stream'
+        order:status: 'orderable'
+        order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "cacheable": "true", "dataset_id": "productType"}'
   products:
     GENERIC_COLLECTION:
       _collection: '{collection}'
@@ -4097,16 +4287,26 @@
       geometry:
         - null
         - '{$.Footprint#from_ewkt}'
-      # The url to download the product "as is" (literal or as a template to be completed either after the search result
-      # is obtained from the provider or during the eodag download phase)
-      eodag:download_link: '$.S3Path.`sub(/^(.*)$/, s3:/\\1)`'
-      # order:status: must be one of succeeded, ordered, orderable
-      order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
       collection:
         - null
         - $.null
-      eodag:quicklook: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
-      eodag:thumbnail: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+    assets_mapping:
+      download_link:
+        href: '$.S3Path.`sub(/^(.*)$/, s3:/\\1)`'
+        roles: '["archive", "data"]'
+        type: 'application/octet-stream'
+        # order:status: must be one of succeeded, ordered, orderable
+        order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
+      quicklook:
+        href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+        title: "quicklook"
+        roles: '["overwiev"]'
+        type: "image/jpeg"
+      thumbnail:
+        href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+        title: "thumbnail"
+        roles: '["thumbnail"]'
+        type: "image/jpeg"
   download: !plugin
     type: AwsDownload
     s3_endpoint: 'https://eodata.cloudferro.com'
@@ -4542,7 +4742,14 @@
         - dataset
         - $.dataset
       qs: $.qs
-      eodag:order_link: 'https://polytope.lumi.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{{"verb": "retrieve", "request": {qs#to_geojson} }}'
+    assets_mapping:
+      download_link:
+        title: "downloadlink"
+        href: ''
+        roles: '["archive", "data"]'
+        type: 'application/octet-stream'
+        order_link: 'https://polytope.lumi.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{"verb": "retrieve", "request": {qs#to_geojson} }'
+        order:status: 'orderable'
   products:
     DT_CLIMATE_ADAPTATION:
       discover_queryables:
@@ -4815,7 +5022,14 @@
         - dataset
         - $.dataset
       qs: $.qs
-      eodag:order_link: 'https://polytope.mn5.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{{"verb": "retrieve", "request": {qs#to_geojson} }}'
+    assets_mapping:
+      download_link:
+        title: "downloadlink"
+        href: ''
+        roles: '["archive", "data"]'
+        type: 'application/octet-stream'
+        order_link: 'https://polytope.mn5.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{{"verb": "retrieve", "request": {qs#to_geojson} }}'
+        order:status: 'orderable'
   products:
     DT_CLIMATE_G1_HIGHRESMIP_CONT_IFS_FESOM_R1:
       dataset: climate-dt
@@ -5132,13 +5346,30 @@
     asset_key_from_href: false
     metadata_mapping:
       eodag:default_geometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
-      eodag:quicklook: '{eodag:thumbnail}'
-      order:status: '{$.properties."order:status"#get_group_name((?P<succeeded>succeeded)|(?P<ordered>shipping)|(?P<orderable>orderable))}'
-      eodag:download_link: '$.assets.downloadLink.href'
       federation:backends: '$.null'
       storage:schemes: '$.null'
       storage:tier: '$.null'
-      assets: '$.null'
+      assets: '$.assets'
+    assets_mapping:
+      download_link:
+        title: "downloadlink"
+        href: '$.assets.downloadLink.href'
+        roles: '["archive", "data"]'
+        type: '$.assets.downloadLink.type'
+        alternate: '$.assets.downloadLink.alternate'
+        order:status: '{$.properties."order:status"#get_group_name((?P<succeeded>succeeded)|(?P<ordered>shipping)|(?P<orderable>orderable))}'
+      quicklook:
+        href: '$.assets["ql.jpg"].href'
+        title: "quicklook"
+        roles: '["overwiev"]'
+        type: '$.assets["ql.jpg"].type'
+        alternate: '$.assets["ql.jpg"].alternate'
+      thumbnail:
+        href: '$.assets["ql.jpg"].href'
+        title: "thumbnail"
+        roles: '["thumbnail"]'
+        type: $.assets["ql.jpg"].type
+        alternate: '$.assets["ql.jpg"].alternate'
     discover_collections:
       fetch_url: 'https://hda.data.destination-earth.eu/stac/v2/collections'
       result_type: json
@@ -5783,13 +6014,6 @@
         - 'geo={geometry#to_rounded_wkt}'
         - '$.geometry'
       eodag:default_geometry: 'POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))'
-      # The url of the quicklook
-      eodag:quicklook: '$.properties.links.previews[?(@.title="Quicklook")].href'
-      # The url to download the product "as is" (literal or as a template to be completed either after the search result
-      # is obtained from the provider or during the eodag download phase)
-      eodag:download_link: '$.properties.links.data[?(@.title="Product download")].href'
-      # order:status set to succeeded for consistency between providers
-      order:status: '{$.null#replace_str("Not Available","succeeded")}'
       assets: '{$.properties.links.sip-entries#assets_list_to_dict}'
       # Additional metadata provided by the providers but that don't appear in the reference spec
       size: '$.properties.productInformation.size'
@@ -5798,6 +6022,23 @@
       acquisitionInformation: '$.null'
       productInformation: '$.null'
       extraInformation: '$.null'
+    assets_mapping:
+      download_link:
+        title: 'downloadlink'
+        href: '$.properties.links.data[?(@.title="Product download")].href'
+        roles: '["archive", "data"]'
+        type: '$.properties.links.data[?(@.title="Product download")].mediaType'
+        order:status: 'succeeded'
+      quicklook:
+        href: '$.properties.links.previews[?(@.title="Quicklook")].href'
+        title: "quicklook"
+        roles: '["overwiev"]'
+        type: "image/jpeg"
+      thumbnail:
+        href: '$.properties.links.previews[?(@.title="Quicklook")].href'
+        title: "thumbnail"
+        roles: '["thumbnail"]'
+        type: "image/jpeg"
   products:
     # S3 SRAL
     S3_SRA:
@@ -6422,11 +6663,22 @@
         - '{$.properties."grid:code"#replace_str(r"^T?(.*)$",r"MGRS-\1")}'
       sci:doi: '{$.properties.sci:doi#replace_str(r"^\[\]$","Not Available")}'
       published: '$.properties.datetime'
-      eodag:download_link: '$.assets[?(@.roles[0] == "data") & (@.type != "application/xml")].href'
-      eodag:quicklook: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
-      eodag:thumbnail: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
-      # order:status set to orderable by default and then updated from plugin
-      order:status: '{$.null#replace_str("Not Available","orderable")}'
+    assets_mapping:
+      download_link:
+        title: 'downloadlink'
+        href: '$.assets[?(@.roles[0] == "data") & (@.type == "application/zip")].href'
+        roles: '["archive", "data"]'
+        order:status: 'succeeded'
+      quicklook:
+        href: '$.assets[?(@.roles[0] == "overview")].href'
+        title: "quicklook"
+        roles: '["overwiev"]'
+        type: "image/jpeg"
+      thumbnail:
+        href: '$.assets[?(@.roles[0] == "overview")].href'
+        title: "thumbnail"
+        roles: '["thumbnail"]'
+        type: "image/jpeg"
   products:
     S1_SAR_OCN:
       product:type: OCN
@@ -6556,11 +6808,22 @@
         - '{$.properties."grid:code"#replace_str(r"^T?(.*)$",r"MGRS-\1")}'
       sci:doi: '{$.properties.sci:doi#replace_str(r"^\[\]$","Not Available")}'
       published: '$.properties.datetime'
-      eodag:download_link: '$.properties.endpoint_url'
-      eodag:quicklook: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
-      eodag:thumbnail: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
-      # order:status set to succeeded for consistency between providers
-      order:status: '{$.null#replace_str("Not Available","succeeded")}'
+    assets_mapping:
+      download_link:
+        href: '$.properties.endpoint_url'
+        roles: '["archive", "data"]'
+        type: 'application/octet-stream'
+        order:status: 'succeeded'
+      quicklook:
+        href: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
+        title: "quicklook"
+        roles: '["overwiev"]'
+        type: 'image/jpeg'
+      thumbnail:
+        href: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
+        title: "thumbnail"
+        roles: '["thumbnail"]'
+        type: 'image/jpeg'
   products:
     S1_SAR_OCN:
       product:type: OCN
@@ -6721,7 +6984,13 @@
         - '{{"area": {geometry#to_nwse_bounds}}}'
         - $.geometry
       qs: $.qs
-      eodag:order_link: 'https://ewds.climate.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{{"inputs": {qs#to_geojson}}}'
+    assets_mapping:
+      download_link:
+        href: ''
+        title: "downloadlink"
+        roles: '["archive", "data"]'
+        type: 'application/octet-stream'
+        order_link: 'https://ewds.climate.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{"inputs": {qs#to_geojson}}'
   products:
     EFAS_HISTORICAL:
       dataset: efas-historical

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -284,7 +284,6 @@
           - '$.onAmazon'
         _path: '$.path'
         _row: '$.row'
-        eodag:download_link: 's3://landsat-pds/c1/L8/{_path:03.0f}/{_row:03.0f}/{title}/'
         eodag:thumbnail: '$.thumbnail'
         eodag:quicklook: 'https://landsat-pds.s3.amazonaws.com/c1/L8/{_path:03.0f}/{_row:03.0f}/{title}/{title}_thumb_large.jpg'
         id:
@@ -467,7 +466,6 @@
         # Custom parameters (not defined in the base document referenced above)
         eodag:thumbnail: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
         _aws_path: '$.awsPath'
-        eodag:download_link: 's3://sentinel-s2-l1c/{_aws_path}'
         eodag:product_path: '$.productPath'
         id:
           - '{{"search":{{"productName":"{id}" }} }}'
@@ -512,7 +510,6 @@
             - 'title'
             - '{title}'
           _aws_path_l2a: '$.tiles[0].path'
-          eodag:download_link: 's3://sentinel-s2-l2a/{_aws_path_l2a}'
           eodag:product_path: '$.path'
           start_datetime: '$.timestamp'
           end_datetime: '$.timestamp'
@@ -1664,7 +1661,7 @@
         href: ""
         roles: '["archive", "data"]'
         type: "application/netcdf"
-        order_link: 'https://ads.atmosphere.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{"inputs": {qs#to_geojson}}'
+        eodag:order_link: 'https://ads.atmosphere.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{"inputs": {qs#to_geojson}}'
   products:
     # See available Public Datasets in https://ads.atmosphere.copernicus.eu/cdsapp#!/search?type=dataset
     CAMS_GAC_FORECAST:
@@ -1840,7 +1837,7 @@
         href: ""
         roles: '["archive", "data"]'
         type: "application/netcdf"
-        order_link: 'https://ads.atmosphere.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{"inputs": {qs#to_geojson}}'
+        eodag:order_link: 'https://ads.atmosphere.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{"inputs": {qs#to_geojson}}'
   products:
     # See available Public Datasets in https://cds.climate.copernicus.eu/cdsapp#!/search?type=dataset
     AG_ERA5:
@@ -2295,7 +2292,7 @@
         roles: '["archive", "data"]'
         type: 'application/octet-stream'
         order:status: '{$.requiresJobQueue#get_group_name((?P<succeeded>False)|(?P<orderable>True))}'
-        order_link: https://my.meteoblue.com/dataset/query?{qs#replace_str(r"^(.*)(\")(queries\")(.)",r"\1\2runOnJobQueue\2\4 true, \2\3\4")}
+        eodag:order_link: https://my.meteoblue.com/dataset/query?{qs#replace_str(r"^(.*)(\")(queries\")(.)",r"\1\2runOnJobQueue\2\4 true, \2\3\4")}
   products:
     NEMSGLOBAL_TCDC:
       product:type: NEMSGLOBAL
@@ -3244,7 +3241,7 @@
         roles: '["archive", "data"]'
         type: 'application/octet-stream'
         order:status: 'orderable'
-        order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{href}","product_id":"{id}", "dataset_id": "{_collection}"}}'
+        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{href}","product_id":"{id}", "dataset_id": "{_collection}"}}'
       quicklook:
         href: '$.properties.thumbnail'
         title: "quicklook"
@@ -3722,14 +3719,12 @@
       dataset:
         - dataset_id
         - $.dataset
-      eodag:download_link: $.properties.location
-      eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "{dataset}"}}'
     assets_mapping:
       download_link:
         href: ''
         roles: '["archive", "data"]'
         type: '$.ContentType'
-        "order_link": 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location#url_decode}","product_id":"{id}", "dataset_id": "{dataset}"}'
+        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location#url_decode}","product_id":"{id}", "dataset_id": "{dataset}"}'
         order:status: 'orderable'
   products:
     SATELLITE_CARBON_DIOXIDE:
@@ -4014,7 +4009,7 @@
         roles: '["archive", "data"]'
         type: 'application/octet-stream'
         order:status: 'orderable'
-        order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "cacheable": "true", "dataset_id": "productType"}'
+        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "cacheable": "true", "dataset_id": "productType"}'
   products:
     GENERIC_COLLECTION:
       _collection: '{collection}'
@@ -4748,7 +4743,7 @@
         href: ''
         roles: '["archive", "data"]'
         type: 'application/octet-stream'
-        order_link: 'https://polytope.lumi.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{"verb": "retrieve", "request": {qs#to_geojson} }'
+        eodag:order_link: 'https://polytope.lumi.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{"verb": "retrieve", "request": {qs#to_geojson} }'
         order:status: 'orderable'
   products:
     DT_CLIMATE_ADAPTATION:
@@ -5028,7 +5023,7 @@
         href: ''
         roles: '["archive", "data"]'
         type: 'application/octet-stream'
-        order_link: 'https://polytope.mn5.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{{"verb": "retrieve", "request": {qs#to_geojson} }}'
+        eodag:order_link: 'https://polytope.mn5.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{{"verb": "retrieve", "request": {qs#to_geojson} }}'
         order:status: 'orderable'
   products:
     DT_CLIMATE_G1_HIGHRESMIP_CONT_IFS_FESOM_R1:
@@ -5333,11 +5328,13 @@
   url: https://hda.data.destination-earth.eu/stac/v2/
   # anchors to avoid duplications
   anchor_orderable_mm: &orderable_mm
-    _order_href: '$.links[?rel=="retrieve"].href'
-    _order_body: '$.links[?rel=="retrieve"].body'
-    eodag:order_link: "{_order_href}?{{{_order_body#replace_str(\"'\", '\"')}}}"
-    eodag:download_link: '$.null'
     assets: '$.null'
+  anchor_orderable_am: &orderable_am
+    download_link:
+      _order_href: '$.links[?rel=="retrieve"].href'
+      _order_body: '$.links[?rel=="retrieve"].body'
+      eodag:order_link: "{_order_href}?{{{_order_body#replace_str(\"'\", '\"')}}}"
+      order:status: 'orderable'
   search: !plugin
     type: StacSearch
     api_endpoint: https://hda.data.destination-earth.eu/stac/v2/search
@@ -5494,90 +5491,134 @@
       _collection: EO.ECMWF.DAT.REANALYSIS_ERA5_SINGLE_LEVELS
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     ERA5_SL_MONTHLY:
       _collection: EO.ECMWF.DAT.REANALYSIS_ERA5_SINGLE_LEVELS_MONTHLY_MEANS
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     ERA5_PL:
       _collection: EO.ECMWF.DAT.ERA5_HOURLY_VARIABLES_ON_PRESSURE_LEVELS
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     ERA5_PL_MONTHLY:
       _collection: EO.ECMWF.DAT.ERA5_MONTHLY_MEANS_VARIABLES_ON_PRESSURE_LEVELS
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     ERA5_LAND:
       _collection: EO.ECMWF.DAT.ERA5_LAND_HOURLY
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     ERA5_LAND_MONTHLY:
       _collection: EO.ECMWF.DAT.ERA5_LAND_MONTHLY
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     UERRA_EUROPE_SL:
       _collection: EO.ECMWF.DAT.REANALYSIS_UERRA_EUROPE_SINGLE_LEVELS
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     GRIDDED_GLACIERS_MASS_CHANGE:
       _collection: EO.ECMWF.DAT.DERIVED_GRIDDED_GLACIER_MASS_CHANGE
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     GLACIERS_DIST_RANDOLPH:
       _collection: EO.ECMWF.DAT.GLACIERS_DISTRIBUTION_DATA_FROM_RANDOLPH_GLACIER_INVENTORY_2000
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     SATELLITE_CARBON_DIOXIDE:
       _collection: EO.ECMWF.DAT.CO2_DATA_FROM_SATELLITE_SENSORS_2002_PRESENT
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     SATELLITE_METHANE:
       _collection: EO.ECMWF.DAT.METHANE_DATA_SATELLITE_SENSORS_2002_PRESENT
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     SEASONAL_POSTPROCESSED_PL:
       _collection: EO.ECMWF.DAT.SEASONAL_FORECAST_ANOMALIES_ON_PRESSURE_LEVELS_2017_PRESENT
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     SATELLITE_SEA_LEVEL_GLOBAL:
       _collection: EO.ECMWF.DAT.SEA_LEVEL_DAILY_GRIDDED_DATA_FOR_GLOBAL_OCEAN_1993_PRESENT
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     SATELLITE_SEA_ICE_EDGE_TYPE:
       _collection: EO.ECMWF.DAT.SATELLITE_SEA_ICE_EDGE_TYPE
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     SATELLITE_SEA_ICE_THICKNESS:
       _collection: EO.ECMWF.DAT.SATELLITE_SEA_ICE_THICKNESS
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     SATELLITE_SEA_ICE_CONCENTRATION:
       _collection: EO.ECMWF.DAT.SATELLITE_SEA_ICE_CONCENTRATION
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     SEASONAL_POSTPROCESSED_SL:
       _collection: EO.ECMWF.DAT.SEASONAL_FORECAST_ANOMALIES_ON_SINGLE_LEVELS_2017_PRESENT
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     SEASONAL_ORIGINAL_SL:
       _collection: EO.ECMWF.DAT.SEASONAL_FORECAST_DAILY_DATA_ON_SINGLE_LEVELS_2017_PRESENT
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     SEASONAL_ORIGINAL_PL:
       _collection: EO.ECMWF.DAT.SEASONAL_FORECAST_DAILY_DATA_ON_PRESSURE_LEVELS_2017_PRESENT
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     SEASONAL_MONTHLY_PL:
       _collection: EO.ECMWF.DAT.SEASONAL_FORECAST_MONTHLY_STATISTICS_ON_PRESSURE_LEVELS_2017_PRESENT
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     SEASONAL_MONTHLY_SL:
       _collection: EO.ECMWF.DAT.SEASONAL_FORECAST_MONTHLY_STATISTICS_ON_SINGLE_LEVELS_2017_PRESENT
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     SIS_HYDRO_MET_PROJ:
       _collection: EO.ECMWF.DAT.SIS_HYDROLOGY_METEOROLOGY_DERIVED_PROJECTIONS
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     # ECMWF - CEMS
     FIRE_HISTORICAL:
       _collection: EO.ECMWF.DAT.CEMS_FIRE_HISTORICAL
@@ -5606,54 +5647,80 @@
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_ATMOSHERIC_COMPO_FORECAST
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     CAMS_EU_AIR_QUALITY_FORECAST:
       _collection: EO.ECMWF.DAT.CAMS_EUROPE_AIR_QUALITY_FORECASTS
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     CAMS_GFE_GFAS:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_FIRE_EMISSIONS_GFAS
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     CAMS_SOLAR_RADIATION:
       _collection: EO.ECMWF.DAT.CAMS_SOLAR_RADIATION_TIMESERIES
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     CAMS_GREENHOUSE_INVERSION:
       _collection: EO.ECMWF.DAT.CAMS_GREENHOUSE_GAS_FLUXES
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     CAMS_EAC4_MONTHLY:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_REANALYSIS_EAC4_MONTHLY_AV_FIELDS
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     CAMS_EU_AIR_QUALITY_RE:
       _collection: EO.ECMWF.DAT.CAMS_EUROPE_AIR_QUALITY_REANALYSES
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     CAMS_EAC4:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_REANALYSIS_EAC4
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     CAMS_GRF_AUX:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_RADIATIVE_FORCING_AUX
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     CAMS_GRF:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_RADIATIVE_FORCING
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     CAMS_GREENHOUSE_EGG4_MONTHLY:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_GREENHOUSE_GAS_REANALYSIS_MONTHLY_AV_FIELDS
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     CAMS_GREENHOUSE_EGG4:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_GREENHOUSE_GAS_REANALYSIS
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     CAMS_GLOBAL_EMISSIONS:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_EMISSION_INVENTORIES
       metadata_mapping:
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     # COPERNICUS ADS - Digital Elevation Model
     COP_DEM_GLO30_DGED:
       _collection: EO.DEM.DAT.COP-DEM_GLO-30-DGED
@@ -5771,11 +5838,15 @@
       metadata_mapping:
         order:status: '{$.null#replace_str("Not Available","orderable")}'
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     DT_CLIMATE_ADAPTATION:
       _collection: EO.ECMWF.DAT.DT_CLIMATE_ADAPTATION
       metadata_mapping:
         order:status: '{$.null#replace_str("Not Available","orderable")}'
         <<: *orderable_mm
+      assets_mapping:
+        <<: *orderable_am
     # AERIS
     AERIS_IAGOS:
       _collection: EO.AERIS.DAT.IAGOS
@@ -6990,7 +7061,7 @@
         title: "downloadlink"
         roles: '["archive", "data"]'
         type: 'application/octet-stream'
-        order_link: 'https://ewds.climate.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{"inputs": {qs#to_geojson}}'
+        eodag:order_link: 'https://ewds.climate.copernicus.eu/api/retrieve/v1/processes/{dataset}/execution?{"inputs": {qs#to_geojson}}'
   products:
     EFAS_HISTORICAL:
       dataset: efas-historical
@@ -7115,12 +7186,14 @@
   products:
     S2_MSI_L2A_MAJA:
       _collection: S2_L2A_MAJA
-      metadata_mapping:
-        eodag:download_link: '$.assets.data.href'
+      assets_mapping:
+        download_link:
+          href: '$.assets.data.href'
     SUPERSITES:
       _collection: SUPERSITES
-      metadata_mapping:
-        eodag:download_link: '$.assets.data.href'
+      assets_mapping:
+        download_link:
+          href: '$.assets.data.href'
     GENERIC_COLLECTION:
       _collection: '{collection}'
   download: !plugin
@@ -7161,8 +7234,10 @@
         platform: '{$.summaries.platform#csv_list}'
     metadata_mapping:
       assets: '{$.assets#dict_with_roles(["data", "thumbnail", "overview"])}'
-      eodag:download_link: '$.assets.enclosure.href'
       title: '{$.properties.title#remove_extension}'
+    assets_mapping:
+      download_link:
+        href: '$.assets.enclosure.href'
   products:
     GENERIC_COLLECTION:
       _collection: '{collection}'
@@ -7537,7 +7612,6 @@
         - '{$.Footprint#from_ewkt}'
       # The url to download the product "as is" (literal or as a template to be completed either after the search result
       # is obtained from the provider or during the eodag download phase)
-      eodag:download_link: '$.S3Path.`sub(/^(.*)$/, s3:/\\1)`'
       # order:status: must be one of succeeded, ordered, orderable
       order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
       collection:
@@ -7545,6 +7619,13 @@
         - $.null
       eodag:quicklook: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
       eodag:thumbnail: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+    assets_mapping:
+      download_link:
+        href: '$.S3Path.`sub(/^(.*)$/, s3:/\\1)`'
+        roles: '["archive", "data"]'
+        type: 'application/octet-stream'
+        # order:status: must be one of succeeded, ordered, orderable
+        order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
   download: !plugin
     type: AwsDownload
     s3_endpoint: 'https://eodata.dataspace.copernicus.eu'

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3176,7 +3176,7 @@
     metadata_mapping:
       _collection:
         - '{{"dataset_id": "{_collection}"}}'
-        - '$.null'
+        - '{_collection}'
       geometry:
         - '{{"bbox": {geometry#to_bounds}}}'
         - '$.geometry'
@@ -3240,11 +3240,11 @@
       sortOrder: '$.null'
     assets_mapping:
       download_link:
-        href: ''
+        href: '$.properties.location'
         roles: '["archive", "data"]'
         type: 'application/octet-stream'
         order:status: 'orderable'
-        order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}'
+        order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{href}","product_id":"{id}", "dataset_id": "{_collection}"}}'
       quicklook:
         href: '$.properties.thumbnail'
         title: "quicklook"

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -71,7 +71,7 @@
       quicklook:
         href: '$.browse[0].browsePath'
         title: "quicklook"
-        roles: '["overwiev"]'
+        roles: '["overview"]'
         type: 'image/jpeg'
       thumbnail:
         href: '$.browse[0].thumbnailPath'
@@ -195,7 +195,7 @@
           _scene_id: '{$.sceneID#replace_str("_L[24]$","")}'
           href: 'https://s3.amazonaws.com/cbers-meta-pds/{_download_url}/{_scene_id}.jpg'
           title: "quicklook"
-          roles: '["overwiev"]'
+          roles: '["overview"]'
           type: 'image/jpeg'
         thumbnail:
           _download_url: '$.downloadUrl'
@@ -297,7 +297,7 @@
         quicklook:
           href: 'https://landsat-pds.s3.amazonaws.com/c1/L8/{_path:03.0f}/{_row:03.0f}/{title}/{title}_thumb_large.jpg'
           title: "quicklook"
-          roles: '["overwiev"]'
+          roles: '["overview"]'
           type: 'image/jpeg'
         thumbnail:
           href: '$.thumbnail'
@@ -343,7 +343,7 @@
         quicklook:
           href: '$.thumbnail'
           title: "quicklook"
-          roles: '["overwiev"]'
+          roles: '["overview"]'
           type: 'image/jpeg'
         thumbnail:
           href: '$.thumbnail'
@@ -427,7 +427,7 @@
         quicklook:
           href: 'https://render.eosda.com/S1/thumb/{title}.png'
           title: "quicklook"
-          roles: '["overwiev"]'
+          roles: '["overview"]'
           type: 'image/png'
         thumbnail:
           href: 'https://render.eosda.com/S1/thumb/{title}.png'
@@ -482,7 +482,7 @@
         quicklook:
           href: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
           title: "quicklook"
-          roles: '["overwiev"]'
+          roles: '["overview"]'
           type: 'image/jpeg'
         thumbnail:
           href: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
@@ -854,7 +854,7 @@
       quicklook:
         href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
         title: "quicklook"
-        roles: '["overwiev"]'
+        roles: '["overview"]'
         type: "image/jpeg"
       thumbnail:
         href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
@@ -1301,7 +1301,7 @@
       quicklook:
         href: '$.assets.reduced_resolution_browse.alternate.s3.href'
         title: "quicklook"
-        roles: '["overwiev"]'
+        roles: '["overview"]'
         type: '$.assets.reduced_resolution_browse.type'
       thumbnail:
         href: '$.assets.thumbnail.alternate.s3.href'
@@ -1504,7 +1504,7 @@
         quicklook:
           href: '$.assets.thumbnail.href'
           title: "thumbnail"
-          roles: '["overwiev"]'
+          roles: '["overview"]'
           type: '$.assets.thumbnail.type'
         thumbnail:
           href: '$.assets.thumbnail.href'
@@ -2074,7 +2074,7 @@
       quicklook:
         href: '$.properties.quicklook'
         title: "quicklook"
-        roles: '["overwiev"]'
+        roles: '["overview"]'
         type: "image/png"
       thumbnail:
         href: '$.properties.thumbnail'
@@ -2597,7 +2597,7 @@
       quicklook:
         href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
         title: "quicklook"
-        roles: '["overwiev"]'
+        roles: '["overview"]'
         type: "image/jpeg"
       thumbnail:
         href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
@@ -3031,7 +3031,7 @@
       quicklook:
         href: '$.assets[?(@.rel == "preview")].href'
         title: "quicklook"
-        roles: '["overwiev"]'
+        roles: '["overview"]'
         type: '$.assets[?(@.rel == "preview")].type'
       thumbnail:
         href: '$.assets[?(@.rel == "preview")].href'
@@ -3246,7 +3246,7 @@
       quicklook:
         href: '$.properties.thumbnail'
         title: "quicklook"
-        roles: '["overwiev"]'
+        roles: '["overview"]'
         type: 'image/jpeg'
       thumbnail:
         href: '$.properties.thumbnail'
@@ -4296,7 +4296,7 @@
       quicklook:
         href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
         title: "quicklook"
-        roles: '["overwiev"]'
+        roles: '["overview"]'
         type: "image/jpeg"
       thumbnail:
         href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
@@ -5359,7 +5359,7 @@
       quicklook:
         href: '$.assets["ql.jpg"].href'
         title: "quicklook"
-        roles: '["overwiev"]'
+        roles: '["overview"]'
         type: '$.assets["ql.jpg"].type'
         alternate: '$.assets["ql.jpg"].alternate'
       thumbnail:
@@ -6104,7 +6104,7 @@
       quicklook:
         href: '$.properties.links.previews[?(@.title="Quicklook")].href'
         title: "quicklook"
-        roles: '["overwiev"]'
+        roles: '["overview"]'
         type: "image/jpeg"
       thumbnail:
         href: '$.properties.links.previews[?(@.title="Quicklook")].href'
@@ -6744,7 +6744,7 @@
       quicklook:
         href: '$.assets[?(@.roles[0] == "overview")].href'
         title: "quicklook"
-        roles: '["overwiev"]'
+        roles: '["overview"]'
         type: "image/jpeg"
       thumbnail:
         href: '$.assets[?(@.roles[0] == "overview")].href'
@@ -6889,7 +6889,7 @@
       quicklook:
         href: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'
         title: "quicklook"
-        roles: '["overwiev"]'
+        roles: '["overview"]'
         type: 'image/jpeg'
       thumbnail:
         href: '$.assets[?(@.roles[0] == "overview")].href.`sub(/^(.*)$/, \\1?scope=gdh)`'

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -3181,6 +3181,7 @@
       id:
         - '{{"datasetIdentifier": "{id}"}}'
         - '{$.id#remove_extension}'
+      _product_id: '$.id'
       start_datetime:
         - '{{"startdate": "{start_datetime}"}}'
         - '$.properties.startdate'
@@ -3241,7 +3242,7 @@
         roles: '["archive", "data"]'
         type: 'application/octet-stream'
         order:status: 'orderable'
-        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{href}","product_id":"{id}", "dataset_id": "{_collection}"}}'
+        eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{href}","product_id":"{_product_id}", "dataset_id": "{_collection}"}}'
       quicklook:
         href: '$.properties.thumbnail'
         title: "quicklook"

--- a/eodag/resources/providers.yml
+++ b/eodag/resources/providers.yml
@@ -189,7 +189,7 @@
           _download_url: '$.downloadUrl'
           href: 's3://cbers-pds/{_download_url}'
           roles: '["archive", "data"]'
-          order:status: 'succeded'
+          order:status: 'succeeded'
         quicklook:
           _download_url: '$.downloadUrl'
           _scene_id: '{$.sceneID#replace_str("_L[24]$","")}'
@@ -294,7 +294,7 @@
         download_link:
           href: 's3://landsat-pds/c1/L8/{_path:03.0f}/{_row:03.0f}/{title}/'
           roles: '["archive", "data"]'
-          order:status: 'succeded'
+          order:status: 'succeeded'
         quicklook:
           href: 'https://landsat-pds.s3.amazonaws.com/c1/L8/{_path:03.0f}/{_row:03.0f}/{title}/{title}_thumb_large.jpg'
           title: "quicklook"
@@ -340,7 +340,7 @@
           href: 's3://modis-pds/MCD43A4.006/{_h_tile}/{_v_tile}/{_scene_id}/'
           roles: '["archive", "data"]'
           type: 'application/octet-stream'
-          order:status: 'succeded'
+          order:status: 'succeeded'
         quicklook:
           href: '$.thumbnail'
           title: "quicklook"
@@ -380,7 +380,7 @@
           href: 's3://naip-analytic/{_aws_path}'
           roles: '["archive", "data"]'
           type: 'application/octet-stream'
-          order:status: 'succeded'
+          order:status: 'succeeded'
     S1_SAR_GRD:
       product:type: GRD
       _collection: sentinel1
@@ -424,7 +424,7 @@
           href: 's3://sentinel-s1-l1c/{_aws_path}'
           roles: '["archive", "data"]'
           type: 'application/octet-stream'
-          order:status: 'succeded'
+          order:status: 'succeeded'
         quicklook:
           href: 'https://render.eosda.com/S1/thumb/{title}.png'
           title: "quicklook"
@@ -480,7 +480,7 @@
           href: 's3://sentinel-s2-l1c/{_aws_path}'
           roles: '["archive", "data"]'
           type: 'application/octet-stream'
-          order:status: 'succeded'
+          order:status: 'succeeded'
         quicklook:
           href: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
           title: "quicklook"
@@ -561,7 +561,7 @@
           href: 's3://sentinel-s2-l2a/{_aws_path_l2a}'
           roles: '["archive", "data"]'
           type: 'application/octet-stream'
-          order:status: 'succeded'
+          order:status: 'succeeded'
   download: !plugin
     type: AwsDownload
     ssl_verify: true

--- a/eodag/resources/stac_provider.yml
+++ b/eodag/resources/stac_provider.yml
@@ -113,11 +113,5 @@ search:
     eo:cloud_cover:
       - '{{"query":{{"eo:cloud_cover":{{"lte":{eo:cloud_cover}}}}}}}'
       - '$.properties."eo:cloud_cover"'
-    # eodag metadata
-    eodag:download_link: '$.null'
-    eodag:quicklook: '$.assets.quicklook.href'
-    eodag:thumbnail: '$.assets.thumbnail.href'
-    # order:status set to succeeded for consistency between providers
-    order:status: '{$.null#replace_str("Not Available","succeeded")}'
     # Normalization code moves assets from properties to product's attr
     assets: '$.assets'

--- a/eodag/utils/s3.py
+++ b/eodag/utils/s3.py
@@ -515,8 +515,8 @@ def update_assets_from_s3(
     s3_endpoint: Optional[str] = None,
     content_url: Optional[str] = None,
 ) -> None:
-    """Update ``EOProduct.assets`` using content listed in its ``remote_location`` or given
-    ``content_url``.
+    """Update ``EOProduct.assets`` using content listed in its ``product.assets["downloadlink"].remote_location``
+    or given ``content_url``.
 
     If url points to a zipped archive, its content will also be be listed.
 
@@ -524,11 +524,15 @@ def update_assets_from_s3(
     :param auth: Authentication plugin
     :param s3_endpoint: s3 endpoint if not hosted on AWS
     :param content_url: s3 URL pointing to the content that must be listed (defaults to
-                        ``product.remote_location`` if empty)
+                        ``product.assets['downloadlink'].remote_location`` if empty)
     """
 
+    if content_url is None and "download_link" in product.assets:
+        content_url = product.assets["download_link"].remote_location
     if content_url is None:
-        content_url = product.remote_location
+        # nothing to list, but still refresh driver based on current assets
+        product.driver = product.get_driver()
+        return None
 
     bucket, prefix = get_bucket_name_and_prefix(content_url)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -355,9 +355,12 @@ class EODagTestCase(EODagTestBase):
         super().setUp()
         self.requests_http_get_patcher = mock.patch("requests.get", autospec=True)
         self.requests_http_get = self.requests_http_get_patcher.start()
+        self.requests_request_patcher = mock.patch("requests.request", autospec=True)
+        self.requests_request = self.requests_request_patcher.start()
 
     def tearDown(self):
         self.requests_http_get_patcher.stop()
+        self.requests_request_patcher.stop()
         super().tearDown()
 
     def assertHttpGetCalledOnceWith(self, expected_url, expected_params=None):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -121,7 +121,10 @@ class EODagTestBase(unittest.TestCase):
             "platform": self.platform,
             "instruments": [self.instrument],
             "title": self.local_filename,
-            "eodag:download_link": self.download_url,
+        }
+
+        self.eoproduct_assets = {
+            "download_link": {"href": self.download_url},
         }
 
     def tearDown(self):
@@ -272,12 +275,14 @@ class EODagTestBase(unittest.TestCase):
         return mock.DEFAULT
 
     def _dummy_product(self, provider=None, properties=None, collection=None, **kwargs):
-        return EOProduct(
+        product = EOProduct(
             self.provider if provider is None else provider,
             self.eoproduct_props if properties is None else properties,
             collection=self.collection if collection is None else collection,
             **kwargs,
         )
+        product.assets.update(self.eoproduct_assets)
+        return product
 
     def _dummy_downloadable_product(
         self,
@@ -295,7 +300,7 @@ class EODagTestBase(unittest.TestCase):
         with open(self.local_product_as_archive_path, "rb") as fh:
             responses.add(
                 responses.GET,
-                product.properties["eodag:download_link"],
+                product.remote_location,
                 body=fh.read(),
                 status=200,
                 content_type="application/zip",

--- a/tests/integration/test_core_search.py
+++ b/tests/integration/test_core_search.py
@@ -858,6 +858,8 @@ class TestCoreSearch(unittest.TestCase):
         self.assertEqual(product.properties["grid:code"], "MGRS-14ULD")
         self.assertIsNotNone(product.geometry)
         # download link from assets
-        self.assertIn("api/download", product.properties.get("eodag:download_link", ""))
+        self.assertIn("api/download", product.assets["download_link"]["href"])
         # quicklook from assets
-        self.assertIn("api/quicklook", product.properties.get("eodag:quicklook", ""))
+        self.assertIn(
+            "api/quicklook", product.assets.get("quicklook", {}).get("href", "")
+        )

--- a/tests/integration/test_core_search.py
+++ b/tests/integration/test_core_search.py
@@ -591,18 +591,16 @@ class TestCoreSearch(unittest.TestCase):
             "provider_matching_download_link",
             "https://foo.bar/baz/search",
         )
+        product_matching_download_link = EOProduct(
+            "provider_matching_download_link",
+            dict(geometry="POINT (0 0)", id="a"),
+        )
+        product_matching_download_link.assets.update(
+            {"download_link": {"href": "https://somewhere/to/download"}}
+        )
         mock_query.side_effect = [
             SearchResult(
-                [
-                    EOProduct(
-                        "provider_matching_download_link",
-                        dict(
-                            geometry="POINT (0 0)",
-                            id="a",
-                            **{"eodag:download_link": "https://somewhere/to/download"},
-                        ),
-                    )
-                ],
+                [product_matching_download_link],
                 1,
             ),
         ]
@@ -620,18 +618,16 @@ class TestCoreSearch(unittest.TestCase):
             "provider_matching_order_link",
             "https://foo.bar/baz/search",
         )
+        product_matching_order_link = EOProduct(
+            "provider_matching_download_link",
+            dict(geometry="POINT (0 0)", id="a"),
+        )
+        product_matching_order_link.assets.update(
+            {"download_link": {"eodag:order_link": "https://somewhere/to/download"}}
+        )
         mock_query.side_effect = [
             SearchResult(
-                [
-                    EOProduct(
-                        "provider_matching_download_link",
-                        dict(
-                            geometry="POINT (0 0)",
-                            id="a",
-                            **{"eodag:order_link": "https://somewhere/to/download"},
-                        ),
-                    )
-                ],
+                [product_matching_order_link],
                 1,
             ),
         ]

--- a/tests/integration/test_core_search_results.py
+++ b/tests/integration/test_core_search_results.py
@@ -60,8 +60,24 @@ STAC_SCHEMA_MAP = _build_stac_schema_map()
 
 
 class TestCoreSearchResults(EODagTestCase):
+    def assert_stac_messages_valid(self, messages):
+        for msg in messages:
+            self.assertTrue(
+                msg.get("valid_stac"),
+                messages,
+            )
+
     def setUp(self):
         super(TestCoreSearchResults, self).setUp()
+        # Give deterministic, JSON-serializable payloads to globally mocked requests
+        # used by stac_validator while avoiding network access in tests.
+        self.requests_http_get.return_value.raise_for_status.return_value = None
+        self.requests_http_get.return_value.status_code = 200
+        self.requests_http_get.return_value.json.return_value = {}
+
+        self.requests_request.return_value.raise_for_status.return_value = None
+        self.requests_request.return_value.status_code = 200
+        self.requests_request.return_value.json.return_value = {}
         # Mock home and eodag conf directory to tmp dir
         self.tmp_home_dir = tempfile.TemporaryDirectory()
         self.expanduser_mock = mock.patch(
@@ -165,8 +181,7 @@ class TestCoreSearchResults(EODagTestCase):
                 schema_map=STAC_SCHEMA_MAP,
             )
             stac.validate_item_collection()
-            for msg in stac.message:
-                self.assertTrue(msg["valid_stac"], stac.message)
+            self.assert_stac_messages_valid(stac.message)
             with open(path, "r") as f:
                 self.make_assertions(f)
 
@@ -195,8 +210,7 @@ class TestCoreSearchResults(EODagTestCase):
                 schema_map=STAC_SCHEMA_MAP,
             )
             stac.run()
-            for msg in stac.message:
-                self.assertTrue(msg["valid_stac"], stac.message)
+            self.assert_stac_messages_valid(stac.message)
             with open(collection_path) as f:
                 collection_dict = json.load(f)
             self.assertEqual(len(collection_dict["links"]), 1)
@@ -228,8 +242,7 @@ class TestCoreSearchResults(EODagTestCase):
                 schema_map=STAC_SCHEMA_MAP,
             )
             stac.validate_item_collection()
-            for msg in stac.message:
-                self.assertTrue(msg["valid_stac"], stac.message)
+            self.assert_stac_messages_valid(stac.message)
 
             # check associated serialized collection
             collection1_path = tmpdir_path / f"{self.search_result[0].collection}.json"
@@ -251,8 +264,7 @@ class TestCoreSearchResults(EODagTestCase):
                 schema_map=STAC_SCHEMA_MAP,
             )
             stac.run()
-            for msg in stac.message:
-                self.assertTrue(msg["valid_stac"], stac.message)
+            self.assert_stac_messages_valid(stac.message)
 
     def test_core_serialize_search_results_without_filename(self):
         """The core api must serialize a search results to STAC feature collection without filename"""
@@ -754,7 +766,7 @@ class TestCoreSearchResults(EODagTestCase):
         self.assertEqual(results[0].properties["id"], "stac-fastapi-eodag-id")
         self.assertEqual(results[0].collection, "foo-collection")
         self.assertEqual(len(results[0].assets), 0)
-        self.assertEqual(results[0].location, NOT_AVAILABLE)
+        self.assertEqual(results[0].location, "")
         self.assertIsInstance(results[0].downloader, Download)
 
         self.assertEqual(results[1].provider, "earth_search")

--- a/tests/integration/test_core_search_results.py
+++ b/tests/integration/test_core_search_results.py
@@ -29,7 +29,6 @@ from stac_validator import stac_validator
 from tests import TEST_RESOURCES_PATH, EODagTestCase
 from tests.context import (
     GENERIC_STAC_PROVIDER,
-    NOT_AVAILABLE,
     Download,
     EODataAccessGateway,
     EOProduct,
@@ -106,10 +105,6 @@ class TestCoreSearchResults(EODagTestCase):
                         "end_datetime": "2018-02-16T00:12:14.035Z",
                         "keyword": {},
                         "product:type": "OCN",
-                        "eodag:download_link": (
-                            "https://catalogue.dataspace.copernicus.eu/odata/v1/Products"
-                            "(578f1768-e66e-5b86-9363-b19f8931cc7b)/$value"
-                        ),
                         "eodag:provider": "cop_dataspace",
                         "platform": "S1A",
                         "eo:cloud_cover": 0,
@@ -144,6 +139,14 @@ class TestCoreSearchResults(EODagTestCase):
                             ]
                         ],
                         "type": "Polygon",
+                    },
+                    "assets": {
+                        "download_link": {
+                            "href": (
+                                "https://catalogue.dataspace.copernicus.eu/odata/v1/Products"
+                                "(578f1768-e66e-5b86-9363-b19f8931cc7b)/$value"
+                            ),
+                        },
                     },
                 }
             ],
@@ -473,6 +476,9 @@ class TestCoreSearchResults(EODagTestCase):
             feature["geometry"], self.geojson_repr["features"][0]["geometry"]
         )
         for key, value in self.geojson_repr["features"][0]["properties"].items():
+            if key in ("eodag:download_link", "eodag:order_link"):
+                # migrated to the "download_link" asset, no longer a top-level property
+                continue
             if key not in ("geometry", "id"):
                 if isinstance(value, dict):
                     self.assertDictEqual(value, feature["properties"][key])

--- a/tests/resources/eodag_search_result.geojson
+++ b/tests/resources/eodag_search_result.geojson
@@ -43,7 +43,10 @@
         "topicCategory": null,
         "snowCover": null,
         "title": "S1A_WV_OCN__2SSV_20180215T235323_20180216T001213_020624_023501_0FD3",
-        "instruments": ["SAR-C", "SAR"],
+        "instruments": [
+          "SAR-C",
+          "SAR"
+        ],
         "orbitType": null,
         "orbitDirection": null,
         "eodag:search_intersection": {
@@ -77,14 +80,18 @@
         "keyword": {},
         "processing:level": null,
         "eodag:sensor_type": null,
-        "eodag:download_link": "https://catalogue.dataspace.copernicus.eu/odata/v1/Products(578f1768-e66e-5b86-9363-b19f8931cc7b)/$value",
         "product:type": "OCN",
         "orbitNumber": 20624,
         "end_datetime": "2018-02-16T00:12:14.035Z",
         "resolution": null,
         "eodag:quicklook": null
       },
-      "id": "578f1768-e66e-5b86-9363-b19f8931cc7b"
+      "id": "578f1768-e66e-5b86-9363-b19f8931cc7b",
+      "assets": {
+        "download_link": {
+          "href": "https://catalogue.dataspace.copernicus.eu/odata/v1/Products(578f1768-e66e-5b86-9363-b19f8931cc7b)/$value"
+        }
+      }
     }
   ]
 }

--- a/tests/resources/eodag_search_result_cop_dataspace.geojson
+++ b/tests/resources/eodag_search_result_cop_dataspace.geojson
@@ -49,7 +49,12 @@
         15.0890199865838
       ],
       "id": "S2A_MSIL1C_20200815T005251_N0500_R002_T55PBS_20230405T155830",
-      "assets": {},
+      "assets": {
+        "download_link": {
+          "href": "https://catalogue.dataspace.copernicus.eu/odata/v1/Products(8a84f4dc-86e6-47d6-ae92-e2040873405d)/$value",
+          "order:status": "succeeded"
+        }
+      },
       "properties": {
         "constellation": "SENTINEL-2",
         "datetime": "2020-08-15T00:52:51.024000Z",
@@ -78,7 +83,6 @@
         "uid": "8a84f4dc-86e6-47d6-ae92-e2040873405d",
         "updated": "2024-05-08T15:16:29.710841Z",
         "eo:cloud_cover": 0.0,
-        "eodag:download_link": "https://catalogue.dataspace.copernicus.eu/odata/v1/Products(8a84f4dc-86e6-47d6-ae92-e2040873405d)/$value",
         "eodag:quicklook": "https://catalogue.dataspace.copernicus.eu/odata/v1/Assets(682f11b1-64e1-4e43-91ac-2ab9c1cc8eee)/$value",
         "eodag:thumbnail": "https://catalogue.dataspace.copernicus.eu/odata/v1/Assets(682f11b1-64e1-4e43-91ac-2ab9c1cc8eee)/$value",
         "grid:code": "MGRS-55PBS",
@@ -219,7 +223,12 @@
         13.568451278586
       ],
       "id": "S2A_MSIL1C_20200815T005251_N0500_R002_T55PEQ_20230405T155830",
-      "assets": {},
+      "assets": {
+        "download_link": {
+          "href": "https://catalogue.dataspace.copernicus.eu/odata/v1/Products(27b9f4f9-a377-4d65-947b-360be6bfa80c)/$value",
+          "order:status": "succeeded"
+        }
+      },
       "properties": {
         "constellation": "SENTINEL-2",
         "datetime": "2020-08-15T00:52:51.024000Z",
@@ -248,7 +257,6 @@
         "uid": "27b9f4f9-a377-4d65-947b-360be6bfa80c",
         "updated": "2024-05-08T15:16:16.326358Z",
         "eo:cloud_cover": 12.6437621427741,
-        "eodag:download_link": "https://catalogue.dataspace.copernicus.eu/odata/v1/Products(27b9f4f9-a377-4d65-947b-360be6bfa80c)/$value",
         "eodag:quicklook": "https://catalogue.dataspace.copernicus.eu/odata/v1/Assets(cda73c56-3ade-46d8-b841-3d501b57c756)/$value",
         "eodag:thumbnail": "https://catalogue.dataspace.copernicus.eu/odata/v1/Assets(cda73c56-3ade-46d8-b841-3d501b57c756)/$value",
         "grid:code": "MGRS-55PEQ",

--- a/tests/resources/eodag_search_result_creodias.geojson
+++ b/tests/resources/eodag_search_result_creodias.geojson
@@ -1,1 +1,207 @@
-{"type": "FeatureCollection", "features": [{"type": "Feature", "geometry": {"type": "Polygon", "coordinates": [[[0.495928592903789, 44.2259641547634], [0.536772323136669, 43.2382625533271], [1.8886830141923, 43.2593919105371], [1.87023728676149, 44.2478306839688], [0.495928592903789, 44.2259641547634]]]}, "id": "S2B_MSIL1C_20190302T105029_N0500_R051_T31TCJ_20221113T065937", "assets": {}, "properties": {"eodag:collection": "S2_MSI_L1C", "eodag:provider": "creodias", "eodag:search_intersection": {"type": "Polygon", "coordinates": [[[1.8886830141923, 43.2593919105371], [0.536772323136669, 43.2382625533271], [0.509087099926865, 43.907759172380565], [1.876583523451459, 43.907759172380565], [1.8886830141923, 43.2593919105371]]]}, "constellation": "SENTINEL-2", "end_datetime": "2019-03-02T10:50:29.024000Z", "instruments": ["MSI"], "platform": "S2B", "providers": [{"name": "ESA", "roles": ["producer"]}], "published": "2024-07-01T13:11:44.547184Z", "start_datetime": "2019-03-02T10:50:29.024000Z", "title": "S2B_MSIL1C_20190302T105029_N0500_R051_T31TCJ_20221113T065937", "uid": "1fd94a5e-11bb-42b6-826a-4413a6a4ed2d", "updated": "2024-07-01T13:11:53.874689Z", "eo:cloud_cover": 99.0289945952402, "eodag:download_link": "https://zipper.creodias.eu/odata/v1/Products(1fd94a5e-11bb-42b6-826a-4413a6a4ed2d)/$value", "eodag:quicklook": "https://datahub.creodias.eu/odata/v1/Assets(df600af8-02ce-4289-bbba-2c08bd68cbf2)/$value", "eodag:thumbnail": "https://datahub.creodias.eu/odata/v1/Assets(df600af8-02ce-4289-bbba-2c08bd68cbf2)/$value", "grid:code": "MGRS-31TCJ", "order:status": "succeeded", "processing:datetime": "2022-11-13T06:59:37.000000Z", "processing:level": "S2MSI1C", "processing:version": 5.0, "product:type": "S2MSI1C", "s2:datastrip_id": "S2B_OPER_MSI_L1C_DS_S2RP_20221113T065937_S20190302T105637_N05.00", "s2:datatake_id": "GS2B_20190302T105029_010373_N05.00", "s2:datatake_type": "INS-NOBS", "sat:absolute_orbit": 10373, "sat:relative_orbit": 51}}, {"type": "Feature", "geometry": {"type": "Polygon", "coordinates": [[[0.533217951221217, 43.3262463358657], [0.572219317968977, 42.3383618251542], [1.90469075283303, 42.3588399177066], [1.8870778350223, 43.3474403888254], [0.533217951221217, 43.3262463358657]]]}, "id": "S2B_MSIL1C_20190302T105029_N0500_R051_T31TCH_20221113T065937", "assets": {}, "properties": {"eodag:collection": "S2_MSI_L1C", "eodag:provider": "creodias", "eodag:search_intersection": {"type": "Polygon", "coordinates": [[[0.533217951221217, 43.3262463358657], [1.8870778350223, 43.3474403888254], [1.8897839144525685, 43.19555008715042], [0.5383777976136153, 43.19555008715042], [0.533217951221217, 43.3262463358657]]]}, "constellation": "SENTINEL-2", "end_datetime": "2019-03-02T10:50:29.024000Z", "instruments": ["MSI"], "platform": "S2B", "providers": [{"name": "ESA", "roles": ["producer"]}], "published": "2024-07-01T13:12:44.760776Z", "start_datetime": "2019-03-02T10:50:29.024000Z", "title": "S2B_MSIL1C_20190302T105029_N0500_R051_T31TCH_20221113T065937", "uid": "31768a81-c4f4-4310-8312-ddd84b86a17d", "updated": "2024-07-01T13:12:57.061569Z", "eo:cloud_cover": 35.1675176923766, "eodag:download_link": "https://zipper.creodias.eu/odata/v1/Products(31768a81-c4f4-4310-8312-ddd84b86a17d)/$value", "eodag:quicklook": "https://datahub.creodias.eu/odata/v1/Assets(dc0af419-128e-4b60-8442-19aa823bf57d)/$value", "eodag:thumbnail": "https://datahub.creodias.eu/odata/v1/Assets(dc0af419-128e-4b60-8442-19aa823bf57d)/$value", "grid:code": "MGRS-31TCH", "order:status": "succeeded", "processing:datetime": "2022-11-13T06:59:37.000000Z", "processing:level": "S2MSI1C", "processing:version": 5.0, "product:type": "S2MSI1C", "s2:datastrip_id": "S2B_OPER_MSI_L1C_DS_S2RP_20221113T065937_S20190302T105637_N05.00", "s2:datatake_id": "GS2B_20190302T105029_010373_N05.00", "s2:datatake_type": "INS-NOBS", "sat:absolute_orbit": 10373, "sat:relative_orbit": 51}}]}
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              0.495928592903789,
+              44.2259641547634
+            ],
+            [
+              0.536772323136669,
+              43.2382625533271
+            ],
+            [
+              1.8886830141923,
+              43.2593919105371
+            ],
+            [
+              1.87023728676149,
+              44.2478306839688
+            ],
+            [
+              0.495928592903789,
+              44.2259641547634
+            ]
+          ]
+        ]
+      },
+      "id": "S2B_MSIL1C_20190302T105029_N0500_R051_T31TCJ_20221113T065937",
+      "assets": {
+        "download_link": {
+          "href": "https://zipper.creodias.eu/odata/v1/Products(1fd94a5e-11bb-42b6-826a-4413a6a4ed2d)/$value",
+          "order:status": "succeeded"
+        }
+      },
+      "properties": {
+        "eodag:collection": "S2_MSI_L1C",
+        "eodag:provider": "creodias",
+        "eodag:search_intersection": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                1.8886830141923,
+                43.2593919105371
+              ],
+              [
+                0.536772323136669,
+                43.2382625533271
+              ],
+              [
+                0.509087099926865,
+                43.907759172380565
+              ],
+              [
+                1.876583523451459,
+                43.907759172380565
+              ],
+              [
+                1.8886830141923,
+                43.2593919105371
+              ]
+            ]
+          ]
+        },
+        "constellation": "SENTINEL-2",
+        "end_datetime": "2019-03-02T10:50:29.024000Z",
+        "instruments": [
+          "MSI"
+        ],
+        "platform": "S2B",
+        "providers": [
+          {
+            "name": "ESA",
+            "roles": [
+              "producer"
+            ]
+          }
+        ],
+        "published": "2024-07-01T13:11:44.547184Z",
+        "start_datetime": "2019-03-02T10:50:29.024000Z",
+        "title": "S2B_MSIL1C_20190302T105029_N0500_R051_T31TCJ_20221113T065937",
+        "uid": "1fd94a5e-11bb-42b6-826a-4413a6a4ed2d",
+        "updated": "2024-07-01T13:11:53.874689Z",
+        "eo:cloud_cover": 99.0289945952402,
+        "eodag:quicklook": "https://datahub.creodias.eu/odata/v1/Assets(df600af8-02ce-4289-bbba-2c08bd68cbf2)/$value",
+        "eodag:thumbnail": "https://datahub.creodias.eu/odata/v1/Assets(df600af8-02ce-4289-bbba-2c08bd68cbf2)/$value",
+        "grid:code": "MGRS-31TCJ",
+        "order:status": "succeeded",
+        "processing:datetime": "2022-11-13T06:59:37.000000Z",
+        "processing:level": "S2MSI1C",
+        "processing:version": 5.0,
+        "product:type": "S2MSI1C",
+        "s2:datastrip_id": "S2B_OPER_MSI_L1C_DS_S2RP_20221113T065937_S20190302T105637_N05.00",
+        "s2:datatake_id": "GS2B_20190302T105029_010373_N05.00",
+        "s2:datatake_type": "INS-NOBS",
+        "sat:absolute_orbit": 10373,
+        "sat:relative_orbit": 51
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              0.533217951221217,
+              43.3262463358657
+            ],
+            [
+              0.572219317968977,
+              42.3383618251542
+            ],
+            [
+              1.90469075283303,
+              42.3588399177066
+            ],
+            [
+              1.8870778350223,
+              43.3474403888254
+            ],
+            [
+              0.533217951221217,
+              43.3262463358657
+            ]
+          ]
+        ]
+      },
+      "id": "S2B_MSIL1C_20190302T105029_N0500_R051_T31TCH_20221113T065937",
+      "assets": {
+        "download_link": {
+          "href": "https://zipper.creodias.eu/odata/v1/Products(31768a81-c4f4-4310-8312-ddd84b86a17d)/$value",
+          "order:status": "succeeded"
+        }
+      },
+      "properties": {
+        "eodag:collection": "S2_MSI_L1C",
+        "eodag:provider": "creodias",
+        "eodag:search_intersection": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                0.533217951221217,
+                43.3262463358657
+              ],
+              [
+                1.8870778350223,
+                43.3474403888254
+              ],
+              [
+                1.8897839144525685,
+                43.19555008715042
+              ],
+              [
+                0.5383777976136153,
+                43.19555008715042
+              ],
+              [
+                0.533217951221217,
+                43.3262463358657
+              ]
+            ]
+          ]
+        },
+        "constellation": "SENTINEL-2",
+        "end_datetime": "2019-03-02T10:50:29.024000Z",
+        "instruments": [
+          "MSI"
+        ],
+        "platform": "S2B",
+        "providers": [
+          {
+            "name": "ESA",
+            "roles": [
+              "producer"
+            ]
+          }
+        ],
+        "published": "2024-07-01T13:12:44.760776Z",
+        "start_datetime": "2019-03-02T10:50:29.024000Z",
+        "title": "S2B_MSIL1C_20190302T105029_N0500_R051_T31TCH_20221113T065937",
+        "uid": "31768a81-c4f4-4310-8312-ddd84b86a17d",
+        "updated": "2024-07-01T13:12:57.061569Z",
+        "eo:cloud_cover": 35.1675176923766,
+        "eodag:quicklook": "https://datahub.creodias.eu/odata/v1/Assets(dc0af419-128e-4b60-8442-19aa823bf57d)/$value",
+        "eodag:thumbnail": "https://datahub.creodias.eu/odata/v1/Assets(dc0af419-128e-4b60-8442-19aa823bf57d)/$value",
+        "grid:code": "MGRS-31TCH",
+        "order:status": "succeeded",
+        "processing:datetime": "2022-11-13T06:59:37.000000Z",
+        "processing:level": "S2MSI1C",
+        "processing:version": 5.0,
+        "product:type": "S2MSI1C",
+        "s2:datastrip_id": "S2B_OPER_MSI_L1C_DS_S2RP_20221113T065937_S20190302T105637_N05.00",
+        "s2:datatake_id": "GS2B_20190302T105029_010373_N05.00",
+        "s2:datatake_type": "INS-NOBS",
+        "sat:absolute_orbit": 10373,
+        "sat:relative_orbit": 51
+      }
+    }
+  ]
+}

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -282,7 +282,10 @@ class EndToEndBase(unittest.TestCase):
             results = [
                 prod
                 for prod in results
-                if prod.properties.get("order:status", "") != ONLINE_STATUS
+                if prod.assets.get("download_link", {}).get(
+                    "order:status", ONLINE_STATUS
+                )
+                != ONLINE_STATUS
             ]
         if check_product:
             self.assertGreater(len(results), 0)

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -576,7 +576,8 @@ class TestApisPluginUsgsApi(BaseApisPluginTest):
             ),
         )
         self.assertEqual(
-            search_results.data[0].properties["order:status"], ONLINE_STATUS
+            search_results.data[0].assets["download_link"]["order:status"],
+            ONLINE_STATUS,
         )
         self.assertEqual(
             search_results.number_matched,

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -818,9 +818,8 @@ class TestApisPluginUsgsApi(BaseApisPluginTest):
                     },
                 ),
             )
-            product.location = product.remote_location = product.properties[
-                "eodag:download_link"
-            ] = "http://somewhere"
+            product.location = product.remote_location = "http://somewhere"
+            product.assets.update({"download_link": {"href": "http://somewhere"}})
             product.properties["id"] = "someproduct"
 
             responses.add(

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -378,7 +378,6 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             "platform": platform,
             "instruments": instrument,
             "title": local_filename,
-            "eodag:download_link": download_url,
         }
 
         product = self._dummy_downloadable_product(
@@ -386,6 +385,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             eoproduct_props,
             collection,
         )
+        product.assets.update({"download_link": {"href": download_url}})
         path = product.download()
 
         expected_path = os.path.join(
@@ -1393,7 +1393,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         self.product.assets.update(
             {
                 "download_link": {
-                    "order_link": self.product.properties["eodag:order_link"],
+                    "eodag:order_link": self.product.properties["eodag:order_link"],
                     "order:status": "orderable",
                 }
             }
@@ -1466,7 +1466,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             )
             self.assertEqual(self.product.remote_location, expected_remote_location)
             self.assertEqual(
-                self.product.properties["eodag:download_link"], expected_remote_location
+                self.product.assets["download_link"]["href"], expected_remote_location
             )
             self.assertEqual(
                 self.product.properties["eodag:status_link"], expected_order_status_link
@@ -1480,10 +1480,10 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
     def test_plugins_download_http_order_get(self, mock_request):
         """HTTPDownload._order() must request using eodag:order_link and GET protocol"""
         plugin = self.get_download_plugin(self.product)
-        self.product.properties[
-            "eodag:download_link"
-        ] = "https://copernicus.nci.org.au/dummy"
-        self.product.properties["eodag:order_link"] = "http://somewhere/order"
+        self.product.assets["download_link"] = {
+            "href": "https://copernicus.nci.org.au/dummy",
+            "eodag:order_link": "http://somewhere/order",
+        }
 
         # customized timeout
         timeout_backup = getattr(plugin.config, "timeout", None)
@@ -1497,7 +1497,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
 
             mock_request.assert_called_once_with(
                 method="GET",
-                url=self.product.properties["eodag:order_link"],
+                url=self.product.assets["download_link"]["eodag:order_link"],
                 auth=auth,
                 headers=USER_AGENT,
                 timeout=10,
@@ -1518,10 +1518,10 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         mock_request.return_value = MockResponse(status_code=500)
 
         plugin = self.get_download_plugin(self.product)
-        self.product.properties[
-            "eodag:download_link"
-        ] = "https://copernicus.nci.org.au/dummy"
-        self.product.properties["eodag:order_link"] = "http://somewhere/order"
+        self.product.assets["download_link"] = {
+            "href": "https://copernicus.nci.org.au/dummy",
+            "eodag:order_link": "http://somewhere/order",
+        }
 
         auth_plugin = self.get_auth_plugin(plugin, self.product)
         auth_plugin.config.credentials = {"username": "foo", "password": "bar"}
@@ -1534,7 +1534,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
 
         mock_request.assert_called_once_with(
             method="GET",
-            url=self.product.properties["eodag:order_link"],
+            url=self.product.assets["download_link"]["eodag:order_link"],
             auth=auth,
             headers=USER_AGENT,
             timeout=5,
@@ -1545,10 +1545,10 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
     def test_plugins_download_http_order_get_raises_if_request_400(self, mock_request):
         # Set up the EOProduct and the necessary properties
         plugin = self.get_download_plugin(self.product)
-        self.product.properties[
-            "eodag:download_link"
-        ] = "https://copernicus.nci.org.au/dummy"
-        self.product.properties["eodag:order_link"] = "http://somewhere/order"
+        self.product.assets["download_link"] = {
+            "href": "https://copernicus.nci.org.au/dummy",
+            "eodag:order_link": "http://somewhere/order",
+        }
 
         auth_plugin = self.get_auth_plugin(plugin, self.product)
         auth_plugin.config.credentials = {"username": "foo", "password": "bar"}
@@ -1567,7 +1567,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
 
         mock_request.assert_called_once_with(
             method="GET",
-            url=self.product.properties["eodag:order_link"],
+            url=self.product.assets["download_link"]["eodag:order_link"],
             auth=auth,
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
@@ -1578,9 +1578,9 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
     def test_plugins_download_http_order_post(self, mock_request):
         """HTTPDownload._order() must request using eodag:order_link and POST protocol"""
         plugin = self.get_download_plugin(self.product)
-        self.product.properties[
-            "eodag:download_link"
-        ] = "https://copernicus.nci.org.au/dummy"
+        self.product.assets["download_link"] = {
+            "href": "https://copernicus.nci.org.au/dummy"
+        }
         plugin.config.order_method = "POST"
 
         auth_plugin = self.get_auth_plugin(plugin, self.product)
@@ -1588,11 +1588,13 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         auth = auth_plugin.authenticate()
 
         # eodag:order_link without query query args
-        self.product.properties["eodag:order_link"] = "http://somewhere/order"
+        self.product.assets["download_link"][
+            "eodag:order_link"
+        ] = "http://somewhere/order"
         plugin._order(self.product, auth=auth)
         mock_request.assert_called_once_with(
             method="POST",
-            url=self.product.properties["eodag:order_link"],
+            url=self.product.assets["download_link"]["eodag:order_link"],
             auth=auth,
             headers=USER_AGENT,
             timeout=HTTP_REQ_TIMEOUT,
@@ -1600,7 +1602,9 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         )
         # eodag:order_link with query query args
         mock_request.reset_mock()
-        self.product.properties["eodag:order_link"] = "http://somewhere/order?foo=bar"
+        self.product.assets["download_link"][
+            "eodag:order_link"
+        ] = "http://somewhere/order?foo=bar"
         plugin._order(self.product, auth=auth)
         mock_request.assert_called_once_with(
             method="POST",
@@ -1614,7 +1618,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
 
         # eodag:order_link with JSON data containing a query string
         mock_request.reset_mock()
-        self.product.properties[
+        self.product.assets["download_link"][
             "eodag:order_link"
         ] = 'http://somewhere/order?{"location": "dataset_id=lorem&data_version=202211", "cacheable": "true"}'
         plugin._order(self.product, auth=auth)
@@ -1642,9 +1646,9 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             "error": {"that": "failed"},
         }
         self.product.properties["eodag:status_link"] = "http://somewhere/order-status"
-        self.product.properties[
-            "eodag:download_link"
-        ] = "https://copernicus.nci.org.au/dummy"
+        self.product.assets["download_link"] = {
+            "href": "https://copernicus.nci.org.au/dummy"
+        }
 
         auth_plugin = self.get_auth_plugin(plugin, self.product)
         auth_plugin.config.credentials = {"username": "foo", "password": "bar"}
@@ -1681,10 +1685,10 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         mock_request.return_value = MockResponse(status_code=500)
 
         plugin: HTTPDownload = self.get_download_plugin(self.product)
-        self.product.properties[
-            "eodag:download_link"
-        ] = "https://copernicus.nci.org.au/dummy"
-        self.product.properties["eodag:order_link"] = "http://somewhere/order"
+        self.product.assets["download_link"] = {
+            "href": "https://copernicus.nci.org.au/dummy",
+            "eodag:order_link": "http://somewhere/order",
+        }
         self.product.properties["eodag:status_link"] = "http://somewhere/orderstatus"
 
         auth_plugin = self.get_auth_plugin(plugin, self.product)
@@ -1712,10 +1716,10 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
     ):
         # Set up the EOProduct and the necessary properties
         plugin: HTTPDownload = self.get_download_plugin(self.product)
-        self.product.properties[
-            "eodag:download_link"
-        ] = "https://copernicus.nci.org.au/dummy"
-        self.product.properties["eodag:order_link"] = "http://somewhere/order"
+        self.product.assets["download_link"] = {
+            "href": "https://copernicus.nci.org.au/dummy",
+            "eodag:order_link": "http://somewhere/order",
+        }
         self.product.properties["eodag:status_link"] = "http://somewhere/orderstatus"
 
         auth_plugin = self.get_auth_plugin(plugin, self.product)
@@ -1760,9 +1764,9 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         }
         self.product.properties["eodag:status_link"] = "http://somewhere/order-status"
         self.product.properties["eodag:search_link"] = "http://somewhere/search-again"
-        self.product.properties[
-            "eodag:download_link"
-        ] = "https://copernicus.nci.org.au/dummy"
+        self.product.assets["download_link"] = {
+            "href": "https://copernicus.nci.org.au/dummy"
+        }
 
         auth_plugin = self.get_auth_plugin(plugin, self.product)
         auth_plugin.config.credentials = {"username": "foo", "password": "bar"}
@@ -1791,7 +1795,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             plugin._order_status(self.product, auth=auth)
 
             self.assertEqual(
-                self.product.properties["eodag:download_link"],
+                self.product.assets["download_link"]["href"],
                 "http://new-download-link",
             )
             self.assertEqual(len(responses.calls), 2)
@@ -1817,9 +1821,9 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         }
         self.product.properties["eodag:status_link"] = "http://somewhere/order-status"
         self.product.properties["eodag:search_link"] = "http://somewhere/search-again"
-        self.product.properties[
-            "eodag:download_link"
-        ] = "https://copernicus.nci.org.au/dummy"
+        self.product.assets["download_link"] = {
+            "href": "https://copernicus.nci.org.au/dummy"
+        }
 
         auth_plugin = self.get_auth_plugin(plugin, self.product)
         auth_plugin.config.credentials = {"username": "foo", "password": "bar"}
@@ -2028,7 +2032,7 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
             ),
             collection="S2_MSI_L2A",
         )
-        self.product.properties["eodag:download_link"] = "s3://sentinel-s2-l2a/123"
+        self.product.assets["download_link"] = {"href": "s3://sentinel-s2-l2a/123"}
         self.product.location = (
             self.product.remote_location
         ) = "http://somebucket.somehost.com/path/to/some/product"
@@ -2477,7 +2481,7 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
     ):
         """AwsDownload.get_rio_env() must return rio env dict"""
 
-        self.product.properties["eodag:download_link"] = "s3://some-bucket/some/prefix"
+        self.product.assets["download_link"]["href"] = "s3://some-bucket/some/prefix"
 
         plugin = self.get_download_plugin(self.product)
         auth_plugin = self.get_auth_plugin(plugin, self.product)

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -1380,6 +1380,7 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         product_dataset = "cams-global-reanalysis-eac4"
 
         plugin = self.get_download_plugin(self.product)
+        plugin.config.ignore_assets = True
         auth = self.get_auth_plugin(plugin, self.product)
         auth.config.credentials = {"apikey": "anicekey"}
         self.product.register_downloader(plugin, auth)
@@ -1389,7 +1390,14 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             f"{endpoint}/processes/{product_dataset}/execution" + '?{"foo": "bar"}'
         )
         self.product.properties["id"] = "CAMS_EAC4_ORDERABLE_12345"
-        self.product.properties["order:status"] = "orderable"
+        self.product.assets.update(
+            {
+                "download_link": {
+                    "order_link": self.product.properties["eodag:order_link"],
+                    "order:status": "orderable",
+                }
+            }
+        )
         self.product.location = self.product.remote_location = (
             NOT_AVAILABLE + '?{"foo": "bar"}'
         )
@@ -1476,7 +1484,6 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
             "eodag:download_link"
         ] = "https://copernicus.nci.org.au/dummy"
         self.product.properties["eodag:order_link"] = "http://somewhere/order"
-        self.product.properties["order:status"] = OFFLINE_STATUS
 
         # customized timeout
         timeout_backup = getattr(plugin.config, "timeout", None)
@@ -1574,7 +1581,6 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         self.product.properties[
             "eodag:download_link"
         ] = "https://copernicus.nci.org.au/dummy"
-        self.product.properties["order:status"] = OFFLINE_STATUS
         plugin.config.order_method = "POST"
 
         auth_plugin = self.get_auth_plugin(plugin, self.product)
@@ -1850,9 +1856,17 @@ class TestDownloadPluginHttpRetry(BaseDownloadPluginTest):
         super(TestDownloadPluginHttpRetry, self).setUp()
 
         self.plugin = self.get_download_plugin(self.product)
+        self.plugin.config.ignore_assets = True
         self.product.location = self.product.remote_location = "http://somewhere"
         self.product.properties["id"] = "someproduct"
-        self.product.properties["order:status"] = OFFLINE_STATUS
+        self.product.assets.update(
+            {
+                "download_link": {
+                    "href": "http://somewhere",
+                    "order:status": OFFLINE_STATUS,
+                }
+            }
+        )
 
     def test_plugins_download_http_retry_error_timeout(self):
         """HTTPDownload.download() must retry on error until timeout"""

--- a/tests/units/test_eoproduct.py
+++ b/tests/units/test_eoproduct.py
@@ -308,7 +308,7 @@ class TestEOProduct(EODagTestBase):
         with self.assertLogs(level="INFO") as cm:
             # Download
             product_dir_path = product.download()
-            responses.assert_call_count(product.properties["eodag:download_link"], 1)
+            responses.assert_call_count(product.remote_location, 1)
 
             self.addCleanup(self._clean_product, product_dir_path)
             self.assertIn("Download url: %s" % product.remote_location, str(cm.output))
@@ -317,7 +317,7 @@ class TestEOProduct(EODagTestBase):
             )
 
         # Check that the mocked request was properly called.
-        responses.assert_call_count(product.properties["eodag:download_link"], 1)
+        responses.assert_call_count(product.remote_location, 1)
 
         # A .downloaded folder should be created, including a text file that
         download_records_dir = pathlib.Path(product_dir_path).parent / ".downloaded"
@@ -334,9 +334,7 @@ class TestEOProduct(EODagTestBase):
             actual_download_url = ""
             with open(os.path.join(download_records_dir, records_file), "r") as fd:
                 actual_download_url = fd.read()
-            self.assertEqual(
-                actual_download_url, product.properties["eodag:download_link"]
-            )
+            self.assertEqual(actual_download_url, product.remote_location)
 
             # Since extraction is True by default, check that the returned path is the
             # product's directory.
@@ -367,15 +365,11 @@ class TestEOProduct(EODagTestBase):
     def test_eoproduct_download_http_delete_archive(self):
         """EOProduct.download must delete the downloaded archive"""
 
+        product = self._dummy_product()
+        product.assets["download_link"]["href"] = "http://example.com/foobar.zip"
+        product.location = product.remote_location = "http://example.com/foobar.zip"
         product = self._dummy_downloadable_product(
-            product=self._dummy_product(
-                properties=dict(
-                    self.eoproduct_props,
-                    **{
-                        "eodag:download_link": "http://example.com/foobar.zip",
-                    },
-                )
-            ),
+            product=product,
             extract=True,
             delete_archive=True,
         )
@@ -385,7 +379,7 @@ class TestEOProduct(EODagTestBase):
 
             # Download, and check that the mocked request was properly called.
             product_dir_path = product.download()
-            responses.assert_call_count(product.properties["eodag:download_link"], 1)
+            responses.assert_call_count(product.remote_location, 1)
 
             # Check that the product's directory exists.
             self.assertTrue(os.path.isdir(product_dir_path))
@@ -438,19 +432,17 @@ class TestEOProduct(EODagTestBase):
         """EOProduct.stream_download return a product file as StreamResponse"""
 
         # Setup
+        product = self._dummy_product()
+        product.assets["download_link"]["href"] = "http://example.com/foobar.zip"
+        product.location = product.remote_location = "http://example.com/foobar.zip"
         product = self._dummy_downloadable_product(
-            product=self._dummy_product(
-                properties=dict(
-                    self.eoproduct_props,
-                    **{"eodag:download_link": "http://example.com/foobar.zip"},
-                )
-            ),
+            product=product,
             extract=False,
         )
 
         # Download, and check that the mocked request was properly called.
         product_stream = product.stream_download()
-        responses.assert_call_count(product.properties["eodag:download_link"], 1)
+        responses.assert_call_count(product.remote_location, 1)
 
         # Check response headers
         self.assertIn(
@@ -509,13 +501,11 @@ class TestEOProduct(EODagTestBase):
     def test_eoproduct_download_http_dynamic_options(self):
         """EOProduct.download must accept the download options to be set automatically"""
 
+        product = self._dummy_product()
+        product.assets["download_link"]["href"] = "http://example.com/foobar.zip"
+        product.location = product.remote_location = "http://example.com/foobar.zip"
         product = self._dummy_downloadable_product(
-            product=self._dummy_product(
-                properties=dict(
-                    self.eoproduct_props,
-                    **{"eodag:download_link": "http://example.com/foobar.zip"},
-                )
-            ),
+            product=product,
             extract=True,
         )
 
@@ -599,16 +589,13 @@ class TestEOProduct(EODagTestBase):
     @responses.activate
     def test_eoproduct_register_downloader_resolve_ok(self):
         """EOProduct.register_downloader must resolve locations and properties"""
+        props = self.eoproduct_props.copy()
+        props["otherProperty"] = "%(output_dir)s/also/resolved"
+        product = self._dummy_product(properties=props)
+        product.assets["download_link"]["href"] = "%(base_uri)s/is/resolved"
+        product.location = product.remote_location = "%(base_uri)s/is/resolved"
         downloadable_product = self._dummy_downloadable_product(
-            product=self._dummy_product(
-                properties=dict(
-                    self.eoproduct_props,
-                    **{
-                        "eodag:download_link": "%(base_uri)s/is/resolved",
-                        "otherProperty": "%(output_dir)s/also/resolved",
-                    },
-                )
-            ),
+            product=product,
             extract=True,
         )
         self.assertEqual(
@@ -620,7 +607,7 @@ class TestEOProduct(EODagTestBase):
             f"{downloadable_product.downloader.config.base_uri}/is/resolved",
         )
         self.assertEqual(
-            downloadable_product.properties["eodag:download_link"],
+            downloadable_product.assets["download_link"]["href"],
             f"{downloadable_product.downloader.config.base_uri}/is/resolved",
         )
         self.assertEqual(
@@ -634,16 +621,13 @@ class TestEOProduct(EODagTestBase):
 
         logger = logging.getLogger("eodag.product")
         with mock.patch.object(logger, "debug") as mock_debug:
+            props = self.eoproduct_props.copy()
+            props["otherProperty"] = "%(/%s/neither/resolved"
+            product = self._dummy_product(properties=props)
+            product.assets["download_link"]["href"] = "%(257B/cannot/be/resolved"
+            product.location = product.remote_location = "%(257B/cannot/be/resolved"
             downloadable_product = self._dummy_downloadable_product(
-                product=self._dummy_product(
-                    properties=dict(
-                        self.eoproduct_props,
-                        **{
-                            "eodag:download_link": "%(257B/cannot/be/resolved",
-                            "otherProperty": "%(/%s/neither/resolved",
-                        },
-                    )
-                ),
+                product=product,
                 extract=False,
             )
             self.assertEqual(downloadable_product.location, "%(257B/cannot/be/resolved")
@@ -651,7 +635,7 @@ class TestEOProduct(EODagTestBase):
                 downloadable_product.remote_location, "%(257B/cannot/be/resolved"
             )
             self.assertEqual(
-                downloadable_product.properties["eodag:download_link"],
+                downloadable_product.assets["download_link"]["href"],
                 "%(257B/cannot/be/resolved",
             )
             self.assertEqual(
@@ -662,8 +646,8 @@ class TestEOProduct(EODagTestBase):
             needed_logs = [
                 f"Could not resolve product.location ({downloadable_product.location})",
                 f"Could not resolve product.remote_location ({downloadable_product.remote_location})",
-                "Could not resolve eodag:download_link property (%s)"
-                % downloadable_product.properties["eodag:download_link"],
+                "Could not resolve download_link asset href (%s)"
+                % downloadable_product.assets["download_link"]["href"],
                 f"Could not resolve otherProperty property ({downloadable_product.properties['otherProperty']})",
             ]
             for needed_log in needed_logs:

--- a/tests/units/test_eoproduct.py
+++ b/tests/units/test_eoproduct.py
@@ -175,7 +175,7 @@ class TestEOProduct(EODagTestBase):
 
     @responses.activate
     def test_eoproduct_get_quicklook_no_quicklook_url(self):
-        """EOProduct.get_quicklook must return an empty string if no quicklook property"""  # noqa
+        """EOProduct.get_quicklook must return an empty string if no quicklook asset"""
         responses.add(
             responses.GET,
             "https://fake.url.to/quicklook",
@@ -184,7 +184,7 @@ class TestEOProduct(EODagTestBase):
             auto_calculate_content_length=True,
         )
         product = self._dummy_product()
-        product.properties["eodag:quicklook"] = None
+        self.assertNotIn("quicklook", product.assets)
 
         quicklook_file_path = product.get_quicklook()
         self.assertEqual(quicklook_file_path, "")
@@ -192,15 +192,9 @@ class TestEOProduct(EODagTestBase):
 
     @responses.activate
     def test_eoproduct_get_quicklook_http_error(self):
-        """EOProduct.get_quicklook must return an empty string if there was an error during retrieval"""  # noqa
-        product = self._dummy_product(
-            properties=dict(
-                self.eoproduct_props,
-                **{
-                    "eodag:quicklook": "https://fake.url.to/quicklook",
-                },
-            )
-        )
+        """EOProduct.get_quicklook must return an empty string if there was an error during retrieval"""
+        product = self._dummy_product()
+        product.assets.update({"quicklook": {"href": "https://fake.url.to/quicklook"}})
         product.register_downloader(self.get_mock_downloader(), None)
         responses.add(
             responses.GET,
@@ -215,7 +209,7 @@ class TestEOProduct(EODagTestBase):
 
     @responses.activate
     def test_eoproduct_get_quicklook_ok_without_auth(self):
-        """EOProduct.get_quicklook must retrieve the quicklook without authentication."""  # noqa
+        """EOProduct.get_quicklook must retrieve the quicklook without authentication."""
         product = self._dummy_product()
         responses.add(
             responses.GET,
@@ -223,7 +217,7 @@ class TestEOProduct(EODagTestBase):
             body=b"Quicklook content",
             status=200,
         )
-        product.properties["eodag:quicklook"] = "https://fake.url.to/quicklook"
+        product.assets.update({"quicklook": {"href": "https://fake.url.to/quicklook"}})
         product.register_downloader(self.get_mock_downloader(), None)
 
         with tempfile.TemporaryDirectory() as output_dir:
@@ -237,7 +231,7 @@ class TestEOProduct(EODagTestBase):
 
     @responses.activate
     def test_eoproduct_get_quicklook_ok(self):
-        """EOProduct.get_quicklook must return the path to the successfully downloaded quicklook"""  # noqa
+        """EOProduct.get_quicklook must return the path to the successfully downloaded quicklook"""
         product = self._dummy_product()
 
         responses.add(
@@ -246,7 +240,7 @@ class TestEOProduct(EODagTestBase):
             body=b"Quicklook content",
             status=200,
         )
-        product.properties["eodag:quicklook"] = "https://fake.url.to/quicklook"
+        product.assets.update({"quicklook": {"href": "https://fake.url.to/quicklook"}})
         product.register_downloader(self.get_mock_downloader(), None)
 
         quicklook_file_path = product.get_quicklook()
@@ -276,7 +270,7 @@ class TestEOProduct(EODagTestBase):
 
     @responses.activate
     def test_eoproduct_get_quicklook_ok_existing(self):
-        """EOProduct.get_quicklook must return the path to an already downloaded quicklook"""  # noqa
+        """EOProduct.get_quicklook must return the path to an already downloaded quicklook"""
 
         # Tmp dir
         quicklook_dir = os.path.join(self.output_dir, "quicklooks")
@@ -290,7 +284,7 @@ class TestEOProduct(EODagTestBase):
             fh.write(b"content")
 
         product = self._dummy_product()
-        product.properties["eodag:quicklook"] = "https://fake.url.to/quicklook"
+        product.assets.update({"quicklook": {"href": "https://fake.url.to/quicklook"}})
         product.register_downloader(self.get_mock_downloader(), None)
         responses.add(
             responses.GET,
@@ -307,7 +301,7 @@ class TestEOProduct(EODagTestBase):
 
     @responses.activate
     def test_eoproduct_download_http_default(self):
-        """eoproduct.download must save the product at output_dir and create a .downloaded dir"""  # noqa
+        """EOProduct.download must save the product at output_dir and create a .downloaded dir"""
 
         product = self._dummy_downloadable_product(extract=True)
 
@@ -371,7 +365,7 @@ class TestEOProduct(EODagTestBase):
 
     @responses.activate
     def test_eoproduct_download_http_delete_archive(self):
-        """eoproduct.download must delete the downloaded archive"""  # noqa
+        """EOProduct.download must delete the downloaded archive"""
 
         product = self._dummy_downloadable_product(
             product=self._dummy_product(
@@ -417,7 +411,7 @@ class TestEOProduct(EODagTestBase):
 
     @responses.activate
     def test_eoproduct_download_http_extract(self):
-        """eoproduct.download over must be able to extract a product"""
+        """EOProduct.download over must be able to extract a product"""
         # Setup
         product = self._dummy_downloadable_product(extract=True)
         product_dir_path = product.download()
@@ -441,7 +435,7 @@ class TestEOProduct(EODagTestBase):
 
     @responses.activate
     def test_eoproduct_stream_download(self):
-        """eoproduct.stream_download return a product file as StreamResponse"""  # noqa
+        """EOProduct.stream_download return a product file as StreamResponse"""
 
         # Setup
         product = self._dummy_downloadable_product(
@@ -478,7 +472,7 @@ class TestEOProduct(EODagTestBase):
 
     @responses.activate
     def test_eoproduct_asset_stream_download(self):
-        """eoproduct.assets[x].stream_download return a asset file as StreamResponse"""  # noqa
+        """EOProduct.assets[x].stream_download return a asset file as StreamResponse"""
         # Setup
         product = self._dummy_downloadable_product(
             assets={
@@ -513,7 +507,7 @@ class TestEOProduct(EODagTestBase):
 
     @responses.activate
     def test_eoproduct_download_http_dynamic_options(self):
-        """eoproduct.download must accept the download options to be set automatically"""
+        """EOProduct.download must accept the download options to be set automatically"""
 
         product = self._dummy_downloadable_product(
             product=self._dummy_product(
@@ -550,7 +544,7 @@ class TestEOProduct(EODagTestBase):
 
     @responses.activate
     def test_eoproduct_download_progress_bar(self):
-        """eoproduct.download must show a progress bar"""
+        """EOProduct.download must show a progress bar"""
         product = self._dummy_downloadable_product(
             product=self._dummy_product(
                 properties=dict(
@@ -588,7 +582,7 @@ class TestEOProduct(EODagTestBase):
         self.assertEqual(progress_callback.pos, 1)
 
     def test_eoproduct_register_downloader(self):
-        """eoproduct.register_donwloader must set download and auth plugins"""
+        """EOProduct.register_downloader must set download and auth plugins"""
         product = self._dummy_product()
 
         self.assertIsNone(product.downloader)
@@ -604,7 +598,7 @@ class TestEOProduct(EODagTestBase):
 
     @responses.activate
     def test_eoproduct_register_downloader_resolve_ok(self):
-        """eoproduct.register_donwloader must resolve locations and properties"""
+        """EOProduct.register_downloader must resolve locations and properties"""
         downloadable_product = self._dummy_downloadable_product(
             product=self._dummy_product(
                 properties=dict(
@@ -636,7 +630,7 @@ class TestEOProduct(EODagTestBase):
 
     @responses.activate
     def test_eoproduct_register_downloader_resolve_ignored(self):
-        """eoproduct.register_donwloader must ignore unresolvable locations and properties"""
+        """EOProduct.register_downloader must ignore unresolvable locations and properties"""
 
         logger = logging.getLogger("eodag.product")
         with mock.patch.object(logger, "debug") as mock_debug:
@@ -676,7 +670,7 @@ class TestEOProduct(EODagTestBase):
                 self.assertIn(needed_log, str(mock_debug.call_args_list))
 
     def test_eoproduct_repr_html(self):
-        """eoproduct html repr must be correctly formatted"""
+        """EOProduct html repr must be correctly formatted"""
         product = self._dummy_product()
         product_repr = html.fromstring(product._repr_html_())
         self.assertIn("EOProduct", product_repr.xpath("//thead/tr/td")[0].text)
@@ -691,7 +685,7 @@ class TestEOProduct(EODagTestBase):
         self.assertIn("Asset", asset_repr.xpath("//thead/tr/td")[0].text)
 
     def test_eoproduct_assets_get_values(self):
-        """eoproduct.assets.get_values must return the expected values"""
+        """EOProduct.assets.get_values must return the expected values"""
         product = self._dummy_product()
         product.assets.update(
             {
@@ -708,7 +702,7 @@ class TestEOProduct(EODagTestBase):
         self.assertEqual(product.assets.get_values("foo?o,o")[0]["href"], "foooo.href")
 
     def test_eoproduct_sorted_properties(self):
-        """eoproduct.properties must be sorted"""
+        """EOProduct.properties must be sorted"""
         product = self._dummy_product(
             properties={
                 "geometry": "POINT (0 0)",
@@ -734,7 +728,7 @@ class TestEOProduct(EODagTestBase):
         )
 
     def test_eoproduct_none_properties(self):
-        """eoproduct none properties must be kept"""
+        """EOProduct none properties must be kept"""
         product = self._dummy_product(
             properties={
                 "geometry": "POINT (0 0)",
@@ -752,7 +746,7 @@ class TestEOProduct(EODagTestBase):
         )
 
     def test_eoproduct_serialize(self):
-        """eoproduct.as_dict must include the required STAC extensions"""
+        """EOProduct.as_dict must include the required STAC extensions"""
         product = self._dummy_product()
         product.properties["grid:code"] = "MGRS-31TCJ"
         product.properties["eo:cloud_cover"] = "bad-formatted"
@@ -788,7 +782,7 @@ class TestEOProduct(EODagTestBase):
         )
 
     def test_eoproduct_as_pystac_object(self):
-        """eoproduct.as_pystac_object must return a pystac.Item"""
+        """EOProduct.as_pystac_object must return a pystac.Item"""
         product = self._dummy_product(
             properties={"id": "dummy_id", "datetime": "2021-01-01T00:00:00Z"}
         )
@@ -797,7 +791,7 @@ class TestEOProduct(EODagTestBase):
         pystac_item.validate()
 
     def test_eoproduct_from_pystac(self):
-        """eoproduct.from_pystac must return an EOProduct instance from a pystac.Item"""
+        """EOProduct.from_pystac must return an EOProduct instance from a pystac.Item"""
         product = self._dummy_product(
             properties={"id": "dummy_id", "datetime": "2021-01-01T00:00:00Z"}
         )

--- a/tests/units/test_metadata_mapping.py
+++ b/tests/units/test_metadata_mapping.py
@@ -1142,6 +1142,10 @@ class TestMetadataMappingBandsNormalize(unittest.TestCase):
 
         # Reduce multibands of eo:bands: only join and move parameters with
         # the same value; per-band fields stay on the bands list.
+        # Reset the asset to a clean state: ``AssetsDict`` merges an incoming
+        # mapping with the existing asset, so reusing ``asset_id`` without
+        # clearing would keep stale fields from the previous scenario.
+        product.assets.clear()
         product.assets.update(
             {
                 asset_id: {
@@ -1201,6 +1205,7 @@ class TestMetadataMappingBandsNormalize(unittest.TestCase):
         )
 
         # Reduce multibands of mixed raster:bands and eo:bands.
+        product.assets.clear()
         product.assets.update(
             {
                 asset_id: {

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2822,7 +2822,7 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
         self, identifier, checksum, endpoint_url="https://geodes.example/data"
     ):
         download_link = f"https://geodes.example/data/{identifier}/file_{checksum}.tif"
-        return EOProduct(
+        product = EOProduct(
             self.provider,
             {
                 "id": identifier,
@@ -2831,6 +2831,8 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
                 "geodes:endpoint_url": endpoint_url,
             },
         )
+        product.assets.update({"download_link": {"href": download_link}})
+        return product
 
     @mock.patch("eodag.plugins.search.geodes.GeodesSearch._request", autospec=True)
     def test_plugins_search_geodes_get_availability(self, mock__request):
@@ -2927,7 +2929,7 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
 
         self.search_plugin._set_availability([product])
 
-        self.assertEqual(product.properties["order:status"], ONLINE_STATUS)
+        self.assertEqual(product.assets["download_link"]["order:status"], ONLINE_STATUS)
 
     @mock.patch(
         "eodag.plugins.search.geodes.GeodesSearch._get_availability", autospec=True
@@ -2950,7 +2952,9 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
 
         self.search_plugin._set_availability([product])
 
-        self.assertEqual(product.properties["order:status"], OFFLINE_STATUS)
+        self.assertEqual(
+            product.assets["download_link"]["order:status"], OFFLINE_STATUS
+        )
 
     @mock.patch(
         "eodag.plugins.search.geodes.GeodesSearch._get_availability", autospec=True
@@ -2961,14 +2965,14 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
         """When no matching product/asset is found in the availability response,
         order:status must be left unchanged and a warning must be logged"""
         product = self._build_product("PROD1", "abc")
-        product.properties["order:status"] = "untouched"
+        product.assets["download_link"]["order:status"] = "untouched"
         # no matching id in response
         mock_get_availability.return_value = {"products": []}
 
         with self.assertLogs("eodag.search.geodes", level="WARNING") as log_ctx:
             self.search_plugin._set_availability([product])
 
-        self.assertEqual(product.properties["order:status"], "untouched")
+        self.assertEqual(product.assets["download_link"]["order:status"], "untouched")
         self.assertTrue(
             any("Could not update availability" in m for m in log_ctx.output)
         )
@@ -2981,7 +2985,7 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
     ):
         """Products whose checksum matches more than one file must be skipped"""
         product = self._build_product("PROD1", "abc")
-        product.properties["order:status"] = "untouched"
+        product.assets["download_link"]["order:status"] = "untouched"
         mock_get_availability.return_value = {
             "products": [
                 {
@@ -2997,7 +3001,7 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
         with self.assertLogs("eodag.search.geodes", level="WARNING"):
             self.search_plugin._set_availability([product])
 
-        self.assertEqual(product.properties["order:status"], "untouched")
+        self.assertEqual(product.assets["download_link"]["order:status"], "untouched")
 
     @mock.patch(
         "eodag.plugins.search.geodes.GeodesSearch._set_availability", autospec=True

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -60,7 +60,6 @@ from eodag.utils.exceptions import (
 from tests.context import (
     DEFAULT_SEARCH_TIMEOUT,
     HTTP_REQ_TIMEOUT,
-    NOT_AVAILABLE,
     TEST_RESOURCES_PATH,
     USER_AGENT,
     AuthenticationError,
@@ -107,18 +106,22 @@ class BaseSearchPluginTest(unittest.TestCase):
     def get_auth_plugin(self, search_plugin):
         return self.plugins_manager.get_auth_plugin(search_plugin)
 
-    def test_get_assets_from_mapping(self):
+    def test_build_assets_from_mapping(self):
         search_plugin = self.get_search_plugin(provider="geodes")
         search_plugin.config.assets_mapping = {
-            "one": {"href": "$.properties.href", "roles": ["a_role"], "title": "One"},
+            "one": {
+                "href": "$.properties.href",
+                "roles": '["a_role"]',
+                "title": "One",
+            },
             "two": {
                 "href": "https://a.static_url.com",
-                "roles": ["a_role"],
+                "roles": '["a_role"]',
                 "title": "Two",
             },
         }
         provider_item = {"id": "ID123456", "properties": {"href": "a.product.com/ONE"}}
-        asset_mappings = search_plugin.get_assets_from_mapping(provider_item)
+        asset_mappings = search_plugin.build_assets_from_mapping(provider_item)
         self.assertEqual(2, len(asset_mappings))
         self.assertEqual("a.product.com/ONE", asset_mappings["one"]["href"])
         self.assertEqual("One", asset_mappings["one"]["title"])
@@ -126,6 +129,129 @@ class BaseSearchPluginTest(unittest.TestCase):
         self.assertEqual("https://a.static_url.com", asset_mappings["two"]["href"])
         self.assertEqual("Two", asset_mappings["two"]["title"])
         self.assertListEqual(["a_role"], asset_mappings["two"]["roles"])
+
+    def test_get_assets_mapping_from_product_inherits(self):
+        """A product with only ``assets_mapping_from_product`` inherits the parent's mapping fully"""
+        search_plugin = self.get_search_plugin(provider="geodes")
+        search_plugin.config.assets_mapping = {}
+        parent_mapping = {
+            "download_link": {"href": "parent_href", "roles": ["data"]},
+            "quicklook": {"href": "parent_ql", "roles": ["overview"]},
+        }
+        search_plugin.config.products = {
+            "PARENT_COLLECTION": {"assets_mapping": parent_mapping},
+            "CHILD_COLLECTION": {"assets_mapping_from_product": "PARENT_COLLECTION"},
+        }
+        resolved = search_plugin.get_assets_mapping("CHILD_COLLECTION")
+        self.assertEqual(parent_mapping, resolved)
+
+    def test_get_assets_mapping_from_product_per_asset_override(self):
+        """A child product can override one asset and inherit the others from the parent"""
+        search_plugin = self.get_search_plugin(provider="geodes")
+        search_plugin.config.assets_mapping = {}
+        search_plugin.config.products = {
+            "PARENT_COLLECTION": {
+                "assets_mapping": {
+                    "download_link": {"href": "parent_dl", "roles": ["data"]},
+                    "quicklook": {"href": "parent_ql", "roles": ["overview"]},
+                    "thumbnail": {"href": "parent_tn", "roles": ["thumbnail"]},
+                }
+            },
+            "CHILD_COLLECTION": {
+                "assets_mapping_from_product": "PARENT_COLLECTION",
+                "assets_mapping": {
+                    "download_link": {"href": "child_dl", "roles": ["data"]},
+                },
+            },
+        }
+        resolved = search_plugin.get_assets_mapping("CHILD_COLLECTION")
+        # download_link overridden, others inherited
+        self.assertEqual("child_dl", resolved["download_link"]["href"])
+        self.assertEqual("parent_ql", resolved["quicklook"]["href"])
+        self.assertEqual("parent_tn", resolved["thumbnail"]["href"])
+
+    def test_get_assets_mapping_from_product_does_not_mutate_parent(self):
+        """Resolving a child product must not mutate the parent's cached config"""
+        search_plugin = self.get_search_plugin(provider="geodes")
+        search_plugin.config.assets_mapping = {}
+        parent_mapping = {
+            "download_link": {"href": "parent_dl", "roles": ["data"]},
+            "quicklook": {"href": "parent_ql", "roles": ["overview"]},
+        }
+        search_plugin.config.products = {
+            "PARENT_COLLECTION": {"assets_mapping": copy_deepcopy(parent_mapping)},
+            "CHILD_COLLECTION": {
+                "assets_mapping_from_product": "PARENT_COLLECTION",
+                "assets_mapping": {
+                    "download_link": {"href": "child_dl", "roles": ["data"]},
+                },
+            },
+        }
+        # Resolve the child first; this previously polluted the parent's config
+        search_plugin.get_assets_mapping("CHILD_COLLECTION")
+        # PARENT_COLLECTION must still expose its original mapping
+        self.assertEqual(
+            parent_mapping,
+            search_plugin.config.products["PARENT_COLLECTION"]["assets_mapping"],
+        )
+        # And resolving the parent after the child must still return the parent's mapping
+        self.assertEqual(
+            parent_mapping, search_plugin.get_assets_mapping("PARENT_COLLECTION")
+        )
+
+    def test_get_assets_mapping_from_product_chain(self):
+        """Multi-hop ``assets_mapping_from_product`` chain resolves transitively, leaf overrides win"""
+        search_plugin = self.get_search_plugin(provider="geodes")
+        search_plugin.config.assets_mapping = {}
+        search_plugin.config.products = {
+            "GRANDPARENT_COLLECTION": {
+                "assets_mapping": {
+                    "download_link": {"href": "gp_dl"},
+                    "quicklook": {"href": "gp_ql"},
+                    "thumbnail": {"href": "gp_tn"},
+                }
+            },
+            "PARENT_COLLECTION": {
+                "assets_mapping_from_product": "GRANDPARENT_COLLECTION",
+                "assets_mapping": {
+                    "quicklook": {"href": "parent_ql"},
+                },
+            },
+            "CHILD_COLLECTION": {
+                "assets_mapping_from_product": "PARENT_COLLECTION",
+                "assets_mapping": {
+                    "download_link": {"href": "child_dl"},
+                },
+            },
+        }
+        resolved = search_plugin.get_assets_mapping("CHILD_COLLECTION")
+        self.assertEqual("child_dl", resolved["download_link"]["href"])
+        self.assertEqual("parent_ql", resolved["quicklook"]["href"])
+        self.assertEqual("gp_tn", resolved["thumbnail"]["href"])
+
+    def test_get_assets_mapping_from_product_cycle(self):
+        """A cycle in ``assets_mapping_from_product`` is detected, logged and broken"""
+        search_plugin = self.get_search_plugin(provider="geodes")
+        search_plugin.config.assets_mapping = {}
+        search_plugin.config.products = {
+            "LEFT_COLLECTION": {
+                "assets_mapping_from_product": "RIGHT_COLLECTION",
+                "assets_mapping": {"download_link": {"href": "left_dl"}},
+            },
+            "RIGHT_COLLECTION": {
+                "assets_mapping_from_product": "LEFT_COLLECTION",
+                "assets_mapping": {"quicklook": {"href": "right_ql"}},
+            },
+        }
+        with self.assertLogs("eodag.search.base", level="WARNING") as logs:
+            resolved = search_plugin.get_assets_mapping("LEFT_COLLECTION")
+        self.assertTrue(
+            any("cycle detected" in msg for msg in logs.output),
+            msg=f"expected cycle warning, got: {logs.output}",
+        )
+        # Both assets are merged once; leaf (LEFT_COLLECTION) wins on collisions
+        self.assertEqual("left_dl", resolved["download_link"]["href"])
+        self.assertEqual("right_ql", resolved["quicklook"]["href"])
 
 
 class TestSearchPluginQueryStringSearchXml(BaseSearchPluginTest):
@@ -2907,13 +3033,6 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
 
         with open(self.provider_resp_dir / "geodes_search.json", encoding="utf-8") as f:
             raw_features = json.load(f)["features"]
-        raw_assets = raw_features[0]["assets"]
-        quicklook_asset = raw_assets[
-            "2025/04/02/S2A/S2A_MSIL1C_20250402T175741_N0511_R141_T14ULD_20250403T022035_quicklook.jpg"
-        ]
-        zip_asset = raw_assets[
-            "S2A_MSIL1C_20250402T175741_N0511_R141_T14ULD_20250403T022035.zip"
-        ]
 
         search_plugin = self.get_search_plugin(provider="geodes")
         normalized = search_plugin.normalize_results(RawSearchResult(raw_features))
@@ -2922,29 +3041,51 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
         self.assertDictEqual(
             dict(normalized[0].assets),
             {
-                "quicklook.jpg": {
-                    "href": quicklook_asset["href"],
-                    "title": "quicklook.jpg",
-                    "description": quicklook_asset["description"],
+                "download_link": {
+                    "href": (
+                        "https://geodes-portal.cnes.fr/api/download/"
+                        "URN:FEATURE:DATA:gdh:25416e3f-1a7f-379a-9b65-a6539b1fd95b:V1"
+                        "/files/86f828c4c7e921615d1cd0476604f780"
+                    ),
+                    "order:status": "succeeded",
+                    "roles": ["archive", "data"],
+                    "title": "downloadlink",
+                    "type": "application/octet-stream",
+                    "file:size": 764210185,
+                    "geodes:reference": False,
+                    "geodes:online": False,
+                    "geodes:datatype": "RAWDATA",
+                    "file:checksum": "86f828c4c7e921615d1cd0476604f780",
+                },
+                "quicklook": {
+                    "href": (
+                        "https://geodes-portal.cnes.fr/api/quicklook/"
+                        "URN:FEATURE:DATA:gdh:25416e3f-1a7f-379a-9b65-a6539b1fd95b:V1"
+                        "/files/1003ae6b1edf05adf7c46cb759ffeaec?scope=gdh"
+                    ),
+                    "roles": ["overwiev"],
+                    "title": "quicklook",
                     "type": "image/jpeg",
-                    "roles": ["overview"],
                     "file:size": 18684,
                     "geodes:reference": False,
                     "geodes:online": True,
                     "geodes:datatype": "QUICKLOOK_SD",
                     "file:checksum": "1003ae6b1edf05adf7c46cb759ffeaec",
                 },
-                "zip": {
-                    "href": zip_asset["href"],
-                    "title": "zip",
-                    "description": zip_asset["description"],
-                    "type": "application/zip",
-                    "roles": ["auxiliary"],
-                    "file:size": 764210185,
+                "thumbnail": {
+                    "href": (
+                        "https://geodes-portal.cnes.fr/api/quicklook/"
+                        "URN:FEATURE:DATA:gdh:25416e3f-1a7f-379a-9b65-a6539b1fd95b:V1"
+                        "/files/1003ae6b1edf05adf7c46cb759ffeaec?scope=gdh"
+                    ),
+                    "roles": ["thumbnail"],
+                    "title": "thumbnail",
+                    "type": "image/jpeg",
+                    "file:size": 18684,
                     "geodes:reference": False,
-                    "geodes:online": False,
-                    "geodes:datatype": "RAWDATA",
-                    "file:checksum": "86f828c4c7e921615d1cd0476604f780",
+                    "geodes:online": True,
+                    "geodes:datatype": "QUICKLOOK_SD",
+                    "file:checksum": "1003ae6b1edf05adf7c46cb759ffeaec",
                 },
             },
         )
@@ -2995,14 +3136,15 @@ class TestSearchPluginMeteoblueSearch(BaseSearchPluginTest):
             ],
             "type": "Polygon",
         }
-        # check eodag:download_link
+        # check download_link asset href
+        download_asset = products.data[0].assets["download_link"]
         self.assertEqual(
-            products.data[0].properties["eodag:download_link"],
+            download_asset["href"],
             f"{endpoint}?" + json.dumps({"geometry": default_geom, **custom_query}),
         )
-        # check eodag:order_link
+        # check download_link asset order_link
         self.assertEqual(
-            products.data[0].properties["eodag:order_link"],
+            download_asset["order_link"],
             f"{endpoint}?"
             + json.dumps(
                 {
@@ -3078,10 +3220,15 @@ class TestSearchPluginCreodiasS3Search(BaseSearchPluginTest):
             }
             product.register_downloader(download_plugin, auth_plugin)
         assets = res.data[0].assets
-        self.assertEqual(3, len(assets))
-        # check if s3 links have been created correctly
-        for asset in assets.values():
+        # 1 download_link asset (from assets_mapping) + 3 s3-listed assets
+        self.assertEqual(4, len(assets))
+        # check if s3 links have been created correctly for s3-listed assets
+        s3_listed_assets = {k: v for k, v in assets.items() if k != "download_link"}
+        self.assertEqual(3, len(s3_listed_assets))
+        for asset in s3_listed_assets.values():
             self.assertIn("s3://eodata/Sentinel-1/SAR/GRD/2014/10/10", asset["href"])
+        # download_link asset is set from the product's metadata
+        self.assertTrue(assets["download_link"]["href"].startswith("s3://eodata/"))
 
         # no occur should occur and assets should be empty if list_objects does not have content
         # (this situation will occur if the product does not have assets but is a tar file)
@@ -3359,8 +3506,8 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         assert eoproduct.properties["title"].startswith(
             f"{self.product_dataset.upper()}"
         )
-        assert eoproduct.properties["eodag:order_link"].startswith("http")
-        assert NOT_AVAILABLE in eoproduct.location
+        assert eoproduct.assets["download_link"]["order_link"].startswith("http")
+        assert eoproduct.location == ""
 
     def test_plugins_search_ecmwfsearch_with_collection(self):
         """ECMWFSearch.query must build a EOProduct from input parameters with predefined collection"""
@@ -4647,9 +4794,9 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
                 end_datetime="2020-02-01T01:00:00Z",
             )
 
-        self.assertIn("native", result[0].assets)
-        asset = result[0].assets["native"]
-        self.assertEqual(asset.get("title"), "native")
+        self.assertIn("download_link", result[0].assets)
+        asset = result[0].assets["download_link"]
+        self.assertEqual(asset.get("title"), "downloadlink")
         self.assertEqual(
             asset.get("href"),
             "https://s3.test.com/bucket1/native/PRODUCT_A/dataset-number-one/"
@@ -4689,16 +4836,16 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
         )
         self.assertEqual("2001-05-01T00:00:00.000Z", product.properties["end_datetime"])
         self.assertEqual(
-            "https://www.abc.com/thumbnailA", product.properties["eodag:thumbnail"]
+            "https://www.abc.com/thumbnailA", product.assets["thumbnail"]["href"]
         )
         self.assertEqual("dataset-number-one", product.properties["dataset"])
         self.assertEqual("a", product.properties["a"])
         self.assertEqual("b", product.properties["b"])
         self.assertEqual("c", product.properties["c"])
-        self.assertIn("native", product.assets)
+        self.assertIn("download_link", product.assets)
         self.assertEqual(
             "https://s3.test.com/bucket1/native/PRODUCT_A/dataset-number-one/item1_20010501",
-            product.assets["native"]["href"],
+            product.assets["download_link"]["href"],
         )
 
         # with use of dataset dates
@@ -4720,13 +4867,11 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
             asset_properties={"z": "z"},
         )
         self.assertEqual("item1_20010501", product.properties["id"])
-        self.assertIn("native", product.assets)
+        self.assertIn("download_link", product.assets)
         self.assertEqual(
             "https://s3.test.com/bucket1/native/PRODUCT_A/dataset-number-one/item1_20010501",
-            product.assets["native"]["href"],
+            product.assets["download_link"]["href"],
         )
-        self.assertIn("z", product.assets["native"])
-        self.assertEqual("z", product.assets["native"]["z"])
 
     def test_plugins_search_cop_marine_discover_queryables(self):
         """Queryables discovery with a CopMarineSearch must return static queryables with an adaptative default value"""  # noqa
@@ -4760,13 +4905,17 @@ class TestSearchPluginWekeoSearch(BaseSearchPluginTest):
         """Check that the WekeoSearch plugin is initialized correctly for wekeo_main provider"""
 
         default_config = load_default_config()["wekeo_main"]
-        # "eodag:order_link" in S1_SAR_GRD but not in provider conf or S1_SAR_SLC conf
+        # order_link is defined once at the provider-level assets_mapping
+        # (no per-product eodag:order_link in metadata_mapping anymore)
         self.assertNotIn("eodag:order_link", default_config.search.metadata_mapping)
-        self.assertIn(
+        self.assertNotIn(
             "eodag:order_link",
-            default_config.products["S1_SAR_GRD"]["metadata_mapping"],
+            default_config.products["S1_SAR_GRD"].get("metadata_mapping", {}),
         )
-        self.assertNotIn("metadata_mapping", default_config.products["S1_SAR_SLC"])
+        self.assertIn(
+            "order_link",
+            default_config.search.assets_mapping["download_link"],
+        )
 
         # metadata_mapping_from_product: from S1_SAR_GRD to S1_SAR_SLC
         self.assertEqual(
@@ -4774,7 +4923,7 @@ class TestSearchPluginWekeoSearch(BaseSearchPluginTest):
             "S1_SAR_GRD",
         )
 
-        # check initialized plugin configuration
+        # check initialized plugin configuration: S1_SAR_SLC inherits S1_SAR_GRD
         self.assertDictEqual(
             self.wekeomain_search_plugin.config.products["S1_SAR_GRD"][
                 "metadata_mapping"
@@ -4784,27 +4933,10 @@ class TestSearchPluginWekeoSearch(BaseSearchPluginTest):
             ],
         )
 
-        # S3_SRA_BS has both metadata_mapping_from_product and metadata_mapping
-        # "metadata_mapping" must override "metadata_mapping_from_product"
-        self.assertIn(
-            "eodag:order_link",
-            default_config.products["S3_SRA_BS"]["metadata_mapping"],
-        )
-        self.assertIn(
-            "eodag:order_link",
-            default_config.products["S3_EFR"]["metadata_mapping"],
-        )
+        # S3_SRA_BS inherits from S3_EFR via metadata_mapping_from_product
         self.assertEqual(
             default_config.products["S3_SRA_BS"]["metadata_mapping_from_product"],
             "S3_EFR",
-        )
-        self.assertNotEqual(
-            self.wekeomain_search_plugin.config.products["S3_SRA_BS"][
-                "metadata_mapping"
-            ]["eodag:order_link"],
-            self.wekeomain_search_plugin.config.products["S3_EFR"]["metadata_mapping"][
-                "eodag:order_link"
-            ],
         )
 
     @mock.patch(
@@ -5611,6 +5743,15 @@ class TestSearchPluginEumetsatDsSearch(BaseSearchPluginTest):
         self.assertDictEqual(
             dict(normalized[0].assets),
             {
+                "download_link": {
+                    "href": "https://api.eumetsat.int/data/download/1.0.0/collections/"
+                    "EO%3AEUM%3ADAT%3A0921/products/PREmm20201201000000120IMPGS01GL",
+                    "title": "downloadlink",
+                    "roles": ["archive", "data"],
+                    "eumesat_ds:type": "application/zip",
+                    "type": "application/octet-stream",
+                    "order:status": "succeeded",
+                },
                 "EOPMetadata.xml": {
                     "href": base_href + "EOPMetadata.xml",
                     "title": "EOPMetadata.xml",

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2827,7 +2827,6 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
             {
                 "id": identifier,
                 "geometry": "POINT (0 0)",
-                "eodag:download_link": download_link,
                 "geodes:endpoint_url": endpoint_url,
             },
         )
@@ -2862,11 +2861,11 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
             {
                 "availability": [
                     {
-                        "href": p1.properties["eodag:download_link"],
+                        "href": p1.assets["download_link"]["href"],
                         "endpointURL": "https://geodes.example/data",
                     },
                     {
-                        "href": p2.properties["eodag:download_link"],
+                        "href": p2.assets["download_link"]["href"],
                         "endpointURL": "https://geodes.example/data",
                     },
                 ]
@@ -2889,8 +2888,10 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
             {
                 "id": "PROD2",
                 "geometry": "POINT (0 0)",
-                "eodag:download_link": "https://geodes.example/data/PROD2/file.tif",
             },
+        )
+        p_no_url.assets.update(
+            {"download_link": {"href": "https://geodes.example/data/PROD2/file.tif"}}
         )
         p_no_link = EOProduct(
             self.provider,
@@ -2907,7 +2908,7 @@ class TestSearchPluginGeodesSearch(BaseSearchPluginTest):
         self.assertEqual(len(prep.query_params["availability"]), 1)
         self.assertEqual(
             prep.query_params["availability"][0]["href"],
-            p_ok.properties["eodag:download_link"],
+            p_ok.assets["download_link"]["href"],
         )
 
     @mock.patch(
@@ -3148,7 +3149,7 @@ class TestSearchPluginMeteoblueSearch(BaseSearchPluginTest):
         )
         # check download_link asset order_link
         self.assertEqual(
-            download_asset["order_link"],
+            download_asset["eodag:order_link"],
             f"{endpoint}?"
             + json.dumps(
                 {
@@ -3510,7 +3511,7 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         assert eoproduct.properties["title"].startswith(
             f"{self.product_dataset.upper()}"
         )
-        assert eoproduct.assets["download_link"]["order_link"].startswith("http")
+        assert eoproduct.assets["download_link"]["eodag:order_link"].startswith("http")
         assert eoproduct.location == ""
 
     def test_plugins_search_ecmwfsearch_with_collection(self):
@@ -4917,7 +4918,7 @@ class TestSearchPluginWekeoSearch(BaseSearchPluginTest):
             default_config.products["S1_SAR_GRD"].get("metadata_mapping", {}),
         )
         self.assertIn(
-            "order_link",
+            "eodag:order_link",
             default_config.search.assets_mapping["download_link"],
         )
 
@@ -5507,7 +5508,7 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
         self.assertEqual(
             "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_BUILT_S_GLOBE_R2023A/"
             "GHS_BUILT_S_E2000_GLOBE_R2023A_4326_3ss/V1-0/tiles/GHS_BUILT_S_E2000_GLOBE_R2023A_4326_3ss_V1_0_R3_C3.zip",
-            properties["eodag:download_link"],
+            products[0].assets["download_link"]["href"],
         )
         geometry = get_geometry_from_various(
             geometry=["-160.008", "69.100", "-150.008", "59.100"]
@@ -5560,7 +5561,7 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
         self.assertEqual(
             "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/ESM_BUILT_VHR2015_Europe_R2019/"
             "ESM_BUILT_VHR2015CLASS_EUROPE_R2019_3035_10/V1-0/tiles/R3_C3.zip",
-            properties["eodag:download_link"],
+            products[0].assets["download_link"]["href"],
         )
         geometry = get_geometry_from_various(
             geometry=["-160.008", "69.100", "-150.008", "59.100"]
@@ -5595,7 +5596,7 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
         self.assertEqual(
             "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL//GHS_FUA_UCDB2015_GLOBE_R2019A"
             "/V1-0/GHS_FUA_UCDB2015_GLOBE_R2019A_54009_1K_V1_0.zip",
-            properties["eodag:download_link"],
+            products[0].assets["download_link"]["href"],
         )
         # product type with several files
         collection = "GHS_UCDB_REGION"
@@ -5625,7 +5626,7 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
         self.assertEqual(
             "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_UCDB_GLOBE_R2024A/GHS_UCDB_REGION_GLOBE_R2024A"
             "/GHS_UCDB_REGION_EUROPE_R2024A/V1-1/GHS_UCDB_REGION_EUROPE_R2024A_V1_1.zip",
-            properties["eodag:download_link"],
+            products[0].assets["download_link"]["href"],
         )
 
         # product type with several files and assets

--- a/tests/units/test_search_result.py
+++ b/tests/units/test_search_result.py
@@ -31,18 +31,31 @@ class TestSearchResult(unittest.TestCase):
     def setUp(self):
         super(TestSearchResult, self).setUp()
         self.search_result = SearchResult([])
-        self.search_result2 = SearchResult(
-            [
-                EOProduct(
-                    provider=None,
-                    properties={"geometry": "POINT (0 0)", "order:status": "succeeded"},
-                ),
-                EOProduct(
-                    provider=None,
-                    properties={"geometry": "POINT (0 0)", "order:status": "orderable"},
-                ),
-            ]
+        online_product = EOProduct(
+            provider=None,
+            properties={"geometry": "POINT (0 0)"},
         )
+        online_product.assets.update(
+            {
+                "download_link": {
+                    "href": "http://somewhere/online",
+                    "order:status": "succeeded",
+                }
+            }
+        )
+        offline_product = EOProduct(
+            provider=None,
+            properties={"geometry": "POINT (0 0)"},
+        )
+        offline_product.assets.update(
+            {
+                "download_link": {
+                    "href": "http://somewhere/offline",
+                    "order:status": "orderable",
+                }
+            }
+        )
+        self.search_result2 = SearchResult([online_product, offline_product])
 
     def test_search_result_filter_online(self):
         """SearchResult.filter_online must only keep online results"""
@@ -51,7 +64,7 @@ class TestSearchResult(unittest.TestCase):
         filtered_size = len(filtered_products)
         self.assertFalse(origin_size == filtered_size)
         for product in filtered_products:
-            assert product.properties["order:status"] == "succeeded"
+            assert product.assets["download_link"]["order:status"] == "succeeded"
 
     def test_search_result_geo_interface(self):
         """SearchResult must provide a FeatureCollection geo-interface"""


### PR DESCRIPTION
Updates and fixes #2091 to move `eodag:download_link` and associated properties to `download_link` asset