### PR TITLE
fix(queryables): prevent type update to be skipped

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -953,12 +953,11 @@ class ECMWFSearch(PostJsonSearch):
             values = (
                 available_values[name]
                 if name in available_values
-                else details.get("values")
+                else details.get("values", [])
             )
 
             # updates the properties with the values given based on the information from the element
-            if values is not None:
-                _update_properties_from_element(prop, element, values)
+            _update_properties_from_element(prop, element, values)
 
             # default value is set with the following priority:
             # input default values > form details default value > no default value

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -4031,6 +4031,11 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
 
         self.assertIsNotNone(queryables)
         self.assertIn("ecmwf_download_format", queryables)
+        self.assertEqual(
+            get_args(queryables["ecmwf_download_format"])[0],
+            str,
+            "Type of keyword ecmwf_download_format must be extracted from form element",
+        )
         self.assertTrue(
             get_args(queryables["ecmwf_download_format"])[1].is_required(),
             "Keyword ecmwf_download_format must be required when details are missing",


### PR DESCRIPTION
Following https://github.com/CS-SI/eodag/pull/2270, the function `_update_properties_from_element(...)` should always being called, also with empty details in form. This is necessary to attempt setting the `type` property (`prop["type"]`) from form element (`element["type"]`).

Before the fix, this was the returned queryables:

`
typing.Annotated[NoneType, FieldInfo(annotation=NoneType, required=True, alias_priority=2, validation_alias=AliasChoices(choices=['ecmwf:download_format', 'download_format']), serialization_alias='ecmwf:download_format', title='download_format', metadata=['json_schema_required'])]
`

Note the type `NoneType` that is fixed by this PR.