### PR TITLE
fix(plugins): accept HH_MM format for EcmwfSearch time param

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -488,7 +488,7 @@ class ECMWFSearch(PostJsonSearch):
 
         # Validate and collect indirect date parameters
         time = validate_datetime_param(
-            params.get("time"), "time", ["%H%M", "%H:%M", "%H%M%S", "%H:%M:%S"]
+            params.get("time"), "time", ["%H%M", "%H:%M", "%H%M%S", "%H:%M:%S", "%H_%M"]
         )
         year = validate_datetime_param(params.get("year"), "year", ["%Y"])
         month = validate_datetime_param(params.get("month"), "month", ["%m"])


### PR DESCRIPTION
This PR aims is to accept %H_%M date format.

In the queryables for AG_ERA5 collection (for exemple) :
```py
>>> qa = dag.list_queryables(provider="cop_cds", collection="AG_ERA5")
>>> qa["ecmwf_time]
typing.Annotated[list[typing.Literal['06_00', '09_00', '12_00', '15_00', '18_00']], FieldInfo(annotation=NoneType, required=True, alias_priority=2, validation_alias=AliasChoices(choices=['ecmwf:time', 'time']), serialization_alias='ecmwf:time', title='Time', description='The time selection applies to the 2m relative humidity variable only.', metadata=['json_schema_required'])]
```
We have time: 06_00, 09_00, 12_00 etc...
But if we do: 
```py
dag.search(
    provider="cop_cds", collection="AG_ERA5",
    **{
        "day": ["02"],
        "month": ["03"],
        "time": ["06_00"],
        "variable": "2m_relative_humidity",
        "version": "1_1",
        "year": ["1981"]
    }
)
```
we get 
```
eodag.utils.exceptions.ValidationError: Malformed parameter "time": time data '06_00' does not match format '%H:%M:%S'
```
and if we use '%H:%M:%S' format like `"time": ["06:00"]` we got `Allowed values are 12_00, 18_00, 15_00, 09_00, 06_00.`

So we need to support %H_%M date format