### PR TITLE
fix(core): StreamResponse.headers as CaseInsensitiveDict

### DIFF
--- a/eodag/utils/streamresponse.py
+++ b/eodag/utils/streamresponse.py
@@ -1,10 +1,37 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026, CS GROUP - France, https://www.csgroup.eu/
+#
+# This file is part of EODAG project
+#     https://www.github.com/CS-SI/EODAG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
 import os
 import signal
 import threading
 from dataclasses import dataclass, field
-from typing import Iterable, Iterator, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Iterable, Iterator, Mapping, Optional, Union
 
-from requests.structures import CaseInsensitiveDict
+if TYPE_CHECKING:
+    from requests.structures import CaseInsensitiveDict
+
+
+def _new_case_insensitive_dict(headers: Optional[Mapping[str, str]] = None):
+    """Create headers mapping with a local import to avoid import-time overhead."""
+    from requests.structures import CaseInsensitiveDict
+
+    return CaseInsensitiveDict(headers) if headers else CaseInsensitiveDict()
 
 
 class StreamResponseContent(Iterable[bytes]):
@@ -88,7 +115,9 @@ class StreamResponse:
     content: StreamResponseContent
     _filename: Optional[str] = field(default=None, repr=False, init=False)
     _size: Optional[int] = field(default=None, repr=False, init=False)
-    headers: CaseInsensitiveDict = field(default_factory=CaseInsensitiveDict)
+    headers: CaseInsensitiveDict[str] = field(
+        default_factory=_new_case_insensitive_dict
+    )
     media_type: Optional[str] = None
     status_code: Optional[int] = None
     arcname: Optional[str] = None
@@ -104,9 +133,7 @@ class StreamResponse:
         arcname: Optional[str] = None,
     ):
         self.content = StreamResponseContent(content)
-        self.headers = (
-            CaseInsensitiveDict(headers) if headers else CaseInsensitiveDict()
-        )
+        self.headers = _new_case_insensitive_dict(headers)
         self.media_type = media_type
         self.status_code = status_code
         self.arcname = arcname

--- a/eodag/utils/streamresponse.py
+++ b/eodag/utils/streamresponse.py
@@ -4,6 +4,8 @@ import threading
 from dataclasses import dataclass, field
 from typing import Iterable, Iterator, Mapping, Optional, Union
 
+from requests.structures import CaseInsensitiveDict
+
 
 class StreamResponseContent(Iterable[bytes]):
     """
@@ -86,7 +88,7 @@ class StreamResponse:
     content: StreamResponseContent
     _filename: Optional[str] = field(default=None, repr=False, init=False)
     _size: Optional[int] = field(default=None, repr=False, init=False)
-    headers: dict[str, str] = field(default_factory=dict)
+    headers: CaseInsensitiveDict = field(default_factory=CaseInsensitiveDict)
     media_type: Optional[str] = None
     status_code: Optional[int] = None
     arcname: Optional[str] = None
@@ -102,7 +104,9 @@ class StreamResponse:
         arcname: Optional[str] = None,
     ):
         self.content = StreamResponseContent(content)
-        self.headers = dict(headers) if headers else {}
+        self.headers = (
+            CaseInsensitiveDict(headers) if headers else CaseInsensitiveDict()
+        )
         self.media_type = media_type
         self.status_code = status_code
         self.arcname = arcname

--- a/tests/units/test_utils_streamingresponse.py
+++ b/tests/units/test_utils_streamingresponse.py
@@ -22,6 +22,39 @@ class StreamResponseTest(unittest.TestCase):
         if os.path.isdir(StreamResponseTest.TMP_DIR):
             shutil.rmtree(StreamResponseTest.TMP_DIR)
 
+    def test_streamresponse_filename_overwrites_lowercase_content_disposition(self):
+        """When headers contain 'content-disposition' (lowercase) and a filename is
+        also provided, the filename setter must overwrite the existing header instead
+        of creating a duplicate 'Content-Disposition' entry."""
+        stream = StreamResponse(
+            content=b"",
+            headers={"content-disposition": 'attachment; filename="old_name.nc"'},
+            filename="new_name.nc",
+        )
+        # Only one Content-Disposition key must exist (CaseInsensitiveDict merges them)
+        matching = [k for k in stream.headers if k.lower() == "content-disposition"]
+        self.assertEqual(len(matching), 1)
+        self.assertIn("new_name.nc", stream.headers["Content-Disposition"])
+
+    def test_streamresponse_headers_are_case_insensitive(self):
+        """Headers must be accessible regardless of key casing."""
+        stream = StreamResponse(
+            content=b"",
+            headers={"Content-Type": "text/plain", "X-Custom-Header": "value"},
+        )
+        # Access with different casings
+        self.assertEqual(stream.headers["content-type"], "text/plain")
+        self.assertEqual(stream.headers["CONTENT-TYPE"], "text/plain")
+        self.assertEqual(stream.headers["x-custom-header"], "value")
+        self.assertEqual(stream.headers["X-CUSTOM-HEADER"], "value")
+
+    def test_streamresponse_headers_default_case_insensitive(self):
+        """Headers must default to a CaseInsensitiveDict when not provided."""
+        from requests.structures import CaseInsensitiveDict
+
+        stream = StreamResponse(content=b"")
+        self.assertIsInstance(stream.headers, CaseInsensitiveDict)
+
     def test_streamresponse_download_generator(self):
 
         content = b""


### PR DESCRIPTION
### Description

Use a case insensitive dict in the class `StreamResponse` to store the headers.

An example when a case sensitive dict creates issues is when the `content-disposition` header is passed in the `headers` parameter and also a filename is given (see for example `HttpDownload#stream_download`):

```python
        return StreamResponse(
            content=chain(iter([first_chunk]), chunk_iterator),
            headers=getattr(product, "headers", {}),
            filename=getattr(product, "filename", None),
            size=getattr(product, "size", None),
        )
```

The setter of `filename` creates a new `Content-Disposition` header instead of overwriting the existing `content-disposition`.

### Test

From `stac-fastapi-eodag`, search

```
POST http://localhost:8000/search
{
    "collections": ["MSG_HRSEVIRI"],
    "datetime": "2019-07-01T00:00:00Z/2019-07-31T00:00:00Z"
}
```

Verify headers:

```console
curl -sS -D - 'http://localhost:8000/data/eumetsat_ds/MSG_HRSEVIRI/MSG4-SEVI-MSG15-0100-NA-20190701001243.039000000Z-NA/downloadLink'
```
