### PR TITLE
feat(providers): add provider dedt_leonardo and update other dedt providers

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -933,7 +933,8 @@ No credentials are needed
   :color: muted
   :class-container: dropdown-fade-in slim-dropdown
 
-  Create an account on `DestinE <https://platform.destine.eu/>`__, then use your ``username``, ``password`` in eodag
+  Create an account on `DestinE <https://platform.destine.eu/>`__ and create a support ticket to request
+  upgraded access for accessing the Digital Twin data. Then use your ``username``, ``password`` in eodag
   credentials.
 
 ----
@@ -965,7 +966,41 @@ No credentials are needed
   :color: muted
   :class-container: dropdown-fade-in slim-dropdown
 
-  Create an account on `DestinE <https://platform.destine.eu/>`__, then use your ``username``, ``password`` in eodag
+  Create an account on `DestinE <https://platform.destine.eu/>`__ and create a support ticket to request
+  upgraded access for accessing the Digital Twin data. Then use your ``username``, ``password`` in eodag
+  credentials.
+
+----
+
+**DEDT Leonardo**
+--------------------
+
+.. grid:: 2
+   :gutter: 2
+   :class-container: sd-d-flex sd-align-items-center
+
+   .. grid-item::
+      :columns: 10
+
+      Destination Earth Digital Twin output on Leonardo HPC.
+
+   .. grid-item::
+      :columns: 2
+      :class: sd-text-right
+
+      .. button-link:: https://polytope.leonardo.apps.dte.destination-earth.eu/openapi
+        :color: primary
+        :outline:
+        :tooltip: DEDT Leonardo OpenAPI
+
+        :fas:`external-link-alt`
+
+.. dropdown:: Registration info
+  :color: muted
+  :class-container: dropdown-fade-in slim-dropdown
+
+  Create an account on `DestinE <https://platform.destine.eu/>`__ and create a support ticket to request
+  upgraded access for accessing the Digital Twin data. Then use your ``username``, ``password`` in eodag
   credentials.
 
 ----

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -933,9 +933,9 @@ No credentials are needed
   :color: muted
   :class-container: dropdown-fade-in slim-dropdown
 
-  Create an account on `DestinE <https://platform.destine.eu/>`__ and create a support ticket to request
-  upgraded access for accessing the Digital Twin data. Then use your ``username``, ``password`` in eodag
-  credentials.
+  Create an account on `DestinE <https://platform.destine.eu/>`__ and create a
+  `support ticket <https://platform.destine.eu/contact>`__ to request upgraded access for accessing the Digital Twin
+  data. Then use your ``username``, ``password`` in eodag credentials.
 
 ----
 
@@ -966,9 +966,9 @@ No credentials are needed
   :color: muted
   :class-container: dropdown-fade-in slim-dropdown
 
-  Create an account on `DestinE <https://platform.destine.eu/>`__ and create a support ticket to request
-  upgraded access for accessing the Digital Twin data. Then use your ``username``, ``password`` in eodag
-  credentials.
+  Create an account on `DestinE <https://platform.destine.eu/>`__ and create a
+  `support ticket <https://platform.destine.eu/contact>`__ to request upgraded access for accessing the Digital Twin
+  data. Then use your ``username``, ``password`` in eodag credentials.
 
 ----
 
@@ -999,9 +999,9 @@ No credentials are needed
   :color: muted
   :class-container: dropdown-fade-in slim-dropdown
 
-  Create an account on `DestinE <https://platform.destine.eu/>`__ and create a support ticket to request
-  upgraded access for accessing the Digital Twin data. Then use your ``username``, ``password`` in eodag
-  credentials.
+  Create an account on `DestinE <https://platform.destine.eu/>`__ and create a
+  `support ticket <https://platform.destine.eu/contact>`__ to request upgraded access for accessing the Digital Twin
+  data. Then use your ``username``, ``password`` in eodag credentials.
 
 ----
 

