### PR TITLE
feat(core): sort assets and remove private fields

### DIFF
--- a/eodag/api/product/_assets.py
+++ b/eodag/api/product/_assets.py
@@ -21,6 +21,8 @@ import re
 from collections import UserDict
 from typing import TYPE_CHECKING, Any, Optional
 
+from typing_extensions import override
+
 from eodag.utils.exceptions import NotAvailableError
 from eodag.utils.repr import dict_to_html_table
 
@@ -60,12 +62,45 @@ class AssetsDict(UserDict):
         self.product = product
         super(AssetsDict, self).__init__(*args, **kwargs)
 
-    def update(self, data: dict[str, Any]) -> None:  # type: ignore
-        """Update assets"""
-        super().update(data)
-
     def __setitem__(self, key: str, value: dict[str, Any]) -> None:
-        super().__setitem__(key, Asset(self.product, key, value))
+        super().__setitem__(key, self._make_asset(key, value))
+        self.sort()
+
+    def _make_asset(self, key: str, value: dict[str, Any]) -> Asset:
+        """Build the :class:`Asset` to store for the given key/value pair.
+
+        Subclasses (e.g. eodag_cube) can override this to use an extended
+        :class:`Asset` subclass without duplicating the sorting and other
+        logic implemented in :meth:`__setitem__`/:meth:`update`.
+
+        :param key: Asset key
+        :param value: Already-validated asset dictionary
+        :returns: The :class:`Asset` instance to store
+        """
+        return Asset(self.product, key, value)
+
+    @override
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        """Used to self update with external value"""
+        incoming = dict(*args, **kwargs)
+
+        if not incoming:
+            return
+
+        super().update(incoming)
+        self.sort()
+
+    def sort(self):
+        """Used to self sort"""
+        sorted_assets = {}
+        # Sort assets
+        for key in sorted(self.data):
+            sorted_asset = self.data[key]
+            # delete private asset fields (fields starting with '_')
+            for private_field in [k for k in sorted_asset if k.startswith("_")]:
+                del sorted_asset[private_field]
+            sorted_assets[key] = sorted_asset
+        self.data = sorted_assets
 
     def as_dict(self) -> dict[str, Any]:
         """Builds a representation of AssetsDict to enable its serialization

--- a/tests/context.py
+++ b/tests/context.py
@@ -28,6 +28,7 @@ from unittest import mock
 from eodag import EODataAccessGateway, api, config, setup_logging
 from eodag.api.core import DEFAULT_LIMIT, DEFAULT_MAX_LIMIT
 from eodag.api.product import EOProduct
+from eodag.api.product._assets import Asset, AssetsDict
 from eodag.api.product.drivers import DRIVERS
 from eodag.api.product.drivers.generic import GenericDriver
 from eodag.api.product.drivers.sentinel1 import Sentinel1Driver

--- a/tests/units/test_assets.py
+++ b/tests/units/test_assets.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026, CS GROUP - France, https://www.csgroup.eu/
+#
+# This file is part of EODAG project
+#     https://www.github.com/CS-SI/EODAG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from tests.context import Asset, AssetsDict, mock
+
+
+class CustomAsset(Asset):
+    pass
+
+
+class CustomAssetsDict(AssetsDict):
+    def _make_asset(self, key, value):
+        return CustomAsset(self.product, key, value)
+
+
+class TestAssetsDict(unittest.TestCase):
+    @mock.patch.object(AssetsDict, "sort")
+    def test_update_and_setitem_use_asset_factory_override(self, mock_sort):
+        """Use the overridden asset factory and sort assets after updates."""
+        assets = CustomAssetsDict(object())
+
+        assets.update(
+            {
+                "z": {"href": "z"},
+                "a": {"href": "a"},
+            }
+        )
+        assets["m"] = {"href": "m"}
+
+        mock_sort.assert_called()
+
+        self.assertTrue(
+            all(isinstance(asset, CustomAsset) for asset in assets.values())
+        )
+
+    def test_update_and_setitem_sort_assets_and_remove_private_fields(self):
+        """Sort assets and remove private fields after updates."""
+        assets = AssetsDict(object())
+
+        assets.update(
+            {
+                "z": {"href": "z", "_internal": "remove"},
+                "a": {"href": "a", "_internal": "remove"},
+            }
+        )
+        assets["m"] = {"href": "m", "_internal": "remove"}
+
+        self.assertEqual(list(assets), ["a", "m", "z"])
+        self.assertDictEqual(
+            {key: dict(asset) for key, asset in assets.items()},
+            {
+                "a": {"href": "a"},
+                "m": {"href": "m"},
+                "z": {"href": "z"},
+            },
+        )


### PR DESCRIPTION
Sort assets by key whenever [EOProduct.assets](https://eodag.readthedocs.io/en/latest/api_reference/eoproduct.html#eodag.api.product._product.EOProduct.assets) is updated,
and remove assets private fields (e.g. `_private_field` that could have been used for mapping)