### PR TITLE
feat(config): removed yaml tags and faster loader

### DIFF
--- a/docs/getting_started_guide/configure.rst
+++ b/docs/getting_started_guide/configure.rst
@@ -152,7 +152,7 @@ Some EODAG core settings can be overriden using environment variables:
   `<python-site-packages>/eodag/resources/providers.yml`.
 * ``EODAG_PROVIDERS_CFG_DIR`` for defining the desired path to the directory containing providers configuration files in place of
   `<python-site-packages>/eodag/resources/providers/`.
-* ``EODAG_COLLECTIONS_CFG_FILE`` for defining the desired path to the collections configuration file in place of
+* ``EODAG_COLLECTIONS_CFG_FILE`` **(deprecated)** for defining the desired path to the collections configuration file in place of
   `<python-site-packages>/eodag/resources/collections.yml`.
 * ``EODAG_EXT_COLLECTIONS_CFG_FILE`` for defining the desired path to the `external collections configuration file\
   <../notebooks/api_user_guide/1_providers_collections_available.ipynb#Collections-discovery>`_

--- a/docs/getting_started_guide/configure.rst
+++ b/docs/getting_started_guide/configure.rst
@@ -152,7 +152,7 @@ Some EODAG core settings can be overriden using environment variables:
   `<python-site-packages>/eodag/resources/providers.yml`.
 * ``EODAG_PROVIDERS_CFG_DIR`` for defining the desired path to the directory containing providers configuration files in place of
   `<python-site-packages>/eodag/resources/providers/`.
-* ``EODAG_COLLECTIONS_CFG_FILE`` **(deprecated)** for defining the desired path to the collections configuration file in place of
+* ``EODAG_COLLECTIONS_CFG_FILE`` for defining the desired path to the collections configuration file in place of
   `<python-site-packages>/eodag/resources/collections.yml`.
 * ``EODAG_EXT_COLLECTIONS_CFG_FILE`` for defining the desired path to the `external collections configuration file\
   <../notebooks/api_user_guide/1_providers_collections_available.ipynb#Collections-discovery>`_

