### PR TITLE
fix(providers): update providers assets mapping conf and CopGhslSearch

### DIFF
--- a/eodag/api/product/metadata_mapping.py
+++ b/eodag/api/product/metadata_mapping.py
@@ -56,7 +56,7 @@ from eodag.utils import (
     update_nested_dict,
 )
 from eodag.utils.dates import get_timestamp, parse_to_utc, to_iso_utc_string
-from eodag.utils.exceptions import ValidationError
+from eodag.utils.exceptions import MisconfiguredError, ValidationError
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -1281,10 +1281,11 @@ def properties_from_json(
     for metadata, template in templates.items():
         try:
             properties[metadata] = format_string(metadata, template, **properties)
-        except ValueError:
+        except (ValueError, AttributeError, KeyError, MisconfiguredError) as e:
             logger.warning(
-                f"Could not parse {metadata} ({template}) using product properties"
+                f"Could not parse {metadata} ({template}) using available properties"
             )
+            logger.debug(repr(e))
             logger.debug(f"available properties: {properties}")
             properties[metadata] = NOT_AVAILABLE
 

--- a/eodag/plugins/search/base.py
+++ b/eodag/plugins/search/base.py
@@ -321,6 +321,14 @@ class Search(PluginTopic):
                 )
             assets_mapping.update(collection_asset_mapping)
 
+            # update _collection value in assets_mapping if provider collection is available
+            provider_collection = self.config.products.get(collection, {}).get(
+                "_collection"
+            )
+            if provider_collection:
+                for asset_key, one_asset_mapping in assets_mapping.items():
+                    assets_mapping[asset_key]["_collection"] = provider_collection
+
         return assets_mapping
 
     def get_sort_by_arg(self, kwargs: dict[str, Any]) -> Optional[SortByList]:

--- a/eodag/plugins/search/build_search_result.py
+++ b/eodag/plugins/search/build_search_result.py
@@ -639,6 +639,7 @@ class ECMWFSearch(PostJsonSearch):
                 START,
                 END,
                 "geometry",
