### PR TITLE
fix(plugins): update properties after EcmwfSearch search by id

### DIFF
--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -1295,6 +1295,48 @@ def _check_id(product: EOProduct) -> EOProduct:
     return product
 
 
+def _apply_eodag_request_params(
+    product: EOProduct,
+) -> None:
+    """Apply ``eodag:request_params`` from the order status response to the product.
+
+    :param product: The product to which the request parameters should be applied
+    """
+    eodag_request_params = product.properties.get("eodag:request_params", {})
+    if not eodag_request_params:
+        return
+    # item properties
+    properties = deepcopy(eodag_request_params)
+    properties.pop("feature", None)
+    properties.pop("area", None)
+    properties.pop("location", None)
+    start_datetime, end_datetime = ecmwf_temporal_to_eodag(properties)
+    properties = {f"ecmwf:{k}": v for k, v in properties.items()}
+    datetime_value = start_datetime or end_datetime
+    if datetime_value:
+        properties["datetime"] = datetime_value
+    if start_datetime:
+        properties[START] = start_datetime
+    if end_datetime:
+        properties[END] = end_datetime
+    product.properties.update(properties)
+
+    # geometry
+    """Extract EODAG geometry from an EOProduct"""
+    geometry = None
+    # ECMWF Polytope uses non-geojson structure for features
+    if "feature" in eodag_request_params:
+        geometry = get_geometry_from_ecmwf_feature(eodag_request_params["feature"])
+    # bounding box in area format
+    if "area" in eodag_request_params:
+        geometry = get_geometry_from_ecmwf_area(eodag_request_params["area"])
+    # single location
+    if "location" in eodag_request_params:
+        geometry = get_geometry_from_ecmwf_location(eodag_request_params["location"])
+    if geometry:
+        product.geometry = geometry
+
+
 def patched_register_downloader(self, downloader, authenticator):
     """Register product donwloader and update properties if searched by id.
 
@@ -1309,6 +1351,7 @@ def patched_register_downloader(self, downloader, authenticator):
     self.register_downloader_only(downloader, authenticator)
     # and also update properties
     _check_id(self)
+    _apply_eodag_request_params(self)
 
 
 class MeteoblueSearch(ECMWFSearch):

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -1295,7 +1295,7 @@ def _check_id(product: EOProduct) -> EOProduct:
     return product
 
 
-def _apply_eodag_request_params(
+def _request_params_to_properties(
     product: EOProduct,
 ) -> None:
     """Apply ``eodag:request_params`` from the order status response to the product.