--- a/eodag/resources/providers/dedt_leonardo.yml
+++ b/eodag/resources/providers/dedt_leonardo.yml
@@ -1,0 +1,94 @@
+dedt_leonardo:
+  priority: 0
+  roles:
+    - host
+  description: Destination Earth Digital Twin Outputs from marenostrum through Polytope API
+  url: https://polytope.leonardo.apps.dte.destination-earth.eu/openapi
+  search:
+    type: ECMWFSearch
+    need_auth: true
+    ssl_verify: true
+    discover_queryables:
+      fetch_url: null
+      collection_fetch_url: null
+      constraints_url: "https://s3.central.data.destination-earth.eu/swift/v1/constraints/dedt_mn5/{dataset}_{activity}_{experiment}_{model}.json"
+      form_url: "https://s3.central.data.destination-earth.eu/swift/v1/constraints/dedt_mn5/form_{dataset}.json"
+    discover_metadata:
+      auto_discovery: true
+      search_param: '{metadata}'
+      metadata_pattern: '^(feature|interpolation|grid)$'
+    metadata_mapping:
+      geometry:
+        - '{{"feature": {geometry#to_geojson_polytope}}}'
+        - "$.geometry"
+      start_datetime: '{$.start_datetime#to_iso_utc_datetime}'
+      end_datetime:
+        - '{{"date": "{start_datetime#to_non_separated_date}/to/{end_datetime#to_non_separated_date}"}}'
+        - '{$.end_datetime#to_iso_utc_datetime}'
+      product:type:
+        - dataset
+        - $.dataset
+      qs: $.qs
+      eodag:order_link: 'https://polytope.leonardo.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{{"verb": "retrieve", "request": {qs#to_geojson} }}'
+  products:
+    DT_CLIMATE_G1_HIGHRESMIP_CONT_IFS_FESOM_R1:
+      dataset: climate-dt
+      class: d1
+      generation: "1"
+      expver: "0001"
+      stream: clte
+      type: fc
+      activity: HighResMIP
+      experiment: cont
+      realization: "1"
+      model: IFS-FESOM
+    DT_CLIMATE_G1_SCENARIOMIP_SSP3_7_0_IFS_FESOM_R1:
+      class: d1
+      dataset: climate-dt
+      generation: "1"
+      expver: "0001"
+      stream: clte
+      type: fc
+      activity: ScenarioMIP
+      experiment: SSP3-7.0
+      realization: "1"
+      model: IFS-FESOM
+  download:
+    type: HTTPDownload
+    ssl_verify: true
+    auth_error_code: 401
+    order_enabled: True
+    order_method: POST
+    order_on_response:
+      metadata_mapping:
+        eodag:order_id: '{$.headers.Location#slice_str(-36,,1)}'
+        _previous_order_id: '{$.json.eodag:order_id#replace_str("Not Available","")}'
+        eodag:combined_order_id: '{eodag:order_id#replace_str("Not Available","")}{_previous_order_id}'
+        eodag:status_link: "https://polytope.leonardo.apps.dte.destination-earth.eu/api/v1/requests/{eodag:combined_order_id#replace_str(r'^$','Not Available')}"
+    order_status:
+      request:
+        method: GET
+        headers:
+      metadata_mapping:
+        eodag:order_status: $.json.status
+        eodag:order_message: $.json.message
+        error_message: $.null
+      success:
+        http_code: 303
+      error:
+        eodag:order_status: failed
+      on_success:
+        result_type: json
+        metadata_mapping:
+          eodag:download_link: $.headers.Location
+    no_auth_download: True
+  auth:
+    type: OIDCAuthorizationCodeFlowAuth
+    oidc_config_url: https://auth.destine.eu/realms/desp/.well-known/openid-configuration
+    redirect_uri: https://polytope.lumi.apps.dte.destination-earth.eu/
+    client_id: polytope-api-public
+    user_consent_needed: false
+    token_exchange_post_data_method: data
+    token_provision: header
+    login_form_xpath: //form[@id='kc-form-login']
+    authentication_uri_source: login-form

--- a/eodag/resources/providers/dedt_leonardo.yml
+++ b/eodag/resources/providers/dedt_leonardo.yml
@@ -81,7 +81,7 @@ dedt_leonardo:
       on_success:
         result_type: json
         metadata_mapping:
-          eodag:download_link: $.headers.location
+          eodag:download_link: $.json.location
     no_auth_download: True
   auth:
     type: OIDCAuthorizationCodeFlowAuth

