### PR TITLE
fix(assets): remove private fields also for technical assets

### DIFF
--- a/eodag/api/product/_assets.py
+++ b/eodag/api/product/_assets.py
@@ -169,20 +169,26 @@ class AssetsDict(UserDict):
 
         return True
 
+    @staticmethod
+    def _remove_private_fields(asset: Asset) -> None:
+        """Delete private asset fields (fields starting with '_')"""
+        for private_field in [key for key in asset if key.startswith("_")]:
+            del asset[private_field]
+
     def sort(self):
         """Used to self sort"""
         sorted_assets = {}
         # Keep technical assets first
         for key in TECHNICAL_ASSET_KEYS:
             if key in self.data:
-                sorted_assets[key] = self.data.pop(key)
+                asset = self.data.pop(key)
+                self._remove_private_fields(asset)
+                sorted_assets[key] = asset
 
         # Sort and add others
         for key in sorted(self.data):
             asset = self.data[key]
-            # delete private asset fields (fields starting with '_')
-            for private_field in [k for k in asset if k[0] == "_"]:
-                del asset[private_field]
+            self._remove_private_fields(asset)
             sorted_assets[key] = asset
         self.data = sorted_assets
 

--- a/eodag/api/product/_assets.py
+++ b/eodag/api/product/_assets.py
@@ -119,11 +119,21 @@ class AssetsDict(UserDict):
         if dl is None:
             return
         href = dl.get("href") or ""
-        if href:
-            if not self.product.location:
-                self.product.location = href
-            if not self.product.remote_location:
-                self.product.remote_location = href
+        if not href:
+            return
+
+        product = getattr(self, "product", None)
+        if product is None:
+            return
+        if not hasattr(product, "location"):
+            return
+        product_location = getattr(product, "location", None)
+        product_remote_location = getattr(product, "remote_location", None)
+
+        if not product_location:
+            product.location = href
+        if not product_remote_location:
+            product.remote_location = href
 
     def _check(self, asset_key: str, asset_value: dict[str, Any]) -> bool:
         """Validate an asset before insertion.

--- a/tests/units/test_assets.py
+++ b/tests/units/test_assets.py
@@ -88,3 +88,18 @@ class TestAssetsDict(unittest.TestCase):
                 "z": {"href": "z", "title": "z", "type": "application/zip"},
             },
         )
+
+    def test_remove_private_fields_from_technical_assets(self):
+        """Remove private fields from technical assets while sorting them first."""
+        assets = AssetsDict(object())
+
+        assets.update(
+            {
+                "thumbnail": {"href": "thumbnail", "_internal": "remove"},
+                "download_link": {"href": "download", "_internal": "remove"},
+                "quicklook": {"href": "quicklook", "_internal": "remove"},
+            }
+        )
+
+        self.assertEqual(list(assets), ["download_link", "quicklook", "thumbnail"])
+        self.assertTrue(all("_internal" not in asset for asset in assets.values()))


### PR DESCRIPTION
Following #2309 and #2091, remove private fields also for technical assets.

Also fix and refactor `AssetsDict._update_product_location` to fix failing tests