### PR TITLE
refactor(config): simplify user config template

### DIFF
--- a/eodag/resources/user_conf_template.yml
+++ b/eodag/resources/user_conf_template.yml
@@ -15,9 +15,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Set priority and credentials here. See the documentation for the complete
+# provider configuration.
 aws_eos:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
     search_auth:
         credentials:
             api_key:
@@ -26,70 +27,39 @@ aws_eos:
             aws_access_key_id:
             aws_secret_access_key:
             aws_profile:
-    download:
-        output_dir:
 cop_ads:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
-    download:
-        extract:
-        output_dir:
     auth:
         credentials:
             apikey:
 cop_cds:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
-    download:
-        extract:
-        output_dir:
     auth:
         credentials:
             apikey:
 cop_dataspace:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
-    download:
-        extract:
-        output_dir:
     auth:
         credentials:
             username:
             password:
 cop_dataspace_s3:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
-    download:
-        output_dir:
     auth:
         credentials:
             aws_access_key_id:
             aws_secret_access_key:
 cop_ewds:
     priority: # Lower value means lower priority (Default: 0)
-    download:
-        output_dir:
     auth:
         credentials:
             apikey:
 cop_ghsl:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
-    download:
-        extract:
-        output_dir:
 cop_marine:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
-    download:
-        extract:
-        output_dir:
 creodias:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
-    download:
-        extract:
-        output_dir:
     auth:
         credentials:
             username:
@@ -97,81 +67,56 @@ creodias:
             totp: # set totp dynamically, see https://eodag.readthedocs.io/en/latest/getting_started_guide/configure.html#authenticate-using-an-otp-one-time-password-two-factor-authentication
 creodias_s3:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
-    download:
-        output_dir:
     auth:
         credentials:
             aws_access_key_id:
             aws_secret_access_key:
 dedl:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
-    download:
-        output_dir:
     auth:
         credentials:
             username:
             password:
 dedt_lumi:
     priority: # Lower value means lower priority (Default: 0)
-    search:
-    download:
-        output_dir:
     auth:
         credentials:
             username:
             password:
 dedt_mn5:
     priority: # Lower value means lower priority (Default: 0)
-    search:
-    download:
-        output_dir:
     auth:
         credentials:
             username:
             password:
 dedt_leonardo:
     priority: # Lower value means lower priority (Default: 0)
-    search:
-    download:
-        output_dir:
     auth:
         credentials:
             username:
             password:
 dlr_eoc_geoservice:
     priority: # Lower value means lower priority (Default: 0)
-    search:
-    download:
-        output_dir:
     auth:
         credentials:
             username:
             password:
 earth_search:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
     auth:
         credentials:
             aws_access_key_id:
             aws_secret_access_key:
             aws_profile:
-    download:
-        output_dir:
 earth_search_gcs:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
     auth:
         credentials:
             aws_access_key_id:
             aws_secret_access_key:
-    download:
-        output_dir:
 ecmwf:
     priority: # Lower value means lower priority (Default: 0)
     api:
-        output_dir:
         credentials:
             username:
             password:
@@ -183,78 +128,47 @@ eocat:
             password:
 eumetsat_ds:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
-        output_dir:
     auth:
         credentials:
             username:
             password:
-    download:
-        output_dir:
 fedeo_ceda:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
-    download:
-        extract:
-        output_dir:
 geodes:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
     auth:
         credentials:
             apikey:
-    download:
-        extract:
-        output_dir:
 geodes_s3:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
     auth:
         credentials:
             aws_access_key_id:
             aws_secret_access_key:
             aws_session_token:
-    download:
-        extract:
-        output_dir:
 hydroweb_next:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
     auth:
         credentials:
             apikey:
-    download:
-        output_dir:
 meteoblue:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
     auth:
         credentials:
             apikey:
-    download:
-        output_dir:
 planetary_computer:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
     auth:
         credentials:
             apikey:
-    download:
-        output_dir:
 sara:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
-    download:
-        extract:
-        output_dir:
-        delete_archive:
     auth:
         credentials:
             username:
             password:
 theia:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
     auth:
         credentials:
             access_key:
@@ -262,46 +176,30 @@ theia:
 usgs:
     priority: # Lower value means lower priority (Default: 0)
     api:
-        extract:
-        output_dir:
-        dl_url_params:
-        product_location_scheme:
         credentials:
             username:
             password:
 usgs_satapi_aws:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
     auth:
         credentials:
             aws_access_key_id:
             aws_secret_access_key:
             aws_profile:
-    download:
-        output_dir:
 wekeo_cmems:
     priority: # Lower value means lower priority (Default: 0)
-    search:
-    download:
-        output_dir:
     auth:
         credentials:
             username:
             password:
 wekeo_ecmwf:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
-    download:
-        output_dir:
     auth:
         credentials:
             username:
             password:
 wekeo_main:
     priority: # Lower value means lower priority (Default: 0)
-    search: # Search parameters configuration
-    download:
-        output_dir:
     auth:
         credentials:
             username:

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1617,6 +1617,22 @@ class TestCore(TestCoreBase):
             os.environ.pop("EODAG__SARA__SEARCH__NEED_AUTH", None)
             os.environ.pop("EODAG__SARA__AUTH__CREDENTIALS__USERNAME", None)
 
+    def test_user_conf_template_keeps_priority_and_credentials(self):
+        """The user configuration template should not include runtime settings."""
+        template_path = res_files("eodag") / "resources" / "user_conf_template.yml"
+        with template_path.open(encoding="utf-8") as file:
+            user_conf = yaml.safe_load(file)
+
+        for provider_conf in user_conf.values():
+            self.assertIn("priority", provider_conf)
+            self.assertTrue(
+                set(provider_conf).issubset(
+                    {"priority", "auth", "search_auth", "download_auth", "api"}
+                )
+            )
+            if "api" in provider_conf:
+                self.assertEqual(set(provider_conf["api"]), {"credentials"})
+
     @mock.patch("eodag.plugins.manager.importlib_metadata.entry_points", autospec=True)
     def test_prune_providers_list_skipped_plugin(self, mock_iter_ep):
         """Providers needing skipped plugin must be pruned on init"""


### PR DESCRIPTION
Fixes #2242.

**Reduce the user configuration template** to provider priority and credential settings, in order to make it **easier to read an use**. 

This removes search, download, extraction, and output settings while preserving `auth`, `search_auth`, `download_auth`, and API credential skeletons where the providers use them.

Add a regression test that ensures the template stays focused on priority and credentials.