### PR TITLE
feat(plugins): expose provider collection in metadata mapping

### DIFF
--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -232,15 +232,38 @@ class Search(PluginTopic):
     def get_metadata_mapping(
         self, collection: Optional[str] = None
     ) -> dict[str, Union[str, list[Optional[str]]]]:
-        """Get the plugin metadata mapping configuration (collection specific if exists)
+        """Get plugin metadata mapping configuration (collection-specific if set).
 
-        :param collection: the desired collection
-        :returns: The collection specific metadata-mapping
+        Uses collection metadata mapping when available, otherwise falls back to
+        provider-level metadata mapping.
+        If provider collection  is available, updates ``"_collection"`` property value
+        in returned metadata mapping.
+
+        :param collection: Optional eodag collection identifier.
+        :returns: Collection-specific metadata mapping, or provider-level mapping.
         """
         if collection:
-            return self.config.products.get(collection, {}).get(
-                "metadata_mapping", self.config.metadata_mapping
+            metadata_mapping = deepcopy(
+                self.config.products.get(collection, {}).get(
+                    "metadata_mapping", self.config.metadata_mapping
+                )
             )
+
+            # update _collection value in metadata_mapping if provider collection is available
+            provider_collection = self.config.products.get(collection, {}).get(
+                "_collection"
+            )
+            if provider_collection and "_collection" in metadata_mapping:
+                if (
+                    isinstance(metadata_mapping["_collection"], list)
+                    and len(metadata_mapping["_collection"]) == 2
+                ):
+                    metadata_mapping["_collection"][1] = (None, provider_collection)
+                else:
+                    metadata_mapping["_collection"] = (None, provider_collection)
+
+            return metadata_mapping
+
         return self.config.metadata_mapping
 
     def get_sort_by_arg(self, kwargs: dict[str, Any]) -> Optional[SortByList]:

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -129,6 +129,49 @@ class BaseSearchPluginTest(unittest.TestCase):
         self.assertEqual("Two", asset_mappings["two"]["title"])
         self.assertListEqual(["a_role"], asset_mappings["two"]["roles"])
 
+    def test_get_metadata_mapping_without_collection(self):
+        """Test that the provider metadata_mapping is returned when no collection is specified"""
+        search_plugin = self.get_search_plugin(provider="geodes")
+        provider_mapping = search_plugin.config.metadata_mapping
+
+        metadata_mapping = search_plugin.get_metadata_mapping()
+
+        self.assertEqual(provider_mapping, metadata_mapping)
+        self.assertEqual(
+            provider_mapping["_collection"], metadata_mapping["_collection"]
+        )
+
+    def test_get_metadata_mapping_with_collection(self):
+        """Test that the collection metadata_mapping is returned when a collection is specified"""
+        search_plugin = self.get_search_plugin(provider="geodes")
+        collection = "S1_SAR_GRD"
+        provider_mapping = search_plugin.config.metadata_mapping
+        collection_mapping = search_plugin.config.products[collection][
+            "metadata_mapping"
+        ]
+
+        metadata_mapping = search_plugin.get_metadata_mapping(collection)
+
+        self.assertEqual(
+            collection_mapping["eo:cloud_cover"],
+            metadata_mapping["eo:cloud_cover"],
+        )
+        self.assertNotEqual(
+            provider_mapping["eo:cloud_cover"],
+            metadata_mapping["eo:cloud_cover"],
+        )
+        self.assertEqual(
+            (None, search_plugin.config.products[collection]["_collection"]),
+            metadata_mapping["_collection"][1],
+        )
+
+        # Check that original mappings are still intact and not modified
+        self.assertEqual(provider_mapping, search_plugin.config.metadata_mapping)
+        self.assertEqual(
+            collection_mapping,
+            search_plugin.config.products[collection]["metadata_mapping"],
+        )
+
 
 class TestSearchPluginQueryStringSearchXml(BaseSearchPluginTest):
     def setUp(self):


### PR DESCRIPTION
Exposes provider collection `_collection` value in metadata mapping, to make it available during `plugin.search` properties mapping mechanism.