### PR TITLE
feat(plugins): normalize_config method for pre-build conf init

### DIFF
--- a/eodag/api/provider.py
+++ b/eodag/api/provider.py
@@ -261,19 +261,44 @@ class ProviderConfig(yaml.YAMLObject):
         except AttributeError:
             pass
 
-        search_conf = getattr(self, "search", None)
-        search_type = getattr(search_conf, "type", None)
-        if search_conf is not None and search_type:
-            try:
-                from eodag.plugins.search.base import Search
+        plugin_topics: tuple[tuple[str, str], ...] = (
+            ("search", "eodag.plugins.search.base"),
+            ("api", "eodag.plugins.apis.base"),
+            ("download", "eodag.plugins.download.base"),
+            ("auth", "eodag.plugins.authentication.base"),
+            ("search_auth", "eodag.plugins.authentication.base"),
+            ("download_auth", "eodag.plugins.authentication.base"),
+        )
+        topic_class_names = {
+            "search": "Search",
+            "api": "Api",
+            "download": "Download",
+            "auth": "Authentication",
+            "search_auth": "Authentication",
+            "download_auth": "Authentication",
+        }
 
-                Search.ensure_plugins_loaded()
-                plugin_cls = Search.get_plugin_by_class_name(search_type)
+        for plugin_key, topic_module in plugin_topics:
+            plugin_conf = getattr(self, plugin_key, None)
+            plugin_type = getattr(plugin_conf, "type", None)
+            if plugin_conf is None or not plugin_type:
+                continue
+
+            try:
+                topic_class_name = topic_class_names[plugin_key]
+                topic_class = getattr(
+                    __import__(topic_module, fromlist=[topic_class_name]),
+                    topic_class_name,
+                )
+                topic_class.ensure_plugins_loaded()
+                plugin_cls = topic_class.get_plugin_by_class_name(plugin_type)
                 if normalize_config := getattr(plugin_cls, "normalize_config", None):
-                    normalize_config(self.name, search_conf)
+                    normalize_config(self.name, plugin_conf)
             except Exception:
                 logger.debug(
-                    "Could not normalize search config for provider %s", self.name
+                    "Could not normalize %s config for provider %s",
+                    plugin_key,
+                    self.name,
                 )
 
 

--- a/eodag/api/provider.py
+++ b/eodag/api/provider.py
@@ -261,6 +261,21 @@ class ProviderConfig(yaml.YAMLObject):
         except AttributeError:
             pass
 
