### PR TITLE
fix(providers): cop_dataspace_s3 and creodias_s3 auth matching url

### DIFF
--- a/eodag/config.py
+++ b/eodag/config.py
@@ -647,7 +647,11 @@ class PluginConfig(yaml.YAMLObject):
         )
 
     def matches_target_auth(self, target_config: Self):
-        """Check if the target auth configuration matches this one"""
+        """Check whether this auth configuration can share credentials with another.
+
+        Matching criteria must be identical: when both ``matching_url`` and
+        ``matching_conf`` are configured, both must match.
+        """
         target_matching_conf = getattr(target_config, "matching_conf", {})
         target_matching_url = getattr(target_config, "matching_url", None)
 

--- a/eodag/plugins/authentication/base.py
+++ b/eodag/plugins/authentication/base.py
@@ -36,10 +36,13 @@ class Authentication(PluginTopic):
     :param provider: provider name
     :param config: Authentication plugin configuration:
 
-        * :attr:`~eodag.config.PluginConfig.matching_url` (``str``): URL pattern to match with search plugin endpoint or
-          download link
+        * :attr:`~eodag.config.PluginConfig.matching_url` (``str``): URL pattern to match with a search plugin endpoint
+            or product download link
         * :attr:`~eodag.config.PluginConfig.matching_conf` (``dict[str, Any]``): Part of the search or download plugin
-          configuration that needs authentication and helps identifying it
+            configuration that needs authentication and helps identifying it.
+
+        At runtime, an auth plugin matches when either criterion matches.
+        When credentials are shared between provider configurations, all configured matching criteria must be identical.
     """
 
     entrypoint_group = "auth"

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -319,13 +319,16 @@ class PluginManager:
         matching_url: Optional[str] = None,
         matching_conf: Optional[PluginConfig] = None,
     ) -> Iterator[Authentication]:
-        """Build and return the authentication plugin for the given collection and
-        provider
+        """Build and return authentication plugins matching the given criteria.
+
+        An auth plugin matches when either its ``matching_url`` pattern matches
+        ``matching_url`` or its ``matching_conf`` is a subset of ``matching_conf``.
+        The requested provider is considered first, followed by other providers.
 
         :param provider: The provider for which to get the authentication plugin
         :param matching_url: url to compare with plugin matching_url pattern
         :param matching_conf: configuration to compare with plugin matching_conf
-        :returns: All the Authentication plugins for the given criteria
+        :returns: Authentication plugins matching the given criteria
         """
         auth_conf: Optional[PluginConfig] = None
 

--- a/eodag/resources/providers/cop_dataspace_s3.yml
+++ b/eodag/resources/providers/cop_dataspace_s3.yml
@@ -251,8 +251,7 @@ cop_dataspace_s3:
     auth_error_code: 403
     s3_endpoint: 'https://eodata.dataspace.copernicus.eu'
     support_presign_url: False
-    matching_conf:
-      s3_endpoint: 'https://eodata.dataspace.copernicus.eu'
+    matching_url: 's3://eodata'
   products:
     # S2
     S2_MSI_L1C:

--- a/eodag/resources/providers/creodias_s3.yml
+++ b/eodag/resources/providers/creodias_s3.yml
@@ -251,8 +251,7 @@ creodias_s3:
     auth_error_code: 403
     s3_endpoint: 'https://eodata.cloudferro.com'
     support_presign_url: False
-    matching_conf:
-      s3_endpoint: 'https://eodata.cloudferro.com'
+    matching_url: 's3://eodata'
   products:
       # S1
     S1_AUX_GNSSRD:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,12 +57,13 @@ class TestEodagCli(unittest.TestCase):
     @contextmanager
     def user_conf(self, conf_file="user_conf.yml", content=b"key: to unused conf"):
         """Utility method"""
-        with self.runner.isolated_filesystem():
-            with open(conf_file, "wb") as fd:
+        with TemporaryDirectory() as tmp_dir:
+            conf_file_path = os.path.join(tmp_dir, conf_file)
+            with open(conf_file_path, "wb") as fd:
                 fd.write(
                     content if isinstance(content, bytes) else content.encode("utf-8")
                 )
-            yield conf_file
+            yield conf_file_path
 
     def setUp(self):
         super(TestEodagCli, self).setUp()


### PR DESCRIPTION
Updates `cop_dataspace_s3` and `creodias_s3` matching url in auth plugin conf.

Also updates [sharing credentials between providers documentation](https://eodag.readthedocs.io/en/latest/plugins_reference/auth.html#eodag.plugins.authentication.base.Authentication).