--- a/eodag/api/provider.py
+++ b/eodag/api/provider.py
@@ -52,7 +52,6 @@ from eodag.utils import (
     update_nested_dict,
 )
 from eodag.utils.exceptions import (
-    MisconfiguredError,
     UnsupportedCollection,
     UnsupportedProvider,
     ValidationError,
@@ -104,10 +103,6 @@ class ProviderConfig(yaml.YAMLObject):
     search_auth: PluginConfig
     download_auth: PluginConfig
 
-    yaml_loader = yaml.Loader
-    yaml_dumper = yaml.SafeDumper
-    yaml_tag = "!provider"
-
     def __setstate__(self, state: dict[str, Any]) -> None:
         """Apply defaults when building from yaml."""
         self.__dict__.update(state)
@@ -118,31 +113,19 @@ class ProviderConfig(yaml.YAMLObject):
         return key in self.__dict__
 
     @classmethod
-    def from_yaml(cls, loader: yaml.Loader, node: Any) -> Iterator[Self]:
-        """Build a :class:`~eodag.api.provider.ProviderConfig` from Yaml"""
-        cls.validate(tuple(node_key.value for node_key, _ in node.value))
-        for node_key, node_value in node.value:
-            if node_key.value == "name":
-                node_value.value = slugify(node_value.value).replace("-", "_")
-            elif node_key.value in PLUGINS_TOPICS_KEYS:
-                if node_value.tag != PluginConfig.yaml_tag:
-                    msg = "Provider plugin topic '%s' must be tagged with '%s'" % (
-                        node_key.value,
-                        PluginConfig.yaml_tag,
-                    )
-                    raise MisconfiguredError(msg)
-        return loader.construct_yaml_object(node, cls)
-
-    @classmethod
     def from_mapping(cls, mapping: dict[str, Any]) -> Self:
         """Build a :class:`~eodag.api.provider.ProviderConfig` from a mapping"""
         cls.validate(mapping)
         # Create a deep copy to avoid modifying the input dict or its nested structures
         mapping_copy = deepcopy(mapping)
+        # Slugify the provider name (normalize spaces and special characters)
+        if "name" in mapping_copy:
+            mapping_copy["name"] = slugify(mapping_copy["name"]).replace("-", "_")
         for key in PLUGINS_TOPICS_KEYS:
-            if not (_mapping := mapping_copy.get(key)):
+            if key not in mapping_copy or mapping_copy[key] is None:
                 continue
 
+            _mapping = mapping_copy[key]
             if not isinstance(_mapping, dict):
                 _mapping = _mapping.__dict__
 

--- a/eodag/api/provider.py
+++ b/eodag/api/provider.py
@@ -21,6 +21,7 @@ import logging
 import os
 import tempfile
 import traceback
+import warnings
 from collections import UserDict
 from inspect import isclass
 from textwrap import shorten
@@ -52,6 +53,7 @@ from eodag.utils import (
     update_nested_dict,
 )
 from eodag.utils.exceptions import (
+    MisconfiguredError,
     UnsupportedCollection,
     UnsupportedProvider,
     ValidationError,
@@ -89,6 +91,10 @@ class ProviderConfig(yaml.YAMLObject):
     :param kwargs: Additional configuration variables for this provider
     """
 
+    yaml_loader = yaml.Loader
+    yaml_dumper = yaml.SafeDumper
+    yaml_tag = "!provider"
+
     name: str
     group: str
     priority: int = 0
@@ -113,9 +119,34 @@ class ProviderConfig(yaml.YAMLObject):
         return key in self.__dict__
 
     @classmethod
+    def from_yaml(cls, loader: yaml.Loader, node: Any) -> Self:
+        """Build a :class:`~eodag.api.provider.ProviderConfig` from Yaml"""
+        warnings.warn(
+            "Usage of deprecated YAML tag '!provider' for provider configuration "
+            "(Please use plain YAML mappings instead)"
+            " -- Deprecated since v4.4.0",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        cls.validate(
+            tuple(node_key.value for node_key, _ in node.value), check_name=False
+        )
+        for node_key, node_value in node.value:
+            if node_key.value == "name":
+                node_value.value = slugify(node_value.value).replace("-", "_")
+            elif node_key.value in PLUGINS_TOPICS_KEYS:
+                if node_value.tag != PluginConfig.yaml_tag:
+                    msg = "Provider plugin topic '%s' must be tagged with '%s'" % (
+                        node_key.value,
+                        PluginConfig.yaml_tag,
+                    )
+                    raise MisconfiguredError(msg)
+        return loader.construct_yaml_object(node, cls)
+
+    @classmethod
     def from_mapping(cls, mapping: dict[str, Any]) -> Self:
         """Build a :class:`~eodag.api.provider.ProviderConfig` from a mapping"""
-        cls.validate(mapping)
+        cls.validate(mapping, check_name=True)
         # Create a deep copy to avoid modifying the input dict or its nested structures
         mapping_copy = deepcopy(mapping)
         # Slugify the provider name (normalize spaces and special characters)
@@ -136,12 +167,15 @@ class ProviderConfig(yaml.YAMLObject):
         return c
 
     @staticmethod
-    def validate(config_keys: Union[tuple[str, ...], dict[str, Any]]) -> None:
+    def validate(
+        config_keys: Union[tuple[str, ...], dict[str, Any]], check_name: bool = True
+    ) -> None:
         """Validate a :class:`~eodag.api.provider.ProviderConfig`
 
         :param config_keys: The configurations keys to validate
+        :param check_name: Whether to require 'name' key (default True). Set to False for legacy YAML tag parsing.
         """
-        if "name" not in config_keys:
+        if check_name and "name" not in config_keys:
             raise ValidationError("Provider config must have name key")
         if not any(k in config_keys for k in PLUGINS_TOPICS_KEYS):
             raise ValidationError("A provider must implement at least one plugin")

--- a/eodag/api/provider.py
+++ b/eodag/api/provider.py
@@ -125,7 +125,7 @@ class ProviderConfig(yaml.YAMLObject):
             "Usage of deprecated YAML tag '!provider' for provider configuration "
             "(Please use plain YAML mappings instead)"
             " -- Deprecated since v4.4.0",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
         cls.validate(

--- a/eodag/api/provider.py
+++ b/eodag/api/provider.py
@@ -21,7 +21,6 @@ import logging
 import os
 import tempfile
 import traceback
-import warnings
 from collections import UserDict
 from inspect import isclass
 from textwrap import shorten
@@ -121,13 +120,6 @@ class ProviderConfig(yaml.YAMLObject):
     @classmethod
     def from_yaml(cls, loader: yaml.Loader, node: Any) -> Self:
         """Build a :class:`~eodag.api.provider.ProviderConfig` from Yaml"""
-        warnings.warn(
-            "Usage of deprecated YAML tag '!provider' for provider configuration "
-            "(Please use plain YAML mappings instead)"
-            " -- Deprecated since v4.5.0",
-            FutureWarning,
-            stacklevel=2,
-        )
         cls.validate(
             tuple(node_key.value for node_key, _ in node.value), check_name=False
         )

--- a/eodag/api/provider.py
+++ b/eodag/api/provider.py
@@ -124,7 +124,7 @@ class ProviderConfig(yaml.YAMLObject):
         warnings.warn(
             "Usage of deprecated YAML tag '!provider' for provider configuration "
             "(Please use plain YAML mappings instead)"
-            " -- Deprecated since v4.4.0",
+            " -- Deprecated since v4.5.0",
             FutureWarning,
             stacklevel=2,
         )

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -601,13 +601,6 @@ class PluginConfig(yaml.YAMLObject):
     @classmethod
     def from_yaml(cls, loader: yaml.Loader, node: Any) -> Self:
         """Build a :class:`~eodag.config.PluginConfig` from Yaml"""
-        warnings.warn(
-            "Usage of deprecated YAML tag '!plugin' for plugin configuration "
-            "(Please use plain YAML mappings instead)"
-            " -- Deprecated since v4.5.0",
-            FutureWarning,
-            stacklevel=2,
-        )
         cls.validate(
             tuple(node_key.value for node_key, _ in node.value), check_type=False
         )

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -103,6 +103,10 @@ class PluginConfig(yaml.YAMLObject):
     This class variables describe available plugins configuration parameters.
     """
 
+    yaml_loader = yaml.Loader
+    yaml_dumper = yaml.SafeDumper
+    yaml_tag = "!plugin"
+
     class Pagination(TypedDict):
         """Search pagination configuration"""
 
@@ -596,18 +600,42 @@ class PluginConfig(yaml.YAMLObject):
         return item in self.__dict__
 
     @classmethod
+    def from_yaml(cls, loader: yaml.Loader, node: Any) -> Self:
+        """Build a :class:`~eodag.config.PluginConfig` from Yaml"""
+        warnings.warn(
+            "Usage of deprecated YAML tag '!plugin' for plugin configuration "
+            "(Please use plain YAML mappings instead)"
+            " -- Deprecated since v4.4.0",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        cls.validate(
+            tuple(node_key.value for node_key, _ in node.value), check_type=False
+        )
+        return loader.construct_yaml_object(node, cls)
+
+    @classmethod
     def from_mapping(cls, mapping: dict[str, Any]) -> Self:
         """Build a :class:`~eodag.config.PluginConfig` from a mapping"""
-        cls.validate(tuple(mapping.keys()))
+        cls.validate(tuple(mapping.keys()), check_type=True)
         c = cls()
         c.__dict__.update(deepcopy(mapping))
         return c
 
     @staticmethod
-    def validate(config_keys: tuple[Any, ...]) -> None:
-        """Validate a :class:`~eodag.config.PluginConfig`"""
+    def validate(config_keys: tuple[Any, ...], check_type: bool = True) -> None:
+        """Validate a :class:`~eodag.config.PluginConfig`
+
+        :param config_keys: The configuration keys to validate
+        :param check_type: Whether to require 'type' or 'credentials' key (default True).
+        Set to False for legacy YAML tag parsing.
+        """
         # credentials may be set without type when the provider uses search_auth plugin.
-        if "type" not in config_keys and "credentials" not in config_keys:
+        if (
+            check_type
+            and "type" not in config_keys
+            and "credentials" not in config_keys
+        ):
             raise ValidationError(
                 "A Plugin config must specify the type of Plugin it configures"
             )
@@ -729,8 +757,17 @@ def load_config(config_path: str) -> dict[str, ProviderConfig]:
     from eodag.api.provider import ProviderConfig as ProviderConfigClass
 
     providers_configs: list[ProviderConfig] = []
+    default_provider_name = pathlib.Path(config_path).stem
     for provider_dict in providers_configs_dicts:
         if provider_dict is not None:
+            if isinstance(provider_dict, ProviderConfigClass):
+                # Legacy standalone !provider files may omit the `name` key.
+                # In that case, use the file stem (e.g. wekeo_main.yml -> wekeo_main).
+                if not getattr(provider_dict, "name", None):
+                    provider_dict.__dict__["name"] = default_provider_name
+                providers_configs.append(provider_dict)
+                continue
+
             # Each provider YAML file has one provider at the top level
             # The dictionary will have the provider name as key and provider config as value
             for provider_name, provider_config in provider_dict.items():
@@ -740,6 +777,12 @@ def load_config(config_path: str) -> dict[str, ProviderConfig]:
                         provider_config["name"] = provider_name
                     provider_obj = ProviderConfigClass.from_mapping(provider_config)
                     providers_configs.append(provider_obj)
+                elif isinstance(provider_config, ProviderConfigClass):
+                    # Handle legacy YAML tags where name is outside the tag (e.g., "ecmwf: !provider")
+                    # Add name if missing since it was not part of the tag node
+                    if not getattr(provider_config, "name", None):
+                        provider_config.__dict__["name"] = provider_name
+                    providers_configs.append(provider_config)
 
     return {p.name: p for p in providers_configs if p is not None}
 

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -35,8 +35,6 @@ from typing_extensions import TypedDict
 from eodag.utils import (
     HTTP_REQ_TIMEOUT,
     USER_AGENT,
-    cached_yaml_load,
-    cached_yaml_load_all,
     deepcopy,
     dict_items_recursive_apply,
     merge_mappings,
@@ -45,6 +43,7 @@ from eodag.utils import (
     uri_to_path,
 )
 from eodag.utils.exceptions import ValidationError
+from eodag.utils.yaml import cached_yaml_load, cached_yaml_load_all
 
 if TYPE_CHECKING:
     from typing import ItemsView, Iterator, ValuesView

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -605,7 +605,7 @@ class PluginConfig(yaml.YAMLObject):
         warnings.warn(
             "Usage of deprecated YAML tag '!plugin' for plugin configuration "
             "(Please use plain YAML mappings instead)"
-            " -- Deprecated since v4.4.0",
+            " -- Deprecated since v4.5.0",
             FutureWarning,
             stacklevel=2,
         )

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -606,7 +606,7 @@ class PluginConfig(yaml.YAMLObject):
             "Usage of deprecated YAML tag '!plugin' for plugin configuration "
             "(Please use plain YAML mappings instead)"
             " -- Deprecated since v4.4.0",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
         cls.validate(

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -32,6 +32,7 @@ from annotated_types import Gt
 from jsonpath_ng import JSONPath
 from typing_extensions import TypedDict
 
+from eodag.api.provider import ProviderConfig as ProviderConfigClass
 from eodag.utils import (
     HTTP_REQ_TIMEOUT,
     USER_AGENT,
@@ -726,8 +727,6 @@ def load_config(config_path: str) -> dict[str, ProviderConfig]:
         raise e
 
     # Convert dictionaries to ProviderConfig objects
-    from eodag.api.provider import ProviderConfig as ProviderConfigClass
-
     providers_configs: list[ProviderConfig] = []
     for provider_dict in providers_configs_dicts:
         if provider_dict is not None:

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -580,10 +580,6 @@ class PluginConfig(yaml.YAMLObject):
     #: which authentication method should be used
     method: str
 
-    yaml_loader = yaml.Loader
-    yaml_dumper = yaml.SafeDumper
-    yaml_tag = "!plugin"
-
     def __or__(self, other: Union[Self, dict[str, Any]]) -> Self:
         """Return a new PluginConfig with merged values."""
         new_config = self.__class__.from_mapping(self.__dict__)
@@ -598,12 +594,6 @@ class PluginConfig(yaml.YAMLObject):
     def __contains__(self, item: str) -> bool:
         """Check if a key is in the PluginConfig."""
         return item in self.__dict__
-
-    @classmethod
-    def from_yaml(cls, loader: yaml.Loader, node: Any) -> Self:
-        """Build a :class:`~eodag.config.PluginConfig` from Yaml"""
-        cls.validate(tuple(node_key.value for node_key, _ in node.value))
-        return loader.construct_yaml_object(node, cls)
 
     @classmethod
     def from_mapping(cls, mapping: dict[str, Any]) -> Self:
@@ -727,11 +717,29 @@ def load_config(config_path: str) -> dict[str, ProviderConfig]:
 
     try:
         # Providers configs are stored in this file as separated yaml documents
-        # Load all of it
-        providers_configs: list[ProviderConfig] = cached_yaml_load_all(config_path)
+        # Load all of it as plain YAML dictionaries
+        providers_configs_dicts: list[dict[str, Any]] = cached_yaml_load_all(
+            config_path
+        )
     except yaml.parser.ParserError as e:
         logger.error("Unable to load configuration")
         raise e
+
+    # Convert dictionaries to ProviderConfig objects
+    from eodag.api.provider import ProviderConfig as ProviderConfigClass
+
+    providers_configs: list[ProviderConfig] = []
+    for provider_dict in providers_configs_dicts:
+        if provider_dict is not None:
+            # Each provider YAML file has one provider at the top level
+            # The dictionary will have the provider name as key and provider config as value
+            for provider_name, provider_config in provider_dict.items():
+                if isinstance(provider_config, dict):
+                    # Add the name to the config if not already present
+                    if "name" not in provider_config:
+                        provider_config["name"] = provider_name
+                    provider_obj = ProviderConfigClass.from_mapping(provider_config)
+                    providers_configs.append(provider_obj)
 
     return {p.name: p for p in providers_configs if p is not None}
 

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -738,9 +738,9 @@ def load_config(config_path: str) -> dict[str, ProviderConfig]:
     try:
         # Providers configs are stored in this file as separated yaml documents
         # Load all of it as plain YAML dictionaries
-        providers_configs_dicts: list[dict[str, Any]] = cached_yaml_load_all(
-            config_path
-        )
+        providers_configs_dicts: list[
+            Optional[Union[dict[str, Any], ProviderConfig]]
+        ] = cached_yaml_load_all(config_path)
     except yaml.parser.ParserError as e:
         logger.error("Unable to load configuration")
         raise e
@@ -755,8 +755,7 @@ def load_config(config_path: str) -> dict[str, ProviderConfig]:
             if isinstance(provider_dict, ProviderConfigClass):
                 # Legacy standalone !provider files may omit the `name` key.
                 # In that case, use the file stem (e.g. wekeo_main.yml -> wekeo_main).
-                if not getattr(provider_dict, "name", None):
-                    provider_dict.__dict__["name"] = default_provider_name
+                provider_dict.__dict__.setdefault("name", default_provider_name)
                 providers_configs.append(provider_dict)
                 continue
 
@@ -765,15 +764,13 @@ def load_config(config_path: str) -> dict[str, ProviderConfig]:
             for provider_name, provider_config in provider_dict.items():
                 if isinstance(provider_config, dict):
                     # Add the name to the config if not already present
-                    if "name" not in provider_config:
-                        provider_config["name"] = provider_name
+                    provider_config.setdefault("name", provider_name)
                     provider_obj = ProviderConfigClass.from_mapping(provider_config)
                     providers_configs.append(provider_obj)
                 elif isinstance(provider_config, ProviderConfigClass):
                     # Handle legacy YAML tags where name is outside the tag (e.g., "ecmwf: !provider")
                     # Add name if missing since it was not part of the tag node
-                    if not getattr(provider_config, "name", None):
-                        provider_config.__dict__["name"] = provider_name
+                    provider_config.__dict__.setdefault("name", provider_name)
                     providers_configs.append(provider_config)
 
     return {p.name: p for p in providers_configs if p is not None}

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -32,7 +32,6 @@ from annotated_types import Gt
 from jsonpath_ng import JSONPath
 from typing_extensions import TypedDict
 
-from eodag.api.provider import ProviderConfig as ProviderConfigClass
 from eodag.utils import (
     HTTP_REQ_TIMEOUT,
     USER_AGENT,
@@ -727,6 +726,8 @@ def load_config(config_path: str) -> dict[str, ProviderConfig]:
         raise e
 
     # Convert dictionaries to ProviderConfig objects
+    from eodag.api.provider import ProviderConfig as ProviderConfigClass
+
     providers_configs: list[ProviderConfig] = []
     for provider_dict in providers_configs_dicts:
         if provider_dict is not None:

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -109,14 +109,20 @@ class PluginManager:
                         "Check that the plugin module (%s) is importable",
                         entry_point.name,
                     )
-                plugin_config_paths = self._get_external_provider_config_paths(
-                    entry_point
-                )
-                if plugin_config_paths:
-                    plugin_configs: dict[str, ProviderConfig] = {}
-                    for path in plugin_config_paths:
-                        plugin_configs.update(load_config(path.as_posix()))
-                    self.providers.update_from_configs(plugin_configs)
+                if entry_point.dist and entry_point.dist.name != "eodag":
+                    # use plugin providers if any
+                    name = entry_point.dist.name
+                    dist = entry_point.dist
+                    plugin_providers_dir_config_path = dist.locate_file(name).joinpath(
+                        "providers"
+                    )
+                    if plugin_providers_dir_config_path:
+                        plugin_configs: dict[str, ProviderConfig] = {}
+                        for path in pathlib.Path(
+                            plugin_providers_dir_config_path
+                        ).iterdir():
+                            plugin_configs.update(load_config(path.as_posix()))
+                        self.providers.update_from_configs(plugin_configs)
         self.rebuild()
 
     def _get_external_provider_config_paths(

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -109,20 +109,14 @@ class PluginManager:
                         "Check that the plugin module (%s) is importable",
                         entry_point.name,
                     )
-                if entry_point.dist and entry_point.dist.name != "eodag":
-                    # use plugin providers if any
-                    name = entry_point.dist.name
-                    dist = entry_point.dist
-                    plugin_providers_dir_config_path = dist.locate_file(name).joinpath(
-                        "providers"
-                    )
-                    if plugin_providers_dir_config_path:
-                        plugin_configs: dict[str, ProviderConfig] = {}
-                        for path in pathlib.Path(
-                            plugin_providers_dir_config_path
-                        ).iterdir():
-                            plugin_configs.update(load_config(path.as_posix()))
-                        self.providers.update_from_configs(plugin_configs)
+                plugin_config_paths = self._get_external_provider_config_paths(
+                    entry_point
+                )
+                if plugin_config_paths:
+                    plugin_configs: dict[str, ProviderConfig] = {}
+                    for path in plugin_config_paths:
+                        plugin_configs.update(load_config(path.as_posix()))
+                    self.providers.update_from_configs(plugin_configs)
         self.rebuild()
 
     def _get_external_provider_config_paths(

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -265,8 +265,25 @@ class Search(PluginTopic):
         if not hasattr(self.config, "sort"):
             raise ValidationError(f"{self.provider} does not support sorting feature")
         # TODO: remove this code block when search args model validation is embeded
-        # remove duplicates
-        sort_by_arg = list(dict.fromkeys(sort_by_arg))
+        # tolerate legacy format: ["sort_param", "ASC"]
+        if (
+            isinstance(sort_by_arg, (list, tuple))
+            and len(sort_by_arg) == 2
+            and isinstance(sort_by_arg[0], str)
+            and isinstance(sort_by_arg[1], str)
+        ):
+            sort_by_arg = [(sort_by_arg[0], sort_by_arg[1])]
+
+        # normalize to hashable tuples and remove duplicates
+        sort_by_arg_normalized: list[tuple[str, str]] = []
+        for sort_by_tuple in sort_by_arg:
+            if not isinstance(sort_by_tuple, (list, tuple)) or len(sort_by_tuple) != 2:
+                raise ValidationError(
+                    "sort_by must be a list of tuples like [('start_datetime', 'ASC')]"
+                )
+            sort_by_arg_normalized.append((sort_by_tuple[0], sort_by_tuple[1]))
+
+        sort_by_arg = list(dict.fromkeys(sort_by_arg_normalized))
 
         sort_by_qs: str = ""
         sort_by_qp: dict[str, Any] = {}

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -21,6 +21,7 @@ import logging
 import re
 import socket
 from copy import copy as copy_copy
+from copy import deepcopy as copy_deepcopy
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -86,7 +87,6 @@ from eodag.utils import (
     REQ_RETRY_TOTAL,
     STAC_SEARCH_PLUGINS,
     USER_AGENT,
-    copy_deepcopy,
     deepcopy,
     dict_items_recursive_apply,
     format_dict_items,

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -49,7 +49,6 @@ import concurrent.futures
 import geojson
 import orjson
 import requests
-import yaml
 from jsonpath_ng import JSONPath
 from lxml import etree
 from pydantic import ConfigDict, Field, create_model
@@ -1768,7 +1767,7 @@ class PostJsonSearch(QueryStringSearch):
                 )["parameters"]
             ):
                 # config backup
-                plugin_config_backup = yaml.dump(self.config)
+                plugin_config_backup = copy_deepcopy(self.config)
 
                 self.config.api_endpoint = query_value
                 self.config.products[collection][
@@ -1800,9 +1799,7 @@ class PostJsonSearch(QueryStringSearch):
                     raise
                 finally:
                     # restore config
-                    self.config = yaml.load(
-                        plugin_config_backup, self.config.yaml_loader
-                    )
+                    self.config = plugin_config_backup
 
                 return eo_products
 

--- a/eodag/resources/providers/aws_eos.yml
+++ b/eodag/resources/providers/aws_eos.yml
@@ -1,11 +1,11 @@
-!provider # MARK: aws_eos
+aws_eos:
   name: aws_eos
   priority: 0
   description: EOS search for Amazon public datasets
   roles:
     - host
   url: https://developers.eos.com/datasets_description.html
-  search: !plugin
+  search:
     type: PostJsonSearch
     api_endpoint: 'https://gate.eos.com/api/lms/search/v2/{_collection}'
     need_auth: true
@@ -384,7 +384,7 @@
           - '$.processedL2A'
         _aws_path_l2a: '$.awsPathL2A'
 
-  download: !plugin
+  download:
     type: AwsDownload
     ssl_verify: true
     products:
@@ -421,11 +421,11 @@
             eodag:product_path: '$.path'
         complementary_url_key:
           - eodag:product_path
-  download_auth: !plugin
+  download_auth:
     type: AwsAuth
     matching_url: s3://
     requester_pays: True
-  search_auth: !plugin
+  search_auth:
     type: HttpQueryStringAuth
     matching_url: https://gate.eos.com
     ssl_verify: true

--- a/eodag/resources/providers/aws_eos.yml
+++ b/eodag/resources/providers/aws_eos.yml
@@ -1,5 +1,4 @@
 aws_eos:
-  name: aws_eos
   priority: 0
   description: EOS search for Amazon public datasets
   roles:

--- a/eodag/resources/providers/cop_ads.yml
+++ b/eodag/resources/providers/cop_ads.yml
@@ -1,4 +1,4 @@
-!provider # MARK: cop_ads
+cop_ads:
   name: cop_ads
   priority: 0
   description: Copernicus Atmosphere Data Store
@@ -13,12 +13,12 @@
           "month": {_date#interval_to_datetime_dict}["month"]
         }}
       - '{$.end_datetime#to_iso_date}'
-  auth: !plugin
+  auth:
     type: HTTPHeaderAuth
     ssl_verify: true
     headers:
       PRIVATE-TOKEN: "{apikey}"
-  download: !plugin
+  download:
     type: HTTPDownload
     timeout: 30
     ssl_verify: true
@@ -49,7 +49,7 @@
         need_search: true
         metadata_mapping:
           eodag:download_link: $.json.asset.value.href
-  search: !plugin
+  search:
     type: ECMWFSearch
     need_auth: true
     ssl_verify: true

--- a/eodag/resources/providers/cop_ads.yml
+++ b/eodag/resources/providers/cop_ads.yml
@@ -1,5 +1,4 @@
 cop_ads:
-  name: cop_ads
   priority: 0
   description: Copernicus Atmosphere Data Store
   roles:

--- a/eodag/resources/providers/cop_cds.yml
+++ b/eodag/resources/providers/cop_cds.yml
@@ -1,5 +1,4 @@
 cop_cds:
-  name: cop_cds
   priority: 0
   description: Copernicus Climate Data Store
   roles:

--- a/eodag/resources/providers/cop_cds.yml
+++ b/eodag/resources/providers/cop_cds.yml
@@ -1,4 +1,4 @@
-!provider # MARK: cop_cds
+cop_cds:
   name: cop_cds
   priority: 0
   description: Copernicus Climate Data Store
@@ -51,12 +51,12 @@
           "time": {start_datetime#get_ecmwf_time}
         }}
       - '{$.end_datetime#to_iso_date}'
-  auth: !plugin
+  auth:
     type: HTTPHeaderAuth
     ssl_verify: true
     headers:
       PRIVATE-TOKEN: "{apikey}"
-  download: !plugin
+  download:
     type: HTTPDownload
     timeout: 30
     ssl_verify: true
@@ -87,7 +87,7 @@
         need_search: true
         metadata_mapping:
           eodag:download_link: $.json.asset.value.href
-  search: !plugin
+  search:
     type: ECMWFSearch
     need_auth: true
     ssl_verify: true

--- a/eodag/resources/providers/cop_dataspace.yml
+++ b/eodag/resources/providers/cop_dataspace.yml
@@ -1,5 +1,4 @@
 cop_dataspace:
-  name: cop_dataspace
   priority: 0
   description: Copernicus Data Space Ecosystem
   roles:

--- a/eodag/resources/providers/cop_dataspace.yml
+++ b/eodag/resources/providers/cop_dataspace.yml
@@ -1,11 +1,11 @@
-!provider # MARK: cop_dataspace
+cop_dataspace:
   name: cop_dataspace
   priority: 0
   description: Copernicus Data Space Ecosystem
   roles:
     - host
   url: https://dataspace.copernicus.eu/
-  search: !plugin
+  search:
     type: ODataV4Search
     api_endpoint: 'https://catalogue.dataspace.copernicus.eu/odata/v1/Products'
     need_auth: false
@@ -29,7 +29,7 @@
       max_limit: 1_000
     sort:
       sort_by_default:
-        - !!python/tuple [start_datetime, ASC]
+        -  [start_datetime, ASC]
       sort_by_tpl: '&$orderby={sort_param} {sort_order}'
       sort_param_mapping:
         start_datetime: ContentDate/Start
@@ -247,14 +247,14 @@
         - $.null
       eodag:quicklook: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
       eodag:thumbnail: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
-  download: !plugin
+  download:
     type: HTTPDownload
     extract: true
     order_enabled: false
     archive_depth: 2
     max_workers: 4
     ssl_verify: true
-  auth: !plugin
+  auth:
     type: KeycloakOIDCPasswordAuth
     matching_url: https://catalogue.dataspace.copernicus.eu
     oidc_config_url: https://identity.dataspace.copernicus.eu/auth/realms/CDSE/.well-known/openid-configuration

--- a/eodag/resources/providers/cop_dataspace_s3.yml
+++ b/eodag/resources/providers/cop_dataspace_s3.yml
@@ -1,5 +1,4 @@
 cop_dataspace_s3:
-  name: cop_dataspace_s3
   priority: 0
   description: Copernicus Data Space Ecosystem through S3 protocol
   roles:

--- a/eodag/resources/providers/cop_dataspace_s3.yml
+++ b/eodag/resources/providers/cop_dataspace_s3.yml
@@ -1,11 +1,11 @@
-!provider # MARK: cop_dataspace_s3
+cop_dataspace_s3:
   name: cop_dataspace_s3
   priority: 0
   description: Copernicus Data Space Ecosystem through S3 protocol
   roles:
     - host
   url: https://dataspace.copernicus.eu/
-  search: !plugin
+  search:
     type: CreodiasS3Search
     api_endpoint: 'https://catalogue.dataspace.copernicus.eu/odata/v1/Products'
     s3_endpoint: 'https://eodata.dataspace.copernicus.eu'
@@ -30,7 +30,7 @@
       max_limit: 1_000
     sort:
       sort_by_default:
-        - !!python/tuple [start_datetime, ASC]
+        -  [start_datetime, ASC]
       sort_by_tpl: '&$orderby={sort_param} {sort_order}'
       sort_param_mapping:
         start_datetime: ContentDate/Start
@@ -178,9 +178,6 @@
       updated:
         - null
         - '$.ModificationDate'
-      sat:relative_orbit:
-        - null
-        - '$.Attributes.relativeOrbitNumber'
       # OpenSearch Parameters for Acquistion Parameters Search (Table 6)
       start_datetime:
         - null
@@ -245,12 +242,12 @@
         - $.null
       eodag:quicklook: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
       eodag:thumbnail: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
-  download: !plugin
+  download:
     type: AwsDownload
     s3_endpoint: 'https://eodata.dataspace.copernicus.eu'
     s3_bucket: 'eodata.dataspace.copernicus.eu'
     ssl_verify: true
-  auth: !plugin
+  auth:
     type: AwsAuth
     auth_error_code: 403
     s3_endpoint: 'https://eodata.dataspace.copernicus.eu'

--- a/eodag/resources/providers/cop_ewds.yml
+++ b/eodag/resources/providers/cop_ewds.yml
@@ -1,5 +1,4 @@
 cop_ewds:
-  name: cop_ewds
   priority: 0
   description:  CEMS Early Warning Data Store
   roles:

--- a/eodag/resources/providers/cop_ewds.yml
+++ b/eodag/resources/providers/cop_ewds.yml
@@ -1,4 +1,4 @@
-!provider # MARK: cop_ewds
+cop_ewds:
   name: cop_ewds
   priority: 0
   description:  CEMS Early Warning Data Store
@@ -59,12 +59,12 @@
           "hmonth": {_date#interval_to_datetime_dict}["month"]
         }}
       - '{$.end_datetime#to_iso_date}'
-  auth: !plugin
+  auth:
     type: HTTPHeaderAuth
     ssl_verify: true
     headers:
       PRIVATE-TOKEN: "{apikey}"
-  download: !plugin
+  download:
     type: HTTPDownload
     timeout: 30
     ssl_verify: true
@@ -96,7 +96,7 @@
         need_search: true
         metadata_mapping:
           eodag:download_link: $.json.asset.value.href
-  search: !plugin
+  search:
     type: ECMWFSearch
     need_auth: true
     ssl_verify: true

--- a/eodag/resources/providers/cop_ghsl.yml
+++ b/eodag/resources/providers/cop_ghsl.yml
@@ -1,11 +1,11 @@
-!provider # MARK: cop_ghsl
+cop_ghsl:
   name: cop_ghsl
   priority: 0
   description: Copernicus Global Human Settlement Layer
   roles:
     - host
   url: https://human-settlement.emergency.copernicus.eu/index.php
-  search: !plugin
+  search:
     type: CopGhslSearch
     api_endpoint: https://human-settlement.emergency.copernicus.eu/data/tilesDLD
     need_auth: false
@@ -118,6 +118,6 @@
       grouped_by: region
       metadata_mapping:
         eodag:download_link: https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_UCDB_GLOBE_R2024A/GHS_UCDB_REGION_GLOBE_R2024A/GHS_UCDB_REGION_{region}_R2024A/V1-1/GHS_UCDB_REGION_{region}_R2024A_V1_1.zip
-  download: !plugin
+  download:
     type: HTTPDownload
     ssl_verify: true

--- a/eodag/resources/providers/cop_ghsl.yml
+++ b/eodag/resources/providers/cop_ghsl.yml
@@ -1,5 +1,4 @@
 cop_ghsl:
-  name: cop_ghsl
   priority: 0
   description: Copernicus Global Human Settlement Layer
   roles:

--- a/eodag/resources/providers/cop_marine.yml
+++ b/eodag/resources/providers/cop_marine.yml
@@ -1,5 +1,4 @@
 cop_marine:
-  name: cop_marine
   priority: 0
   description: Copernicus Marine Data Store
   roles:

--- a/eodag/resources/providers/cop_marine.yml
+++ b/eodag/resources/providers/cop_marine.yml
@@ -1,11 +1,11 @@
-!provider # MARK: cop_marine
+cop_marine:
   name: cop_marine
   priority: 0
   description: Copernicus Marine Data Store
   roles:
     - host
   url: https://marine.copernicus.eu/
-  search: !plugin
+  search:
     type: CopMarineSearch
     api_endpoint: 'https://stac.marine.copernicus.eu/metadata/{_collection}/product.stac.json'
     need_auth: false
@@ -155,11 +155,11 @@
       _collection: OCEANCOLOUR_GLO_BGC_L4_MY_009_108
     GENERIC_COLLECTION:
       _collection: '{collection}'
-  download: !plugin
+  download:
     type: AwsDownload
     s3_endpoint: https://s3.waw3-1.cloudferro.com
     bucket_path_level: 0
-  auth: !plugin
+  auth:
     type: AwsAuth
     matching_url: s3://
     s3_endpoint: https://s3.waw3-1.cloudferro.com

--- a/eodag/resources/providers/creodias.yml
+++ b/eodag/resources/providers/creodias.yml
@@ -1,11 +1,11 @@
-!provider # MARK: creodias
+creodias:
   name: creodias
   priority: 0
   description: CloudFerro DIAS
   roles:
     - host
   url: https://creodias.eu/
-  search: !plugin
+  search:
     type: ODataV4Search
     api_endpoint: 'https://datahub.creodias.eu/odata/v1/Products'
     need_auth: false
@@ -29,7 +29,7 @@
       max_limit: 1_000
     sort:
       sort_by_default:
-        - !!python/tuple [start_datetime, ASC]
+        -  [start_datetime, ASC]
       sort_by_tpl: '&$orderby={sort_param} {sort_order}'
       sort_param_mapping:
         start_datetime: ContentDate/Start
@@ -243,13 +243,13 @@
         - $.null
       eodag:quicklook: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
       eodag:thumbnail: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
-  download: !plugin
+  download:
     type: HTTPDownload
     extract: true
     order_enabled: false
     archive_depth: 2
     ssl_verify: true
-  auth: !plugin
+  auth:
     type: KeycloakOIDCPasswordAuth
     matching_url: https://[-\w]+.creodias.eu
     oidc_config_url: https://identity.cloudferro.com/auth/realms/Creodias-new/.well-known/openid-configuration

--- a/eodag/resources/providers/creodias.yml
+++ b/eodag/resources/providers/creodias.yml
@@ -1,5 +1,4 @@
 creodias:
-  name: creodias
   priority: 0
   description: CloudFerro DIAS
   roles:

--- a/eodag/resources/providers/creodias_s3.yml
+++ b/eodag/resources/providers/creodias_s3.yml
@@ -1,11 +1,11 @@
-!provider # MARK: creodias_s3
+creodias_s3:
   name: creodias_s3
   priority: 0
   description: CloudFerro DIAS data through S3 protocol
   roles:
     - host
   url: https://creodias.eu/
-  search: !plugin
+  search:
     type: CreodiasS3Search
     api_endpoint: 'https://datahub.creodias.eu/odata/v1/Products'
     s3_endpoint: 'https://eodata.cloudferro.com'
@@ -30,7 +30,7 @@
       max_limit: 1_000
     sort:
       sort_by_default:
-        - !!python/tuple [start_datetime, ASC]
+        -  [start_datetime, ASC]
       sort_by_tpl: '&$orderby={sort_param} {sort_order}'
       sort_param_mapping:
         start_datetime: ContentDate/Start
@@ -242,12 +242,12 @@
         - $.null
       eodag:quicklook: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
       eodag:thumbnail: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
-  download: !plugin
+  download:
     type: AwsDownload
     s3_endpoint: 'https://eodata.cloudferro.com'
     s3_bucket: 'eodata'
     ssl_verify: true
-  auth: !plugin
+  auth:
     type: AwsAuth
     auth_error_code: 403
     s3_endpoint: 'https://eodata.cloudferro.com'

--- a/eodag/resources/providers/creodias_s3.yml
+++ b/eodag/resources/providers/creodias_s3.yml
@@ -1,5 +1,4 @@
 creodias_s3:
-  name: creodias_s3
   priority: 0
   description: CloudFerro DIAS data through S3 protocol
   roles:

--- a/eodag/resources/providers/dedl.yml
+++ b/eodag/resources/providers/dedl.yml
@@ -1,4 +1,4 @@
-!provider # MARK: dedl
+dedl:
   name: dedl
   priority: 0
   roles:
@@ -12,7 +12,7 @@
     eodag:order_link: "{_order_href}?{{{_order_body#replace_str(\"'\", '\"')}}}"
     eodag:download_link: '$.null'
     assets: '$.null'
-  search: !plugin
+  search:
     type: StacSearch
     api_endpoint: https://hda.data.destination-earth.eu/stac/v2/search
     need_auth: true
@@ -50,7 +50,7 @@
         platform: platform
         gsd: gsd
         eo:cloud_cover: eo:cloud_cover
-  download: !plugin
+  download:
     type: HTTPDownload
     auth_error_code: 403
     timeout: 20
@@ -74,7 +74,7 @@
         metadata_mapping:
           eodag:download_link: '$.json.assets.downloadLink.href'
           order:status: $.json.properties."order:status"
-  auth: !plugin
+  auth:
     type: OIDCTokenExchangeAuth
     matching_url: https://[-\w\.]+.data.destination-earth.eu
     subject:

--- a/eodag/resources/providers/dedl.yml
+++ b/eodag/resources/providers/dedl.yml
@@ -1,5 +1,4 @@
 dedl:
-  name: dedl
   priority: 0
   roles:
     - host

--- a/eodag/resources/providers/dedt_lumi.yml
+++ b/eodag/resources/providers/dedt_lumi.yml
@@ -1,11 +1,11 @@
-!provider # MARK: dedt_lumi
+dedt_lumi:
   name: dedt_lumi
   priority: 0
   roles:
     - host
   description: Destination Earth Digital Twin Outputs from LUMI through Polytope API
   url: https://polytope.lumi.apps.dte.destination-earth.eu/openapi
-  search: !plugin
+  search:
     type: ECMWFSearch
     need_auth: true
     ssl_verify: true
@@ -231,7 +231,7 @@
       experiment: SSP3-7.0
       realization: "1"
       model: IFS-FESOM
-  download: !plugin
+  download:
     type: HTTPDownload
     ssl_verify: true
     auth_error_code: 401
@@ -260,7 +260,7 @@
         metadata_mapping:
           eodag:download_link: $.headers.Location
     no_auth_download: True
-  auth: !plugin
+  auth:
     type: OIDCAuthorizationCodeFlowAuth
     oidc_config_url: https://auth.destine.eu/realms/desp/.well-known/openid-configuration
     redirect_uri: https://polytope.lumi.apps.dte.destination-earth.eu/

--- a/eodag/resources/providers/dedt_lumi.yml
+++ b/eodag/resources/providers/dedt_lumi.yml
@@ -1,5 +1,4 @@
 dedt_lumi:
-  name: dedt_lumi
   priority: 0
   roles:
     - host

--- a/eodag/resources/providers/dedt_mn5.yml
+++ b/eodag/resources/providers/dedt_mn5.yml
@@ -1,11 +1,11 @@
-!provider # MARK: dedt_mn5
+dedt_mn5:
   name: dedt_mn5
   priority: 0
   roles:
     - host
   description: Destination Earth Digital Twin Outputs from marenostrum through Polytope API
   url: https://polytope.mn5.apps.dte.destination-earth.eu/openapi
-  search: !plugin
+  search:
     type: ECMWFSearch
     need_auth: true
     ssl_verify: true
@@ -285,7 +285,7 @@
       experiment: Tplus2.0K
       realization: "5"
       model: IFS-FESOM
-  download: !plugin
+  download:
     type: HTTPDownload
     ssl_verify: true
     auth_error_code: 401
@@ -314,7 +314,7 @@
         metadata_mapping:
           eodag:download_link: $.headers.Location
     no_auth_download: True
-  auth: !plugin
+  auth:
     type: OIDCAuthorizationCodeFlowAuth
     oidc_config_url: https://auth.destine.eu/realms/desp/.well-known/openid-configuration
     redirect_uri: https://polytope.lumi.apps.dte.destination-earth.eu/

--- a/eodag/resources/providers/dedt_mn5.yml
+++ b/eodag/resources/providers/dedt_mn5.yml
@@ -1,5 +1,4 @@
 dedt_mn5:
-  name: dedt_mn5
   priority: 0
   roles:
     - host

--- a/eodag/resources/providers/dlr_eoc_geoservice.yml
+++ b/eodag/resources/providers/dlr_eoc_geoservice.yml
@@ -1,16 +1,16 @@
-!provider # MARK: DLR EOC Geoservice
+dlr_eoc_geoservice:
   name: dlr_eoc_geoservice
   priority: 0
   description: DLR Earth Observation Center (EOC) Geoservice
   roles:
     - host
   url: https://geoservice.dlr.de
-  search: !plugin
+  search:
     type: StacSearch
     api_endpoint: https://geoservice.dlr.de/eoc/ogc/stac/v1/search
     sort:
       sort_by_default:
-        - !!python/tuple [start_datetime, ASC]
+        -  [start_datetime, ASC]
       sort_param_mapping:
         id: id
         start_datetime: properties.datetime
@@ -28,7 +28,7 @@
         eodag:download_link: '$.assets.data.href'
     GENERIC_COLLECTION:
       _collection: '{collection}'
-  download: !plugin
+  download:
     type: HTTPDownload
     auth_error_code:
       - 401
@@ -38,6 +38,6 @@
         ignore_assets: true
       SUPERSITES:
         ignore_assets: true
-  auth: !plugin
+  auth:
     type: GenericAuth
     matching_url: https://download.geoservice.dlr.de

--- a/eodag/resources/providers/dlr_eoc_geoservice.yml
+++ b/eodag/resources/providers/dlr_eoc_geoservice.yml
@@ -1,5 +1,4 @@
 dlr_eoc_geoservice:
-  name: dlr_eoc_geoservice
   priority: 0
   description: DLR Earth Observation Center (EOC) Geoservice
   roles:

--- a/eodag/resources/providers/earth_search.yml
+++ b/eodag/resources/providers/earth_search.yml
@@ -1,4 +1,4 @@
-!provider # MARK: earth_search
+earth_search:
   name: earth_search
   priority: 0
   roles:
@@ -18,7 +18,7 @@
     grid:code:
       - '{{"query":{{"mgrs:utm_zone":{{"eq":"{grid:code#slice_str(5,7,1)}"}},"mgrs:latitude_band":{{"eq":"{grid:code#slice_str(7,8,1)}"}},"mgrs:grid_square":{{"eq":"{grid:code#slice_str(8,10,1)}"}}}}}}'
       - 'MGRS-{mgrs:utm_zone}{mgrs:latitude_band}{mgrs:grid_square}'
-  search: !plugin
+  search:
     type: StacSearch
     api_endpoint: https://earth-search.aws.element84.com/v1/search
     need_auth: false
@@ -42,7 +42,7 @@
       max_limit: 500
     sort:
       sort_by_default:
-        - !!python/tuple [start_datetime, ASC]
+        -  [start_datetime, ASC]
       sort_param_mapping:
         id: id
         start_datetime: properties.datetime
@@ -87,7 +87,7 @@
       _collection: cop-dem-glo-90
     GENERIC_COLLECTION:
       _collection: '{collection}'
-  download: !plugin
+  download:
     type: AwsDownload
     ssl_verify: true
     products:
@@ -97,7 +97,7 @@
         complementary_url_key:
           - eodag:product_path
           - eodag:tile_path
-  auth: !plugin
+  auth:
     type: AwsAuth
     matching_url: s3://
     requester_pays: True

--- a/eodag/resources/providers/earth_search.yml
+++ b/eodag/resources/providers/earth_search.yml
@@ -1,5 +1,4 @@
 earth_search:
-  name: earth_search
   priority: 0
   roles:
     - host

--- a/eodag/resources/providers/earth_search_gcs.yml
+++ b/eodag/resources/providers/earth_search_gcs.yml
@@ -1,5 +1,4 @@
 earth_search_gcs:
-  name: earth_search_gcs
   priority: 0
   roles:
     - host

--- a/eodag/resources/providers/earth_search_gcs.yml
+++ b/eodag/resources/providers/earth_search_gcs.yml
@@ -1,11 +1,11 @@
-!provider # MARK: earth_search_gcs
+earth_search_gcs:
   name: earth_search_gcs
   priority: 0
   roles:
     - host
   description: Google Cloud Storage through Earth Search
   url: https://www.element84.com/earth-search/
-  search: !plugin
+  search:
     type: StacSearch
     api_endpoint: https://earth-search.aws.element84.com/v0/search
     need_auth: false
@@ -29,7 +29,7 @@
       max_limit: 500
     sort:
       sort_by_default:
-        - !!python/tuple [start_datetime, ASC]
+        -  [start_datetime, ASC]
       sort_param_mapping:
         id: id
         start_datetime: properties.datetime
@@ -56,7 +56,7 @@
         eodag:download_link: 's3://gcp-public-data-landsat/LC08/01/{wrsPath:03d}/{wrsRow:03d}/{title}'
     GENERIC_COLLECTION:
       _collection: '{collection}'
-  download: !plugin
+  download:
     type: AwsDownload
     s3_endpoint: https://storage.googleapis.com
     ignore_assets: True
@@ -64,7 +64,7 @@
     products:
       S2_MSI_L1C:
         default_bucket: 'gcp-public-data-sentinel-2'
-  auth: !plugin
+  auth:
     type: AwsAuth
     matching_url: s3://
     s3_endpoint: https://storage.googleapis.com

--- a/eodag/resources/providers/ecmwf.yml
+++ b/eodag/resources/providers/ecmwf.yml
@@ -1,11 +1,11 @@
-!provider # MARK: ecmwf
+ecmwf:
   name: ecmwf
   priority: 0
   description: ECMWF archive products
   roles:
     - host
   url: https://www.ecmwf.int
-  api: !plugin
+  api:
     type: EcmwfApi
     auth_endpoint: https://api.ecmwf.int/v1
     metadata_mapping:

--- a/eodag/resources/providers/ecmwf.yml
+++ b/eodag/resources/providers/ecmwf.yml
@@ -1,5 +1,4 @@
 ecmwf:
-  name: ecmwf
   priority: 0
   description: ECMWF archive products
   roles:

--- a/eodag/resources/providers/eocat.yml
+++ b/eodag/resources/providers/eocat.yml
@@ -1,5 +1,4 @@
 eocat:
-  name: eocat
   priority: 0
   description: ESA Catalog provides interoperable access, following ISO/OGC interface guidelines, to Earth Observation metadata
   roles:

--- a/eodag/resources/providers/eocat.yml
+++ b/eodag/resources/providers/eocat.yml
@@ -1,11 +1,11 @@
-!provider # MARK: eocat
+eocat:
   name: eocat
   priority: 0
   description: ESA Catalog provides interoperable access, following ISO/OGC interface guidelines, to Earth Observation metadata
   roles:
     - host
   url: https://eocat.esa.int/eo-catalogue
-  search: !plugin
+  search:
     type: StacSearch
     api_endpoint: 'https://eocat.esa.int/eo-catalogue/search'
     ssl_verify: false
@@ -27,10 +27,10 @@
   products:
     GENERIC_COLLECTION:
       _collection: '{collection}'
-  download: !plugin
+  download:
     type: HTTPDownload
     ignore_assets: true
-  auth: !plugin
+  auth:
     type: EOIAMAuth
     matching_url: https://[-\w\.]+.eo.esa.int
     auth_uri: 'https://eoiam-idp.eo.esa.int'

--- a/eodag/resources/providers/eumetsat_ds.yml
+++ b/eodag/resources/providers/eumetsat_ds.yml
@@ -1,5 +1,4 @@
 eumetsat_ds:
-  name: eumetsat_ds
   priority: 0
   description: EUMETSAT Data Store
   roles:

--- a/eodag/resources/providers/eumetsat_ds.yml
+++ b/eodag/resources/providers/eumetsat_ds.yml
@@ -1,4 +1,4 @@
-!provider # MARK: eumetsat_ds
+eumetsat_ds:
   name: eumetsat_ds
   priority: 0
   description: EUMETSAT Data Store
@@ -14,7 +14,7 @@
     sat:absolute_orbit:
       - orbit
       - '$.properties.acquisitionInformation[0].acquisitionParameters.orbitNumber'
-  search: !plugin
+  search:
     type: EumetsatDsSearch
     api_endpoint: 'https://api.eumetsat.int/data/search-products/1.0.0/os'
     need_auth: false
@@ -31,7 +31,7 @@
       max_limit: 500
     sort:
       sort_by_default:
-        - !!python/tuple [start_datetime, ASC]
+        -  [start_datetime, ASC]
       sort_by_tpl: '&sort={sort_param},{sort_order}'
       sort_param_mapping:
         start_datetime: start,time
@@ -460,12 +460,12 @@
       _collection: EO:EUM:DAT:0921
     GENERIC_COLLECTION:
       _collection: '{collection}'
-  download: !plugin
+  download:
     type: HTTPDownload
     extract: true
     ignore_assets: True
     ssl_verify: true
-  auth: !plugin
+  auth:
     type: TokenAuth
     matching_url: https://api.eumetsat.int
     auth_uri: 'https://api.eumetsat.int/token'

--- a/eodag/resources/providers/fedeo_ceda.yml
+++ b/eodag/resources/providers/fedeo_ceda.yml
@@ -1,11 +1,11 @@
-!provider # MARK: fedeo_ceda
+fedeo_ceda:
   name: fedeo_ceda
   priority: 0
   description: CEDA datasets through FedEO Catalog
   roles:
     - host
   url: https://fedeo.ceos.org/
-  search: !plugin
+  search:
     type: StacSearch
     api_endpoint: 'https://fedeo.ceos.org/search'
     ssl_verify: true
@@ -45,5 +45,5 @@
   products:
     GENERIC_COLLECTION:
       _collection: '{collection}'
-  download: !plugin
+  download:
     type: HTTPDownload

--- a/eodag/resources/providers/fedeo_ceda.yml
+++ b/eodag/resources/providers/fedeo_ceda.yml
@@ -1,5 +1,4 @@
 fedeo_ceda:
-  name: fedeo_ceda
   priority: 0
   description: CEDA datasets through FedEO Catalog
   roles:

--- a/eodag/resources/providers/geodes.yml
+++ b/eodag/resources/providers/geodes.yml
@@ -1,11 +1,11 @@
-!provider  # MARK: geodes
+geodes:
   name: geodes
   priority: 0
   roles:
     - host
   description: French National Space Agency (CNES) Earth Observation portal
   url: https://geodes.cnes.fr
-  search: !plugin
+  search:
     type: GeodesSearch
     api_endpoint: https://geodes-portal.cnes.fr/api/stac/search
     need_auth: false
@@ -28,7 +28,7 @@
     sort:
       sort_by_tpl: '{{"sortBy": [ {{"field": "{sort_param}", "direction": "{sort_order}" }} ] }}'
       sort_by_default:
-        - !!python/tuple [start_datetime, ASC]
+        -  [start_datetime, ASC]
       sort_param_mapping:
         id: identifier
         start_datetime: start_datetime
@@ -117,14 +117,14 @@
       _collection: THEIA_WATERQUAL_SENTINEL2_L2B
     GENERIC_COLLECTION:
       _collection: '{collection}'
-  download: !plugin
+  download:
     type: HTTPDownload
     ignore_assets: true
     archive_depth: 2
     auth_error_code:
       - 401
       - 403
-  auth: !plugin
+  auth:
     type: HTTPHeaderAuth
     matching_url: https://geodes-portal.cnes.fr
     headers:

--- a/eodag/resources/providers/geodes.yml
+++ b/eodag/resources/providers/geodes.yml
@@ -1,5 +1,4 @@
 geodes:
-  name: geodes
   priority: 0
   roles:
     - host

--- a/eodag/resources/providers/geodes_s3.yml
+++ b/eodag/resources/providers/geodes_s3.yml
@@ -1,5 +1,4 @@
 geodes_s3:
-  name: geodes_s3
   priority: 0
   roles:
     - host

--- a/eodag/resources/providers/geodes_s3.yml
+++ b/eodag/resources/providers/geodes_s3.yml
@@ -1,11 +1,11 @@
-!provider  # MARK: geodes_s3
+geodes_s3:
   name: geodes_s3
   priority: 0
   roles:
     - host
   description: French National Space Agency (CNES) Earth Observation portal with internal s3 Datalake
   url: https://geodes.cnes.fr
-  search: !plugin
+  search:
     type: StacListAssets
     api_endpoint: https://geodes-portal.cnes.fr/api/stac/search
     s3_endpoint: https://s3.datalake.cnes.fr
@@ -29,7 +29,7 @@
     sort:
       sort_by_tpl: '{{"sortBy": [ {{"field": "{sort_param}", "direction": "{sort_order}" }} ] }}'
       sort_by_default:
-        - !!python/tuple [start_datetime, ASC]
+        -  [start_datetime, ASC]
       sort_param_mapping:
         id: identifier
         start_datetime: start_datetime
@@ -118,11 +118,11 @@
       _collection: THEIA_WATERQUAL_SENTINEL2_L2B
     GENERIC_COLLECTION:
       _collection: '{collection}'
-  download: !plugin
+  download:
     type: AwsDownload
     s3_endpoint: https://s3.datalake.cnes.fr
     ignore_assets: True
-  auth: !plugin
+  auth:
     type: AwsAuth
     auth_error_code: 403
     s3_endpoint: https://s3.datalake.cnes.fr

--- a/eodag/resources/providers/hydroweb_next.yml
+++ b/eodag/resources/providers/hydroweb_next.yml
@@ -1,5 +1,4 @@
 hydroweb_next:
-  name: hydroweb_next
   priority: 0
   roles:
     - host

--- a/eodag/resources/providers/hydroweb_next.yml
+++ b/eodag/resources/providers/hydroweb_next.yml
@@ -1,11 +1,11 @@
-!provider # MARK: hydroweb_next
+hydroweb_next:
   name: hydroweb_next
   priority: 0
   roles:
     - host
   description: hydroweb.next thematic hub for hydrology data access
   url: https://hydroweb.next.theia-land.fr
-  search: !plugin
+  search:
     type: StacSearch
     api_endpoint: https://hydroweb.next.theia-land.fr/api/v1/rs-catalog/stac/search
     need_auth: true
@@ -22,7 +22,7 @@
       next_page_token_key: page
     sort:
       sort_by_default:
-        - !!python/tuple [start_datetime, ASC]
+        -  [start_datetime, ASC]
       sort_param_mapping:
         id: id
         start_datetime: properties.start_datetime
@@ -51,11 +51,11 @@
   products:
     GENERIC_COLLECTION:
       _collection: '{collection}'
-  download: !plugin
+  download:
     type: HTTPDownload
     auth_error_code: 401
     ssl_verify: true
-  auth: !plugin
+  auth:
     type: HTTPHeaderAuth
     matching_url: https://hydroweb.next.theia-land.fr
     headers:

--- a/eodag/resources/providers/meteoblue.yml
+++ b/eodag/resources/providers/meteoblue.yml
@@ -1,11 +1,11 @@
-!provider # MARK: meteoblue
+meteoblue:
   name: meteoblue
   priority: 0
   roles:
     - host
   description: Meteoblue
   url: https://www.meteoblue.com
-  search: !plugin
+  search:
     type: MeteoblueSearch
     api_endpoint: 'https://my.meteoblue.com/dataset/query'
     need_auth: true
@@ -65,7 +65,7 @@
     GENERIC_COLLECTION:
       _collection: '{collection}'
       geometry: {"type": "Polygon", "coordinates": [[[180, -90], [180, 90], [-180, 90], [-180, -90], [180, -90]]]}
-  download: !plugin
+  download:
     type: HTTPDownload
     ssl_verify: true
     method: POST
@@ -89,7 +89,7 @@
           eodag:order_id: '$.json.id'
           eodag:download_link: 'http://queueresults.meteoblue.com/{eodag:order_id}'
           eodag:download_method: '{$.null#replace_str("Not Available","GET")}'
-  auth: !plugin
+  auth:
     type: HttpQueryStringAuth
     matching_url: https?://[a-z]+.meteoblue.com
     auth_uri: 'http://my.meteoblue.com/dataset/meta?dataset=NEMSAUTO'

--- a/eodag/resources/providers/meteoblue.yml
+++ b/eodag/resources/providers/meteoblue.yml
@@ -1,5 +1,4 @@
 meteoblue:
-  name: meteoblue
   priority: 0
   roles:
     - host

--- a/eodag/resources/providers/planetary_computer.yml
+++ b/eodag/resources/providers/planetary_computer.yml
@@ -1,5 +1,4 @@
 planetary_computer:
-  name: planetary_computer
   priority: 0
   roles:
     - host

--- a/eodag/resources/providers/planetary_computer.yml
+++ b/eodag/resources/providers/planetary_computer.yml
@@ -1,11 +1,11 @@
-!provider # MARK: planetary_computer
+planetary_computer:
   name: planetary_computer
   priority: 0
   roles:
     - host
   description: Microsoft Planetary Computer
   url: https://planetarycomputer.microsoft.com
-  search: !plugin
+  search:
     type: StacSearch
     api_endpoint: https://planetarycomputer.microsoft.com/api/stac/v1/search
     need_auth: false
@@ -43,11 +43,11 @@
       _collection: naip
     GENERIC_COLLECTION:
       _collection: '{collection}'
-  download: !plugin
+  download:
     type: HTTPDownload
     auth_error_code: 403
     ssl_verify: true
-  auth: !plugin
+  auth:
     type: SASAuth
     matching_url: https://[-\w\.]+.blob.core.windows.net
     auth_uri: 'https://planetarycomputer.microsoft.com/api/sas/v1/sign?href={url}'

--- a/eodag/resources/providers/sara.yml
+++ b/eodag/resources/providers/sara.yml
@@ -1,5 +1,4 @@
 sara:
-  name: sara
   priority: 0
   description: Sentinel Australasia Regional Access
   roles:

--- a/eodag/resources/providers/sara.yml
+++ b/eodag/resources/providers/sara.yml
@@ -1,11 +1,11 @@
-!provider # MARK: sara
+sara:
   name: sara
   priority: 0
   description: Sentinel Australasia Regional Access
   roles:
     - host
   url: https://www.copernicus.gov.au/
-  search: !plugin
+  search:
     type: QueryStringSearch
     # The endpoint is based off of the collection. There is a generic endpoint,
     # but can be very slow if not enough metdata is provided.
@@ -20,7 +20,7 @@
       max_limit: 500
     sort:
       sort_by_default:
-        - !!python/tuple [start_datetime, ASC]
+        -  [start_datetime, ASC]
       sort_by_tpl: '&sortParam={sort_param}&sortOrder={sort_order}'
       sort_param_mapping:
         start_datetime: startDate
@@ -268,14 +268,14 @@
       processing:level: LEVEL-2
     GENERIC_COLLECTION:
       _collection: '{collection}'
-  download: !plugin
+  download:
     type: HTTPDownload
     extract: true
     archive_depth: 2
     order_enabled: true
     auth_error_code: 403
     ssl_verify: true
-  auth: !plugin
+  auth:
     type: GenericAuth
     matching_url: https://copernicus.nci.org.au
     method: basic

--- a/eodag/resources/providers/theia.yml
+++ b/eodag/resources/providers/theia.yml
@@ -1,5 +1,4 @@
 theia:
-  name: theia
   priority: 0
   description: Data Terra Theia, environmental thematic hub for land data access.
   roles:

--- a/eodag/resources/providers/theia.yml
+++ b/eodag/resources/providers/theia.yml
@@ -1,11 +1,11 @@
-!provider # MARK: theia
+theia:
   name: theia
   priority: 0
   description: Data Terra Theia, environmental thematic hub for land data access.
   roles:
     - host
   url: https://api.datastore-mtd.theia.data-terra.org/
-  search: !plugin
+  search:
     type: StacSearch
     api_endpoint: 'https://api.datastore-mtd.theia.data-terra.org/search'
     timeout: 90
@@ -18,7 +18,7 @@
         platform: '{$.summaries.platform#csv_list}'
     sort:
       sort_by_default:
-        - !!python/tuple [start_datetime, ASC]
+        -  [start_datetime, ASC]
       sort_param_mapping:
         id: id
         start_datetime: properties.datetime
@@ -28,9 +28,9 @@
   products:
     GENERIC_COLLECTION:
       _collection: '{collection}'
-  download: !plugin
+  download:
     type: HTTPDownload
-  auth: !plugin
+  auth:
     type: SASAuth
     matching_url: https://s3-data.meso.umontpellier.fr
     auth_uri: 'https://signing.stac.teledetection.fr/sign?url={url}'

--- a/eodag/resources/providers/usgs.yml
+++ b/eodag/resources/providers/usgs.yml
@@ -1,11 +1,11 @@
-!provider # MARK: usgs
+usgs:
   name: usgs
   priority: 0
   description: U.S geological survey catalog for Landsat products
   roles:
     - host
   url: https://earthexplorer.usgs.gov/
-  api: !plugin
+  api:
     type: UsgsApi
     need_auth: true
     pagination:

--- a/eodag/resources/providers/usgs.yml
+++ b/eodag/resources/providers/usgs.yml
@@ -1,5 +1,4 @@
 usgs:
-  name: usgs
   priority: 0
   description: U.S geological survey catalog for Landsat products
   roles:

--- a/eodag/resources/providers/usgs_satapi_aws.yml
+++ b/eodag/resources/providers/usgs_satapi_aws.yml
@@ -1,5 +1,4 @@
 usgs_satapi_aws:
-  name: usgs_satapi_aws
   priority: 0
   roles:
     - host

--- a/eodag/resources/providers/usgs_satapi_aws.yml
+++ b/eodag/resources/providers/usgs_satapi_aws.yml
@@ -1,11 +1,11 @@
-!provider # MARK: usgs_satapi_aws
+usgs_satapi_aws:
   name: usgs_satapi_aws
   priority: 0
   roles:
     - host
   description: USGS Landsatlook SAT API
   url: https://landsatlook.usgs.gov/stac-server
-  search: !plugin
+  search:
     type: StacSearch
     api_endpoint: https://landsatlook.usgs.gov/stac-server/search
     need_auth: false
@@ -39,10 +39,10 @@
       _collection: landsat-c2l2alb-ta
     GENERIC_COLLECTION:
       _collection: '{collection}'
-  download: !plugin
+  download:
     type: AwsDownload
     ssl_verify: true
-  auth: !plugin
+  auth:
     type: AwsAuth
     matching_url: s3://
     requester_pays: True

--- a/eodag/resources/providers/wekeo_cmems.yml
+++ b/eodag/resources/providers/wekeo_cmems.yml
@@ -1,4 +1,4 @@
-!provider  # MARK: wekeo_cmems
+wekeo_cmems:
   name: wekeo_cmems
   group: wekeo
   priority: 0
@@ -6,7 +6,7 @@
     - host
   description: WEkEO - Copernicus Marine Service
   url: https://www.wekeo.eu/
-  search: !plugin
+  search:
     type: PostJsonSearch
     api_endpoint: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/search'
     need_auth: true
@@ -70,7 +70,7 @@
   products:
     GENERIC_COLLECTION:
       _collection: '{collection}'
-  auth: !plugin
+  auth:
     type: TokenAuth
     matching_url: https://[-\w\.]+.wekeo2.eu
     auth_uri: 'https://gateway.prod.wekeo2.eu/hda-broker/gettoken'
@@ -78,7 +78,7 @@
     token_type: json
     token_key: access_token
     refresh_token_key: refresh_token
-  download: !plugin
+  download:
     type: HTTPDownload
     auth_error_code: 401
     order_enabled: true

--- a/eodag/resources/providers/wekeo_cmems.yml
+++ b/eodag/resources/providers/wekeo_cmems.yml
@@ -1,5 +1,4 @@
 wekeo_cmems:
-  name: wekeo_cmems
   group: wekeo
   priority: 0
   roles:

--- a/eodag/resources/providers/wekeo_ecmwf.yml
+++ b/eodag/resources/providers/wekeo_ecmwf.yml
@@ -1,5 +1,4 @@
 wekeo_ecmwf:
-  name: wekeo_ecmwf
   group: wekeo
   priority: 0
   roles:

--- a/eodag/resources/providers/wekeo_ecmwf.yml
+++ b/eodag/resources/providers/wekeo_ecmwf.yml
@@ -1,4 +1,4 @@
-!provider  # MARK: wekeo_ecmwf
+wekeo_ecmwf:
   name: wekeo_ecmwf
   group: wekeo
   priority: 0
@@ -37,7 +37,7 @@
         }}
       - $.properties.startdate
     end_datetime: $.properties.enddate
-  search: !plugin
+  search:
     type: WekeoECMWFSearch
     api_endpoint: https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/search
     need_auth: true
@@ -276,7 +276,7 @@
           # longitude/latitude to order from wekeo_ecmwf, location to validate against cop_ads constraints
           - '{{"longitude": {geometry#to_longitude_latitude}["lon"], "latitude": {geometry#to_longitude_latitude}["lat"], "location": {{"longitude": {geometry#to_longitude_latitude}["lon"], "latitude": {geometry#to_longitude_latitude}["lat"]}}}}'
           - '$.null'
-  auth: !plugin
+  auth:
     type: TokenAuth
     auth_uri: 'https://gateway.prod.wekeo2.eu/hda-broker/gettoken'
     refresh_uri: 'https://gateway.prod.wekeo2.eu/hda-broker/refreshtoken'
@@ -284,7 +284,7 @@
     token_key: access_token
     refresh_token_key: refresh_token
     token_expiration_key: expires_in
-  download: !plugin
+  download:
     type: HTTPDownload
     auth_error_code: 401
     order_enabled: true

--- a/eodag/resources/providers/wekeo_main.yml
+++ b/eodag/resources/providers/wekeo_main.yml
@@ -23,8 +23,6 @@
     sar:polarizations:
       - '{{"polarisationChannels": "{sar:polarizations#csv_list(%26)}"}}'
       - '$.null'
-    sar:polarizations:
-      - '{{"polarisationChannels": "{sar:polarizations#csv_list(%26)}"}}'
     sat:relative_orbit:
       - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
       - '$.null'

--- a/eodag/resources/providers/wekeo_main.yml
+++ b/eodag/resources/providers/wekeo_main.yml
@@ -23,6 +23,8 @@
     sar:polarizations:
       - '{{"polarisationChannels": "{sar:polarizations#csv_list(%26)}"}}'
       - '$.null'
+    sar:polarizations:
+      - '{{"polarisationChannels": "{sar:polarizations#csv_list(%26)}"}}'
     sat:relative_orbit:
       - '{{"relativeOrbitNumber": "{sat:relative_orbit}"}}'
       - '$.null'

--- a/eodag/resources/providers/wekeo_main.yml
+++ b/eodag/resources/providers/wekeo_main.yml
@@ -1,4 +1,4 @@
-!provider  # MARK: wekeo_main
+wekeo_main:
   name: wekeo_main # wekeo_main
   group: wekeo
   priority: 0
@@ -44,7 +44,7 @@
           "enddate": "{id#replace_str(r'^.*_([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])([0-9][0-9])_.*$',r'\1-\2-\3T\4%3A\5%3A00Z')}"
         }}
       - '{$.id#remove_extension}'