+        search_conf = getattr(self, "search", None)
+        search_type = getattr(search_conf, "type", None)
+        if search_conf is not None and search_type:
+            try:
+                from eodag.plugins.search.base import Search
+
+                Search.ensure_plugins_loaded()
+                plugin_cls = Search.get_plugin_by_class_name(search_type)
+                if normalize_config := getattr(plugin_cls, "normalize_config", None):
+                    normalize_config(self.name, search_conf)
+            except Exception:
+                logger.debug(
+                    "Could not normalize search config for provider %s", self.name
+                )
+
 
 class Provider:
     """

--- a/eodag/api/provider.py
+++ b/eodag/api/provider.py
@@ -41,15 +41,13 @@ from eodag.api.product.metadata_mapping import (
     NOT_AVAILABLE,
     mtd_cfg_as_conversion_and_querypath,
 )
-from eodag.config import PluginConfig, credentials_in_auth, load_stac_provider_config
+from eodag.config import PluginConfig, credentials_in_auth
 from eodag.utils import (
     GENERIC_COLLECTION,
-    STAC_SEARCH_PLUGINS,
     cast_scalar_value,
     deepcopy,
     merge_mappings,
     slugify,
-    update_nested_dict,
 )
 from eodag.utils.exceptions import (
     MisconfiguredError,
@@ -233,8 +231,6 @@ class ProviderConfig(yaml.YAMLObject):
 
     def _apply_defaults(self: Self) -> None:
         """Applies some default values to provider config."""
-        stac_search_default_conf = load_stac_provider_config()
-
         # For the provider, set the default output_dir of its download plugin
         # as tempdir in a portable way
         for download_topic_key in ("download", "api"):
@@ -244,22 +240,6 @@ class ProviderConfig(yaml.YAMLObject):
                     download_conf.output_dir = tempfile.gettempdir()
                 if not getattr(download_conf, "delete_archive", None):
                     download_conf.delete_archive = True
-
-        try:
-            if (
-                stac_search_default_conf is not None
-                and self.search
-                and self.search.type in STAC_SEARCH_PLUGINS
-            ):
-                # search config set to stac defaults overriden with provider config
-                per_provider_stac_provider_config = deepcopy(stac_search_default_conf)
-                self.search.__dict__ = update_nested_dict(
-                    per_provider_stac_provider_config["search"],
-                    self.search.__dict__,
-                    allow_empty_values=True,
-                )
-        except AttributeError:
-            pass
 
         plugin_topics: tuple[tuple[str, str], ...] = (
             ("search", "eodag.plugins.search.base"),

--- a/eodag/api/provider.py
+++ b/eodag/api/provider.py
@@ -267,7 +267,7 @@ class ProviderConfig(yaml.YAMLObject):
                 logger.debug(
                     "Could not normalize %s config for provider %s",
                     plugin_key,
-                    self.name,
+                    getattr(self, "name", None),
                 )
 
 

--- a/eodag/api/provider.py
+++ b/eodag/api/provider.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import logging
 import os
-import tempfile
 import traceback
 from collections import UserDict
 from inspect import isclass
@@ -231,16 +230,6 @@ class ProviderConfig(yaml.YAMLObject):
 
     def _apply_defaults(self: Self) -> None:
         """Applies some default values to provider config."""
-        # For the provider, set the default output_dir of its download plugin
-        # as tempdir in a portable way
-        for download_topic_key in ("download", "api"):
-            if download_topic_key in vars(self):
-                download_conf = getattr(self, download_topic_key)
-                if not getattr(download_conf, "output_dir", None):
-                    download_conf.output_dir = tempfile.gettempdir()
-                if not getattr(download_conf, "delete_archive", None):
-                    download_conf.delete_archive = True
-
         plugin_topics: tuple[tuple[str, str], ...] = (
             ("search", "eodag.plugins.search.base"),
             ("api", "eodag.plugins.apis.base"),

--- a/eodag/plugins/apis/base.py
+++ b/eodag/plugins/apis/base.py
@@ -17,8 +17,13 @@
 # limitations under the License.
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from eodag.plugins.download.base import Download
 from eodag.plugins.search.base import Search
+
+if TYPE_CHECKING:
+    from eodag.config import PluginConfig
 
 
 class Api(Search, Download):
@@ -59,3 +64,8 @@ class Api(Search, Download):
     :param config: An EODAG plugin configuration
     :type config: dict[str, Any]
     """
+
+    @classmethod
+    def normalize_config(cls, provider: str, config: PluginConfig) -> PluginConfig:
+        """Normalize API plugin config defaults."""
+        return Download.normalize_config(provider, config)

--- a/eodag/plugins/authentication/base.py
+++ b/eodag/plugins/authentication/base.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
     from mypy_boto3_s3 import S3ServiceResource
     from requests.auth import AuthBase
 
+    from eodag.config import PluginConfig
+
 
 class Authentication(PluginTopic):
     """Plugins authentication Base plugin
@@ -39,6 +41,17 @@ class Authentication(PluginTopic):
         * :attr:`~eodag.config.PluginConfig.matching_conf` (``dict[str, Any]``): Part of the search or download plugin
           configuration that needs authentication and helps identifying it
     """
+
+    entrypoint_group = "auth"
+
+    @classmethod
+    def normalize_config(cls, provider: str, config: "PluginConfig") -> "PluginConfig":
+        """Normalize plugin config defaults.
+
+        Subclasses can override this method to apply authentication-specific
+        defaults before plugin instantiation.
+        """
+        return config
 
     def authenticate(self) -> Union[AuthBase, S3ServiceResource]:
         """Authenticate"""