@@ -1311,7 +1311,9 @@ def _apply_eodag_request_params(
     properties.pop("area", None)
     properties.pop("location", None)
     start_datetime, end_datetime = ecmwf_temporal_to_eodag(properties)
-    properties = {f"ecmwf:{k}": v for k, v in properties.items()}
+    properties = {
+        f"ecmwf:{k}": v for k, v in properties.items() if k in ALLOWED_KEYWORDS
+    }
     datetime_value = start_datetime or end_datetime
     if datetime_value:
         properties["datetime"] = datetime_value
@@ -1328,10 +1330,10 @@ def _apply_eodag_request_params(
     if "feature" in eodag_request_params:
         geometry = get_geometry_from_ecmwf_feature(eodag_request_params["feature"])
     # bounding box in area format
-    if "area" in eodag_request_params:
+    if geometry is None and "area" in eodag_request_params:
         geometry = get_geometry_from_ecmwf_area(eodag_request_params["area"])
     # single location
-    if "location" in eodag_request_params:
+    if geometry is None and "location" in eodag_request_params:
         geometry = get_geometry_from_ecmwf_location(eodag_request_params["location"])
     if geometry:
         product.geometry = geometry
@@ -1351,7 +1353,7 @@ def patched_register_downloader(self, downloader, authenticator):
     self.register_downloader_only(downloader, authenticator)
     # and also update properties
     _check_id(self)
-    _apply_eodag_request_params(self)
+    _request_params_to_properties(self)
 
 
 class MeteoblueSearch(ECMWFSearch):

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -3092,9 +3092,10 @@ class TestSearchPluginMeteoblueSearch(BaseSearchPluginTest):
 
 
 class MockResponse:
-    def __init__(self, json_data, status_code):
+    def __init__(self, json_data, status_code, headers=None):
         self.json_data = json_data
         self.status_code = status_code
+        self.headers = headers
 
     def json(self):
         return self.json_data
@@ -3102,6 +3103,9 @@ class MockResponse:
     def raise_for_status(self):
         if self.status_code != 200:
             raise RequestError
+
+    def headers(self):
+        return self.headers
 
 
 class TestSearchPluginCreodiasS3Search(BaseSearchPluginTest):
@@ -3600,6 +3604,86 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
             ecmwf_temporal_to_eodag(dict(date=["20220215"])),
             ("2022-02-15T00:00:00.000Z", "2022-02-15T00:00:00.000Z"),
         )
+
+    def test_plugins_search_ecmwfsearch_normalize_results(self):
+        """ECMWFSearch should add request params to properties and set
+        start/end datetime if year/month/day/time are present in normalize_results"""
+        params = {
+            "year": "2020",
+            "month": ["2"],
+            "day": ["20", "21"],
+            "time": ["01:00"],
+            "collection": "ERA5_SL",
+        }
+        raw_search_results = RawSearchResult([{}])
+        raw_search_results.search_params = params
+        raw_search_results.query_params = params
+        raw_search_results.collection_def_params = (
+            self.search_plugin.get_collection_def_params("ERA5_SL")
+        )
+        normalized_result = self.search_plugin.normalize_results(
+            raw_search_results, **params
+        )
+        product = normalized_result[0]
+        self.assertEqual(
+            product.properties["start_datetime"], "2020-02-20T01:00:00.000Z"
+        )
+        self.assertEqual(product.properties["end_datetime"], "2020-02-21T01:00:00.000Z")
+        self.assertEqual(product.properties["ecmwf:year"], "2020")
+        self.assertEqual(product.properties["ecmwf:month"], ["2"])
+        self.assertEqual(product.properties["ecmwf:day"], ["20", "21"])
+        self.assertEqual(product.properties["ecmwf:time"], ["01:00"])
+        self.assertEqual(product.collection, "ERA5_SL")
+
+    @mock.patch("eodag.plugins.download.http.requests.request", autospec=True)
+    def test_plugins_search_ecmwfsearch_normalize_results_check_id(self, mock_requests):
+        """ECMWFSearch should add params from status request to properties"""
+        params = {"collection": "ERA5_SL", "id": "123"}
+        status_response = {
+            "processID": "era5-sl",
+            "type": "process",
+            "created": "2026-08-05T16:05:34.935629",
+            "started": "2026-08-05T16:05:51.203071",
+            "finished": "2026-08-05T16:05:56.188265",
+            "updated": "2026-08-05T16:05:56.188265",
+            "jobID": "123",
+            "status": "accepted",
+            "metadata": {
+                "request": {
+                    "ids": {
+                        "time": ["00:00"],
+                        "year": ["2020"],
+                        "month": ["01"],
+                        "day": ["01"],
+                        "variable": ["carbon_dioxide"],
+                    }
+                }
+            },
+        }
+        mock_requests.return_value = MockResponse(
+            status_response, 200, {"Content-Type": "application/json"}
+        )
+        raw_search_results = RawSearchResult([{}])
+        raw_search_results.search_params = params
+        raw_search_results.query_params = params
+        raw_search_results.collection_def_params = (
+            self.search_plugin.get_collection_def_params("ERA5_SL")
+        )
+        normalized_result = self.search_plugin.normalize_results(
+            raw_search_results, **params
+        )
+        product = normalized_result[0]
+        download_plugin = self.plugins_manager.get_download_plugin(product)
+        product.register_downloader(download_plugin, None)
+        self.assertEqual(
+            product.properties["start_datetime"], "2020-01-01T00:00:00.000Z"
+        )
+        self.assertEqual(product.properties["end_datetime"], "2020-01-01T00:00:00.000Z")
+        self.assertEqual(product.properties["ecmwf:year"], ["2020"])
+        self.assertEqual(product.properties["ecmwf:month"], ["01"])
+        self.assertEqual(product.properties["ecmwf:day"], ["01"])
+        self.assertEqual(product.properties["ecmwf:time"], ["00:00"])
+        self.assertEqual(product.collection, "ERA5_SL")
 
     def test_plugins_search_ecmwfsearch_get_available_values_from_contraints(self):
         """ECMWFSearch must return available values from constraints"""

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -3679,6 +3679,7 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
             product.properties["start_datetime"], "2020-01-01T00:00:00.000Z"
         )
         self.assertEqual(product.properties["end_datetime"], "2020-01-01T00:00:00.000Z")
+        self.assertEqual(product.properties["datetime"], "2020-01-01T00:00:00.000Z")
         self.assertEqual(product.properties["ecmwf:year"], ["2020"])
         self.assertEqual(product.properties["ecmwf:month"], ["01"])
         self.assertEqual(product.properties["ecmwf:day"], ["01"])


### PR DESCRIPTION
fix: apply `eodag:request_params` to product properties

The Copernicus providers return the search parameters in the order status request. The EODAG library stores them in the `eodag:request_params`. This PR gets the parameters from `eodag:request_params` and copy them in the item's properties.