--- a/eodag/resources/providers/dedt_leonardo.yml
+++ b/eodag/resources/providers/dedt_leonardo.yml
@@ -2,7 +2,7 @@ dedt_leonardo:
   priority: 0
   roles:
     - host
-  description: Destination Earth Digital Twin Outputs from marenostrum through Polytope API
+  description: Destination Earth Digital Twin Outputs from Leonardo HPC through Polytope API
   url: https://polytope.leonardo.apps.dte.destination-earth.eu/openapi
   search:
     type: ECMWFSearch

--- a/eodag/resources/providers/dedt_leonardo.yml
+++ b/eodag/resources/providers/dedt_leonardo.yml
@@ -62,7 +62,7 @@ dedt_leonardo:
     order_method: POST
     order_on_response:
       metadata_mapping:
-        eodag:order_id: '{$.headers.location#slice_str(2,,1)}'
+        eodag:order_id: '{$.headers.Location#replace_str(r".*\W(\w+)$",r"\1")}'
         _previous_order_id: '{$.json.eodag:order_id#replace_str("Not Available","")}'
         eodag:combined_order_id: '{eodag:order_id#replace_str("Not Available","")}{_previous_order_id}'
         eodag:status_link: "https://polytope.leonardo.apps.dte.destination-earth.eu/api/v1/requests/{eodag:combined_order_id#replace_str(r'^$','Not Available')}"

--- a/eodag/resources/providers/dedt_leonardo.yml
+++ b/eodag/resources/providers/dedt_leonardo.yml
@@ -11,8 +11,8 @@ dedt_leonardo:
     discover_queryables:
       fetch_url: null
       collection_fetch_url: null
-      constraints_url: "https://s3.central.data.destination-earth.eu/swift/v1/constraints/dedt_mn5/{dataset}_{activity}_{experiment}_{model}.json"
-      form_url: "https://s3.central.data.destination-earth.eu/swift/v1/constraints/dedt_mn5/form_{dataset}.json"
+      constraints_url: "https://s3.central.data.destination-earth.eu/swift/v1/constraints/dedt_leonardo/{dataset}_{activity}_{experiment}_{model}.json"
+      form_url: "https://s3.central.data.destination-earth.eu/swift/v1/constraints/dedt_leonardo/form_{dataset}.json"
     discover_metadata:
       auto_discovery: true
       search_param: '{metadata}'
@@ -57,11 +57,12 @@ dedt_leonardo:
     type: HTTPDownload
     ssl_verify: true
     auth_error_code: 401
+    timeout: 10
     order_enabled: True
     order_method: POST
     order_on_response:
       metadata_mapping:
-        eodag:order_id: '{$.headers.Location#slice_str(-36,,1)}'
+        eodag:order_id: '{$.headers.location#slice_str(2,,1)}'
         _previous_order_id: '{$.json.eodag:order_id#replace_str("Not Available","")}'
         eodag:combined_order_id: '{eodag:order_id#replace_str("Not Available","")}{_previous_order_id}'
         eodag:status_link: "https://polytope.leonardo.apps.dte.destination-earth.eu/api/v1/requests/{eodag:combined_order_id#replace_str(r'^$','Not Available')}"
@@ -80,7 +81,7 @@ dedt_leonardo:
       on_success:
         result_type: json
         metadata_mapping:
-          eodag:download_link: $.headers.Location
+          eodag:download_link: $.headers.location
     no_auth_download: True
   auth:
     type: OIDCAuthorizationCodeFlowAuth

--- a/eodag/resources/providers/dedt_lumi.yml
+++ b/eodag/resources/providers/dedt_lumi.yml
@@ -257,7 +257,7 @@ dedt_lumi:
       on_success:
         result_type: json
         metadata_mapping:
-          eodag:download_link: $.headers.Location
+          eodag:download_link: $.json.location
     no_auth_download: True
   auth:
     type: OIDCAuthorizationCodeFlowAuth