--- a/eodag/plugins/base.py
+++ b/eodag/plugins/base.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import importlib_metadata
+
 from eodag.utils.exceptions import PluginNotFoundError
 
 if TYPE_CHECKING:
@@ -63,6 +65,22 @@ class PluginTopic(metaclass=EODAGPluginMount):
     def __init__(self, provider: str, config: PluginConfig) -> None:
         self.config = config
         self.provider = provider
+
+    @classmethod
+    def ensure_plugins_loaded(cls) -> None:
+        """Load plugin classes for this topic from entry points if needed."""
+        if getattr(cls, "_plugins_loaded", False):
+            return
+
+        for entry_point in importlib_metadata.entry_points(
+            group=f"eodag.plugins.{cls.__name__.lower()}"
+        ):
+            try:
+                entry_point.load()
+            except (ModuleNotFoundError, ImportError):
+                continue
+
+        setattr(cls, "_plugins_loaded", True)
 
     def __repr__(self) -> str:
         config = getattr(self, "config", None)

--- a/eodag/plugins/base.py
+++ b/eodag/plugins/base.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 import importlib_metadata
 
@@ -62,6 +62,8 @@ class EODAGPluginMount(type):
 class PluginTopic(metaclass=EODAGPluginMount):
     """Base of all plugin topics in eodag"""
 
+    entrypoint_group: Optional[str] = None
+
     def __init__(self, provider: str, config: PluginConfig) -> None:
         self.config = config
         self.provider = provider
@@ -72,8 +74,10 @@ class PluginTopic(metaclass=EODAGPluginMount):
         if getattr(cls, "_plugins_loaded", False):
             return
 
+        topic_group = cls.entrypoint_group or cls.__name__.lower()
+
         for entry_point in importlib_metadata.entry_points(
-            group=f"eodag.plugins.{cls.__name__.lower()}"
+            group=f"eodag.plugins.{topic_group}"
         ):
             try:
                 entry_point.load()

--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -103,6 +103,15 @@ class Download(PluginTopic):
         super(Download, self).__init__(provider, config)
         self._authenticate = bool(getattr(self.config, "authenticate", False))
 