-  search: !plugin
+  search:
     type: WekeoSearch
     api_endpoint: https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/search
     timeout: 60
@@ -454,7 +454,7 @@
           - '{{"uid": "{id}"}}'
           - '$.id'
         eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "EO:EEA:DAT:CLMS_HRVPP_VPP-LAEA"}}'
-  auth: !plugin
+  auth:
     type: TokenAuth
     matching_url: https://[-\w\.]+.wekeo2.eu
     auth_uri: 'https://gateway.prod.wekeo2.eu/hda-broker/gettoken'
@@ -463,7 +463,7 @@
     token_key: access_token
     refresh_token_key: refresh_token
     token_expiration_key: expires_in
-  download: !plugin
+  download:
     type: HTTPDownload
     base_uri: https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess
     flatten_top_dirs: true

--- a/eodag/resources/providers/wekeo_main.yml
+++ b/eodag/resources/providers/wekeo_main.yml
@@ -1,5 +1,4 @@
 wekeo_main:
-  name: wekeo_main # wekeo_main
   group: wekeo
   priority: 0
   roles:

--- a/eodag/types/__init__.py
+++ b/eodag/types/__init__.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy as copy_deepcopy
 from typing import Annotated, Any, Literal, Optional, Type, Union, get_args, get_origin
 
 from annotated_types import Gt, Lt
