### PR TITLE
test: rebased tests following downloadlink move to assets

### DIFF
--- a/eodag/plugins/search/cop_ghsl.py
+++ b/eodag/plugins/search/cop_ghsl.py
@@ -552,6 +552,9 @@ class CopGhslSearch(Search):
         """fetch the tiles matching the given filters from the provider"""
 
         logger.debug(f"get tiles for filter parameters {params}")
+        collection_config = {
+            k: v for k, v in collection_config.items() if "_mapping" not in k
+        }
         collection = params.pop("collection")
         ssl_verify = getattr(self.config, "ssl_verify", True)
         timeout = getattr(self.config, "timeout", HTTP_REQ_TIMEOUT)

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -2170,6 +2170,7 @@ class TestDownloadPluginAws(BaseDownloadPluginTest):
                     size=2,
                     bucket_name="somebucket",
                     rel_path="dummy_product/sub/file2.tif",
+                    data_type="image/tiff",
                 ),
             ],
         )

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -1378,20 +1378,6 @@ class TestSearchPluginQueryStringSearch(BaseSearchPluginTest):
         self.assertEqual(raw.next_page_token, 3)
         self.assertEqual(raw.next_page_token_key, "page")
 
-    def test_plugins_search_querystringsearch_init_raises_on_empty_metadata_mapping_from_product(
-        self,
-    ):
-        """QueryStringSearch.__init__ must reject an empty metadata_mapping inherited from another product."""
-        provider = "earth_search"
-        plugin_cfg = copy_deepcopy(self.get_search_plugin(provider=provider).config)
-        plugin_cfg.products["S1_SAR_GRD"][
-            "metadata_mapping_from_product"
-        ] = "S2_MSI_L1C"
-        plugin_cfg.products["S2_MSI_L1C"]["metadata_mapping"] = {}
-
-        with self.assertRaises(MisconfiguredError):
-            QueryStringSearch(provider, plugin_cfg)
-
     def test_plugins_search_querystringsearch_clear_resets_pagination_state(self):
         """QueryStringSearch.clear must reset URLs, parameters, and page state."""
         self.sara_search_plugin.search_urls = ["https://example.test"]
@@ -5845,8 +5831,8 @@ class TestSearchPluginCopMarineSearch(BaseSearchPluginTest):
         self.assertEqual(
             "item_20200102_20200103_direct_20210101", product.properties["id"]
         )
-        self.assertEqual("native", next(iter(product.assets.keys())))
-        asset = product.assets["native"]
+        self.assertEqual("download_link", next(iter(product.assets.keys())))
+        asset = product.assets["download_link"]
         self.assertEqual(123, asset["file:size"])
         self.assertEqual("d41d8cd98f00b204e9800998ecf8427e", asset["file:checksum"])
         self.assertEqual("2020-01-04T00:00:00.000Z", asset["updated"])
@@ -6637,18 +6623,16 @@ class TestSearchPluginCopGhslSearch(BaseSearchPluginTest):
         with self.assertRaises(MisconfiguredError):
             plugin._get_tiles_for_filters({}, deepcopy(params))
 
-        product_type_config = deepcopy(plugin.config.products.get(collection, {}))
+        product_type_config = plugin.config.products.get(collection, {})
         mock_requests_get.return_value = MockResponse({}, status_code=404)
         self.assertIsNone(
             plugin._get_tiles_for_filters(product_type_config, deepcopy(params))
         )
 
-        product_type_config = deepcopy(plugin.config.products.get(collection, {}))
         mock_requests_get.side_effect = requests.exceptions.Timeout()
         with self.assertRaises(TimeOutError):
             plugin._get_tiles_for_filters(product_type_config, deepcopy(params))
 
-        product_type_config = deepcopy(plugin.config.products.get(collection, {}))
         mock_requests_get.side_effect = requests.exceptions.RequestException("boom")
         with self.assertRaises(RequestError):
             plugin._get_tiles_for_filters(product_type_config, deepcopy(params))


### PR DESCRIPTION
Rebases tests added in #2326 , to adapt to changes introduced by download-link move to assets in #2091