+                "_collection",
             } and not self._is_discoverable_metadata_key(key):
                 raise ValidationError(
                     f"'{key}' is not a queryable parameter for {self.provider}", {key}

--- a/eodag/plugins/search/cop_ghsl.py
+++ b/eodag/plugins/search/cop_ghsl.py
@@ -283,7 +283,8 @@ class CopGhslSearch(Search):
         if the bbox is given in metres, it is transformed to longitude and latitude
         """
         products = []
-        metadata_mapping = params.pop("metadata_mapping", {})
+        metadata_mapping = self.get_metadata_mapping(collection)
+        metadata_mapping.pop("eodag:default_geometry", None)
         parsed_metadata_mapping = mtd_cfg_as_conversion_and_querypath(metadata_mapping)
 
         filter_geometry = params.pop("geometry", None)
@@ -293,9 +294,13 @@ class CopGhslSearch(Search):
         end_index = start_index + per_page - 1
 
         # parameters that need formatting
-        dataset = metadata_mapping.get("dataset", None)
+        dataset = metadata_mapping.get("dataset")
         if not dataset:
             raise MisconfiguredError(f"dataset mapping not available for {collection}")
+        elif not isinstance(dataset, str):
+            msg = f"dataset mapping for {collection} is not a string: {dataset}"
+            raise MisconfiguredError(msg)
+
         id_params = deepcopy(params)
         id_params["proj:code"] = id_params["proj:code"].replace("EPSG:", "")
         if "tile_size" in parsed_metadata_mapping:
@@ -370,13 +375,30 @@ class CopGhslSearch(Search):
                 # create id
                 product_id = f"{product_id_base}__{tile['tileID']}"
                 properties["id"] = properties["title"] = product_id
-                download_link = metadata_mapping.get("eodag:download_link").format(
-                    dataset=dataset, tile_id=tile["tileID"]
+
+                # assets & download link
+                assets_mapping = self.get_assets_mapping(collection)
+                download_link_template = assets_mapping.get("download_link", {}).get(
+                    "href"
                 )
-                properties["eodag:download_link"] = download_link
+                if download_link_template is None:
+                    msg = (
+                        "Required download link configuration by CopGhslSearch._create_products_from_tiles"
+                        f" missing for collection {collection}"
+                    )
+                    raise MisconfiguredError(msg)
+                else:
+                    assets_mapping["download_link"]["href"] = (
+                        download_link_template.format(
+                            dataset=dataset, tile_id=tile["tileID"]
+                        )
+                    )
                 product = EOProduct(
                     provider="cop_ghsl", properties=properties, collection=collection
                 )
+                # apply assets & download link
+                product.assets.update(assets_mapping)
+
                 if not filter_geometry or filter_geometry.intersects(product.geometry):
                     if current_index >= start_index and current_index <= end_index:
                         products.append(product)
@@ -398,17 +420,20 @@ class CopGhslSearch(Search):
         properties["order:status"] = "succeeded"
         if "proj:code" in filters:
             filters["proj:code"] = filters["proj:code"].replace("EPSG:", "")
-        collection_config = self.config.products.get(collection, {})
-        download_link = collection_config.get("metadata_mapping", {}).get(
-            "eodag:download_link", None
-        )
-        if not download_link:
-            raise MisconfiguredError(
-                f"Download link configuration missing for collection {collection}"
+        # assets & download link
+        assets_mapping = self.get_assets_mapping(collection)
+        download_link_template = assets_mapping.get("download_link", {}).get("href")
+        if not assets_mapping or (
+            assets_mapping.keys() == {"download_link"}
+            and download_link_template is None
+        ):
+            msg = (
+                f"Download link asset configuration missing for collection {collection}"
             )
+            raise MisconfiguredError(msg)
 
-        # collection with assets mapping
-        assets_mapping = filters.pop("assets_mapping", None)
+        # collection with several assets mapping
+        assets_mapping = self.get_assets_mapping(collection)
         products = []
         per_page = getattr(prep, "limit", DEFAULT_LIMIT)
         page = getattr(prep, "PAGE", 1)
@@ -417,7 +442,6 @@ class CopGhslSearch(Search):
         grouped_by = filters.pop("grouped_by", None)
         if grouped_by:  # dataset with several files differentiated by one parameter
             format_params = {k: str(v) for k, v in filters.items() if v}
-            format_params.pop("metadata_mapping", None)
             grouped_by_values = filters[grouped_by]
             if isinstance(grouped_by_values, str) or isinstance(grouped_by_values, int):
                 grouped_by_values = [grouped_by_values]
@@ -431,9 +455,10 @@ class CopGhslSearch(Search):
                 properties.update(format_params)
                 if "proj:code" in filter_params:
                     properties["proj:code"] = filter_params["proj:code"]
-                properties["eodag:download_link"] = download_link.format(
-                    **format_params
-                )
+                if download_link_template is not None:
+                    assets_mapping["download_link"]["href"] = (
+                        download_link_template.format(**format_params)
+                    )
                 datetimes = self._get_start_and_end_from_properties(format_params)
                 properties["start_datetime"] = datetimes["start_date"]
                 properties["end_datetime"] = datetimes["end_date"]
@@ -441,9 +466,15 @@ class CopGhslSearch(Search):
                 product = EOProduct(
                     provider="cop_ghsl", properties=properties, collection=collection
                 )
+                if download_link_template is not None:
+                    product.assets.update(
+                        {"download_link": assets_mapping["download_link"]}
+                    )
                 if assets_mapping:  # item with several assets
                     assets = AssetsDict(product=product)
                     for key, mapping in assets_mapping.items():
+                        if key == "download_link":
+                            continue
                         filters = {k.replace(":", "_"): v for k, v in filters.items()}
                         download_link = mapping["href"].format(**filters)
                         assets.update(
@@ -455,7 +486,7 @@ class CopGhslSearch(Search):
                                 }
                             }
                         )
-                    product.assets = assets
+                    product.assets.update(assets)
                 products.append(product)
                 if i == end_index:
                     break
@@ -465,10 +496,10 @@ class CopGhslSearch(Search):
             datetimes = self._get_start_and_end_from_properties(properties)
             properties["start_datetime"] = datetimes["start_date"]
             properties["end_datetime"] = datetimes["end_date"]
-            properties["eodag:download_link"] = download_link
             product = EOProduct(
                 provider="cop_ghsl", properties=properties, collection=collection
             )
+            product.assets.update({"download_link": assets_mapping["download_link"]})
             products.append(product)
             num_products = 1
         if prep.count:
@@ -490,7 +521,11 @@ class CopGhslSearch(Search):
         available_values = _get_available_values_from_constraints(
             constraints_values, {}, collection
         )
-        collection_config = deepcopy(self.config.products.get(collection, {}))
+        collection_config = {
+            key: value
+            for key, value in self.config.products.get(collection, {}).items()
+            if "_mapping" not in key
+        }
         for key, values in available_values.items():
             for value in values:
                 param_value = value
@@ -530,8 +565,6 @@ class CopGhslSearch(Search):
 
         params.pop("geometry", None)
         params.update(collection_config)
-        params.pop("metadata_mapping", None)
-        params.pop("assets_mapping", None)
 
         self._check_input_parameters_valid(collection, params)
         # update parameters based on changes during validation
@@ -608,7 +641,11 @@ class CopGhslSearch(Search):
             collection = kwargs["collection"] = prep.collection
         if not isinstance(collection, str):
             raise MisconfiguredError("invalid collection %s", collection)
-        collection_config = deepcopy(self.config.products.get(collection, {}))
+        collection_config = {
+            key: value
+            for key, value in self.config.products.get(collection, {}).items()
+            if "_mapping" not in key
+        }
         if "id" in kwargs and "ALL" not in kwargs["id"]:
             tiles_or_none = self._get_tile_from_product_id(kwargs)
         else:
@@ -630,7 +667,6 @@ class CopGhslSearch(Search):
             )
 
         # create products from tiles
-        kwargs.update(collection_config)
         kwargs["page"] = page
         kwargs["per_page"] = limit
         constraints_filters = self._fetch_constraints(collection)

--- a/eodag/resources/providers/aws_eos.yml
+++ b/eodag/resources/providers/aws_eos.yml
@@ -175,9 +175,6 @@ aws_eos:
           - '$.onAmazon'
         _path: '$.path'
         _row: '$.row'
-        eodag:download_link: 's3://landsat-pds/c1/L8/{_path:03.0f}/{_row:03.0f}/{title}/'
-        eodag:thumbnail: '$.thumbnail'
-        eodag:quicklook: 'https://landsat-pds.s3.amazonaws.com/c1/L8/{_path:03.0f}/{_row:03.0f}/{title}/{title}_thumb_large.jpg'
         id:
           - '{{"search":{{"productID":"{id}" }} }}'
           - '{title}'
@@ -356,9 +353,7 @@ aws_eos:
           - '{{"search":{{"zenithAngle":"{view:incidence_angle}" }} }}'
           - '$.zenithAngle'
         # Custom parameters (not defined in the base document referenced above)
-        eodag:thumbnail: '{$.thumbnail#replace_str("sentinel-s2-l1c.s3.amazonaws.com","roda.sentinel-hub.com/sentinel-s2-l1c")}'
         _aws_path: '$.awsPath'
-        eodag:download_link: 's3://sentinel-s2-l1c/{_aws_path}'
         eodag:product_path: '$.productPath'
         id:
           - '{{"search":{{"productName":"{id}" }} }}'
@@ -403,7 +398,6 @@ aws_eos:
             - 'title'
             - '{title}'
           _aws_path_l2a: '$.tiles[0].path'
-          eodag:download_link: 's3://sentinel-s2-l2a/{_aws_path_l2a}'
           eodag:product_path: '$.path'
           start_datetime: '$.timestamp'
           end_datetime: '$.timestamp'

--- a/eodag/resources/providers/cop_dataspace_s3.yml
+++ b/eodag/resources/providers/cop_dataspace_s3.yml
@@ -231,16 +231,27 @@ cop_dataspace_s3:
       geometry:
         - null
         - '{$.Footprint#from_ewkt}'
-      # The url to download the product "as is" (literal or as a template to be completed either after the search result
-      # is obtained from the provider or during the eodag download phase)
-      eodag:download_link: '$.S3Path.`sub(/^(.*)$/, s3:/\\1)`'
       # order:status: must be one of succeeded, ordered, orderable
       order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
       collection:
         - null
         - $.null
-      eodag:quicklook: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
-      eodag:thumbnail: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+    assets_mapping:
+      download_link:
+        href: '$.S3Path.`sub(/^(.*)$/, s3:/\\1)`'
+        roles: '["archive", "data"]'
+        type: '$.ContentType'
+        order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
+      quicklook:
+        href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+        title: "quicklook"
+        roles: '["overwiev"]'
+        type: "image/jpeg"
+      thumbnail:
+        href: '$.Assets[?(@.Type="QUICKLOOK")].DownloadLink'
+        title: "thumbnail"
+        roles: '["thumbnail"]'
+        type: "image/jpeg"
   download:
     type: AwsDownload
     s3_endpoint: 'https://eodata.dataspace.copernicus.eu'

--- a/eodag/resources/providers/cop_ghsl.yml
+++ b/eodag/resources/providers/cop_ghsl.yml
@@ -24,20 +24,32 @@ cop_ghsl:
       metadata_mapping:
         tile_size: '{$.tile_size#replace_str_tuple((("m", ""), ("k", "000")))}'
         dataset: GHS_BUILT_S_{add_filter}_E{year}_GLOBE_R2023A_{proj_code}_{tile_size}
-        eodag:download_link: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_BUILT_S_GLOBE_R2023A/{dataset}/V1-0/tiles/{dataset}_V1_0_{tile_id}.zip'
+      assets_mapping:
+        download_link:
+          href: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_BUILT_S_GLOBE_R2023A/{dataset}/V1-0/tiles/{dataset}_V1_0_{tile_id}.zip'
+          roles: '["archive", "data"]'
+          type: 'application/zip'
     GHS_BUILT_H:
       _collection: builtH
       year: '2018'
       metadata_mapping:
         tile_size: '{$.tile_size#replace_str("m", "")}'
         dataset: GHS_BUILT_H_{add_filter}_E{year}_GLOBE_R2023A_{proj_code}_{tile_size}
-        eodag:download_link: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_BUILT_H_GLOBE_R2023A/{dataset}/V1-0/tiles/{dataset}_V1_0_{tile_id}.zip'
+      assets_mapping:
+        download_link:
+          href: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_BUILT_H_GLOBE_R2023A/{dataset}/V1-0/tiles/{dataset}_V1_0_{tile_id}.zip'
+          roles: '["archive", "data"]'
+          type: 'application/zip'
     GHS_BUILT_V:
       _collection: builtV
       metadata_mapping:
         tile_size: '{$.tile_size#replace_str_tuple((("m", ""), ("k", "000")))}'
         dataset: GHS_BUILT_V_{add_filter}_E{year}_GLOBE_R2023A_{proj_code}_{tile_size}
-        eodag:download_link: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_BUILT_V_GLOBE_R2023A/{dataset}/V1-0/tiles/{dataset}_V1_0_{tile_id}.zip'
+      assets_mapping:
+        download_link:
+          href: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_BUILT_V_GLOBE_R2023A/{dataset}/V1-0/tiles/{dataset}_V1_0_{tile_id}.zip'
+          roles: '["archive", "data"]'
+          type: 'application/zip'
     GHS_BUILT_C:
       _collection: builtC
       year: '2018'
@@ -46,7 +58,11 @@ cop_ghsl:
       metadata_mapping:
         tile_size: '{$.tile_size#replace_str("m", "")}'
         dataset: GHS_BUILT_C_{add_filter}_E{year}_GLOBE_R2023A_{proj_code}_{tile_size}
-        eodag:download_link: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_BUILT_C_GLOBE_R2023A/{dataset}/V1-0/tiles/{dataset}_V1_0_{tile_id}.zip'
+      assets_mapping:
+        download_link:
+          href: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_BUILT_C_GLOBE_R2023A/{dataset}/V1-0/tiles/{dataset}_V1_0_{tile_id}.zip'
+          roles: '["archive", "data"]'
+          type: 'application/zip'
     GHS_LAND:
       _collection: land
       year: '2018'
@@ -54,13 +70,21 @@ cop_ghsl:
       metadata_mapping:
         tile_size: '{$.tile_size#replace_str_tuple((("m", ""), ("k", "000")))}'
         dataset: GHS_LAND_E2018_GLOBE_R2022A_{proj_code}_{tile_size}
-        eodag:download_link: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_LAND_GLOBE_R2022A/{dataset}/V1-0/tiles/{dataset}_V1_0_{tile_id}.zip'
+      assets_mapping:
+        download_link:
+          href: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_LAND_GLOBE_R2022A/{dataset}/V1-0/tiles/{dataset}_V1_0_{tile_id}.zip'
+          roles: '["archive", "data"]'
+          type: 'application/zip'
     GHS_POP:
       _collection: POP
       metadata_mapping:
         tile_size: '{$.tile_size#replace_str_tuple((("m", ""), ("k", "000")))}'
         dataset: GHS_POP_E{year}_GLOBE_R2023A_{proj_code}_{tile_size}
-        eodag:download_link: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_POP_GLOBE_R2023A/{dataset}/V1-0/tiles/{dataset}_V1_0_{tile_id}.zip'
+      assets_mapping:
+        download_link:
+          href: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_POP_GLOBE_R2023A/{dataset}/V1-0/tiles/{dataset}_V1_0_{tile_id}.zip'
+          roles: '["archive", "data"]'
+          type: 'application/zip'
     GHS_SMOD:
       _collection: SMOD
       tile_size: 1k
@@ -68,7 +92,11 @@ cop_ghsl:
       metadata_mapping:
         tile_size: '{$.tile_size#replace_str("k", "000")}'
         dataset: GHS_SMOD_E{year}_GLOBE_R2023A_{proj_code}_{tile_size}
-        eodag:download_link: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_SMOD_GLOBE_R2023A/{dataset}/V2-0/tiles/{dataset}_V2_0_{tile_id}.zip'
+      assets_mapping:
+        download_link:
+          href: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_SMOD_GLOBE_R2023A/{dataset}/V2-0/tiles/{dataset}_V2_0_{tile_id}.zip'
+          roles: '["archive", "data"]'
+          type: 'application/zip'
     GHS_ESM:
       _collection: ESM
       year: '2015'
@@ -77,20 +105,33 @@ cop_ghsl:
         tile_size: '{$.tile_size#replace_str("2m", "02")}'
         dataset: ESM_BUILT_VHR2015_EUROPE_R2019_3035_{tile_size}
         _dataset_modified: '{$.dataset#replace_str("VHR2015_EUROPE_R2019_3035_10m","VHR2015CLASS_EUROPE_R2019_3035_10")}'  # modify dataset if tile_size is 10m
-        eodag:download_link: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/ESM_BUILT_VHR2015_Europe_R2019/{dataset}/V1-0/tiles/{tile_id}.zip'
+      assets_mapping:
+        download_link:
+          href: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/ESM_BUILT_VHR2015_Europe_R2019/{dataset}/V1-0/tiles/{tile_id}.zip'
+          roles: '["archive", "data"]'
+          type: 'application/zip'
     # collections with one file
     GHS_DUC:
       _collection: DUC
-      metadata_mapping:
-        eodag:download_link: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL//GHS_DUC_GLOBE_R2023A/V2-0/GHS_DUC_MT_GLOBE_R2023A_V2_0.zip'
+      assets_mapping:
+        download_link:
+          href: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL//GHS_DUC_GLOBE_R2023A/V2-0/GHS_DUC_MT_GLOBE_R2023A_V2_0.zip'
+          roles: '["archive", "data"]'
+          type: 'application/zip'
     GHS_FUA:
       _collection: FUA
-      metadata_mapping:
-        eodag:download_link: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL//GHS_FUA_UCDB2015_GLOBE_R2019A/V1-0/GHS_FUA_UCDB2015_GLOBE_R2019A_54009_1K_V1_0.zip'
+      assets_mapping:
+        download_link:
+          href: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL//GHS_FUA_UCDB2015_GLOBE_R2019A/V1-0/GHS_FUA_UCDB2015_GLOBE_R2019A_54009_1K_V1_0.zip'
+          roles: '["archive", "data"]'
+          type: 'application/zip'
     GHS_BUILT_LAUSTAT:
       _collection: BUILT_LAUSTAT
-      metadata_mapping:
-        eodag:download_link: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL//GHS_BUILT_LAUSTAT_EUROPE_R2023A/V1-0/GHS-BUILT-LAUSTAT_EUROPE_R2023A.zip'
+      assets_mapping:
+        download_link:
+          href: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL//GHS_BUILT_LAUSTAT_EUROPE_R2023A/V1-0/GHS-BUILT-LAUSTAT_EUROPE_R2023A.zip'
+          roles: '["archive", "data"]'
+          type: 'application/zip'
     # products with several files
     GHS_ENACT_POP:
       _collection: ENACT_POP
@@ -110,13 +151,19 @@ cop_ghsl:
     GHS_UCDB_DOMAIN:
       _collection: UCDB
       grouped_by: thematic_domain
-      metadata_mapping:
-        eodag:download_link: https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_UCDB_GLOBE_R2024A/GHS_UCDB_THEME_GLOBE_R2024A/GHS_UCDB_THEME_{thematic_domain}_GLOBE_R2024A/V1-1/GHS_UCDB_THEME_{thematic_domain}_GLOBE_R2024A_V1_1.zip
+      assets_mapping:
+        download_link:
+          href: https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_UCDB_GLOBE_R2024A/GHS_UCDB_THEME_GLOBE_R2024A/GHS_UCDB_THEME_{thematic_domain}_GLOBE_R2024A/V1-1/GHS_UCDB_THEME_{thematic_domain}_GLOBE_R2024A_V1_1.zip
+          roles: '["archive", "data"]'
+          type: 'application/zip'
     GHS_UCDB_REGION:
       _collection: UCDB
       grouped_by: region
-      metadata_mapping:
-        eodag:download_link: https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_UCDB_GLOBE_R2024A/GHS_UCDB_REGION_GLOBE_R2024A/GHS_UCDB_REGION_{region}_R2024A/V1-1/GHS_UCDB_REGION_{region}_R2024A_V1_1.zip
+      assets_mapping:
+        download_link:
+          href: https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_UCDB_GLOBE_R2024A/GHS_UCDB_REGION_GLOBE_R2024A/GHS_UCDB_REGION_{region}_R2024A/V1-1/GHS_UCDB_REGION_{region}_R2024A_V1_1.zip
+          roles: '["archive", "data"]'
+          type: 'application/zip'
   download:
     type: HTTPDownload
     ssl_verify: true

--- a/eodag/resources/providers/cop_ghsl.yml
+++ b/eodag/resources/providers/cop_ghsl.yml
@@ -137,8 +137,6 @@ cop_ghsl:
       _collection: ENACT_POP
       grouped_by: month
       year: '2011'
-      metadata_mapping:
-        eodag:download_link: https://jeodpp.jrc.ec.europa.eu
       assets_mapping:
         day:
           href: 'https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/ENACT/ENACT_POP_2011_EU28_R2020A/ENACT_POP_D{month}2011_EU28_R2020A_{proj_code}_{tile_size}/V1-0/ENACT_POP_D{month}2011_EU28_R2020A_{proj_code}_{tile_size}_V1_0.zip'

--- a/eodag/resources/providers/dedl.yml
+++ b/eodag/resources/providers/dedl.yml
@@ -165,8 +165,12 @@ dedl:
     # ECMWF - COPERNICUS CDS
     ERA5_SL:
       _collection: EO.ECMWF.DAT.REANALYSIS_ERA5_SINGLE_LEVELS
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping:
+        download_link:
+          href: '$.null'
+          _order_href: '$.links[?rel=="retrieve"].href'
+          _order_body: '$.links[?rel=="retrieve"].body'
+          order_link: "{_order_href}?{{{_order_body#replace_str(\"'\", '\"')}}}"
     ERA5_SL_MONTHLY:
       _collection: EO.ECMWF.DAT.REANALYSIS_ERA5_SINGLE_LEVELS_MONTHLY_MEANS
       metadata_mapping:

--- a/eodag/resources/providers/dedl.yml
+++ b/eodag/resources/providers/dedl.yml
@@ -4,13 +4,6 @@ dedl:
     - host
   description: DEDL STAC
   url: https://hda.data.destination-earth.eu/stac/v2/
-  # anchors to avoid duplications
-  anchor_orderable_mm: &orderable_mm
-    _order_href: '$.links[?rel=="retrieve"].href'
-    _order_body: '$.links[?rel=="retrieve"].body'
-    eodag:order_link: "{_order_href}?{{{_order_body#replace_str(\"'\", '\"')}}}"
-    eodag:download_link: '$.null'
-    assets: '$.null'
   search:
     type: StacSearch
     api_endpoint: https://hda.data.destination-earth.eu/stac/v2/search
@@ -173,88 +166,67 @@ dedl:
           order_link: "{_order_href}?{{{_order_body#replace_str(\"'\", '\"')}}}"
     ERA5_SL_MONTHLY:
       _collection: EO.ECMWF.DAT.REANALYSIS_ERA5_SINGLE_LEVELS_MONTHLY_MEANS
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     ERA5_PL:
       _collection: EO.ECMWF.DAT.ERA5_HOURLY_VARIABLES_ON_PRESSURE_LEVELS
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     ERA5_PL_MONTHLY:
       _collection: EO.ECMWF.DAT.ERA5_MONTHLY_MEANS_VARIABLES_ON_PRESSURE_LEVELS
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     ERA5_LAND:
       _collection: EO.ECMWF.DAT.ERA5_LAND_HOURLY
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     ERA5_LAND_MONTHLY:
       _collection: EO.ECMWF.DAT.ERA5_LAND_MONTHLY
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     UERRA_EUROPE_SL:
       _collection: EO.ECMWF.DAT.REANALYSIS_UERRA_EUROPE_SINGLE_LEVELS
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     GRIDDED_GLACIERS_MASS_CHANGE:
       _collection: EO.ECMWF.DAT.DERIVED_GRIDDED_GLACIER_MASS_CHANGE
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     GLACIERS_DIST_RANDOLPH:
       _collection: EO.ECMWF.DAT.GLACIERS_DISTRIBUTION_DATA_FROM_RANDOLPH_GLACIER_INVENTORY_2000
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     SATELLITE_CARBON_DIOXIDE:
       _collection: EO.ECMWF.DAT.CO2_DATA_FROM_SATELLITE_SENSORS_2002_PRESENT
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     SATELLITE_METHANE:
       _collection: EO.ECMWF.DAT.METHANE_DATA_SATELLITE_SENSORS_2002_PRESENT
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     SEASONAL_POSTPROCESSED_PL:
       _collection: EO.ECMWF.DAT.SEASONAL_FORECAST_ANOMALIES_ON_PRESSURE_LEVELS_2017_PRESENT
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     SATELLITE_SEA_LEVEL_GLOBAL:
       _collection: EO.ECMWF.DAT.SEA_LEVEL_DAILY_GRIDDED_DATA_FOR_GLOBAL_OCEAN_1993_PRESENT
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     SATELLITE_SEA_ICE_EDGE_TYPE:
       _collection: EO.ECMWF.DAT.SATELLITE_SEA_ICE_EDGE_TYPE
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     SATELLITE_SEA_ICE_THICKNESS:
       _collection: EO.ECMWF.DAT.SATELLITE_SEA_ICE_THICKNESS
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     SATELLITE_SEA_ICE_CONCENTRATION:
       _collection: EO.ECMWF.DAT.SATELLITE_SEA_ICE_CONCENTRATION
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     SEASONAL_POSTPROCESSED_SL:
       _collection: EO.ECMWF.DAT.SEASONAL_FORECAST_ANOMALIES_ON_SINGLE_LEVELS_2017_PRESENT
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     SEASONAL_ORIGINAL_SL:
       _collection: EO.ECMWF.DAT.SEASONAL_FORECAST_DAILY_DATA_ON_SINGLE_LEVELS_2017_PRESENT
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     SEASONAL_ORIGINAL_PL:
       _collection: EO.ECMWF.DAT.SEASONAL_FORECAST_DAILY_DATA_ON_PRESSURE_LEVELS_2017_PRESENT
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     SEASONAL_MONTHLY_PL:
       _collection: EO.ECMWF.DAT.SEASONAL_FORECAST_MONTHLY_STATISTICS_ON_PRESSURE_LEVELS_2017_PRESENT
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     SEASONAL_MONTHLY_SL:
       _collection: EO.ECMWF.DAT.SEASONAL_FORECAST_MONTHLY_STATISTICS_ON_SINGLE_LEVELS_2017_PRESENT
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     SIS_HYDRO_MET_PROJ:
       _collection: EO.ECMWF.DAT.SIS_HYDROLOGY_METEOROLOGY_DERIVED_PROJECTIONS
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     # ECMWF - CEMS
     FIRE_HISTORICAL:
       _collection: EO.ECMWF.DAT.CEMS_FIRE_HISTORICAL
@@ -281,56 +253,43 @@ dedl:
     # COPERNICUS ADS
     CAMS_GAC_FORECAST:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_ATMOSHERIC_COMPO_FORECAST
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     CAMS_EU_AIR_QUALITY_FORECAST:
       _collection: EO.ECMWF.DAT.CAMS_EUROPE_AIR_QUALITY_FORECASTS
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     CAMS_GFE_GFAS:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_FIRE_EMISSIONS_GFAS
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     CAMS_SOLAR_RADIATION:
       _collection: EO.ECMWF.DAT.CAMS_SOLAR_RADIATION_TIMESERIES
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     CAMS_GREENHOUSE_INVERSION:
       _collection: EO.ECMWF.DAT.CAMS_GREENHOUSE_GAS_FLUXES
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     CAMS_EAC4_MONTHLY:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_REANALYSIS_EAC4_MONTHLY_AV_FIELDS
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     CAMS_EU_AIR_QUALITY_RE:
       _collection: EO.ECMWF.DAT.CAMS_EUROPE_AIR_QUALITY_REANALYSES
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     CAMS_EAC4:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_REANALYSIS_EAC4
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     CAMS_GRF_AUX:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_RADIATIVE_FORCING_AUX
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     CAMS_GRF:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_RADIATIVE_FORCING
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     CAMS_GREENHOUSE_EGG4_MONTHLY:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_GREENHOUSE_GAS_REANALYSIS_MONTHLY_AV_FIELDS
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     CAMS_GREENHOUSE_EGG4:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_GREENHOUSE_GAS_REANALYSIS
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     CAMS_GLOBAL_EMISSIONS:
       _collection: EO.ECMWF.DAT.CAMS_GLOBAL_EMISSION_INVENTORIES
-      metadata_mapping:
-        <<: *orderable_mm
+      assets_mapping_from_product: ERA5_SL
     # COPERNICUS ADS - Digital Elevation Model
     COP_DEM_GLO30_DGED:
       _collection: EO.DEM.DAT.COP-DEM_GLO-30-DGED
@@ -445,202 +404,130 @@ dedl:
     # DT Output
     DT_EXTREMES:
       _collection: EO.ECMWF.DAT.DT_EXTREMES
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping:
+        download_link:
+          href: '$.null'
+          _order_href: '$.links[?rel=="retrieve"].href'
+          _order_body: '$.links[?rel=="retrieve"].body'
+          order_link: "{_order_href}?{{{_order_body#replace_str(\"'\", '\"')}}}"
+          order:status: '{$.null#replace_str("Not Available","orderable")}'
     DT_CLIMATE_ADAPTATION:
       _collection: EO.ECMWF.DAT.DT_CLIMATE_ADAPTATION
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_ADAPTATION_IFS_NEMO:
       _collection: EO.ECMWF.DAT.DT_CLIMATE_ADAPTATION_IFS-NEMO
-      metadata_mapping:
-        assets: $.assets
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_ADAPTATION_ICON:
       _collection: EO.ECMWF.DAT.DT_CLIMATE_ADAPTATION_ICON
-      metadata_mapping:
-        assets: $.assets
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G1_CMIP6_HIST_ICON_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G1.CMIP6_HIST_ICON.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G1_CMIP6_HIST_IFS_NEMO_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G1.CMIP6_HIST_IFS-NEMO.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G1_HIGHRESMIP_CONT_IFS_FESOM_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G1.HIGHRESMIP_CONT_IFS-FESOM.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G1_HIGHRESMIP_CONT_IFS_NEMO_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G1.HIGHRESMIP_CONT_IFS-NEMO.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G1_SCENARIOMIP_SSP3_7_0_ICON_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G1.SCENARIOMIP_SSP3-7.0_ICON.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G1_SCENARIOMIP_SSP3_7_0_IFS_FESOM_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G1.SCENARIOMIP_SSP3-7.0_IFS-FESOM.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G1_SCENARIOMIP_SSP3_7_0_IFS_NEMO_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G1.SCENARIOMIP_SSP3-7.0_IFS-NEMO.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G1_STORY_NUDGING_CONT_IFS_FESOM_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G1.STORY-NUDGING_CONT_IFS-FESOM.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G1_STORY_NUDGING_HIST_IFS_FESOM_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G1.STORY-NUDGING_HIST_IFS-FESOM.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G1_STORY_NUDGING_TPLUS2_0K_IFS_FESOM_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G1.STORY-NUDGING_TPLUS2.0K_IFS-FESOM.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G1_CMIP6_HIST_IFS_FESOM_R1:
       _collection: EO.ECMWF.DAT.NG.DT_CLIMATE.G1.CMIP6_HIST_IFS-FESOM.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G1_SCENARIOMIP_SSP3_7_0_IFS_FESOM_R2:
       _collection: EO.ECMWF.DAT.NG.DT_CLIMATE.G1.SCENARIOMIP_SSP3-7.0_IFS-FESOM.R2
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_BASELINE_CONT_ICON_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.BASELINE_CONT_ICON.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_BASELINE_CONT_IFS_FESOM_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.BASELINE_CONT_IFS-FESOM.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_BASELINE_CONT_IFS_NEMO_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.BASELINE_CONT_IFS-NEMO.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_BASELINE_HIST_ICON_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.BASELINE_HIST_ICON.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_BASELINE_HIST_IFS_FESOM_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.BASELINE_HIST_IFS-FESOM.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_BASELINE_HIST_IFS_NEMO_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.BASELINE_HIST_IFS-NEMO.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_PROJECTIONS_SSP3_7_0_ICON_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.PROJECTIONS_SSP3-7.0_ICON.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_PROJECTIONS_SSP3_7_0_IFS_FESOM_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.PROJECTIONS_SSP3-7.0_IFS-FESOM.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_PROJECTIONS_SSP3_7_0_IFS_NEMO_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.PROJECTIONS_SSP3-7.0_IFS-NEMO.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_STORY_NUDGING_CONT_IFS_FESOM_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.STORY-NUDGING_CONT_IFS-FESOM.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_STORY_NUDGING_CONT_IFS_FESOM_R2:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.STORY-NUDGING_CONT_IFS-FESOM.R2
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_STORY_NUDGING_CONT_IFS_FESOM_R3:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.STORY-NUDGING_CONT_IFS-FESOM.R3
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_STORY_NUDGING_CONT_IFS_FESOM_R4:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.STORY-NUDGING_CONT_IFS-FESOM.R4
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_STORY_NUDGING_CONT_IFS_FESOM_R5:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.STORY-NUDGING_CONT_IFS-FESOM.R5
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_STORY_NUDGING_HIST_IFS_FESOM_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.STORY-NUDGING_HIST_IFS-FESOM.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_STORY_NUDGING_HIST_IFS_FESOM_R2:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.STORY-NUDGING_HIST_IFS-FESOM.R2
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_STORY_NUDGING_HIST_IFS_FESOM_R3:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.STORY-NUDGING_HIST_IFS-FESOM.R3
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_STORY_NUDGING_HIST_IFS_FESOM_R4:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.STORY-NUDGING_HIST_IFS-FESOM.R4
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_STORY_NUDGING_HIST_IFS_FESOM_R5:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.STORY-NUDGING_HIST_IFS-FESOM.R5
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_STORY_NUDGING_TPLUS2_0K_IFS_FESOM_R1:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.STORY-NUDGING_TPLUS2.0K_IFS-FESOM.R1
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_STORY_NUDGING_TPLUS2_0K_IFS_FESOM_R2:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.STORY-NUDGING_TPLUS2.0K_IFS-FESOM.R2
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_STORY_NUDGING_TPLUS2_0K_IFS_FESOM_R3:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.STORY-NUDGING_TPLUS2.0K_IFS-FESOM.R3
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_STORY_NUDGING_TPLUS2_0K_IFS_FESOM_R4:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.STORY-NUDGING_TPLUS2.0K_IFS-FESOM.R4
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     DT_CLIMATE_G2_STORY_NUDGING_TPLUS2_0K_IFS_FESOM_R5:
       _collection: EO.ECMWF.DAT.D1.DT_CLIMATE.G2.STORY-NUDGING_TPLUS2.0K_IFS-FESOM.R5
-      metadata_mapping:
-        order:status: '{$.null#replace_str("Not Available","orderable")}'
-        <<: *orderable_mm
+      assets_mapping_from_product: DT_EXTREMES
     # AERIS
     AERIS_IAGOS:
       _collection: EO.AERIS.DAT.IAGOS

--- a/eodag/resources/providers/dlr_eoc_geoservice.yml
+++ b/eodag/resources/providers/dlr_eoc_geoservice.yml
@@ -19,12 +19,18 @@ dlr_eoc_geoservice:
   products:
     S2_MSI_L2A_MAJA:
       _collection: S2_L2A_MAJA
-      metadata_mapping:
-        eodag:download_link: '$.assets.data.href'
+      assets_mapping:
+        download_link:
+          href: '$.assets.data.href'
+          roles: '["archive", "data"]'
+          type: 'application/octet-stream'
     SUPERSITES:
       _collection: SUPERSITES
-      metadata_mapping:
-        eodag:download_link: '$.assets.data.href'
+      assets_mapping:
+        download_link:
+          href: '$.assets.data.href'
+          roles: '["archive", "data"]'
+          type: 'application/octet-stream'
     GENERIC_COLLECTION:
       _collection: '{collection}'
   download:
@@ -33,10 +39,6 @@ dlr_eoc_geoservice:
       - 401
       - 403
     products:
-      S2_MSI_L2A_MAJA:
-        ignore_assets: true
-      SUPERSITES:
-        ignore_assets: true
   auth:
     type: GenericAuth
     matching_url: https://download.geoservice.dlr.de

--- a/eodag/resources/providers/wekeo_ecmwf.yml
+++ b/eodag/resources/providers/wekeo_ecmwf.yml
@@ -53,39 +53,39 @@ wekeo_ecmwf:
       fetch_url: null
     dynamic_discover_queryables:
       - collection_selector: # cop_ads
-          - field: dataset
+          - field: _collection
             prefix: EO:ECMWF:DAT:CAMS
         discover_queryables:
           fetch_url: null
           collection_fetch_url: null
-          constraints_url: https://ads.atmosphere.copernicus.eu/api/catalogue/v1/collections/{dataset#wekeo_to_cop_collection(EO:ECMWF:DAT:)}/constraints.json
-          form_url: https://ads.atmosphere.copernicus.eu/api/catalogue/v1/collections/{dataset#wekeo_to_cop_collection(EO:ECMWF:DAT:)}/form.json
+          constraints_url: https://ads.atmosphere.copernicus.eu/api/catalogue/v1/collections/{_collection#wekeo_to_cop_collection(EO:ECMWF:DAT:)}/constraints.json
+          form_url: https://ads.atmosphere.copernicus.eu/api/catalogue/v1/collections/{_collection#wekeo_to_cop_collection(EO:ECMWF:DAT:)}/form.json
       - collection_selector: # cop_cds
-          - field: dataset
+          - field: _collection
             prefix: EO:ECMWF:DAT:SATELLITE
-          - field: dataset
+          - field: _collection
             prefix: EO:ECMWF:DAT:SEASONAL
-          - field: dataset
+          - field: _collection
             prefix: EO:ECMWF:DAT:INSITU
-          - field: dataset
+          - field: _collection
             prefix: EO:ECMWF:DAT:DERIVED
-          - field: dataset
+          - field: _collection
             prefix: EO:ECMWF:DAT:REANALYSIS
-          - field: dataset
+          - field: _collection
             prefix: EO:ECMWF:DAT:SIS
         discover_queryables:
           fetch_url: null
           collection_fetch_url: null
-          constraints_url: https://cds.climate.copernicus.eu/api/catalogue/v1/collections/{dataset#wekeo_to_cop_collection(EO:ECMWF:DAT:)}/constraints.json
-          form_url: https://cds.climate.copernicus.eu/api/catalogue/v1/collections/{dataset#wekeo_to_cop_collection(EO:ECMWF:DAT:)}/form.json
+          constraints_url: https://cds.climate.copernicus.eu/api/catalogue/v1/collections/{_collection#wekeo_to_cop_collection(EO:ECMWF:DAT:)}/constraints.json
+          form_url: https://cds.climate.copernicus.eu/api/catalogue/v1/collections/{_collection#wekeo_to_cop_collection(EO:ECMWF:DAT:)}/form.json
       - collection_selector: # cop_ewds
-          - field: dataset
+          - field: _collection
             prefix: EO:ECMWF:DAT:CEMS
         discover_queryables:
           fetch_url: null
           collection_fetch_url: null
-          constraints_url: https://ewds.climate.copernicus.eu/api/catalogue/v1/collections/{dataset#wekeo_to_cop_collection(EO:ECMWF:DAT:)}/constraints.json
-          form_url: https://ewds.climate.copernicus.eu/api/catalogue/v1/collections/{dataset#wekeo_to_cop_collection(EO:ECMWF:DAT:)}/form.json
+          constraints_url: https://ewds.climate.copernicus.eu/api/catalogue/v1/collections/{_collection#wekeo_to_cop_collection(EO:ECMWF:DAT:)}/constraints.json
+          form_url: https://ewds.climate.copernicus.eu/api/catalogue/v1/collections/{_collection#wekeo_to_cop_collection(EO:ECMWF:DAT:)}/form.json
     metadata_mapping:
       geometry:
         - '{{"bbox": {geometry#to_bounds}}}'
@@ -97,28 +97,25 @@ wekeo_ecmwf:
         # map 'date' to validate request against copernicus queryables
         - '{{"enddate": "{end_datetime#to_iso_utc_datetime}", "date": "{start_datetime#to_iso_date}/{end_datetime#to_iso_date}"}}'
         - $.properties.enddate
-      product:type:
-        - dataset_id
-        - $.dataset
-      dataset:
-        - dataset_id
-        - $.dataset
-      eodag:download_link: $.properties.location
-      eodag:order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{eodag:download_link}","product_id":"{id}", "dataset_id": "{dataset}"}}'
+      _collection:
+        - '{{"dataset_id": "{_collection}"}}'
+        - '$.null'
     assets_mapping:
       download_link:
-        href: ''
+        href: '$.null'
         roles: '["archive", "data"]'
-        type: '$.ContentType'
-        "order_link": 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location#url_decode}","product_id":"{id}", "dataset_id": "{dataset}"}'
+        type: 'application/octet-stream'
         order:status: 'orderable'
+        _location: '$.properties.location'
+        _id: '{$.id#remove_extension}'
+        order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{_location}","product_id":"{_id}", "dataset_id": "{_collection}"}}'
   products:
     SATELLITE_CARBON_DIOXIDE:
-      dataset: EO:ECMWF:DAT:SATELLITE_CARBON_DIOXIDE
+      _collection: EO:ECMWF:DAT:SATELLITE_CARBON_DIOXIDE
       metadata_mapping:
         <<: *day_month_year
     SATELLITE_FIRE_BURNED_AREA:
-      dataset: EO:ECMWF:DAT:SATELLITE_FIRE_BURNED_AREA
+      _collection: EO:ECMWF:DAT:SATELLITE_FIRE_BURNED_AREA
       metadata_mapping:
         start_datetime:
           - |
@@ -130,59 +127,59 @@ wekeo_ecmwf:
           - $.properties.startdate
         end_datetime: $.properties.enddate
     SATELLITE_METHANE:
-      dataset: EO:ECMWF:DAT:SATELLITE_METHANE
+      _collection: EO:ECMWF:DAT:SATELLITE_METHANE
       metadata_mapping:
         <<: *day_month_year
     SATELLITE_SEA_ICE_EDGE_TYPE:
-      dataset: EO:ECMWF:DAT:SATELLITE_SEA_ICE_EDGE_TYPE
+      _collection: EO:ECMWF:DAT:SATELLITE_SEA_ICE_EDGE_TYPE
       metadata_mapping:
         <<: *day_month_year
     SATELLITE_SEA_ICE_THICKNESS:
-      dataset: EO:ECMWF:DAT:SATELLITE_SEA_ICE_THICKNESS
+      _collection: EO:ECMWF:DAT:SATELLITE_SEA_ICE_THICKNESS
       metadata_mapping:
         <<: *month_year
     SATELLITE_SEA_ICE_CONCENTRATION:
-      dataset: EO:ECMWF:DAT:SATELLITE_SEA_ICE_CONCENTRATION
+      _collection: EO:ECMWF:DAT:SATELLITE_SEA_ICE_CONCENTRATION
       metadata_mapping:
         <<: *day_month_year
     SATELLITE_SEA_LEVEL_GLOBAL:
-      dataset: EO:ECMWF:DAT:SATELLITE_SEA_LEVEL_GLOBAL
+      _collection: EO:ECMWF:DAT:SATELLITE_SEA_LEVEL_GLOBAL
       metadata_mapping:
         <<: *day_month_year
     SEASONAL_ORIGINAL_SL:
-      dataset: EO:ECMWF:DAT:SEASONAL_ORIGINAL_SINGLE_LEVELS
+      _collection: EO:ECMWF:DAT:SEASONAL_ORIGINAL_SINGLE_LEVELS
       metadata_mapping:
         <<: *day_month_year
     SEASONAL_ORIGINAL_PL:
-      dataset: EO:ECMWF:DAT:SEASONAL_ORIGINAL_PRESSURE_LEVELS
+      _collection: EO:ECMWF:DAT:SEASONAL_ORIGINAL_PRESSURE_LEVELS
       metadata_mapping:
         <<: *day_month_year
     SEASONAL_POSTPROCESSED_SL:
-      dataset: EO:ECMWF:DAT:SEASONAL_POSTPROCESSED_SINGLE_LEVELS
+      _collection: EO:ECMWF:DAT:SEASONAL_POSTPROCESSED_SINGLE_LEVELS
       metadata_mapping:
         <<: *month_year
     SEASONAL_POSTPROCESSED_PL:
-      dataset: EO:ECMWF:DAT:SEASONAL_POSTPROCESSED_PRESSURE_LEVELS
+      _collection: EO:ECMWF:DAT:SEASONAL_POSTPROCESSED_PRESSURE_LEVELS
       metadata_mapping:
         <<: *month_year
     SEASONAL_MONTHLY_SL:
-      dataset: EO:ECMWF:DAT:SEASONAL_MONTHLY_SINGLE_LEVELS
+      _collection: EO:ECMWF:DAT:SEASONAL_MONTHLY_SINGLE_LEVELS
       metadata_mapping:
         <<: *month_year
     SEASONAL_MONTHLY_PL:
-      dataset: EO:ECMWF:DAT:SEASONAL_MONTHLY_PRESSURE_LEVELS
+      _collection: EO:ECMWF:DAT:SEASONAL_MONTHLY_PRESSURE_LEVELS
       metadata_mapping:
         <<: *month_year
     GLACIERS_DIST_RANDOLPH:
-      dataset: EO:ECMWF:DAT:INSITU_GLACIERS_EXTENT
+      _collection: EO:ECMWF:DAT:INSITU_GLACIERS_EXTENT
       metadata_mapping:
         <<: *day_month_year
     FIRE_HISTORICAL:
-      dataset: EO:ECMWF:DAT:CEMS_FIRE_HISTORICAL_V1
+      _collection: EO:ECMWF:DAT:CEMS_FIRE_HISTORICAL_V1
       metadata_mapping:
         <<: *day_month_year
     GRIDDED_GLACIERS_MASS_CHANGE:
-      dataset: EO:ECMWF:DAT:DERIVED_GRIDDED_GLACIER_MASS_CHANGE
+      _collection: EO:ECMWF:DAT:DERIVED_GRIDDED_GLACIER_MASS_CHANGE
       metadata_mapping:
         start_datetime:
           - |
@@ -192,23 +189,23 @@ wekeo_ecmwf:
           - $.properties.startdate
         end_datetime: $.properties.enddate
     UERRA_EUROPE_SL:
-      dataset: EO:ECMWF:DAT:REANALYSIS_UERRA_EUROPE_SINGLE_LEVELS
+      _collection: EO:ECMWF:DAT:REANALYSIS_UERRA_EUROPE_SINGLE_LEVELS
       metadata_mapping:
         <<: *time_day_month_year
     AG_ERA5:
-      dataset: EO:ECMWF:DAT:SIS_AGROMETEOROLOGICAL_INDICATORS
+      _collection: EO:ECMWF:DAT:SIS_AGROMETEOROLOGICAL_INDICATORS
       metadata_mapping:
         <<: *day_month_year
     ERA5_SL:
-      dataset: EO:ECMWF:DAT:REANALYSIS_ERA5_SINGLE_LEVELS
+      _collection: EO:ECMWF:DAT:REANALYSIS_ERA5_SINGLE_LEVELS
       metadata_mapping:
         <<: *time_day_month_year
     ERA5_PL:
-      dataset: EO:ECMWF:DAT:REANALYSIS_ERA5_PRESSURE_LEVELS
+      _collection: EO:ECMWF:DAT:REANALYSIS_ERA5_PRESSURE_LEVELS
       metadata_mapping:
         <<: *time_day_month_year
     ERA5_SL_MONTHLY:
-      dataset: EO:ECMWF:DAT:REANALYSIS_ERA5_SINGLE_LEVELS_MONTHLY_MEANS
+      _collection: EO:ECMWF:DAT:REANALYSIS_ERA5_SINGLE_LEVELS_MONTHLY_MEANS
       metadata_mapping:
         start_datetime:
           - |
@@ -220,19 +217,19 @@ wekeo_ecmwf:
           - $.properties.startdate
         end_datetime: $.properties.enddate
     ERA5_PL_MONTHLY:
-      dataset: EO:ECMWF:DAT:REANALYSIS_ERA5_PRESSURE_LEVELS_MONTHLY_MEANS
+      _collection: EO:ECMWF:DAT:REANALYSIS_ERA5_PRESSURE_LEVELS_MONTHLY_MEANS
       metadata_mapping_from_product: ERA5_SL_MONTHLY
     ERA5_LAND:
-      dataset: EO:ECMWF:DAT:REANALYSIS_ERA5_LAND
+      _collection: EO:ECMWF:DAT:REANALYSIS_ERA5_LAND
       metadata_mapping:
         <<: *time_day_month_year
     ERA5_LAND_MONTHLY:
-      dataset: EO:ECMWF:DAT:REANALYSIS_ERA5_LAND_MONTHLY_MEANS
+      _collection: EO:ECMWF:DAT:REANALYSIS_ERA5_LAND_MONTHLY_MEANS
       metadata_mapping_from_product: ERA5_SL_MONTHLY
     CAMS_EAC4:
-      dataset: EO:ECMWF:DAT:CAMS_GLOBAL_REANALYSIS_EAC4
+      _collection: EO:ECMWF:DAT:CAMS_GLOBAL_REANALYSIS_EAC4
     CAMS_GLOBAL_EMISSIONS:
-      dataset: EO:ECMWF:DAT:CAMS_GLOBAL_EMISSION_INVENTORIES
+      _collection: EO:ECMWF:DAT:CAMS_GLOBAL_EMISSION_INVENTORIES
       metadata_mapping:
         start_datetime:
           - |
@@ -242,39 +239,39 @@ wekeo_ecmwf:
           - $.properties.startdate
         end_datetime: $.properties.enddate
     CAMS_EAC4_MONTHLY:
-      dataset: EO:ECMWF:DAT:CAMS_GLOBAL_REANALYSIS_EAC4_MONTHLY
+      _collection: EO:ECMWF:DAT:CAMS_GLOBAL_REANALYSIS_EAC4_MONTHLY
       metadata_mapping:
         <<: *month_year
     CAMS_GREENHOUSE_INVERSION:
-      dataset: EO:ECMWF:DAT:CAMS_GLOBAL_GREENHOUSE_GAS_INVERSION
+      _collection: EO:ECMWF:DAT:CAMS_GLOBAL_GREENHOUSE_GAS_INVERSION
       metadata_mapping:
         <<: *month_year
     CAMS_EU_AIR_QUALITY_RE:
-      dataset: EO:ECMWF:DAT:CAMS_EUROPE_AIR_QUALITY_REANALYSES
+      _collection: EO:ECMWF:DAT:CAMS_EUROPE_AIR_QUALITY_REANALYSES
       metadata_mapping:
         <<: *month_year
     CAMS_GRF:
-      dataset: EO:ECMWF:DAT:CAMS_GLOBAL_RADIATIVE_FORCINGS
+      _collection: EO:ECMWF:DAT:CAMS_GLOBAL_RADIATIVE_FORCINGS
       metadata_mapping:
         <<: *month_year
     CAMS_GRF_AUX:
-      dataset: EO:ECMWF:DAT:CAMS_GLOBAL_RADIATIVE_FORCING_AUXILLIARY_VARIABLES
+      _collection: EO:ECMWF:DAT:CAMS_GLOBAL_RADIATIVE_FORCING_AUXILLIARY_VARIABLES
       metadata_mapping:
         <<: *month_year
     CAMS_GREENHOUSE_EGG4:
-      dataset: EO:ECMWF:DAT:CAMS_GLOBAL_GHG_REANALYSIS_EGG4
+      _collection: EO:ECMWF:DAT:CAMS_GLOBAL_GHG_REANALYSIS_EGG4
     CAMS_GREENHOUSE_EGG4_MONTHLY:
-      dataset: EO:ECMWF:DAT:CAMS_GLOBAL_GHG_REANALYSIS_EGG4_MONTHLY
+      _collection: EO:ECMWF:DAT:CAMS_GLOBAL_GHG_REANALYSIS_EGG4_MONTHLY
       metadata_mapping:
         <<: *month_year
     CAMS_EU_AIR_QUALITY_FORECAST:
-      dataset: EO:ECMWF:DAT:CAMS_EUROPE_AIR_QUALITY_FORECASTS
+      _collection: EO:ECMWF:DAT:CAMS_EUROPE_AIR_QUALITY_FORECASTS
     CAMS_GAC_FORECAST:
-      dataset: EO:ECMWF:DAT:CAMS_GLOBAL_ATMOSPHERIC_COMPOSITION_FORECASTS
+      _collection: EO:ECMWF:DAT:CAMS_GLOBAL_ATMOSPHERIC_COMPOSITION_FORECASTS
     CAMS_GFE_GFAS:
-      dataset: EO:ECMWF:DAT:CAMS_GLOBAL_FIRE_EMISSIONS_GFAS
+      _collection: EO:ECMWF:DAT:CAMS_GLOBAL_FIRE_EMISSIONS_GFAS
     CAMS_SOLAR_RADIATION:
-      dataset: EO:ECMWF:DAT:CAMS_SOLAR_RADIATION_TIMESERIES
+      _collection: EO:ECMWF:DAT:CAMS_SOLAR_RADIATION_TIMESERIES
       altitude: "-999"
       metadata_mapping:
         geometry:

--- a/eodag/resources/providers/wekeo_main.yml
+++ b/eodag/resources/providers/wekeo_main.yml
@@ -99,11 +99,13 @@ wekeo_main:
       sortOrder: '$.null'
     assets_mapping:
       download_link:
-        href: ''
+        href: '$.null'
         roles: '["archive", "data"]'
         type: 'application/octet-stream'
         order:status: 'orderable'
-        order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{"location": "{$.properties.location}","product_id":"{id}", "dataset_id": "{_collection}"}'
+        _location: '$.properties.location'
+        _id: '{$.id#remove_extension}'
+        order_link: 'https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/download?{{"location": "{_location}","product_id":"{_id}", "dataset_id": "{_collection}"}}'
       quicklook:
         href: '$.properties.thumbnail'
         title: "quicklook"

--- a/tests/context.py
+++ b/tests/context.py
@@ -74,8 +74,11 @@ from eodag.plugins.download.http import HTTPDownload
 from eodag.plugins.manager import PluginManager
 from eodag.plugins.search import PreparedSearch
 from eodag.plugins.search.base import Search
-from eodag.plugins.search.build_search_result import ecmwf_temporal_to_eodag
-from eodag.plugins.search.qssearch import QueryStringSearch
+from eodag.plugins.search.build_search_result import (
+    ECMWFSearch,
+    ecmwf_temporal_to_eodag,
+)
+from eodag.plugins.search.qssearch import QueryStringSearch, StacSearch
 from eodag.types import model_fields_to_annotated
 from eodag.types.queryables import CommonQueryables, Queryables, QueryablesDict
 from eodag.utils import (

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,7 +34,10 @@ from tests.context import (
     HTTP_REQ_TIMEOUT,
     TEST_RESOURCES_PATH,
     USER_AGENT,
+    ECMWFSearch,
     EODataAccessGateway,
+    PluginManager,
+    StacSearch,
     ValidationError,
     config,
     get_ext_collections_conf,
@@ -284,6 +287,60 @@ class TestConfigFunctions(unittest.TestCase):
                 self.assertEqual(download_plugin.output_dir, tempfile.gettempdir())
             # priority is set to 0 for all providers
             self.assertEqual(value.priority, 0)
+
+    def test_default_providers_use_assets(self):
+        """Default providers must expose assets without legacy product properties."""
+        providers_config = config.load_default_config()
+
+        def find_legacy_download_link(value, path):
+            if isinstance(value, dict):
+                for key, nested_value in value.items():
+                    nested_path = f"{path}.{key}"
+                    if key == "eodag:download_link":
+                        return nested_path
+                    if legacy_path := find_legacy_download_link(
+                        nested_value, nested_path
+                    ):
+                        return legacy_path
+            elif isinstance(value, list):
+                for index, nested_value in enumerate(value):
+                    if legacy_path := find_legacy_download_link(
+                        nested_value, f"{path}[{index}]"
+                    ):
+                        return legacy_path
+            return None
+
+        for provider_name, provider_config in providers_config.items():
+            search_config = getattr(provider_config, "search", None) or getattr(
+                provider_config, "api", None
+            )
+            self.assertIsNone(
+                find_legacy_download_link(
+                    getattr(search_config, "metadata_mapping", {}), "metadata_mapping"
+                ),
+                f"{provider_name} uses eodag:download_link in its metadata_mapping config",
+            )
+
+        for provider_name, provider_config in providers_config.items():
+            self.assertIsNone(
+                find_legacy_download_link(provider_config.products, "products"),
+                f"{provider_name} uses eodag:download_link in its products config",
+            )
+
+        plugins_manager = PluginManager(ProvidersDict.from_configs(providers_config))
+        for provider_name in plugins_manager.providers:
+            search_plugin = next(
+                plugins_manager.get_search_plugins(provider=provider_name)
+            )
+            has_assets_mapping = all(
+                search_plugin.get_assets_mapping(collection)
+                for collection in search_plugin.config.products
+            )
+            self.assertTrue(
+                has_assets_mapping
+                or isinstance(search_plugin, (StacSearch, ECMWFSearch)),
+                f"{provider_name} is not configured to return assets",
+            )
 
     def test_load_config_providers_whitelist(self):
         """Config must be loaded with only the selected whitelist of providers"""

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -4701,7 +4701,7 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
         # with additional param
         queryables = search_plugin.discover_queryables(
             collection="ERA5_SL_MONTHLY",
-            dataset="EO:ECMWF:DAT:REANALYSIS_ERA5_SINGLE_LEVELS_MONTHLY_MEANS",
+            _collection="EO:ECMWF:DAT:REANALYSIS_ERA5_SINGLE_LEVELS_MONTHLY_MEANS",
             **{"ecmwf:variable": "a"},
         )
         self.assertIsNotNone(queryables)

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -108,6 +108,8 @@ class BaseSearchPluginTest(unittest.TestCase):
     def get_auth_plugin(self, search_plugin):
         return self.plugins_manager.get_auth_plugin(search_plugin)
 
+
+class TestSearchPluginBaseSearch(BaseSearchPluginTest):
     def test_build_assets_from_mapping(self):
         search_plugin = self.get_search_plugin(provider="geodes")
         search_plugin.config.assets_mapping = {
@@ -173,6 +175,46 @@ class BaseSearchPluginTest(unittest.TestCase):
         self.assertEqual(
             collection_mapping,
             search_plugin.config.products[collection]["metadata_mapping"],
+        )
+
+    def test_get_assets_mapping_without_collection(self):
+        """Test that the provider assets_mapping is returned when no collection is specified"""
+        search_plugin = self.get_search_plugin(provider="dedl")
+        provider_mapping = search_plugin.config.assets_mapping
+        self.assertNotIn("_collection", provider_mapping)
+
+        assets_mapping = search_plugin.get_assets_mapping()
+
+        self.assertEqual(provider_mapping, assets_mapping)
+        self.assertNotIn("_collection", assets_mapping)
+
+    def test_get_assets_mapping_with_collection(self):
+        """Test that the collection assets_mapping is returned when a collection is specified"""
+        search_plugin = self.get_search_plugin(provider="dedl")
+        collection = "ERA5_SL"
+        provider_mapping = search_plugin.config.assets_mapping
+        collection_mapping = search_plugin.config.products[collection]["assets_mapping"]
+
+        assets_mapping = search_plugin.get_assets_mapping(collection)
+
+        self.assertEqual(
+            collection_mapping["download_link"],
+            assets_mapping["download_link"],
+        )
+        self.assertNotEqual(
+            provider_mapping["download_link"],
+            assets_mapping["download_link"],
+        )
+        self.assertEqual(
+            search_plugin.config.products[collection]["_collection"],
+            assets_mapping["download_link"]["_collection"],
+        )
+
+        # Check that original mappings are still intact and not modified
+        self.assertEqual(provider_mapping, search_plugin.config.assets_mapping)
+        self.assertEqual(
+            collection_mapping,
+            search_plugin.config.products[collection]["assets_mapping"],
         )
 
     def test_get_assets_mapping_from_product_inherits(self):

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -1580,8 +1580,7 @@ class TestSearchPluginPostJsonSearch(BaseSearchPluginTest):
         self, mock_normalize, mock_request
     ):
         provider = "wekeo_ecmwf"
-        search_plugins = self.plugins_manager.get_search_plugins(provider=provider)
-        search_plugin = next(search_plugins)
+        search_plugin = self.get_search_plugin(provider=provider)
         mock_request.return_value = MockResponse({"features": []}, 200)
         # year, month, day, time given -> don't use default dates
         search_plugin.query(
@@ -5870,7 +5869,7 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
     ):
         """test if the input parameters are correctly validated"""
         mock_fetch_constraints.return_value = {"constraints": self.constraints}
-        plugin = next(self.plugins_manager.get_search_plugins(provider="cop_ghsl"))
+        plugin = self.get_search_plugin(provider="cop_ghsl")
         # missing parameter
         input_params = {"year": "2020", "proj:code": "EPSG:54009"}
         with self.assertRaises(ValidationError):
@@ -5974,19 +5973,19 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
             json_data=provider_tiles, status_code=200
         )
         collection = "GHS_BUILT_S"
-        plugin = next(
-            self.plugins_manager.get_search_plugins(
-                collection=collection, provider="cop_ghsl"
-            )
-        )
-        product_type_config = deepcopy(plugin.config.products.get(collection, {}))
+        plugin = self.get_search_plugin(collection=collection, provider="cop_ghsl")
+        collection_config = {
+            key: value
+            for key, value in plugin.config.products.get(collection, {}).items()
+            if "_mapping" not in key
+        }
         input_params = {
             "year": ["2000", "2005"],
             "proj:code": "EPSG:4326",
             "tile_size": "3ss",
             "collection": collection,
         }
-        tiles, unit = plugin._get_tiles_for_filters(product_type_config, input_params)
+        tiles, unit = plugin._get_tiles_for_filters(collection_config, input_params)
         self.assertEqual("lat/lon", unit)
         self.assertEqual(2, len(tiles))
         self.assertIn("2000", tiles)
@@ -6042,11 +6041,7 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
             json_data=provider_tiles, status_code=200
         )
         collection = "GHS_BUILT_S"
-        plugin = next(
-            self.plugins_manager.get_search_plugins(
-                collection=collection, provider="cop_ghsl"
-            )
-        )
+        plugin = self.get_search_plugin(collection=collection, provider="cop_ghsl")
         params = {
             "collection": collection,
             "id": "GHS_BUILT_S__4326_3ss_2000_NRES__R3_C4",
@@ -6098,13 +6093,8 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
             ],
         }
         collection = "GHS_BUILT_S"
-        plugin = next(
-            self.plugins_manager.get_search_plugins(
-                collection=collection, provider="cop_ghsl"
-            )
-        )
-        product_type_config = deepcopy(plugin.config.products.get(collection, {}))
-        params = product_type_config
+        plugin = self.get_search_plugin(collection, "cop_ghsl")
+        params = {}
         params["year"] = ["2000", "2005"]
         params["proj:code"] = "EPSG:4326"
         params["tile_size"] = "3ss"
@@ -6117,6 +6107,7 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
         self.assertEqual(8, count)
         self.assertEqual(5, len(products))
         properties = products[0].properties
+        assets = products[0].assets
         self.assertEqual("2000-01-01T00:00:00.000Z", properties["start_datetime"])
         self.assertEqual("2000-12-31T23:59:59.000Z", properties["end_datetime"])
         self.assertEqual("2000", properties["year"])
@@ -6124,7 +6115,7 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
         self.assertEqual(
             "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_BUILT_S_GLOBE_R2023A/"
             "GHS_BUILT_S_E2000_GLOBE_R2023A_4326_3ss/V1-0/tiles/GHS_BUILT_S_E2000_GLOBE_R2023A_4326_3ss_V1_0_R3_C3.zip",
-            properties["eodag:download_link"],
+            assets["download_link"]["href"],
         )
         geometry = get_geometry_from_various(
             geometry=["-160.008", "69.100", "-150.008", "59.100"]
@@ -6154,11 +6145,7 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
             ],
         }
         collection = "GHS_ESM"
-        plugin = next(
-            self.plugins_manager.get_search_plugins(
-                collection=collection, provider="cop_ghsl"
-            )
-        )
+        plugin = self.get_search_plugin(collection=collection, provider="cop_ghsl")
         product_type_config = deepcopy(plugin.config.products.get(collection, {}))
         params = product_type_config
         params["tile_size"] = "10m"
@@ -6170,6 +6157,7 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
         self.assertEqual(4, count)
         self.assertEqual(4, len(products))
         properties = products[0].properties
+        assets = products[0].assets
         self.assertEqual("2015-01-01T00:00:00.000Z", properties["start_datetime"])
         self.assertEqual("2015-12-31T23:59:59.000Z", properties["end_datetime"])
         self.assertEqual("2015", properties["year"])
@@ -6177,7 +6165,7 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
         self.assertEqual(
             "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/ESM_BUILT_VHR2015_Europe_R2019/"
             "ESM_BUILT_VHR2015CLASS_EUROPE_R2019_3035_10/V1-0/tiles/R3_C3.zip",
-            properties["eodag:download_link"],
+            assets["download_link"]["href"],
         )
         geometry = get_geometry_from_various(
             geometry=["-160.008", "69.100", "-150.008", "59.100"]
@@ -6190,11 +6178,7 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
         prep = PreparedSearch(limit=5)
         # product type with one file
         collection = "GHS_FUA"
-        plugin = next(
-            self.plugins_manager.get_search_plugins(
-                collection=collection, provider="cop_ghsl"
-            )
-        )
+        plugin = self.get_search_plugin(collection=collection, provider="cop_ghsl")
         plugin.config.collection_config = {
             "collection": collection,
             "extent": {
@@ -6207,20 +6191,17 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
         self.assertEqual(1, count)
         self.assertEqual(1, len(products))
         properties = products[0].properties
+        assets = products[0].assets
         self.assertEqual("2015-01-01T00:00:00Z", properties["start_datetime"])
         self.assertEqual("2015-12-31T00:00:00Z", properties["end_datetime"])
         self.assertEqual(
             "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL//GHS_FUA_UCDB2015_GLOBE_R2019A"
             "/V1-0/GHS_FUA_UCDB2015_GLOBE_R2019A_54009_1K_V1_0.zip",
-            properties["eodag:download_link"],
+            assets["download_link"]["href"],
         )
         # product type with several files
         collection = "GHS_UCDB_REGION"
-        plugin = next(
-            self.plugins_manager.get_search_plugins(
-                collection=collection, provider="cop_ghsl"
-            )
-        )
+        plugin = self.get_search_plugin(collection=collection, provider="cop_ghsl")
         plugin.config.collection_config = {
             "collection": collection,
             "extent": {
@@ -6236,22 +6217,19 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
         self.assertEqual(1, count)
         self.assertEqual(1, len(products))
         properties = products[0].properties
+        assets = products[0].assets
         self.assertEqual("1975-01-01T00:00:00Z", properties["start_datetime"])
         self.assertEqual("2030-12-31T00:00:00Z", properties["end_datetime"])
         self.assertEqual("EUROPE", properties["region"])
         self.assertEqual(
             "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_UCDB_GLOBE_R2024A/GHS_UCDB_REGION_GLOBE_R2024A"
             "/GHS_UCDB_REGION_EUROPE_R2024A/V1-1/GHS_UCDB_REGION_EUROPE_R2024A_V1_1.zip",
-            properties["eodag:download_link"],
+            assets["download_link"]["href"],
         )
 
         # product type with several files and assets
         collection = "GHS_ENACT_POP"
-        plugin = next(
-            self.plugins_manager.get_search_plugins(
-                collection=collection, provider="cop_ghsl"
-            )
-        )
+        plugin = self.get_search_plugin(collection=collection, provider="cop_ghsl")
         filters = {
             "grouped_by": "month",
             "month": "02",
@@ -6284,15 +6262,14 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
     def test_plugins_search_cop_ghsl_discover_queryables(self, mock_fetch_constraints):
         """test that the correct queryables are returned"""
         mock_fetch_constraints.return_value = {"constraints": self.constraints}
-        plugin = next(
-            self.plugins_manager.get_search_plugins(
-                collection="GHS_BUILT_S", provider="cop_ghsl"
-            )
-        )
+        plugin = self.get_search_plugin(collection="GHS_BUILT_S", provider="cop_ghsl")
         kwargs = {"collection": "GHS_BUILT_S"}
-        collection_config = plugin.config.products.get("GHS_BUILT_S", {})
+        collection_config = {
+            key: value
+            for key, value in plugin.config.products.get("GHS_BUILT_S", {}).items()
+            if "_mapping" not in key
+        }
         kwargs.update(collection_config)
-        kwargs.pop("metadata_mapping")
         queryables = plugin.discover_queryables(**kwargs)
         self.assertEqual(6, len(queryables))
         expected_queryables = [
@@ -6326,10 +6303,12 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
             constraint["month"] = ["01", "02"]
         mock_fetch_constraints.return_value = {"constraints": constraints}
         kwargs = {"collection": "GHS_ENACT_POP"}
-        collection_config = plugin.config.products.get("GHS_ENACT_POP", {})
+        collection_config = {
+            key: value
+            for key, value in plugin.config.products.get("GHS_ENACT_POP", {}).items()
+            if "_mapping" not in key
+        }
         kwargs.update(collection_config)
-        kwargs.pop("metadata_mapping")
-        kwargs.pop("assets_mapping")
         queryables = plugin.discover_queryables(**kwargs)
         self.assertEqual(6, len(queryables))
         expected_queryables = [


### PR DESCRIPTION
Following #2091, updates providers assets mapping configuration.

Refactors and fixes `CopGhslSearch` to handle assets instead of `eodag:download_link` property.

And also exposes  provider collection in assets mapping, like performed in #2288 for metadata mapping.