### PR TITLE
fix(providers): dedt order_id in response case and path

### DIFF
--- a/eodag/plugins/download/http.py
+++ b/eodag/plugins/download/http.py
@@ -264,7 +264,7 @@ class HTTPDownload(Download):
         json_response = response.json()
 
         properties_update = properties_from_json(
-            {"json": json_response, "headers": {**response.headers}},
+            {"json": json_response, "headers": response.headers},
             on_response_mm_jsonpath,
         )
         product.properties.update(
@@ -442,7 +442,7 @@ class HTTPDownload(Download):
             )
             logger.debug("Parsing order status response")
             status_dict = properties_from_json(
-                {"json": response.json(), "headers": {**response.headers}},
+                {"json": response.json(), "headers": response.headers},
                 status_mm_jsonpath,
             )
 
@@ -578,7 +578,7 @@ class HTTPDownload(Download):
                         "Parsing on-success metadata-mapping using order status response"
                     )
                     properties_update = properties_from_json(
-                        {"json": json_response, "headers": {**response.headers}},
+                        {"json": json_response, "headers": response.headers},
                         on_success_mm_querypath,
                     )
                     # only keep properties to update (remove product.properties added for parsing)

--- a/eodag/resources/providers/dedt_lumi.yml
+++ b/eodag/resources/providers/dedt_lumi.yml
@@ -238,7 +238,7 @@ dedt_lumi:
     order_method: POST
     order_on_response:
       metadata_mapping:
-        eodag:order_id: '{$.headers.Location#slice_str(-36,,1)}'
+        eodag:order_id: '{$.headers.Location#replace_str(r".*\W(\w+)$",r"\1")}'
         _previous_order_id: '{$.json.eodag:order_id#replace_str("Not Available","")}'
         eodag:combined_order_id: '{eodag:order_id#replace_str("Not Available","")}{_previous_order_id}'
         eodag:status_link: "https://polytope.lumi.apps.dte.destination-earth.eu/api/v1/requests/{eodag:combined_order_id#replace_str(r'^$','Not Available')}"

--- a/eodag/resources/providers/dedt_mn5.yml
+++ b/eodag/resources/providers/dedt_mn5.yml
@@ -292,7 +292,7 @@ dedt_mn5:
     order_method: POST
     order_on_response:
       metadata_mapping:
-        eodag:order_id: '{$.headers.Location#slice_str(-36,,1)}'
+        eodag:order_id: '{$.headers.Location#replace_str(r".*\W(\w+)$",r"\1")}'
         _previous_order_id: '{$.json.eodag:order_id#replace_str("Not Available","")}'
         eodag:combined_order_id: '{eodag:order_id#replace_str("Not Available","")}{_previous_order_id}'
         eodag:status_link: "https://polytope.mn5.apps.dte.destination-earth.eu/api/v1/requests/{eodag:combined_order_id#replace_str(r'^$','Not Available')}"

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -1686,10 +1686,13 @@ class TestDownloadPluginHttp(BaseDownloadPluginTest):
         self.product.properties["eodag:status_link"] = "http://somewhere/order-status"
         response = mock_request.return_value
         response.status_code = 200
-        response.headers = {
-            "Content-Type": "application/json",
-            "location": "http://somewhere/download",
-        }
+        # Use different case for header keys to test that case-insensitivity is preserved
+        response.headers = CaseInsensitiveDict(
+            {
+                "Content-Type": "application/json",
+                "Location": "http://somewhere/download",
+            }
+        )
         response.json.side_effect = ValueError("empty response")
 
         plugin._order_status(self.product)


### PR DESCRIPTION
Completes https://github.com/CS-SI/eodag/pull/2279 to fix another issue raised in #2278 with order response headers case and content path.

Preserves case-insensitive headers and updates `order_id` path in dedt providers configurations.