### PR TITLE
fix(providers): disable ssl verify on fedeo_ceda

### DIFF
--- a/eodag/resources/providers/fedeo_ceda.yml
+++ b/eodag/resources/providers/fedeo_ceda.yml
@@ -7,7 +7,7 @@ fedeo_ceda:
   search:
     type: StacSearch
     api_endpoint: 'https://fedeo.ceos.org/search'
-    ssl_verify: true
+    ssl_verify: false
     timeout: 60
     retry_status_forcelist: [400, 401, 429, 500, 502, 503, 504]
     pagination:


### PR DESCRIPTION
Disable ssl verify on `fedeo_ceda` following a recent issue appearing during search requests on this provider:
```
requests.exceptions.SSLError: HTTPSConnectionPool(host='fedeo.ceos.org', port=443): Max retries exceeded with url: /search?startRecord=1 (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1081)')))
```
