### PR TITLE
fix: add schema_href to FederationExtension

### DIFF
--- a/eodag/types/stac_extensions.py
+++ b/eodag/types/stac_extensions.py
@@ -492,6 +492,7 @@ class FederationExtension(BaseStacExtension):
 
     FIELDS: type[BaseModel] = FederationFields
 
+    schema_href: str = "https://api.openeo.org/extensions/federation/0.2.0"
     field_name_prefix: Optional[str] = "federation"
 
 

--- a/tests/units/test_eoproduct.py
+++ b/tests/units/test_eoproduct.py
@@ -789,12 +789,26 @@ class TestEOProduct(EODagTestBase):
 
     def test_eoproduct_as_pystac_object(self):
         """eoproduct.as_pystac_object must return a pystac.Item"""
+        from pystac.validation.stac_validator import JsonSchemaSTACValidator
+
+        class OfflineValidator(JsonSchemaSTACValidator):
+            """Skip extension schemas that are not already cached locally."""
+
+            def validate_extension(
+                self, stac_dict, stac_object_type, stac_version, extension_id, href=None
+            ):
+                if extension_id not in self.schema_cache:
+                    return None
+                return super().validate_extension(
+                    stac_dict, stac_object_type, stac_version, extension_id, href
+                )
+
         product = self._dummy_product(
             properties={"id": "dummy_id", "datetime": "2021-01-01T00:00:00Z"}
         )
         pystac_item = product.as_pystac_object()
         self.assertIsInstance(pystac_item, Item)
-        pystac_item.validate()
+        pystac_item.validate(validator=OfflineValidator())
 
     def test_eoproduct_from_pystac(self):
         """eoproduct.from_pystac must return an EOProduct instance from a pystac.Item"""


### PR DESCRIPTION
The Federation extension does not advertise its conformance class.

Also update the validation test to use only local schemas, avoiding schema downloads during test execution.

Validation of the Federation extension currently fails because the advertised conformance class URLs are not accessible: https://github.com/Open-EO/openeo-api/issues/598