### PR TITLE
refactor(plugins): search plugins using update_assets_from_s3

### DIFF
--- a/eodag/resources/providers/cop_dataspace_s3.yml
+++ b/eodag/resources/providers/cop_dataspace_s3.yml
@@ -231,8 +231,6 @@ cop_dataspace_s3:
       geometry:
         - null
         - '{$.Footprint#from_ewkt}'
-      # order:status: must be one of succeeded, ordered, orderable
-      order:status: '{$.Online#get_group_name((?P<succeeded>True)|(?P<orderable>False))}'
       collection:
         - null
         - $.null

--- a/eodag/resources/providers/geodes_s3.yml
+++ b/eodag/resources/providers/geodes_s3.yml
@@ -86,6 +86,8 @@ geodes_s3:
         - '{$.properties."grid:code"#replace_str(r"^T?(.*)$",r"MGRS-\1")}'
       sci:doi: '{$.properties.sci:doi#replace_str(r"^\[\]$","Not Available")}'
       published: '$.properties.datetime'
+      endpoint_url: '$.null'
+      endpoint_description: '$.null'
     assets_mapping:
       download_link:
         href: '$.properties.endpoint_url'

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -6390,3 +6390,50 @@ class TestSearchPluginEumetsatDsSearch(BaseSearchPluginTest):
                 },
             },
         )
+
+
+class TestSearchPluginStacListAssets(BaseSearchPluginTest):
+    @mock.patch("eodag.plugins.search.stac_list_assets.update_assets_from_s3")
+    def test_plugins_search_stac_list_assets_register_downloader_updates_assets(
+        self, mock_update_assets_from_s3
+    ):
+        """StacListAssets must patch the product downloader registration to refresh S3 assets."""
+        search_plugin = self.get_search_plugin(provider="geodes_s3")
+
+        products = search_plugin.normalize_results(
+            [
+                {
+                    "id": "foo",
+                    "geometry": {"type": "Point", "coordinates": [0.0, 0.0]},
+                    "properties": {
+                        "identifier": "foo",
+                        "start_datetime": "2020-01-01T00:00:00Z",
+                        "end_datetime": "2020-01-02T00:00:00Z",
+                    },
+                    "assets": {
+                        "data": {
+                            "href": "s3://bucket/path/data.tif",
+                            "roles": ["data"],
+                            "title": "data",
+                        }
+                    },
+                }
+            ]
+        )
+
+        self.assertEqual(len(products), 1)
+        product = products[0]
+        self.assertTrue(hasattr(product, "register_downloader_only"))
+        self.assertIsNot(product.register_downloader, product.register_downloader_only)
+
+        downloader = mock.Mock()
+        downloader.config = mock.Mock(s3_endpoint="https://s3.example.com")
+        authenticator = mock.Mock()
+
+        product.register_downloader(downloader, authenticator)
+
+        self.assertIs(product.downloader, downloader)
+        self.assertIs(product.downloader_auth, authenticator)
+        mock_update_assets_from_s3.assert_called_once_with(
+            product, authenticator, "https://s3.example.com"
+        )


### PR DESCRIPTION
Updates search plugins using [update_assets_from_s3](https://eodag.readthedocs.io/en/latest/api_reference/utils.html#eodag.utils.s3.update_assets_from_s3) (`StacListAssets` and `CreodiasS3Search`) and add test.