### PR TITLE
fix(plugins): retry PostJsonSearch requests

### DIFF
--- a/eodag/plugins/search/qssearch.py
+++ b/eodag/plugins/search/qssearch.py
@@ -2025,6 +2025,13 @@ class PostJsonSearch(QueryStringSearch):
         exception_message = prep.exception_message
         timeout = getattr(self.config, "timeout", DEFAULT_SEARCH_TIMEOUT)
         ssl_verify = getattr(self.config, "ssl_verify", True)
+        retry_total = getattr(self.config, "retry_total", REQ_RETRY_TOTAL)
+        retry_backoff_factor = getattr(
+            self.config, "retry_backoff_factor", REQ_RETRY_BACKOFF_FACTOR
+        )
+        retry_status_forcelist = getattr(
+            self.config, "retry_status_forcelist", REQ_RETRY_STATUS_FORCELIST
+        )
         try:
             # auth if needed
             RequestsKwargs = TypedDict(
@@ -2054,7 +2061,16 @@ class PostJsonSearch(QueryStringSearch):
                 logger.debug("Query kwargs: %s" % geojson.dumps(kwargs))
             except TypeError:
                 logger.debug("Query kwargs: %s" % kwargs)
-            response = requests.post(
+            session = requests.Session()
+            retries = Retry(
+                total=retry_total,
+                backoff_factor=retry_backoff_factor,
+                status_forcelist=retry_status_forcelist,
+                allowed_methods={"POST"},
+                raise_on_status=False,
+            )
+            session.mount(url, HTTPAdapter(max_retries=retries))
+            response = session.post(
                 url,
                 json=prep.query_params,
                 headers=USER_AGENT,

--- a/eodag/resources/providers/fedeo_ceda.yml
+++ b/eodag/resources/providers/fedeo_ceda.yml
@@ -9,6 +9,7 @@ fedeo_ceda:
     api_endpoint: 'https://fedeo.ceos.org/search'
     ssl_verify: true
     timeout: 60
+    retry_status_forcelist: [400, 401, 429, 500, 502, 503, 504]
     pagination:
       next_page_url_tpl: '{url}?startRecord={next_page_token}'
       next_page_query_obj: '{{"limit":{limit}}}'

--- a/tests/integration/test_core_search.py
+++ b/tests/integration/test_core_search.py
@@ -95,7 +95,7 @@ class TestCoreSearch(unittest.TestCase):
         autospec=True,
     )
     @mock.patch(
-        "eodag.plugins.search.qssearch.requests.post",
+        "eodag.plugins.search.qssearch.requests.Session.post",
         autospec=True,
         side_effect=RequestException,
     )
@@ -127,7 +127,7 @@ class TestCoreSearch(unittest.TestCase):
         autospec=True,
     )
     @mock.patch(
-        "eodag.plugins.search.qssearch.requests.post",
+        "eodag.plugins.search.qssearch.requests.Session.post",
         autospec=True,
         side_effect=RequestException,
     )
@@ -230,7 +230,7 @@ class TestCoreSearch(unittest.TestCase):
         autospec=True,
     )
     @mock.patch(
-        "eodag.plugins.search.qssearch.requests.post",
+        "eodag.plugins.search.qssearch.requests.Session.post",
         autospec=True,
         side_effect=RequestException,
     )
@@ -272,7 +272,7 @@ class TestCoreSearch(unittest.TestCase):
         side_effect=RequestException,
     )
     @mock.patch(
-        "eodag.plugins.search.qssearch.requests.post",
+        "eodag.plugins.search.qssearch.requests.Session.post",
         autospec=True,
         side_effect=RequestException,
     )
@@ -822,7 +822,7 @@ class TestCoreSearch(unittest.TestCase):
         self.assertEqual("DEDT_LUMI_123-456", result[0].properties["title"])
 
     @mock.patch(
-        "eodag.plugins.search.qssearch.requests.post",
+        "eodag.plugins.search.qssearch.requests.Session.post",
         autospec=True,
     )
     @mock.patch(

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -1322,6 +1322,27 @@ class TestSearchPluginPostJsonSearch(BaseSearchPluginTest):
 
         run()
 
+    def test_plugins_search_postjsonsearch_retries_status_errors(self):
+        """A PostJsonSearch request must retry configured status errors."""
+        search_plugin = self.get_search_plugin(provider="fedeo_ceda")
+        search_plugin.config.retry_total = 1
+        search_plugin.config.retry_backoff_factor = 0
+        url = search_plugin.config.api_endpoint
+        prep = PreparedSearch(url=url)
+        prep.query_params = {}
+
+        @responses.activate(registry=responses.registries.FirstMatchRegistry)
+        def run():
+            responses.add(responses.POST, url, status=400)
+            responses.add(responses.POST, url, status=200)
+
+            response = search_plugin._request(prep)
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(responses.calls), 2)
+
+        run()
+
     def test_plugins_search_postjsonsearch_request_auth_error(self):
         """A query with a PostJsonSearch must handle auth errors"""
 
@@ -1343,7 +1364,7 @@ class TestSearchPluginPostJsonSearch(BaseSearchPluginTest):
 
         run()
 