@@ -29,7 +30,6 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, PydanticUndefined
 from typing_extensions import TypedDict
 
-from eodag.utils import copy_deepcopy
 from eodag.utils.exceptions import ValidationError
 
 # Types mapping from JSON Schema and OpenAPI 3.1.0 specifications to Python

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -1480,19 +1480,21 @@ def _get_legacy_aware_yaml_loader() -> type:
     # Constructor for !provider tag - wrap the content with provider name as key
     def provider_constructor(loader, node):
         if isinstance(node, yaml.MappingNode):
-            mapping = loader.construct_mapping(node)
-            # Extract the provider name from the config, wrap it as a key
-            if "name" in mapping:
-                provider_name = mapping["name"]
-                return {provider_name: mapping}
-            # If no name is found, return as-is (will likely cause validation error)
-            return mapping
+            # Reuse legacy YAMLObject deserialization logic (and deprecation warning)
+            # from ProviderConfig. Since load_config already handles ProviderConfigClass
+            # objects directly, return the object as-is.
+            from eodag.api.provider import ProviderConfig
+
+            provider_config = ProviderConfig.from_yaml(loader, node)
+            return provider_config
         return None
 
-    # Constructor for !plugin tag - just return the dict as-is
+    # Constructor for !plugin tag - reuse legacy deserialization logic
     def plugin_constructor(loader, node):
         if isinstance(node, yaml.MappingNode):