--- a/eodag/resources/providers/dedt_mn5.yml
+++ b/eodag/resources/providers/dedt_mn5.yml
@@ -31,28 +31,6 @@ dedt_mn5:
       qs: $.qs
       eodag:order_link: 'https://polytope.mn5.apps.dte.destination-earth.eu/api/v1/requests/destination-earth?{{"verb": "retrieve", "request": {qs#to_geojson} }}'
   products:
-    DT_CLIMATE_G1_HIGHRESMIP_CONT_IFS_FESOM_R1:
-      dataset: climate-dt
-      class: d1
-      generation: "1"
-      expver: "0001"
-      stream: clte
-      type: fc
-      activity: HighResMIP
-      experiment: cont
-      realization: "1"
-      model: IFS-FESOM
-    DT_CLIMATE_G1_SCENARIOMIP_SSP3_7_0_IFS_FESOM_R1:
-      class: d1
-      dataset: climate-dt
-      generation: "1"
-      expver: "0001"
-      stream: clte
-      type: fc
-      activity: ScenarioMIP
-      experiment: SSP3-7.0
-      realization: "1"
-      model: IFS-FESOM
     DT_CLIMATE_G2_BASELINE_CONT_IFS_NEMO_R1:
       discover_queryables:
         form_url: "https://s3.central.data.destination-earth.eu/swift/v1/constraints/dedt_mn5/form_climate-dt-phase2.json"
@@ -311,7 +289,7 @@ dedt_mn5:
       on_success:
         result_type: json
         metadata_mapping:
-          eodag:download_link: $.headers.Location
+          eodag:download_link: $.json.location
     no_auth_download: True
   auth:
     type: OIDCAuthorizationCodeFlowAuth

--- a/eodag/resources/user_conf_template.yml
+++ b/eodag/resources/user_conf_template.yml
@@ -131,6 +131,15 @@ dedt_mn5:
         credentials:
             username:
             password:
+dedt_leonardo:
+    priority: # Lower value means lower priority (Default: 0)
+    search:
+    download:
+        output_dir:
+    auth:
+        credentials:
+            username:
+            password:
 dlr_eoc_geoservice:
     priority: # Lower value means lower priority (Default: 0)
     search:

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -153,8 +153,8 @@ class TestCore(TestCoreBase):
         "COP_DEM_GLO90_DTED": ["creodias", "creodias_s3", "dedl", "wekeo_main"],
         "DT_CLIMATE_ADAPTATION": ["dedl", "dedt_lumi"],
         "DT_EXTREMES": ["dedl", "dedt_lumi"],
-        "DT_CLIMATE_G1_HIGHRESMIP_CONT_IFS_FESOM_R1": ["dedt_mn5"],
-        "DT_CLIMATE_G1_SCENARIOMIP_SSP3_7_0_IFS_FESOM_R1": ["dedt_mn5"],
+        "DT_CLIMATE_G1_HIGHRESMIP_CONT_IFS_FESOM_R1": ["dedt_leonardo"],
+        "DT_CLIMATE_G1_SCENARIOMIP_SSP3_7_0_IFS_FESOM_R1": ["dedt_leonardo"],
         "DT_CLIMATE_G2_BASELINE_CONT_IFS_NEMO_R1": ["dedt_mn5"],
         "DT_CLIMATE_G2_BASELINE_HIST_IFS_NEMO_R1": ["dedt_mn5"],
         "DT_CLIMATE_G2_PROJECTIONS_SSP3_7_0_IFS_NEMO_R1": ["dedt_mn5"],
@@ -919,6 +919,7 @@ class TestCore(TestCoreBase):
         "creodias",
         "creodias_s3",
         "dedl",
+        "dedt_leonardo",
         "dedt_lumi",
         "dedt_mn5",
         "dlr_eoc_geoservice",
@@ -2275,6 +2276,7 @@ class TestCore(TestCoreBase):
                 ],
             },
             "dedt_lumi": None,
+            "dedt_leonardo": None,
             "dedt_mn5": None,
             "dlr_eoc_geoservice": {
                 "sortables": [


### PR DESCRIPTION
udpates for the dedt providers:

- add new provider `dedt_leonardo`
- move 2 collections from `dedt_mn5` to `dedt_leonardo`
- update the configuration of `dedt_mn5` and `dedt_lumi` after Polytope update
- add information about upgraded access to provider documentation