+    @classmethod
+    def normalize_config(cls, provider: str, config: PluginConfig) -> PluginConfig:
+        """Normalize plugin config defaults.
+
+        Subclasses can override this method to apply plugin-specific defaults
+        before plugin instantiation.
+        """
+        return config
+
     @abstractmethod
     def download(
         self,

--- a/eodag/plugins/download/base.py
+++ b/eodag/plugins/download/base.py
@@ -110,6 +110,10 @@ class Download(PluginTopic):
         Subclasses can override this method to apply plugin-specific defaults
         before plugin instantiation.
         """
+        if not getattr(config, "output_dir", None):
+            config.output_dir = tempfile.gettempdir()
+        if not getattr(config, "delete_archive", None):
+            setattr(config, "delete_archive", True)
         return config
 
     @abstractmethod

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -91,6 +91,15 @@ class Search(PluginTopic):
         if hasattr(self.config, "discover_metadata"):
             self.config.discover_metadata.setdefault("metadata_prefix", provider)
 
+    @classmethod
+    def normalize_config(cls, provider: str, config: PluginConfig) -> PluginConfig:
+        """Normalize plugin config defaults.
+
+        Subclasses can override this method to apply plugin-specific defaults
+        before plugin instantiation.
+        """
+        return config
+
     def clear(self) -> None:
         """Method used to clear a search context between two searches."""
         pass

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -70,6 +70,7 @@ from eodag.api.product.metadata_mapping import (
     properties_from_xml,
 )
 from eodag.api.search_result import RawSearchResult, SearchResult
+from eodag.config import load_stac_provider_config
 from eodag.plugins.search import PreparedSearch
 from eodag.plugins.search.base import Search
 from eodag.types import json_field_definition_to_python, model_fields_to_annotated
@@ -85,7 +86,6 @@ from eodag.utils import (
     REQ_RETRY_BACKOFF_FACTOR,
     REQ_RETRY_STATUS_FORCELIST,
     REQ_RETRY_TOTAL,
-    STAC_SEARCH_PLUGINS,
     USER_AGENT,
     deepcopy,
     dict_items_recursive_apply,
@@ -2100,24 +2100,29 @@ class StacSearch(PostJsonSearch):
     :attr:`~eodag.config.PluginConfig.DiscoverQueryables.collection_fetch_url` in the
     :attr:`~eodag.config.PluginConfig.discover_queryables` config have to be set to ``null``.
 
-    Plugins inheriting from ``StacSearch`` have to be referenced in :const:`~eodag.utils.STAC_SEARCH_PLUGINS`
-    to be correctly initialized with the expected STAC configuration and features.
+    Plugins inheriting from ``StacSearch`` are initialized with STAC defaults
+    through :meth:`normalize_config`.
     """
 
+    @classmethod
+    def normalize_config(cls, provider: str, config: PluginConfig) -> PluginConfig:
+        """Normalize plugin config defaults for STAC-based search plugins."""
+        stac_search_default_conf = load_stac_provider_config()
+
+        if stac_search_default_conf is not None:
+            per_provider_stac_provider_config = deepcopy(stac_search_default_conf)
+            config.__dict__ = update_nested_dict(
+                per_provider_stac_provider_config["search"],
+                config.__dict__,
+                allow_empty_values=True,
+            )
+
+        return config
+
     def __init__(self, provider: str, config: PluginConfig) -> None:
-        try:
-            # backup results_entry overwritten by init
-            results_entry = config.results_entry
-        except AttributeError:
-            plugin_name = self.__class__.__name__
-            if plugin_name not in STAC_SEARCH_PLUGINS:
-                raise MisconfiguredError(
-                    "Missing results_entry in %s configuration. If %s is expected to be used as "
-                    "a STAC plugin, it must be referenced in STAC_SEARCH_PLUGINS."
-                    % (provider, plugin_name)
-                )
-            else:
-                raise
+        config = self.normalize_config(provider, config)
+        # backup results_entry overwritten by init
+        results_entry = config.results_entry
 
         super(StacSearch, self).__init__(provider, config)
 

--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -397,7 +397,7 @@ class QueryStringSearch(Search):
             )
 
         # parse jsonpath on init: collection specific metadata-mapping
