### PR TITLE
fix(plugins): don't send empty values in HTTP headers with SASAuth plugin

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -1179,8 +1179,8 @@ No credentials are needed
   Most datasets are anonymously accessible, but a subscription key may be needed to increase `rate limits and access
   private datasets <https://planetarycomputer.microsoft.com/docs/concepts/sas/#rate-limits-and-access-restrictions>`_.
 
-  Create an account `here <https://planetarycomputer.microsoft.com/account/request>`__, then view your keys by signing in
-  with your Microsoft account `here <https://planetarycomputer.developer.azure-api.net/>`__.
+  Create an Azure account and subscription `here <https://azure.microsoft.com/pricing/purchase-options/azure-account>`__, then
+  retrieve your subscription keys from Azure API Management.
 
 ----
 

--- a/eodag/plugins/authentication/sas_auth.py
+++ b/eodag/plugins/authentication/sas_auth.py
@@ -133,7 +133,7 @@ class SASAuth(Authentication):
         ssl_verify = getattr(self.config, "ssl_verify", True)
         if matching_url := getattr(self.config, "matching_url", None):
             matching_url = re.compile(matching_url)
-        if credentials:
+        if any(credentials.values()):
             not_empty_credentials = {k: v for k, v in credentials.items() if v}
             headers_update = format_dict_items(
                 self.config.headers, **not_empty_credentials

--- a/eodag/plugins/authentication/sas_auth.py
+++ b/eodag/plugins/authentication/sas_auth.py
@@ -134,7 +134,10 @@ class SASAuth(Authentication):
         if matching_url := getattr(self.config, "matching_url", None):
             matching_url = re.compile(matching_url)
         if credentials:
-            headers_update = format_dict_items(self.config.headers, **credentials)
+            not_empty_credentials = {k: v for k, v in credentials.items() if v}
+            headers_update = format_dict_items(
+                self.config.headers, **not_empty_credentials
+            )
             headers.update(headers_update)
 
         return RequestsSASAuth(

--- a/tests/units/test_auth_plugins.py
+++ b/tests/units/test_auth_plugins.py
@@ -332,12 +332,12 @@ class TestAuthPluginTokenAuth(BaseAuthPluginTest):
 
         # check if returned auth object is an instance of requests.AuthBase
         auth = auth_plugin.authenticate()
-        assert isinstance(auth, AuthBase)
+        self.assertIsInstance(auth, AuthBase)
 
         # check if token is integrated to the request
         req = mock.Mock(headers={})
         auth(req)
-        assert req.headers["Authorization"] == "Bearer this_is_test_token"
+        self.assertEqual(req.headers["Authorization"], "Bearer this_is_test_token")
 
     @mock.patch(
         "eodag.plugins.authentication.token.requests.Session.request", autospec=True
@@ -430,12 +430,12 @@ class TestAuthPluginTokenAuth(BaseAuthPluginTest):
 
         # check if returned auth object is an instance of requests.AuthBase
         auth = auth_plugin.authenticate()
-        assert isinstance(auth, AuthBase)
+        self.assertIsInstance(auth, AuthBase)
 
         # check if token is integrated to the request
         req = mock.Mock(headers={})
         auth(req)
-        assert req.headers["Authorization"] == "Bearer this_is_test_token"
+        self.assertEqual(req.headers["Authorization"], "Bearer this_is_test_token")
 
         # token request should be sent
         mock_requests_post.assert_called_once_with(
@@ -454,7 +454,7 @@ class TestAuthPluginTokenAuth(BaseAuthPluginTest):
         mock_requests_post.reset_mock()
         # second call should use existing token
         auth = auth_plugin.authenticate()
-        assert isinstance(auth, AuthBase)
+        self.assertIsInstance(auth, AuthBase)
         mock_requests_post.assert_not_called()
 
         # reset expiration -> token should be fetched again
@@ -468,10 +468,12 @@ class TestAuthPluginTokenAuth(BaseAuthPluginTest):
         }
         auth = auth_plugin.authenticate()
 
-        assert isinstance(auth, AuthBase)
+        self.assertIsInstance(auth, AuthBase)
         req = mock.Mock(headers={})
         auth(req)
-        assert req.headers["Authorization"] == "Bearer this_is_a_refreshed_token"
+        self.assertEqual(
+            req.headers["Authorization"], "Bearer this_is_a_refreshed_token"
+        )
 
         mock_requests_post.assert_called_once_with(
             mock.ANY,
@@ -1681,18 +1683,18 @@ class TestAuthPluginSASAuth(BaseAuthPluginTest):
 
         # check if returned auth object is an instance of requests.AuthBase
         auth = auth_plugin.authenticate()
-        assert isinstance(auth, AuthBase)
+        self.assertIsInstance(auth, AuthBase)
 
         # check if the full signed url and the subscription key are integrated to the request
         url = "url"
         req = mock.Mock(headers={}, url=url)
         auth(req)
-        assert req.url == "this_is_test_full_signed_url"
-        assert req.headers["Ocp-Apim-Subscription-Key"] == "foo"
+        self.assertEqual(req.url, "this_is_test_full_signed_url")
+        self.assertEqual(req.headers["Ocp-Apim-Subscription-Key"], "foo")
 
         # check SAS get request call arguments
         args, kwargs = mock_requests_get.call_args
-        assert args[0] == auth_plugin.config.auth_uri.format(url=url)
+        self.assertEqual(args[0], auth_plugin.config.auth_uri.format(url=url))
         auth_plugin_headers = {"Ocp-Apim-Subscription-Key": "foo"}
         self.assertDictEqual(kwargs["headers"], dict(auth_plugin_headers, **USER_AGENT))
 
@@ -1705,7 +1707,7 @@ class TestAuthPluginSASAuth(BaseAuthPluginTest):
         """
         auth_plugin = self.get_auth_plugin("foo_provider")
 
-        auth_plugin.config.credentials = {}
+        auth_plugin.config.credentials = {"apikey": None}
 
         # mock full signed url get request response
         mock_requests_get.return_value = mock.Mock()
@@ -1716,19 +1718,19 @@ class TestAuthPluginSASAuth(BaseAuthPluginTest):
 
         # check if returned auth object is an instance of requests.AuthBase
         auth = auth_plugin.authenticate()
-        assert isinstance(auth, AuthBase)
+        self.assertIsInstance(auth, AuthBase)
 
         # check if only the full signed url is integrated to the request
         url = "url"
         req = mock.Mock(headers={}, url=url)
         auth(req)
-        assert req.url == "this_is_test_full_signed_url"
+        self.assertEqual(req.url, "this_is_test_full_signed_url")
 
         # check SAS get request call arguments
         args, kwargs = mock_requests_get.call_args
-        assert args[0] == auth_plugin.config.auth_uri.format(url=url)
+        self.assertEqual(args[0], auth_plugin.config.auth_uri.format(url=url))
         # check if headers only has the user agent as a request call argument
-        assert kwargs["headers"] == USER_AGENT
+        self.assertEqual(kwargs["headers"], USER_AGENT)
 
     @mock.patch("eodag.plugins.authentication.sas_auth.requests.get", autospec=True)
     def test_plugins_auth_sasauth_request_error(self, mock_requests_get):
@@ -1742,7 +1744,7 @@ class TestAuthPluginSASAuth(BaseAuthPluginTest):
 
         # check if returned auth object is an instance of requests.AuthBase
         auth = auth_plugin.authenticate()
-        assert isinstance(auth, AuthBase)
+        self.assertIsInstance(auth, AuthBase)
 
         req = mock.Mock(headers={}, url="url")
         with self.assertRaises(AuthenticationError):
@@ -1874,7 +1876,7 @@ class TestAuthPluginKeycloakOIDCPasswordAuth(BaseAuthPluginTest):
 
             # check if returned auth object is an instance of requests.AuthBase
             auth = auth_plugin.authenticate()
-            assert isinstance(auth, AuthBase)
+            self.assertIsInstance(auth, AuthBase)
             self.assertEqual(auth.key, "totoken")
             self.assertEqual(auth.token, "obtained-token")
             self.assertEqual(auth.where, "qs")
@@ -1885,7 +1887,7 @@ class TestAuthPluginKeycloakOIDCPasswordAuth(BaseAuthPluginTest):
         # check that stored token is used if available
         auth = auth_plugin.authenticate()
         # check if returned auth object is an instance of requests.AuthBase
-        assert isinstance(auth, AuthBase)
+        self.assertIsInstance(auth, AuthBase)
         self.assertEqual(auth.key, "totoken")
         self.assertEqual(auth.token, "obtained-token")
         self.assertEqual(auth.where, "qs")
@@ -1913,7 +1915,7 @@ class TestAuthPluginKeycloakOIDCPasswordAuth(BaseAuthPluginTest):
 
             # check if returned auth object is an instance of requests.AuthBase
             auth = auth_plugin.authenticate()
-            assert isinstance(auth, AuthBase)
+            self.assertIsInstance(auth, AuthBase)
 
             # check if query string is integrated to the request
             req = Request("GET", "https://httpbin.org/get").prepare()
@@ -1954,7 +1956,7 @@ class TestAuthPluginKeycloakOIDCPasswordAuth(BaseAuthPluginTest):
 
             # check if returned auth object is an instance of requests.AuthBase
             auth = auth_plugin.authenticate()
-            assert isinstance(auth, AuthBase)
+            self.assertIsInstance(auth, AuthBase)
 
             # check if token header is integrated to the request
             req = Request("GET", "https://httpbin.org/get").prepare()
@@ -2006,7 +2008,7 @@ class TestAuthPluginKeycloakOIDCPasswordAuth(BaseAuthPluginTest):
 
             # check if returned auth object is an instance of requests.AuthBase
             auth = auth_plugin.authenticate()
-            assert isinstance(auth, AuthBase)
+            self.assertIsInstance(auth, AuthBase)
             self.assertEqual(auth.key, "totoken")
             self.assertEqual(auth.token, "obtained-token")
             self.assertEqual(auth.where, "qs")
@@ -2039,7 +2041,7 @@ class TestAuthPluginKeycloakOIDCPasswordAuth(BaseAuthPluginTest):
 
             # check if returned auth object is an instance of requests.AuthBase
             auth = auth_plugin.authenticate()
-            assert isinstance(auth, AuthBase)
+            self.assertIsInstance(auth, AuthBase)
             self.assertEqual(auth.key, "totoken")
             self.assertEqual(auth.token, "new-token")
             self.assertEqual(auth.where, "qs")


### PR DESCRIPTION
Credentials are optional for `planetary_computer`. The user may use a user configuration without setting the `apikey`, as in the following example:

```yaml
planetary_computer:
    priority: # Lower value means lower priority (Default: 0)
    search: # Search parameters configuration
    auth:
        credentials:
            apikey:
    download:
        output_dir: /home/user/Download/eodag
```

This causes an invalid header with `None` value.

In this PR:

- check the headers don't store empty values before sending the request;
- update Planetary Computer registration documentation.