-            return loader.construct_mapping(node)
+            from eodag.config import PluginConfig
+
+            return PluginConfig.from_yaml(loader, node)
         return None
 
     # Constructor for !!python/tuple tag - convert to tuple

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, Union, cast
 from urllib.parse import urlparse, urlsplit
 from urllib.request import url2pathname
 
+import yaml
+
 if sys.version_info >= (3, 12):
     from typing import Unpack  # type: ignore # noqa
 else:
@@ -1461,14 +1463,62 @@ def cached_parse(str_to_parse: str) -> JSONPath:
     return parse(str_to_parse)
 
 
+def _get_legacy_aware_yaml_loader() -> type:
+    """Create a YAML loader that supports both legacy tags (!provider, !plugin, !!python/tuple) and safe loading.
+
+    Uses CSafeLoader for performance (C implementation) while adding support for legacy EODAG tags.
+
+    :returns: A YAML Loader class that handles legacy tags while maintaining security.
+    """
+
+    class LegacyAwareLoader(yaml.CSafeLoader):
+        """YAML loader that accepts legacy EODAG tags (!provider, !plugin, !!python/tuple)
+        and converts them to safe Python objects. Uses CSafeLoader for performance."""
+
+        pass
+
+    # Constructor for !provider tag - wrap the content with provider name as key
+    def provider_constructor(loader, node):
+        if isinstance(node, yaml.MappingNode):
+            mapping = loader.construct_mapping(node)
+            # Extract the provider name from the config, wrap it as a key
+            if "name" in mapping:
+                provider_name = mapping["name"]
+                return {provider_name: mapping}
+            # If no name is found, return as-is (will likely cause validation error)
+            return mapping
+        return None
+
+    # Constructor for !plugin tag - just return the dict as-is
+    def plugin_constructor(loader, node):
+        if isinstance(node, yaml.MappingNode):
+            return loader.construct_mapping(node)
+        return None
+
+    # Constructor for !!python/tuple tag - convert to tuple
+    def python_tuple_constructor(loader, node):
+        if isinstance(node, yaml.SequenceNode):
+            return tuple(loader.construct_sequence(node))
+        elif isinstance(node, yaml.ScalarNode):
+            return (loader.construct_scalar(node),)
+        return None
+
+    # Register the constructors for legacy tags
+    LegacyAwareLoader.add_constructor("!provider", provider_constructor)
+    LegacyAwareLoader.add_constructor("!plugin", plugin_constructor)
+    LegacyAwareLoader.add_constructor(
+        "tag:yaml.org,2002:python/tuple", python_tuple_constructor
+    )
+
+    return LegacyAwareLoader
+
+
 @functools.lru_cache()
 def _mutable_cached_yaml_load(config_path: str) -> Any:
-    import yaml
-
     with open(
         os.path.abspath(os.path.realpath(config_path)), mode="r", encoding="utf-8"
     ) as fh:
-        return yaml.load(fh, Loader=yaml.CSafeLoader)
+        return yaml.load(fh, Loader=_get_legacy_aware_yaml_loader())
 
 
 def cached_yaml_load(config_path: str) -> dict[str, Any]:
@@ -1482,10 +1532,8 @@ def cached_yaml_load(config_path: str) -> dict[str, Any]:
 
 @functools.lru_cache()
 def _mutable_cached_yaml_load_all(config_path: str) -> list[Any]:
-    import yaml
-
     with open(config_path, "r") as fh:
-        return list(yaml.load_all(fh, Loader=yaml.CSafeLoader))
+        return list(yaml.load_all(fh, Loader=_get_legacy_aware_yaml_loader()))
 
 
 def cached_yaml_load_all(config_path: str) -> list[Any]:

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -41,7 +41,6 @@ import types
 import unicodedata
 import warnings
 from collections import defaultdict
-from copy import deepcopy as copy_deepcopy
 from email.message import Message
 from glob import glob
 from importlib.metadata import metadata
@@ -51,8 +50,6 @@ from tempfile import mkdtemp
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, Union, cast
 from urllib.parse import urlparse, urlsplit
 from urllib.request import url2pathname
-
-import yaml
 
 if sys.version_info >= (3, 12):
     from typing import Unpack  # type: ignore # noqa
@@ -66,6 +63,7 @@ from .exceptions import MisconfiguredError
 from .logging import get_disable_tqdm
 from .logging import logging as eodag_logging
 from .streamresponse import StreamResponse, StreamResponseContent
+from .yaml import LegacyAwareLoader, cached_yaml_load, cached_yaml_load_all
 
 if TYPE_CHECKING:
     from jsonpath_ng import JSONPath, jsonpath
@@ -1463,92 +1461,6 @@ def cached_parse(str_to_parse: str) -> JSONPath:
     return parse(str_to_parse)
 
 
-def _get_legacy_aware_yaml_loader() -> type:
-    """Create a YAML loader that supports both legacy tags (!provider, !plugin, !!python/tuple) and safe loading.
-
-    Uses CSafeLoader for performance (C implementation) while adding support for legacy EODAG tags.
-
-    :returns: A YAML Loader class that handles legacy tags while maintaining security.
-    """
-
-    class LegacyAwareLoader(yaml.CSafeLoader):
-        """YAML loader that accepts legacy EODAG tags (!provider, !plugin, !!python/tuple)
-        and converts them to safe Python objects. Uses CSafeLoader for performance."""
-
-        pass
-
-    # Constructor for !provider tag - wrap the content with provider name as key
-    def provider_constructor(loader, node):
-        if isinstance(node, yaml.MappingNode):
-            # Reuse legacy YAMLObject deserialization logic (and deprecation warning)
-            # from ProviderConfig. Since load_config already handles ProviderConfigClass
-            # objects directly, return the object as-is.
-            from eodag.api.provider import ProviderConfig
-
-            provider_config = ProviderConfig.from_yaml(loader, node)
-            return provider_config
-        return None
-
-    # Constructor for !plugin tag - reuse legacy deserialization logic
-    def plugin_constructor(loader, node):
-        if isinstance(node, yaml.MappingNode):
-            from eodag.config import PluginConfig
-
-            return PluginConfig.from_yaml(loader, node)
-        return None
-
-    # Constructor for !!python/tuple tag - convert to tuple
-    def python_tuple_constructor(loader, node):
-        if isinstance(node, yaml.SequenceNode):
-            return tuple(loader.construct_sequence(node))
-        elif isinstance(node, yaml.ScalarNode):
-            return (loader.construct_scalar(node),)
-        return None
-
-    # Register the constructors for legacy tags
-    LegacyAwareLoader.add_constructor("!provider", provider_constructor)
-    LegacyAwareLoader.add_constructor("!plugin", plugin_constructor)
-    LegacyAwareLoader.add_constructor(
-        "tag:yaml.org,2002:python/tuple", python_tuple_constructor
-    )
-
-    return LegacyAwareLoader
-
-
-@functools.lru_cache()
-def _mutable_cached_yaml_load(config_path: str) -> Any:
-    with open(
-        os.path.abspath(os.path.realpath(config_path)), mode="r", encoding="utf-8"
-    ) as fh:
-        return yaml.load(fh, Loader=_get_legacy_aware_yaml_loader())
-
-
-def cached_yaml_load(config_path: str) -> dict[str, Any]:
-    """Cached :func:`yaml.load`
-
-    :param config_path: path to the yaml configuration file
-    :returns: loaded yaml configuration
-    """
-    return copy_deepcopy(_mutable_cached_yaml_load(config_path))
-
-
-@functools.lru_cache()
-def _mutable_cached_yaml_load_all(config_path: str) -> list[Any]:
-    with open(config_path, "r") as fh:
-        return list(yaml.load_all(fh, Loader=_get_legacy_aware_yaml_loader()))
-
-
-def cached_yaml_load_all(config_path: str) -> list[Any]:
-    """Cached :func:`yaml.load_all`
-
-    Load all configurations stored in the configuration file as separated yaml documents
-
-    :param config_path: path to the yaml configuration file
-    :returns: list of configurations
-    """
-    return copy_deepcopy(_mutable_cached_yaml_load_all(config_path))
-
-
 def get_bucket_name_and_prefix(
     url: str, bucket_path_level: Optional[int] = None
 ) -> tuple[Optional[str], Optional[str]]:
@@ -1961,6 +1873,7 @@ __all__ = [
     "md5sum",
     "obj_md5sum",
     "cached_parse",
+    "LegacyAwareLoader",
     "cached_yaml_load",
     "cached_yaml_load_all",
     "get_bucket_name_and_prefix",

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -1468,7 +1468,7 @@ def _mutable_cached_yaml_load(config_path: str) -> Any:
     with open(
         os.path.abspath(os.path.realpath(config_path)), mode="r", encoding="utf-8"
     ) as fh:
-        return yaml.load(fh, Loader=yaml.SafeLoader)
+        return yaml.load(fh, Loader=yaml.CSafeLoader)
 
 
 def cached_yaml_load(config_path: str) -> dict[str, Any]:
@@ -1485,7 +1485,7 @@ def _mutable_cached_yaml_load_all(config_path: str) -> list[Any]:
     import yaml
 
     with open(config_path, "r") as fh:
-        return list(yaml.load_all(fh, Loader=yaml.Loader))
+        return list(yaml.load_all(fh, Loader=yaml.CSafeLoader))
 
 
 def cached_yaml_load_all(config_path: str) -> list[Any]:

--- a/eodag/utils/yaml.py
+++ b/eodag/utils/yaml.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026, CS GROUP - France, https://www.csgroup.eu/
+#
+# This file is part of EODAG project
+#     https://www.github.com/CS-SI/EODAG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import functools
+import os
+from copy import deepcopy as copy_deepcopy
+from typing import Any
+
+import yaml
+
+
+class LegacyAwareLoader(yaml.CSafeLoader):
+    """YAML loader that accepts legacy EODAG tags (!provider, !plugin, !!python/tuple)
+    and converts them to safe Python objects. Uses CSafeLoader for performance."""
+
+
+# Constructor for !provider tag - reuse legacy deserialization logic
+# from ProviderConfig and keep deprecation warnings.
+def provider_constructor(loader, node):
+    if isinstance(node, yaml.MappingNode):
+        from eodag.api.provider import ProviderConfig
+
+        return ProviderConfig.from_yaml(loader, node)
+    return None
+
+
+# Constructor for !plugin tag - reuse legacy deserialization logic.
+def plugin_constructor(loader, node):
+    if isinstance(node, yaml.MappingNode):
+        from eodag.config import PluginConfig
+
+        return PluginConfig.from_yaml(loader, node)
+    return None
+
+
+# Constructor for !!python/tuple tag - convert to tuple.
+def python_tuple_constructor(loader, node):
+    if isinstance(node, yaml.SequenceNode):
+        return tuple(loader.construct_sequence(node))
+    elif isinstance(node, yaml.ScalarNode):
+        return (loader.construct_scalar(node),)
+    return None
+
+
+# Register constructors for legacy tags.
+LegacyAwareLoader.add_constructor("!provider", provider_constructor)
+LegacyAwareLoader.add_constructor("!plugin", plugin_constructor)
+LegacyAwareLoader.add_constructor(
+    "tag:yaml.org,2002:python/tuple", python_tuple_constructor
+)
+
+
+@functools.lru_cache()
+def _mutable_cached_yaml_load(config_path: str) -> Any:
+    with open(
+        os.path.abspath(os.path.realpath(config_path)), mode="r", encoding="utf-8"
+    ) as fh:
+        return yaml.load(fh, Loader=LegacyAwareLoader)
+
+
+def cached_yaml_load(config_path: str) -> dict[str, Any]:
+    """Cached :func:`yaml.load`
+
+    :param config_path: path to the yaml configuration file
+    :returns: loaded yaml configuration
+    """
+    return copy_deepcopy(_mutable_cached_yaml_load(config_path))
+
+
+@functools.lru_cache()
+def _mutable_cached_yaml_load_all(config_path: str) -> list[Any]:
+    with open(config_path, "r") as fh:
+        return list(yaml.load_all(fh, Loader=LegacyAwareLoader))
+
+
+def cached_yaml_load_all(config_path: str) -> list[Any]:
+    """Cached :func:`yaml.load_all`
+
+    Load all configurations stored in the configuration file as separated yaml documents
+
+    :param config_path: path to the yaml configuration file
+    :returns: list of configurations
+    """
+    return copy_deepcopy(_mutable_cached_yaml_load_all(config_path))
+
+
+__all__ = [
+    "LegacyAwareLoader",
+    "cached_yaml_load",
+    "cached_yaml_load_all",
+]

--- a/eodag/utils/yaml.py
+++ b/eodag/utils/yaml.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import functools
 import os
+import warnings
 from copy import deepcopy as copy_deepcopy
 from typing import Any
 
@@ -37,6 +38,13 @@ def provider_constructor(loader, node):
     if isinstance(node, yaml.MappingNode):
         from eodag.api.provider import ProviderConfig
 
+        warnings.warn(
+            "Usage of deprecated YAML tag '!provider' for provider configuration "
+            "(Please use plain YAML mappings instead)"
+            " -- Deprecated since v4.5.0",
+            FutureWarning,
+            stacklevel=2,
+        )
         return ProviderConfig.from_yaml(loader, node)
     return None
 
@@ -46,6 +54,13 @@ def plugin_constructor(loader, node):
     if isinstance(node, yaml.MappingNode):
         from eodag.config import PluginConfig
 
+        warnings.warn(
+            "Usage of deprecated YAML tag '!plugin' for plugin configuration "
+            "(Please use plain YAML mappings instead)"
+            " -- Deprecated since v4.5.0",
+            FutureWarning,
+            stacklevel=2,
+        )
         return PluginConfig.from_yaml(loader, node)
     return None
 

--- a/tests/context.py
+++ b/tests/context.py
@@ -100,10 +100,10 @@ from eodag.utils import (
     sanitize,
     parse_header,
     get_ssl_context,
-    cached_yaml_load_all,
     StreamResponse,
     MockResponse,
 )
+from eodag.utils.yaml import cached_yaml_load_all
 from eodag.utils.dates import get_timestamp, to_iso_utc_string
 from eodag.utils.env import is_env_var_true
 from eodag.utils.requests import fetch_json

--- a/tests/integration/test_config_ext_plugin.py
+++ b/tests/integration/test_config_ext_plugin.py
@@ -22,6 +22,7 @@ import sys
 import unittest
 from tempfile import TemporaryDirectory
 
+import pytest
 from pytest import MonkeyPatch
 
 from tests import TEST_RESOURCES_PATH
@@ -77,7 +78,11 @@ class TestExternalPluginConfig(unittest.TestCase):
 
             # New EODataAccessGateway instance, check if new conf has been loaded
             # (+1 from legacy providers.yml, +1 from providers/ dir)
-            self.dag = EODataAccessGateway()
+            with pytest.warns(
+                (DeprecationWarning, FutureWarning),
+                match=r"Usage of deprecated (YAML tag|environment variable)",
+            ):
+                self.dag = EODataAccessGateway()
             self.assertEqual(len(self.dag._providers), default_providers_count + 2)
             self.assertIn("fakeplugin_provider", self.dag._providers)
             self.assertIn("fakeplugin_provider2", self.dag._providers)

--- a/tests/resources/fake_ext_plugin/eodag_fakeplugin/providers.yml
+++ b/tests/resources/fake_ext_plugin/eodag_fakeplugin/providers.yml
@@ -1,8 +1,8 @@
 ---
-fakeplugin_provider:
+!provider
   name: fakeplugin_provider
   priority: 0
-  api:
+  api: !plugin
     type: FakePluginAPI
     endpoint: 'https://fakeplugin-endpoint'
   products:

--- a/tests/resources/fake_ext_plugin/eodag_fakeplugin/providers.yml
+++ b/tests/resources/fake_ext_plugin/eodag_fakeplugin/providers.yml
@@ -1,8 +1,8 @@
 ---
-!provider
+fakeplugin_provider:
   name: fakeplugin_provider
   priority: 0
-  api: !plugin
+  api:
     type: FakePluginAPI
     endpoint: 'https://fakeplugin-endpoint'
   products:

--- a/tests/resources/mundi_conf.yml
+++ b/tests/resources/mundi_conf.yml
@@ -1,6 +1,6 @@
-!provider
+mundi:
   name: mundi
-  search: !plugin
+  search:
     type: QueryStringSearch
     api_endpoint: 'https://{_collection}.browse.catalog.mundiwebservices.com/opensearch'
     need_auth: false
@@ -62,7 +62,7 @@
         _collection: '{collection}'
         instruments: '{instruments}'
         processing:level: '{processing:level}'
-  auth: !plugin
+  auth:
     type: HTTPHeaderAuth
     headers:
         Cookie: "seeedtoken={apikey}"

--- a/tests/resources/onda_conf.yml
+++ b/tests/resources/onda_conf.yml
@@ -1,11 +1,11 @@
-!provider # MARK: onda
+onda:
   name: onda
   priority: 0
   description: Serco DIAS
   roles:
     - host
   url: https://www.onda-dias.eu/cms/
-  search: !plugin
+  search:
     type: ODataV4Search
     api_endpoint: 'https://catalogue.onda-dias.eu/dias-catalogue/Products'
     timeout: 60
@@ -26,7 +26,8 @@
       max_limit: 2_000
     sort:
       sort_by_default:
-        - !!python/tuple [startTimeFromAscendingNode, ASC]
+        - startTimeFromAscendingNode
+        - ASC
       sort_by_tpl: '&$orderby={sort_param} {sort_order}'
       sort_param_mapping:
         startTimeFromAscendingNode: beginPosition
@@ -292,7 +293,7 @@
     GENERIC_COLLECTION:
       _collection: '{collection}'
       constellation: '{constellation}'
-  download: !plugin
+  download:
     type: HTTPDownload
     # base_uri used to parse eodag:download_link
     base_uri: 'https://catalogue.onda-dias.eu/dias-catalogue/Products'
@@ -304,5 +305,5 @@
     ssl_verify: true
     order_headers:
       Content-Type: application/json
-  auth: !plugin
+  auth:
     type: GenericAuth

--- a/tests/resources/providers/file_providers_override.yml
+++ b/tests/resources/providers/file_providers_override.yml
@@ -15,13 +15,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-!provider
+foo_provider:
   name: foo_provider
   priority: 2
   roles:
     - host
   description: provider for test
-  search: !plugin
+  search:
     type: StacSearch
     api_endpoint: https://foo.bar/search
   products:
@@ -31,6 +31,6 @@
       _collection: TEST_PRODUCT_2
     GENERIC_COLLECTION:
       _collection: '{collection}'
-  download: !plugin
+  download:
     type: HTTPDownload
     base_uri: https://foo.bar

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,7 @@ from importlib.resources import files as res_files
 from io import StringIO
 from tempfile import TemporaryDirectory
 
+import pytest
 import yaml
 
 from eodag.api.provider import ProviderConfig, ProvidersDict
@@ -46,14 +47,22 @@ from tests.context import (
 
 def load_provider_config_from_string(yaml_string: str) -> ProviderConfig:
     """Load a provider config from a YAML string using legacy-aware YAML tags."""
-    data = yaml.load(StringIO(yaml_string), Loader=LegacyAwareLoader)
+    with pytest.warns(
+        FutureWarning,
+        match=r".*deprecated YAML tag '!(provider|plugin)'.*",
+    ):
+        data = yaml.load(StringIO(yaml_string), Loader=LegacyAwareLoader)
     mapping = data.__dict__ if isinstance(data, ProviderConfig) else data
     return ProviderConfig.from_mapping(mapping)
 
 
 def load_plugin_config_from_string(yaml_string: str) -> PluginConfig:
     """Load a plugin config from a YAML string using legacy-aware YAML tags."""
-    data = yaml.load(StringIO(yaml_string), Loader=LegacyAwareLoader)
+    with pytest.warns(
+        FutureWarning,
+        match=r".*deprecated YAML tag '!plugin'.*",
+    ):
+        data = yaml.load(StringIO(yaml_string), Loader=LegacyAwareLoader)
     mapping = data.__dict__ if isinstance(data, PluginConfig) else data
     return PluginConfig.from_mapping(mapping)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,7 +26,7 @@ from tempfile import TemporaryDirectory
 
 import yaml
 
-from eodag.api.provider import ProvidersDict
+from eodag.api.provider import ProviderConfig, ProvidersDict
 from eodag.config import PluginConfig
 from eodag.utils import deepcopy
 from tests.context import (
@@ -41,6 +41,45 @@ from tests.context import (
     load_stac_provider_config,
     mock,
 )
+
+
+def load_provider_config_from_string(yaml_string: str) -> ProviderConfig:
+    """Load a provider config from a YAML string, converting from dict to ProviderConfig.
+
+    The YAML string should not contain custom tags (!provider, !plugin).
+    """
+    # Remove !provider and !plugin tags if present for backward compatibility with test strings
+    yaml_string = yaml_string.replace("!provider", "").replace("!plugin", "")
+
+    # Load as a plain dict
+    data = yaml.load(StringIO(yaml_string), Loader=yaml.CSafeLoader)
+
+    # If the dict has a top-level provider key, extract it
+    if isinstance(data, dict) and len(data) == 1:
+        provider_name, provider_config = next(iter(data.items()))
+        if isinstance(provider_config, dict) and "name" not in provider_config:
+            provider_config["name"] = provider_name
+            data = provider_config
+        elif isinstance(provider_config, dict):
+            data = provider_config
+
+    # Convert to ProviderConfig object
+    return ProviderConfig.from_mapping(data)
+
+
+def load_plugin_config_from_string(yaml_string: str) -> PluginConfig:
+    """Load a plugin config from a YAML string, converting from dict to PluginConfig.
+
+    The YAML string should not contain custom tags (!plugin).
+    """
+    # Remove !plugin tags if present for backward compatibility with test strings
+    yaml_string = yaml_string.replace("!plugin", "")
+
+    # Load as a plain dict
+    data = yaml.load(StringIO(yaml_string), Loader=yaml.CSafeLoader)
+
+    # Convert to PluginConfig object
+    return PluginConfig.from_mapping(data)
 
 
 class TestProviderConfig(unittest.TestCase):
@@ -60,7 +99,7 @@ class TestProviderConfig(unittest.TestCase):
                 unslugified_provider_name
             )
         )
-        provider_config = yaml.load(stream, Loader=yaml.Loader)
+        provider_config = load_provider_config_from_string(stream.getvalue())
         self.assertEqual(provider_config.name, slugified_provider_name)
 
     def test_provider_config_valid(self):
@@ -68,7 +107,7 @@ class TestProviderConfig(unittest.TestCase):
         # Not defining any plugin at all
         invalid_stream = StringIO("""!provider\nname: my_provider""")
         self.assertRaises(
-            ValidationError, yaml.load, invalid_stream, Loader=yaml.Loader
+            ValidationError, load_provider_config_from_string, invalid_stream.getvalue()
         )
 
         # Not defining a class for a plugin
@@ -80,7 +119,7 @@ class TestProviderConfig(unittest.TestCase):
             """
         )
         self.assertRaises(
-            ValidationError, yaml.load, invalid_stream, Loader=yaml.Loader
+            ValidationError, load_provider_config_from_string, invalid_stream.getvalue()
         )
 
         # Not giving a name to the provider
@@ -91,7 +130,7 @@ class TestProviderConfig(unittest.TestCase):
             """
         )
         self.assertRaises(
-            ValidationError, yaml.load, invalid_stream, Loader=yaml.Loader
+            ValidationError, load_provider_config_from_string, invalid_stream.getvalue()
         )
 
         # Specifying an api plugin and a search or download or auth plugin at the same
@@ -121,13 +160,19 @@ class TestProviderConfig(unittest.TestCase):
             """
         )
         self.assertRaises(
-            ValidationError, yaml.load, invalid_stream1, Loader=yaml.Loader
+            ValidationError,
+            load_provider_config_from_string,
+            invalid_stream1.getvalue(),
         )
         self.assertRaises(
-            ValidationError, yaml.load, invalid_stream2, Loader=yaml.Loader
+            ValidationError,
+            load_provider_config_from_string,
+            invalid_stream2.getvalue(),
         )
         self.assertRaises(
-            ValidationError, yaml.load, invalid_stream3, Loader=yaml.Loader
+            ValidationError,
+            load_provider_config_from_string,
+            invalid_stream3.getvalue(),
         )
 
     def test_provider_config_update(self):
@@ -142,7 +187,7 @@ class TestProviderConfig(unittest.TestCase):
                     pluginParam2: value2
         """
         )
-        provider_config = yaml.load(valid_stream, Loader=yaml.Loader)
+        provider_config = load_provider_config_from_string(valid_stream.getvalue())
         overrides = {
             "provider_param": "new val",
             "api": {"pluginparam2": "newVal", "newParam": "val"},
@@ -176,8 +221,8 @@ class TestProviderConfig(unittest.TestCase):
                     pluginParam2: value3
         """
         )
-        provider1_config1 = yaml.load(config_stream1, Loader=yaml.Loader)
-        provider1_config2 = yaml.load(config_stream2, Loader=yaml.Loader)
+        provider1_config1 = load_provider_config_from_string(config_stream1.getvalue())
+        provider1_config2 = load_provider_config_from_string(config_stream2.getvalue())
 
         provider2_config1 = deepcopy(provider1_config1.__dict__)
         provider2_config1.update({"name": "provider2"})
@@ -217,7 +262,7 @@ class TestPluginConfig(unittest.TestCase):
         """
         )
         self.assertRaises(
-            ValidationError, yaml.load, invalid_stream, Loader=yaml.Loader
+            ValidationError, load_plugin_config_from_string, invalid_stream.getvalue()
         )
 
         valid_stream = StringIO(
@@ -226,7 +271,9 @@ class TestPluginConfig(unittest.TestCase):
                     param1: value
         """
         )
-        self.assertIsInstance(yaml.load(valid_stream, Loader=yaml.Loader), PluginConfig)
+        self.assertIsInstance(
+            load_plugin_config_from_string(valid_stream.getvalue()), PluginConfig
+        )
 
     def test_plugin_config_update(self):
         """A plugin config must be update-able by a dict"""
@@ -239,7 +286,7 @@ class TestPluginConfig(unittest.TestCase):
                         subParam_2: v2
         """
         )
