### PR TITLE
fix(plugins): do no sort query parameters content

### DIFF
--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -1760,11 +1760,6 @@ class PostJsonSearch(QueryStringSearch):
 
             qp, _ = self.build_query_string(collection, keywords)
 
-        # Force sort qp list parameters
-        for key in qp:
-            if isinstance(qp[key], list) and key != "area":
-                qp[key].sort()
-
         for query_param, query_value in qp.items():
             if (
                 query_param

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -3258,6 +3258,23 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         self.assertNotIn("start_datetime", eoproduct.properties)
         self.assertNotIn("end_datetime", eoproduct.properties)
 
+    def test_plugins_search_ecmwfsearch_dont_sort_params(self):
+        """ECMWFSearch.query must not sort query parameters and keep user order"""
+
+        results = self.search_plugin.query(
+            collection=self.collection,
+            **self.query_dates,
+            **self.custom_query_params,
+            ecmwf_pressure_level=["2", "1", "3", "10"],
+        )
+        eoproduct = results.data[0]
+        self.assertIn("qs", eoproduct.properties)
+        self.assertIn("pressure_level", eoproduct.properties["qs"])
+        self.assertListEqual(
+            eoproduct.properties["qs"]["pressure_level"],
+            ["2", "1", "3", "10"],
+        )
+
     def test_plugins_search_ecmwfsearch_with_year_month_day_filter(self):
         """ECMWFSearch.query must use have datetime in response if year, month, day used in filters"""
         results = self.search_plugin.query(


### PR DESCRIPTION
Fixes #2257 

Do no sort query parameters content in `PostJsonSearch` / `EcmwfSearch`.
Removes queried lists content sort introduced in https://github.com/CS-SI/eodag/pull/2008 and not appropriate.
