### PR TITLE
fix(collections): STAC extensions type adapter and adapted tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,8 @@ name: Run Tests
 
 on:
   push:
-    branches: [master, develop, v5_download_link_asset]
+    branches: [master, develop, v5.x.x]
   pull_request:
-    branches: [master, develop, v5_download_link_asset]
   schedule:
     - cron: "0 7 * * 1"
   workflow_dispatch:

--- a/eodag/api/collection.py
+++ b/eodag/api/collection.py
@@ -22,7 +22,7 @@ import re
 from collections import UserDict, UserList
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional, cast
 
-from pydantic import AnyUrl, BaseModel, ConfigDict, Field, PrivateAttr
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, PrivateAttr, TypeAdapter
 from pydantic import ValidationError as PydanticValidationError
 from pydantic import model_validator
 from pydantic_core import InitErrorDetails, PydanticCustomError
@@ -31,7 +31,6 @@ from stac_pydantic.collection import Extent, SpatialExtent, TimeInterval
 from stac_pydantic.links import Links
 from stac_pydantic.shared import SEMVER_REGEX
 
-from eodag.api.product.metadata_mapping import NOT_AVAILABLE
 from eodag.types.queryables import CommonStacMetadata
 from eodag.types.stac_metadata import create_stac_metadata_model
 from eodag.utils import STAC_VERSION
@@ -55,6 +54,7 @@ RFC3339_PATTERN = (
     r"(?:T(\d{2}):(\d{2}):(\d{2})(\.\d+)?"
     r"(Z|([+-])(\d{2}):(\d{2}))?)?$"
 )
+STAC_EXTENSIONS_ADAPTER = TypeAdapter(list[AnyUrl])
 
 
 class Collection(StacCollection):
@@ -440,9 +440,9 @@ class Collection(StacCollection):
                                 default_json is not None
                                 and error["loc"][1] in default_json
                             ):
-                                values_dict[wrong_field][
-                                    error["loc"][1]
-                                ] = default_json[error["loc"][1]]
+                                values_dict[wrong_field][error["loc"][1]] = (
+                                    default_json[error["loc"][1]]
+                                )
                         else:
                             try:
                                 values_dict[wrong_field].remove(error["input"])
@@ -508,13 +508,16 @@ class Collection(StacCollection):
         )
 
         # update directly the instance as the called method is applied on it
-        self.stac_extensions = cast(
-            list[AnyUrl], summaries_validated.get_conformance_classes()
+        self.stac_extensions = STAC_EXTENSIONS_ADAPTER.validate_python(
+            summaries_validated.get_conformance_classes()
         )
 
         collection_dict = super().model_dump(
             by_alias=by_alias, exclude_unset=exclude_unset, **kwargs
         )
+        collection_dict["stac_extensions"] = [
+            str(extension) for extension in collection_dict["stac_extensions"]
+        ]
 
         # restore to default value
         self.stac_extensions = Collection.model_fields["stac_extensions"].get_default()
@@ -542,8 +545,8 @@ class Collection(StacCollection):
         )
 
         # update directly the instance as the called method is applied on it
-        self.stac_extensions = cast(
-            list[AnyUrl], summaries_validated.get_conformance_classes()
+        self.stac_extensions = STAC_EXTENSIONS_ADAPTER.validate_python(
+            summaries_validated.get_conformance_classes()
         )
 
         collection_str = super().model_dump_json(

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -3082,15 +3082,18 @@ class TestCoreSearch(TestCoreBase):
             self.dag.guess_collection()
 
     def test_guess_collection_has_no_limit(self):
-        """guess_collection must run a whoosh search without any limit"""
+        """guess_collection must run all found collections without any limit"""
         # Filter that should give more than 10 products referenced in the catalog.
-        opt_prods = [
+        optical_collections = [
             c
             for c in self.dag.list_collections(fetch_providers=False)
-            if c.eodag_sensor_type == "OPTICAL"
+            if c.eodag_sensor_type == ["OPTICAL"]
         ]
-        if len(opt_prods) <= 10:
-            self.skipTest("This test requires that more than 10 products are 'OPTICAL'")
+        self.assertGreater(
+            len(optical_collections),
+            10,
+            "This test requires that more than 10 products are 'OPTICAL'",
+        )
         guesses = self.dag.guess_collection(
             sensor_type="OPTICAL",
         )


### PR DESCRIPTION
Following #2052, add STAC extensions [type adapter](https://pydantic.dev/docs/validation/latest/concepts/type_adapter/) to fix the following warning:

> PydanticSerializationUnexpectedValue(Expected `<class 'pydantic.networks.AnyUrl'>` but got `<class 'str'>` with value `'https://stac-extensions.github.io/processing/v1.2.0/schema.json'` - serialized value may not be as expected.)
return self.__pydantic_serializer__.to_json(

Also adapt tests, and CI to v5.x.x dev branch