-    @mock.patch("eodag.plugins.search.qssearch.requests.post", autospec=True)
+    @mock.patch("eodag.plugins.search.qssearch.requests.Session.post", autospec=True)
     def test_plugins_search_postjsonsearch_search_quota_exceeded(self, mock__request):
         """A query with a PostJsonSearch must handle a 429 response returned by the provider"""
 
@@ -1461,7 +1482,7 @@ class TestSearchPluginPostJsonSearch(BaseSearchPluginTest):
         "eodag.plugins.search.qssearch.QueryStringSearch.normalize_results",
         autospec=True,
     )
-    @mock.patch("eodag.plugins.search.qssearch.requests.post", autospec=True)
+    @mock.patch("eodag.plugins.search.qssearch.requests.Session.post", autospec=True)
     def test_plugins_search_postjsonsearch_search_cloudcover_awseos(
         self, mock_requests_post, mock_normalize_results
     ):
@@ -1529,7 +1550,7 @@ class TestSearchPluginPostJsonSearch(BaseSearchPluginTest):
         )
         self.assertNotIn("bar", products.data[0].properties)
 
-    @mock.patch("eodag.plugins.search.qssearch.requests.post", autospec=True)
+    @mock.patch("eodag.plugins.search.qssearch.requests.Session.post", autospec=True)
     @mock.patch(
         "eodag.plugins.search.qssearch.PostJsonSearch.normalize_results", autospec=True
     )
@@ -1552,6 +1573,7 @@ class TestSearchPluginPostJsonSearch(BaseSearchPluginTest):
             },
         )
         mock_request.assert_called_with(
+            mock.ANY,
             "https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/search",
             json={
                 "year": "2020",
@@ -1573,6 +1595,7 @@ class TestSearchPluginPostJsonSearch(BaseSearchPluginTest):
             start_datetime="2021-02-01T03:00:00Z",
         )
         mock_request.assert_called_with(
+            mock.ANY,
             "https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/search",
             json={
                 "year": ["2021"],
@@ -1623,6 +1646,7 @@ class TestSearchPluginPostJsonSearch(BaseSearchPluginTest):
         )
         search_plugin.query(collection="ERA5_SL", prep=PreparedSearch())
         mock_request.assert_called_with(
+            mock.ANY,
             "https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/search",
             json={
                 "dataset_id": "EO:ECMWF:DAT:REANALYSIS_ERA5_SINGLE_LEVELS",
@@ -1665,6 +1689,7 @@ class TestSearchPluginPostJsonSearch(BaseSearchPluginTest):
         )
         search_plugin.query(collection="CAMS_EAC4", prep=PreparedSearch())
         mock_request.assert_called_with(
+            mock.ANY,
             "https://gateway.prod.wekeo2.eu/hda-broker/api/v1/dataaccess/search",
             json={
                 "dataset_id": "EO:ECMWF:DAT:CAMS_GLOBAL_REANALYSIS_EAC4",
@@ -1780,7 +1805,7 @@ class TestSearchPluginPostJsonSearch(BaseSearchPluginTest):
         with self.assertRaises(ValidationError):
             self.awseos_search_plugin._request(PreparedSearch())
 
-    @mock.patch("eodag.plugins.search.qssearch.requests.post", autospec=True)
+    @mock.patch("eodag.plugins.search.qssearch.requests.Session.post", autospec=True)
     def test_plugins_search_postjsonsearch_request_translates_errors(self, mock_post):
         """PostJsonSearch must translate timeout, auth, quota, and generic request errors."""
         response = requests.Response()
@@ -2422,7 +2447,7 @@ class TestSearchPluginStacSearch(BaseSearchPluginTest):
         self.assertIn("some-asset", products[0].assets)
         self.assertEqual(products[0].assets["some-asset"]["title"], "My custom title")
 
-    @mock.patch("eodag.plugins.search.qssearch.requests.post", autospec=True)
+    @mock.patch("eodag.plugins.search.qssearch.requests.Session.post", autospec=True)
     def test_plugins_search_stacsearch_opened_time_intervals(self, mock_requests_post):
         """Opened time intervals must be handled by StacSearch plugin"""
         mock_requests_post.return_value = mock.Mock()
@@ -3270,7 +3295,7 @@ class TestSearchPluginMeteoblueSearch(BaseSearchPluginTest):
         self.auth_plugin.config.credentials = {"cred": "entials"}
         self.auth = self.auth_plugin.authenticate()
 
-    @mock.patch("eodag.plugins.search.qssearch.requests.post", autospec=True)
+    @mock.patch("eodag.plugins.search.qssearch.requests.Session.post", autospec=True)
     def test_plugins_search_buildpostsearchresult_count_and_search(
         self, mock_requests_post
     ):
@@ -3286,6 +3311,7 @@ class TestSearchPluginMeteoblueSearch(BaseSearchPluginTest):
         )
 
         mock_requests_post.assert_called_with(
+            mock.ANY,
             self.search_plugin.config.api_endpoint,
             json=mock.ANY,
             headers=USER_AGENT,


### PR DESCRIPTION
`PostJsonSearch` plugin now applies its configured retry count, backoff, and status list to POST requests. POST is explicitly enabled in urllib3 Retry, and exhausted status retries return the final response so the existing authentication and quota error handling remains in effect.

The `fedeo_ceda` configuration now includes status 400 in its retry list. A regression test covers a 400 response followed by a successful retry.

Fixes #2307