-        for collection in self.config.products.keys():
+        for collection in getattr(self.config, "products", {}).keys():
             collection_metadata_mapping = {}
             # collection specific metadata-mapping
             if any(

--- a/eodag/utils/__init__.py
+++ b/eodag/utils/__init__.py
@@ -85,7 +85,8 @@ GENERIC_COLLECTION = "GENERIC_COLLECTION"
 #: if no existing provider can be used
 GENERIC_STAC_PROVIDER = "generic_stac_provider"
 
-#: List of known STAC search plugins. Required to complete plugin configuration with STAC plugins specific features.
+#: Deprecated: list of known STAC search plugin class names kept for backward
+#: compatibility. This constant is no longer used internally for STAC behavior.
 STAC_SEARCH_PLUGINS = [
     "GeodesSearch",
     "StacSearch",

--- a/eodag/utils/deserialize.py
+++ b/eodag/utils/deserialize.py
@@ -18,9 +18,10 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, cast
 
-from eodag.utils import GENERIC_STAC_PROVIDER, STAC_SEARCH_PLUGINS
+from eodag.plugins.search.qssearch import StacSearch
+from eodag.utils import GENERIC_STAC_PROVIDER
 from eodag.utils.exceptions import MisconfiguredError
 
 if TYPE_CHECKING:
@@ -131,7 +132,7 @@ def _import_stac_item_from_known_provider(
     for search_plugin in plugins_manager.get_search_plugins(provider=provider):
         # only try STAC search plugins
         if (
-            search_plugin.config.type in STAC_SEARCH_PLUGINS
+            isinstance(search_plugin, StacSearch)
             and search_plugin.provider != GENERIC_STAC_PROVIDER
             and hasattr(search_plugin, "normalize_results")
         ):
@@ -140,7 +141,7 @@ def _import_stac_item_from_known_provider(
             )
             # compare the item href with the provider base URL
             if item_href and item_href.startswith(provider_base_url):
-                products = search_plugin.normalize_results([feature])
+                products = search_plugin.normalize_results(cast(Any, [feature]))
                 if len(products) == 0 or len(products[0].assets) == 0:
                     continue
                 logger.debug(

--- a/eodag/utils/deserialize.py
+++ b/eodag/utils/deserialize.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Optional, cast
 
-from eodag.plugins.search.qssearch import StacSearch
 from eodag.utils import GENERIC_STAC_PROVIDER
 from eodag.utils.exceptions import MisconfiguredError
 
@@ -127,6 +126,9 @@ def _import_stac_item_from_known_provider(
     :param provider: The associated provider from which configuration should be used for mapping.
     :returns: An EOProduct created from the STAC item
     """
+    # Delayed import to avoid import cycle with eodag.api.product.
+    from eodag.plugins.search.qssearch import StacSearch
+
     item_hrefs = [f for f in feature.get("links", []) if f.get("rel") == "self"]
     item_href = item_hrefs[0]["href"] if len(item_hrefs) > 0 else None
     for search_plugin in plugins_manager.get_search_plugins(provider=provider):

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -2298,7 +2298,7 @@ class TestCore(TestCoreBase):
                 ],
                 "max_sort_params": 1,
             },
-            "cop_marine": None,
+            "cop_marine": {"max_sort_params": None, "sortables": []},
             "fedeo_ceda": {"max_sort_params": None, "sortables": []},
             "geodes": {
                 "max_sort_params": None,

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -2667,35 +2667,17 @@ class TestSearchPluginStacSearch(BaseSearchPluginTest):
         # provider-only param still present
         self.assertIn("some_param", queryables)
 
-    def test_plugins_search_stacsearch_missing_results_entry_misconfigured(self):
-        """StacSearch must raise MisconfiguredError when results_entry is missing
-        for a subclass not referenced in STAC_SEARCH_PLUGINS"""
+    def test_plugins_search_stacsearch_uses_stac_defaults(self):
+        """StacSearch must use STAC defaults from normalize_results."""
         from eodag.config import PluginConfig
         from eodag.plugins.search.qssearch import StacSearch
 
-        class _UnregisteredStacSearch(StacSearch):
+        class _NewStacSearch(StacSearch):
             pass
 
         config = PluginConfig()
-        # do not set results_entry on purpose
-        with self.assertRaises(MisconfiguredError) as ctx:
-            _UnregisteredStacSearch("some_provider", config)
-        self.assertIn("results_entry", str(ctx.exception))
-        self.assertIn("_UnregisteredStacSearch", str(ctx.exception))
-        self.assertIn("STAC_SEARCH_PLUGINS", str(ctx.exception))
-
-    def test_plugins_search_stacsearch_missing_results_entry_reraises_for_known_plugin(
-        self,
-    ):
-        """StacSearch must re-raise AttributeError when results_entry is missing
-        for a subclass referenced in STAC_SEARCH_PLUGINS"""
-        from eodag.config import PluginConfig
-        from eodag.plugins.search.geodes import GeodesSearch
-
-        config = PluginConfig()
-        # GeodesSearch is in STAC_SEARCH_PLUGINS so AttributeError must be re-raised
-        with self.assertRaises(AttributeError):
-            GeodesSearch("geodes", config)
+        plugin = _NewStacSearch("some_provider", config)
+        self.assertEqual(plugin.config.results_entry, "features")
 
 
 class TestSearchPluginGeodesSearch(BaseSearchPluginTest):


### PR DESCRIPTION
Move plugins configuration defaults setting to new `plugin.normalize_config` class method.

Method is called during `ProviderConfig` creation and plugin init.

This deprecates `STAC_SEARCH_PLUGINS` constant in favor of `StacSearch` inheritance check.