-        plugin_config = yaml.load(valid_stream, Loader=yaml.Loader)
+        plugin_config = load_plugin_config_from_string(valid_stream.getvalue())
         overrides = {
             "type": "MyOtherPlugin",
             "new_plugin_param": "a value",
@@ -523,8 +570,8 @@ class TestStacProviderConfig(unittest.TestCase):
     def test_existing_stac_provider_conf(self):
         """Existing / pre-configured STAC providers conf should mix providers.yml and  stac_provider.yml infos."""
         with mock.patch(
-            "eodag.api.provider.ProviderConfig.__setstate__",
-            lambda self, state: self.__dict__.update(state),
+            "eodag.api.provider.ProviderConfig._apply_defaults",
+            lambda self: None,
         ):
             providers_dir = pathlib.Path(
                 str(res_files("eodag") / "resources" / "providers")
@@ -532,8 +579,14 @@ class TestStacProviderConfig(unittest.TestCase):
             providers_configs = {}
             for provider_conf_file in providers_dir.glob("*.yml"):
                 with open(provider_conf_file, "r") as fh:
-                    provider_conf = yaml.load(fh, Loader=yaml.Loader)
-                    providers_configs[provider_conf.name] = provider_conf
+                    provider_conf_dict = yaml.load(fh, Loader=yaml.CSafeLoader)
+                    # Handle the new format where provider name is the top-level key
+                    for provider_name, provider_config in provider_conf_dict.items():
+                        if isinstance(provider_config, dict):
+                            if "name" not in provider_config:
+                                provider_config["name"] = provider_name
+                            provider_conf = ProviderConfig.from_mapping(provider_config)
+                            providers_configs[provider_conf.name] = provider_conf
 
         raw_provider_search_conf = providers_configs["usgs_satapi_aws"].search.__dict__
         common_stac_provider_search_conf = load_stac_provider_config()["search"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,10 +17,8 @@
 # limitations under the License.
 
 import os
-import pathlib
 import tempfile
 import unittest
-from importlib.resources import files as res_files
 from io import StringIO
 from tempfile import TemporaryDirectory
 
@@ -554,24 +552,12 @@ class TestStacProviderConfig(unittest.TestCase):
 
     def test_existing_stac_provider_conf(self):
         """Existing / pre-configured STAC providers conf should mix providers.yml and  stac_provider.yml infos."""
+        # Load raw provider configs (without stac_provider.yml defaults applied).
         with mock.patch(
             "eodag.api.provider.ProviderConfig._apply_defaults",
             lambda self: None,
         ):
-            providers_dir = pathlib.Path(
-                str(res_files("eodag") / "resources" / "providers")
-            )
-            providers_configs = {}
-            for provider_conf_file in providers_dir.glob("*.yml"):
-                with open(provider_conf_file, "r") as fh:
-                    provider_conf_dict = yaml.load(fh, Loader=yaml.CSafeLoader)
-                    # Handle the new format where provider name is the top-level key
-                    for provider_name, provider_config in provider_conf_dict.items():
-                        if isinstance(provider_config, dict):
-                            if "name" not in provider_config:
-                                provider_config["name"] = provider_name
-                            provider_conf = ProviderConfig.from_mapping(provider_config)
-                            providers_configs[provider_conf.name] = provider_conf
+            providers_configs = config.load_default_config()
 
         raw_provider_search_conf = providers_configs["usgs_satapi_aws"].search.__dict__
         common_stac_provider_search_conf = load_stac_provider_config()["search"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,7 @@ import yaml
 from eodag.api.provider import ProviderConfig, ProvidersDict
 from eodag.config import PluginConfig
 from eodag.utils import deepcopy
+from eodag.utils.yaml import LegacyAwareLoader
 from tests.context import (
     EXT_COLLECTIONS_CONF_URI,
     HTTP_REQ_TIMEOUT,
@@ -44,42 +45,17 @@ from tests.context import (
 
 
 def load_provider_config_from_string(yaml_string: str) -> ProviderConfig:
-    """Load a provider config from a YAML string, converting from dict to ProviderConfig.
-
-    The YAML string should not contain custom tags (!provider, !plugin).
-    """
-    # Remove !provider and !plugin tags if present for backward compatibility with test strings
-    yaml_string = yaml_string.replace("!provider", "").replace("!plugin", "")
-
-    # Load as a plain dict
-    data = yaml.load(StringIO(yaml_string), Loader=yaml.CSafeLoader)
-
-    # If the dict has a top-level provider key, extract it
-    if isinstance(data, dict) and len(data) == 1:
-        provider_name, provider_config = next(iter(data.items()))
-        if isinstance(provider_config, dict) and "name" not in provider_config:
-            provider_config["name"] = provider_name
-            data = provider_config
-        elif isinstance(provider_config, dict):
-            data = provider_config
-
-    # Convert to ProviderConfig object
-    return ProviderConfig.from_mapping(data)
+    """Load a provider config from a YAML string using legacy-aware YAML tags."""
+    data = yaml.load(StringIO(yaml_string), Loader=LegacyAwareLoader)
+    mapping = data.__dict__ if isinstance(data, ProviderConfig) else data
+    return ProviderConfig.from_mapping(mapping)
 
 
 def load_plugin_config_from_string(yaml_string: str) -> PluginConfig:
-    """Load a plugin config from a YAML string, converting from dict to PluginConfig.
-
-    The YAML string should not contain custom tags (!plugin).
-    """
-    # Remove !plugin tags if present for backward compatibility with test strings
-    yaml_string = yaml_string.replace("!plugin", "")
-
-    # Load as a plain dict
-    data = yaml.load(StringIO(yaml_string), Loader=yaml.CSafeLoader)
-
-    # Convert to PluginConfig object
-    return PluginConfig.from_mapping(data)
+    """Load a plugin config from a YAML string using legacy-aware YAML tags."""
+    data = yaml.load(StringIO(yaml_string), Loader=LegacyAwareLoader)
+    mapping = data.__dict__ if isinstance(data, PluginConfig) else data
+    return PluginConfig.from_mapping(mapping)
 
 
 class TestProviderConfig(unittest.TestCase):

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -28,6 +28,7 @@ import unittest
 from importlib.resources import files as res_files
 from tempfile import TemporaryDirectory
 
+import pytest
 import yaml
 from concurrent.futures import ThreadPoolExecutor
 from lxml import html
@@ -2519,7 +2520,10 @@ class TestCoreConfWithEnvVar(TestCoreBase):
             os.environ["EODAG_PROVIDERS_CFG_FILE"] = os.path.join(
                 TEST_RESOURCES_PROVIDERS_PATH, "file_providers_override.yml"
             )
-            self.dag = EODataAccessGateway()
+            with pytest.warns(
+                DeprecationWarning, match=r".*EODAG_PROVIDERS_CFG_FILE.*"
+            ):
+                self.dag = EODataAccessGateway()
             # only foo_provider in conf
             self.assertEqual(self.dag.providers.names, ["foo_provider"])
             self.assertEqual(
@@ -2581,7 +2585,10 @@ class TestCoreConfWithEnvVar(TestCoreBase):
 
         # check collections
         try:
-            self.dag = EODataAccessGateway()
+            with pytest.warns(
+                DeprecationWarning, match=r".*EODAG_PROVIDERS_CFG_FILE.*"
+            ):
+                self.dag = EODataAccessGateway()
             col = self.dag.list_collections(fetch_providers=False)
             self.assertEqual(2, len(col))
             self.assertEqual("TEST_PRODUCT_1", col[0].id)
@@ -4800,7 +4807,10 @@ class TestCoreStrictMode(TestCoreBase):
         """list_collections must only return collections from the main config in strict mode"""
         try:
             os.environ["EODAG_STRICT_COLLECTIONS"] = "true"
-            dag = EODataAccessGateway()
+            with pytest.warns(
+                DeprecationWarning, match=r".*EODAG_PROVIDERS_CFG_FILE.*"
+            ):
+                dag = EODataAccessGateway()
 
             # In strict mode, TEST_PRODUCT_2 should not be listed
             collections = dag.list_collections(fetch_providers=False)
@@ -4815,7 +4825,8 @@ class TestCoreStrictMode(TestCoreBase):
         if "EODAG_STRICT_COLLECTIONS" in os.environ:
             del os.environ["EODAG_STRICT_COLLECTIONS"]
 
-        dag = EODataAccessGateway()
+        with pytest.warns(DeprecationWarning, match=r".*EODAG_PROVIDERS_CFG_FILE.*"):
+            dag = EODataAccessGateway()
 
         # In permissive mode, TEST_PRODUCT_2 should be listed
         collections = dag.list_collections(fetch_providers=False)

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -2555,30 +2555,18 @@ class TestCoreConfWithEnvVar(TestCoreBase):
         config_path = os.path.join(
             TEST_RESOURCES_PROVIDERS_PATH, "file_providers_override.yml"
         )
-        providers_config_dicts: list[dict] = cached_yaml_load_all(config_path)
-        # Convert the first provider dict to use as base; access nested dict for provider config
-        first_provider_dict = providers_config_dicts[0]
-        if len(providers_config_dicts) == 1 and isinstance(first_provider_dict, dict):
-            # Handle new format where provider name is top-level key
-            for provider_name, provider_config in first_provider_dict.items():
-                if isinstance(provider_config, dict):
-                    provider_config["products"]["TEST_PRODUCT_1"] = {
-                        "_collection": "TP1"
-                    }
-                    provider_config["products"]["TEST_PRODUCT_2"] = {
-                        "_collection": "TP2"
-                    }
-                    with open(
-                        os.path.join(
-                            self.tmp_home_dir.name, "file_providers_override2.yml"
-                        ),
-                        "w",
-                    ) as f:
-                        f.write(yaml.dump({provider_name: provider_config}))
-        # set env variables
-        os.environ["EODAG_PROVIDERS_CFG_FILE"] = os.path.join(
+        providers_config_dict = cached_yaml_load_all(config_path)[0]
+        provider_name, provider_config = next(iter(providers_config_dict.items()))
+        provider_config["products"]["TEST_PRODUCT_1"] = {"_collection": "TP1"}
+        provider_config["products"]["TEST_PRODUCT_2"] = {"_collection": "TP2"}
+
+        providers_override_path = os.path.join(
             self.tmp_home_dir.name, "file_providers_override2.yml"
         )
+        with open(providers_override_path, "w") as f:
+            f.write(yaml.dump({provider_name: provider_config}))
+        # set env variables
+        os.environ["EODAG_PROVIDERS_CFG_FILE"] = providers_override_path
         os.environ["EODAG_COLLECTIONS_CFG_FILE"] = os.path.join(
             TEST_RESOURCES_PATH, "file_collections_override.yml"
         )

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -40,8 +40,9 @@ from shapely.geometry import LineString, MultiPolygon, Polygon
 from eodag import __version__ as eodag_version
 from eodag.api.collection import Collection, CollectionsList
 from eodag.types.queryables import QueryablesDict
-from eodag.utils import GENERIC_COLLECTION, cached_yaml_load_all
+from eodag.utils import GENERIC_COLLECTION
 from eodag.utils.exceptions import ValidationError
+from eodag.utils.yaml import cached_yaml_load_all
 from tests import TEST_RESOURCES_PATH, TEST_RESOURCES_PROVIDERS_PATH
 from tests.context import (
     DEFAULT_LIMIT,

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -2551,13 +2551,26 @@ class TestCoreConfWithEnvVar(TestCoreBase):
         config_path = os.path.join(
             TEST_RESOURCES_PROVIDERS_PATH, "file_providers_override.yml"
         )
-        providers_config: list[ProviderConfig] = cached_yaml_load_all(config_path)
-        providers_config[0].products["TEST_PRODUCT_1"] = {"_collection": "TP1"}
-        providers_config[0].products["TEST_PRODUCT_2"] = {"_collection": "TP2"}
-        with open(
-            os.path.join(self.tmp_home_dir.name, "file_providers_override2.yml"), "w"
-        ) as f:
-            f.write(yaml.dump(providers_config[0]))
+        providers_config_dicts: list[dict] = cached_yaml_load_all(config_path)
+        # Convert the first provider dict to use as base; access nested dict for provider config
+        first_provider_dict = providers_config_dicts[0]
+        if len(providers_config_dicts) == 1 and isinstance(first_provider_dict, dict):
+            # Handle new format where provider name is top-level key
+            for provider_name, provider_config in first_provider_dict.items():
+                if isinstance(provider_config, dict):
+                    provider_config["products"]["TEST_PRODUCT_1"] = {
+                        "_collection": "TP1"
+                    }
+                    provider_config["products"]["TEST_PRODUCT_2"] = {
+                        "_collection": "TP2"
+                    }
+                    with open(
+                        os.path.join(
+                            self.tmp_home_dir.name, "file_providers_override2.yml"
+                        ),
+                        "w",
+                    ) as f:
+                        f.write(yaml.dump({provider_name: provider_config}))
         # set env variables
         os.environ["EODAG_PROVIDERS_CFG_FILE"] = os.path.join(
             self.tmp_home_dir.name, "file_providers_override2.yml"

--- a/tests/units/test_provider.py
+++ b/tests/units/test_provider.py
@@ -20,11 +20,8 @@ import unittest
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
-import yaml
-
 from tests.context import (
     EODataAccessGateway,
-    MisconfiguredError,
     PluginConfig,
     Provider,
     ProviderConfig,
@@ -257,18 +254,20 @@ class TestProviderConfig(unittest.TestCase):
         self.assertIsNot(new_config.search, original_config.search)
 
     def test_provider_config_from_yaml_requires_plugin_tag(self):
-        """ProviderConfig.from_yaml must reject untagged plugin topics."""
+        """ProviderConfig.from_mapping must reject invalid plugin topics."""
+        # Test that invalid plugin config (missing type) raises ValidationError
         with self.assertRaisesRegex(
-            MisconfiguredError, "plugin topic 'search' must be tagged with '!plugin'"
+            ValidationError,
+            "A Plugin config must specify the type of Plugin it configures",
         ):
-            yaml.load(
-                """
-!provider
-name: test-provider
-search:
-  type: StacSearch
-""",
-                Loader=yaml.Loader,
+            ProviderConfig.from_mapping(
+                {
+                    "name": "test-provider",
+                    "search": {
+                        # Missing 'type' field - should fail validation
+                    },
+                    "products": {},
+                }
             )
 
 

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -135,9 +135,13 @@ class TestSearchPluginQueryStringSearchXml(BaseSearchPluginTest):
         provider = "mundi"
 
         # manually add conf as this provider is not supported any more
-        mundi_config = cached_yaml_load_all(
+        mundi_config_dict = cached_yaml_load_all(
             Path(TEST_RESOURCES_PATH) / "mundi_conf.yml"
         )[0]
+        # Provider YAML now uses provider name as top-level key
+        provider_name, mundi_config = next(iter(mundi_config_dict.items()))
+        if "name" not in mundi_config:
+            mundi_config["name"] = provider_name
         self.plugins_manager.providers[provider] = Provider(mundi_config)
         self.plugins_manager.rebuild()
 
@@ -1575,9 +1579,13 @@ class TestSearchPluginODataV4Search(BaseSearchPluginTest):
         super(TestSearchPluginODataV4Search, self).setUp()
 
         # manually add conf as this provider is not supported any more
-        onda_config = cached_yaml_load_all(Path(TEST_RESOURCES_PATH) / "onda_conf.yml")[
-            0
-        ]
+        onda_config_dict = cached_yaml_load_all(
+            Path(TEST_RESOURCES_PATH) / "onda_conf.yml"
+        )[0]
+        # Provider YAML now uses provider name as top-level key
+        provider_name, onda_config = next(iter(onda_config_dict.items()))
+        if "name" not in onda_config:
+            onda_config["name"] = provider_name
         self.plugins_manager.providers["onda"] = Provider(onda_config)
         self.plugins_manager.rebuild()
 


### PR DESCRIPTION
Closes #2075
Removes all yaml tags in providers configuration files (same syntax as for `~/.config/eodag/eodag.yml` user configuration file). 

Usage of `CSafeLoader` as pyyaml loader : `EODataAccessGateway` cold instantiation is now ~ **40% faster**.
