### PR TITLE
feat(core): standardize global settings using pydantic

### DIFF
--- a/docs/api_reference/index.rst
+++ b/docs/api_reference/index.rst
@@ -18,6 +18,7 @@ The API Reference provides an overview of all public objects, functions and meth
    collection
    provider
    utils
+   settings
    exceptions
    types
    call_graphs
@@ -89,6 +90,14 @@ The API Reference provides an overview of all public objects, functions and meth
          :shadow: md
 
          Utility functions for logging, callbacks, text search, notebook integration, S3 operations, xarray support, and miscellaneous helpers.
+
+   .. grid-item-card:: :octicon:`gear;1.5em`  Settings
+         :link: settings
+         :link-type: doc
+         :text-align: center
+         :shadow: md
+
+         Configuration management and access to EODAG settings, including user and provider configuration files.
 
    .. grid-item-card:: :octicon:`alert;1.5em`  Exceptions
          :link: exceptions

--- a/docs/api_reference/settings.rst
+++ b/docs/api_reference/settings.rst
@@ -1,0 +1,14 @@
+.. module:: eodag.config
+
+========
+Settings
+========
+
+``EODAGSettings`` defines the global EODAG configuration parameters. Values can be provided directly when creating the
+settings object or overridden with ``EODAG_``-prefixed environment variables. See
+`Core configuration using environment variables <../getting_started_guide/configure.rst#core-configuration-using-environment-variables>`_
+for detailled information on the supported environment variables.
+
+.. autopydantic_settings:: EODAGSettings
+	:settings-hide-paramlist:
+	:exclude-members: __init__, warn_deprecated_settings, resolved_cfg_file, resolved_locations_cfg_file

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -378,8 +378,24 @@ def _html_page_context(app, pagename, templatename, context, doctree):
         context["theme_use_edit_page_button"] = False
 
 
+def _hide_base_settings_parameters(app, what, name, obj, options, lines):
+    """Hide inherited BaseSettings constructor parameters from EODAGSettings."""
+    if name != "eodag.config.EODAGSettings":
+        return
+
+    filtered_lines = []
+    skip_parameter = False
+    for line in lines:
+        if line.startswith(":param "):
+            skip_parameter = line.startswith(":param _")
+        if not skip_parameter:
+            filtered_lines.append(line)
+    lines[:] = filtered_lines
+
+
 def setup(app):
     """dummy docstring for pydocstyle"""
+    app.connect("autodoc-process-docstring", _hide_base_settings_parameters)
     app.connect("html-page-context", _html_page_context)
     app.connect("build-finished", _build_finished)
     app.set_translator("html", PatchedHTMLTranslator)

--- a/docs/getting_started_guide/configure.rst
+++ b/docs/getting_started_guide/configure.rst
@@ -151,7 +151,9 @@ Each configuration parameter can be set with an environment variable.
 Core configuration using environment variables
 """"""""""""""""""""""""""""""""""""""""""""""
 
-Some EODAG core settings can be overriden using environment variables:
+Some EODAG core settings are handled using `Pydantic settings <https://pydantic-docs.helpmanual.io/usage/settings/>`_
+through `EODAGSettings <../api_reference/settings.rst#eodag.config.EODAGSettings>`_ and can be overriden using
+environment variables:
 
 * ``EODAG_CFG_DIR`` customized configuration directory in place of `~/.config/eodag`.
 * ``EODAG_CFG_FILE`` for defining the desired path to the `user configuration file\

--- a/eodag/__init__.py
+++ b/eodag/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018, CS GROUP - France, https://www.csgroup.eu/
 #
 # This file is part of EODAG project
@@ -33,16 +32,18 @@ except PackageNotFoundError:  # pragma: no cover
 
 # exportable content
 __all__ = [
+    "EODAGSettings",
     "EODataAccessGateway",
     "EOProduct",
     "SearchResult",
-    "setup_logging",
     "config",
+    "setup_logging",
 ]
 
 # Lazy imports (PEP 562) — avoid loading heavy dependencies on ``import eodag``
 _LAZY_IMPORTS: dict[str, tuple[str, Optional[str]]] = {
     "EODataAccessGateway": (".api.core", "EODataAccessGateway"),
+    "EODAGSettings": (".config", "EODAGSettings"),
     "EOProduct": (".api.product", "EOProduct"),
     "SearchResult": (".api.search_result", "SearchResult"),
     "setup_logging": (".utils.logging", "setup_logging"),

--- a/eodag/api/collection.py
+++ b/eodag/api/collection.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 from pydantic import ValidationError as PydanticValidationError
-from pydantic import model_validator
+from pydantic import ValidationInfo, model_validator
 from pydantic_core import ErrorDetails, InitErrorDetails, PydanticCustomError
 from stac_pydantic.collection import Extent, Provider, SpatialExtent, TimeInterval
 from stac_pydantic.links import Links
@@ -33,7 +33,6 @@ from eodag.api.product.metadata_mapping import NOT_AVAILABLE
 from eodag.types.queryables import CommonStacMetadata
 from eodag.types.stac_metadata import create_stac_metadata_model
 from eodag.utils import STAC_VERSION
-from eodag.utils.env import is_env_var_true
 from eodag.utils.exceptions import ValidationError
 from eodag.utils.repr import dict_to_html_table
 
@@ -113,13 +112,24 @@ class Collection(BaseModel):
         self._id = self.id
 
     @classmethod
+    def create(cls, validate_collections: bool = False, **kwargs: Any) -> Collection:
+        """Create a Collection with optional validation warning logging."""
+        return cls.model_validate(
+            kwargs,
+            context={"validate_collections": validate_collections},
+        )
+
+    @classmethod
     def create_with_dag(cls, dag: EODataAccessGateway, **kwargs) -> Collection:
         """Create a Collection with a EODataAccessGateway instance.
 
         :param dag: The gateway instance to use to search products and to list queryables of the collection instance
         :param kwargs: The collection attributes
         """
-        instance = cls(**kwargs)
+        instance = cls.create(
+            validate_collections=dag.settings.validate_collections,
+            **kwargs,
+        )
         instance._dag = dag
         return instance
 
@@ -148,14 +158,20 @@ class Collection(BaseModel):
     @model_validator(mode="wrap")
     @classmethod
     def validate_collection(
-        cls, values: dict[str, Any] | Self, handler: ModelWrapValidatorHandler[Self]
+        cls,
+        values: dict[str, Any] | Self,
+        handler: ModelWrapValidatorHandler[Self],
+        info: ValidationInfo,
     ) -> Self:
         """Allow to create a collection instance with bad formatted attributes (except ``id``).
         Set incorrectly formatted attributes to ``None`` and ignore extra attributes.
-        Log a warning about validation errors if ``EODAG_VALIDATE_COLLECTIONS`` environment variable is set to ``True``.
+        Log a warning about validation errors when validation logging is enabled.
         """
         errors: list[ErrorDetails] = []
         continue_validation: bool = True
+        validate_collections = bool(
+            info.context and info.context.get("validate_collections", False)
+        )
 
         # iterate over each step of validation where error(s) raise(s)
         while continue_validation:
@@ -189,8 +205,8 @@ class Collection(BaseModel):
             else:
                 continue_validation = False
 
-        # log a warning if there were validation errors and the env var is set to True
-        if errors and is_env_var_true("EODAG_VALIDATE_COLLECTIONS"):
+        # log a warning if there were validation errors and logging is enabled
+        if errors and validate_collections:
             # log all errors at once
             error_title = f"collection {values_dict['id']}"
             init_errors: list[InitErrorDetails] = [

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -20,18 +20,15 @@ from __future__ import annotations
 import datetime as dt
 import itertools
 import logging
-import os
 import re
-import shutil
-import tempfile
 import warnings
 from collections import deque
+from collections.abc import Iterator
 from copy import deepcopy
 from importlib.metadata import version
-from importlib.resources import files as res_files
 from operator import attrgetter, itemgetter
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterator, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import geojson
 import yaml
@@ -44,12 +41,16 @@ from eodag.api.provider import Provider, ProvidersDict
 from eodag.api.search_result import SearchResult
 from eodag.config import (
     PLUGINS_TOPICS_KEYS,
+    EODAGSettings,
     PluginConfig,
     SimpleYamlProxyConfig,
     credentials_in_auth,
+    ensure_cfg_dir_exists,
+    ensure_locations_config_exists,
+    ensure_user_config_exists,
     get_ext_collections_conf,
-    load_default_config,
-    load_yml_config,
+    load_locations_config,
+    load_provider_configs,
 )
 from eodag.plugins.manager import PluginManager
 from eodag.plugins.search import PreparedSearch
@@ -67,13 +68,11 @@ from eodag.utils import (
     GENERIC_STAC_PROVIDER,
     _deprecated,
     get_geometry_from_various,
-    makedirs,
     sort_dict,
     string_to_jsonpath,
     uri_to_path,
 )
 from eodag.utils.dates import get_datetime, rfc3339_str_to_datetime
-from eodag.utils.env import is_env_var_true
 from eodag.utils.exceptions import (
     AuthenticationError,
     NoMatchingCollection,
@@ -98,6 +97,23 @@ if TYPE_CHECKING:
 logger = logging.getLogger("eodag.core")
 
 
+def ensure_config_files(
+    settings: EODAGSettings,
+) -> EODAGSettings:
+    """Ensure EODAG configuration files and directories exist."""
+
+    settings.cfg_dir = ensure_cfg_dir_exists(settings.cfg_dir)
+
+    ensure_user_config_exists(settings.resolved_cfg_file)
+
+    ensure_locations_config_exists(
+        settings.resolved_locations_cfg_file,
+        settings.cfg_dir,
+    )
+
+    return settings
+
+
 class EODataAccessGateway:
     """An API for downloading a wide variety of geospatial products originating
     from different types of providers.
@@ -108,80 +124,79 @@ class EODataAccessGateway:
 
     def __init__(
         self,
-        user_conf_file_path: Optional[str] = None,
-        locations_conf_path: Optional[str] = None,
+        user_conf_file_path: str | None = None,
+        locations_conf_path: str | None = None,
+        settings: EODAGSettings | None = None,
     ) -> None:
-        collections_config_path = os.getenv("EODAG_COLLECTIONS_CFG_FILE") or str(
-            res_files("eodag") / "resources" / "collections.yml"
+        if user_conf_file_path is not None:
+            warnings.warn(
+                "'user_conf_file_path' is deprecated. "
+                "Use EODAGSettings(cfg_file=...) instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        if locations_conf_path is not None:
+            warnings.warn(
+                "'locations_conf_path' is deprecated. "
+                "Use EODAGSettings(locations_cfg_file=...) instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        settings_kwargs: dict[str, Any] = {}
+
+        if user_conf_file_path is not None:
+            settings_kwargs["cfg_file"] = Path(user_conf_file_path)
+
+        if locations_conf_path is not None:
+            settings_kwargs["locations_cfg_file"] = Path(locations_conf_path)
+
+        if settings is not None and settings_kwargs:
+            raise ValueError(
+                "'settings' cannot be used together with "
+                "'user_conf_file_path' or 'locations_conf_path'."
+            )
+
+        self.settings = ensure_config_files(
+            settings or EODAGSettings(**settings_kwargs)
         )
-        collections_config_dict = SimpleYamlProxyConfig(collections_config_path).source
+
+        collections_config_dict = SimpleYamlProxyConfig(
+            str(self.settings.collections_cfg_file)
+        ).source
+
         self.collections_config = self._collections_config_init(collections_config_dict)
 
-        self._providers = ProvidersDict.from_configs(load_default_config())
-
-        env_var_cfg_dir = "EODAG_CFG_DIR"
-        self.conf_dir = os.getenv(
-            env_var_cfg_dir,
-            default=os.path.join(os.path.expanduser("~"), ".config", "eodag"),
+        self._providers = ProvidersDict.from_configs(
+            load_provider_configs(
+                self.settings.providers_cfg_file, self.settings.providers_cfg_dir
+            ),
+            whitelist=self.settings.providers_whitelist,
         )
-        try:
-            makedirs(self.conf_dir)
-        except OSError as e:
-            logger.debug(e)
-            tmp_conf_dir = os.path.join(tempfile.gettempdir(), ".config", "eodag")
-            logger.warning(
-                f"Cannot create configuration directory {self.conf_dir}. "
-                + f"Falling back to temporary directory {tmp_conf_dir}."
-            )
-            if os.getenv(env_var_cfg_dir) is None:
-                logger.warning(
-                    "You can set the path of the configuration directory "
-                    + f"with the environment variable {env_var_cfg_dir}"
-                )
-            self.conf_dir = tmp_conf_dir
-            makedirs(self.conf_dir)
 
         self._plugins_manager = PluginManager(self._providers)
         self._providers = self._plugins_manager.providers
 
-        # First level override: From a user configuration file
-        if user_conf_file_path is None:
-            env_var_name = "EODAG_CFG_FILE"
-            standard_configuration_path = os.path.join(self.conf_dir, "eodag.yml")
-            user_conf_file_path = os.getenv(env_var_name)
-            if user_conf_file_path is None:
-                user_conf_file_path = standard_configuration_path
-                source = str(
-                    res_files("eodag") / "resources" / "user_conf_template.yml"
-                )
-                if os.path.isfile(source) and not os.path.isfile(
-                    standard_configuration_path
-                ):
-                    shutil.copy(
-                        source,
-                        standard_configuration_path,
-                    )
-        self._providers.update_from_config_file(user_conf_file_path)
+        # Update with user configuration
+        self._providers.update_from_config_file(str(self.settings.resolved_cfg_file))
 
-        # Second level override: From environment variables
+        # Environment overrides still apply to providers
         self._providers.update_from_env()
 
-        # init updated providers conf
-        strict_mode = is_env_var_true("EODAG_STRICT_COLLECTIONS")
-
         for provider in self._providers.values():
-            provider.sync_collections(self, strict_mode)
+            provider.sync_collections(self, self.settings.strict_collections)
 
-        # re-build _plugins_manager using up-to-date providers_config
         self._plugins_manager.rebuild(self._providers)
 
         # filter out providers needing auth that have no credentials set
         self._prune_providers_list()
 
-        # Sort providers taking into account of possible new priority orders
         self._plugins_manager.sort_providers()
 
-        self.set_locations_conf(locations_conf_path)
+        self.locations_config = load_locations_config(
+            str(self.settings.resolved_locations_cfg_file)
+        )
 
     def _collections_config_init(
         self, collections_config_dict: dict[str, Any]
@@ -472,74 +487,6 @@ class EODataAccessGateway:
             # rebuild _plugins_manager with updated providers list
             self._plugins_manager.rebuild(self._providers)
 
-    def set_locations_conf(self, locations_conf_path: Optional[str]) -> None:
-        """Set locations configuration.
-        This configuration (YML format) will contain a shapefile list associated
-        to a name and attribute parameters needed to identify the needed geometry.
-        You can also configure parent attributes, which can be used for creating
-        a catalogs path when using eodag as a REST server.
-        Example of locations configuration file content:
-
-        .. code-block:: yaml
-
-            shapefiles:
-                - name: country
-                  path: /path/to/countries_list.shp
-                  attr: ISO3
-                - name: department
-                  path: /path/to/FR_departments.shp
-                  attr: code_insee
-                  parent:
-                    name: country
-                    attr: FRA
-
-        :param locations_conf_path: Path to the locations configuration file
-        """
-        if locations_conf_path is None:
-            locations_conf_path = os.getenv("EODAG_LOCS_CFG_FILE")
-            if locations_conf_path is None:
-                locations_conf_path = os.path.join(self.conf_dir, "locations.yml")
-                if not os.path.isfile(locations_conf_path):
-                    # Ensure the directory exists
-                    os.makedirs(os.path.dirname(locations_conf_path), exist_ok=True)
-
-                    # copy locations conf file and replace path example
-                    locations_conf_template = str(
-                        res_files("eodag") / "resources" / "locations_conf_template.yml"
-                    )
-                    with (
-                        open(locations_conf_template) as infile,
-                        open(locations_conf_path, "w") as outfile,
-                    ):
-                        # The template contains paths in the form of:
-                        # /path/to/locations/file.shp
-                        path_template = "/path/to/locations/"
-                        for line in infile:
-                            line = line.replace(
-                                path_template,
-                                os.path.join(self.conf_dir, "shp") + os.path.sep,
-                            )
-                            outfile.write(line)
-                    # copy sample shapefile dir
-                    shutil.copytree(
-                        str(res_files("eodag") / "resources" / "shp"),
-                        os.path.join(self.conf_dir, "shp"),
-                    )
-
-        if os.path.isfile(locations_conf_path):
-            locations_config = load_yml_config(locations_conf_path)
-
-            main_key = next(iter(locations_config))
-            main_locations_config = locations_config[main_key]
-
-            logger.info("Locations configuration loaded from %s" % locations_conf_path)
-            self.locations_config: list[dict[str, Any]] = main_locations_config
-        else:
-            logger.info(
-                "Could not load locations configuration from %s" % locations_conf_path
-            )
-            self.locations_config = []
-
     def list_collections(
         self, provider: Optional[str] = None, fetch_providers: bool = True
     ) -> CollectionsList:
@@ -588,8 +535,7 @@ class EODataAccessGateway:
         :param provider: The name of a provider or provider-group for which collections
                          list should be updated. Defaults to all providers (None value).
         """
-        strict_mode = is_env_var_true("EODAG_STRICT_COLLECTIONS")
-        if strict_mode:
+        if self.settings.strict_collections:
             return
 
         # providers discovery confs that are fetchable
@@ -608,19 +554,15 @@ class EODataAccessGateway:
 
         if not already_fetched:
             # get ext_collections conf
-            ext_collections_cfg_file = os.getenv("EODAG_EXT_COLLECTIONS_CFG_FILE")
-            if ext_collections_cfg_file is not None:
-                ext_collections_conf = get_ext_collections_conf(
-                    ext_collections_cfg_file
-                )
-            else:
-                ext_collections_conf = get_ext_collections_conf()
+            ext_collections_conf = get_ext_collections_conf(
+                self.settings.ext_collections_cfg_uri
+            )
 
-                if not ext_collections_conf:
-                    # empty ext_collections conf
-                    ext_collections_conf = (
-                        self.discover_collections(provider=provider) or {}
-                    )
+            if not ext_collections_conf:
+                # empty ext_collections conf
+                ext_collections_conf = (
+                    self.discover_collections(provider=provider) or {}
+                )
 
             # update eodag collections list with new conf
             self.update_collections_list(ext_collections_conf)
@@ -629,7 +571,7 @@ class EODataAccessGateway:
         # and collections list would need to be fetched
 
         # get ext_collections conf for user modified providers
-        default_providers = ProvidersDict.from_configs(load_default_config())
+        default_providers = ProvidersDict.from_configs(load_provider_configs())
         for (
             provider,
             user_discovery_conf,
@@ -652,31 +594,25 @@ class EODataAccessGateway:
                         PluginConfig.DiscoverCollections,
                         dict(
                             default_discovery_conf,
-                            **{
-                                "results_entry": string_to_jsonpath(
-                                    default_discovery_conf["results_entry"], force=True
-                                )
-                            },
+                            results_entry=string_to_jsonpath(
+                                default_discovery_conf["results_entry"], force=True
+                            ),
                             **mtd_cfg_as_conversion_and_querypath(
-                                dict(
-                                    generic_collection_id=default_discovery_conf[
+                                {
+                                    "generic_collection_id": default_discovery_conf[
                                         "generic_collection_id"
                                     ]
-                                )
+                                }
                             ),
-                            **dict(
-                                generic_collection_parsable_properties=mtd_cfg_as_conversion_and_querypath(
-                                    default_discovery_conf[
-                                        "generic_collection_parsable_properties"
-                                    ]
-                                )
+                            generic_collection_parsable_properties=mtd_cfg_as_conversion_and_querypath(
+                                default_discovery_conf[
+                                    "generic_collection_parsable_properties"
+                                ]
                             ),
-                            **dict(
-                                generic_collection_parsable_metadata=mtd_cfg_as_conversion_and_querypath(
-                                    default_discovery_conf[
-                                        "generic_collection_parsable_metadata"
-                                    ]
-                                )
+                            generic_collection_parsable_metadata=mtd_cfg_as_conversion_and_querypath(
+                                default_discovery_conf[
+                                    "generic_collection_parsable_metadata"
+                                ]
                             ),
                         ),
                     )

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -130,7 +130,7 @@ class EODataAccessGateway:
     ) -> None:
         if user_conf_file_path is not None:
             warnings.warn(
-                "'user_conf_file_path' is deprecated. "
+                "'user_conf_file_path' parameter is deprecated. "
                 "Use EODAGSettings(cfg_file=...) instead.",
                 DeprecationWarning,
                 stacklevel=2,
@@ -138,7 +138,7 @@ class EODataAccessGateway:
 
         if locations_conf_path is not None:
             warnings.warn(
-                "'locations_conf_path' is deprecated. "
+                "'locations_conf_path' parameter is deprecated. "
                 "Use EODAGSettings(locations_cfg_file=...) instead.",
                 DeprecationWarning,
                 stacklevel=2,

--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -50,13 +50,16 @@ from eodag.plugins.authentication.aws_auth import AwsAuth
 from eodag.types.queryables import CommonStacMetadata
 from eodag.types.stac_metadata import create_stac_metadata_model
 
-try:
-    # import from eodag-cube if installed
-    from eodag_cube.api.product import (  # pyright: ignore[reportMissingImports]
-        AssetsDict,
-    )
-except ImportError:
+if TYPE_CHECKING:
     from ._assets import AssetsDict
+else:
+    try:
+        # Import extended assets from eodag-cube if installed.
+        from eodag_cube.api.product import (  # pyright: ignore[reportMissingImports]
+            AssetsDict,
+        )
+    except ImportError:
+        from ._assets import AssetsDict
 
 from eodag.api.product.drivers import DRIVERS
 from eodag.api.product.drivers.generic import GenericDriver

--- a/eodag/api/product/_product.py
+++ b/eodag/api/product/_product.py
@@ -50,16 +50,13 @@ from eodag.plugins.authentication.aws_auth import AwsAuth
 from eodag.types.queryables import CommonStacMetadata
 from eodag.types.stac_metadata import create_stac_metadata_model
 
-if TYPE_CHECKING:
+try:
+    # import from eodag-cube if installed
+    from eodag_cube.api.product import (  # pyright: ignore[reportMissingImports]
+        AssetsDict,
+    )
+except ImportError:
     from ._assets import AssetsDict
-else:
-    try:
-        # Import extended assets from eodag-cube if installed.
-        from eodag_cube.api.product import (  # pyright: ignore[reportMissingImports]
-            AssetsDict,
-        )
-    except ImportError:
-        from ._assets import AssetsDict
 
 from eodag.api.product.drivers import DRIVERS
 from eodag.api.product.drivers.generic import GenericDriver

--- a/eodag/api/provider.py
+++ b/eodag/api/provider.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2025, CS GROUP - France, https://www.csgroup.eu/
 #
 # This file is part of EODAG project
@@ -607,6 +606,8 @@ class ProvidersDict(UserDict[str, Provider]):
     :param providers: Initial providers to populate the dictionary.
     """
 
+    whitelist: Optional[list[str]] = None
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         # configs of providers removed from active providers list
@@ -916,6 +917,7 @@ class ProvidersDict(UserDict[str, Provider]):
     @staticmethod
     def _get_whitelisted_configs(
         configs: Mapping[str, Union[ProviderConfig, dict[str, Any]]],
+        whitelist: Optional[list[str]] = None,
     ) -> Mapping[str, Union[ProviderConfig, dict[str, Any]]]:
         """
         Filter configs according to the EODAG_PROVIDERS_WHITELIST environment variable, if set.
@@ -923,8 +925,14 @@ class ProvidersDict(UserDict[str, Provider]):
         :param configs: The dictionary of provider configurations.
         :return: Filtered configurations.
         """
-        whitelist = set(os.getenv("EODAG_PROVIDERS_WHITELIST", "").split(","))
-        if not whitelist or whitelist == {""}:
+        if whitelist is None:
+            whitelist = [
+                provider
+                for provider in os.getenv("EODAG_PROVIDERS_WHITELIST", "").split(",")
+                if provider
+            ]
+
+        if not whitelist:
             return configs
         return {name: conf for name, conf in configs.items() if name in whitelist}
 
@@ -937,7 +945,10 @@ class ProvidersDict(UserDict[str, Provider]):
 
         :param configs: A dictionary mapping provider names to configurations.
         """
-        configs = self._get_whitelisted_configs(configs)
+        configs = self._get_whitelisted_configs(
+            configs,
+            getattr(self, "whitelist", None),
+        )
         for name, conf in configs.items():
             if isinstance(conf, dict) and conf.get("name") != name:
                 if "name" in conf:
@@ -1057,7 +1068,9 @@ class ProvidersDict(UserDict[str, Provider]):
 
     @classmethod
     def from_configs(
-        cls, configs: Mapping[str, Union[ProviderConfig, dict[str, Any]]]
+        cls,
+        configs: Mapping[str, Union[ProviderConfig, dict[str, Any]]],
+        whitelist: Optional[list[str]] = None,
     ) -> Self:
         """
         Build a ProvidersDict from a configuration mapping.
@@ -1067,5 +1080,6 @@ class ProvidersDict(UserDict[str, Provider]):
         :return: An instance of :class:`~eodag.api.provider.ProvidersDict` populated with the given configurations.
         """
         providers = cls()
+        providers.whitelist = whitelist
         providers.update_from_configs(configs)
         return providers

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -23,7 +23,7 @@ import tempfile
 import warnings
 from importlib.resources import files as res_files
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, Union, cast
 
 import orjson
 import requests
@@ -157,13 +157,13 @@ class EODAGSettings(BaseSettings):
         default=False, description="Log collections validation errors as warning."
     )
 
-    @computed_field
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def resolved_cfg_file(self) -> Path:
         """Get the resolved path to the main EODAG user configuration file."""
         return self.cfg_file or self.cfg_dir / "eodag.yml"
 
-    @computed_field
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def resolved_locations_cfg_file(self) -> Path:
         """Get the resolved path to the locations configuration file."""
@@ -927,7 +927,7 @@ def credentials_in_auth(auth_conf: PluginConfig) -> bool:
     )
 
 
-def load_locations_config(location_cfg_file: str) -> dict[str, Any]:
+def load_locations_config(location_cfg_file: str) -> list[dict[str, Any]]:
     """Load locations configuration.
 
     This configuration (YML format) will contain a shapefile list associated
@@ -949,9 +949,12 @@ def load_locations_config(location_cfg_file: str) -> dict[str, Any]:
                 name: country
                 attr: FRA
     """
-    locations_config = load_yml_config(location_cfg_file)
+    raw_locations_config = load_yml_config(location_cfg_file)
 
-    locations_config = next(iter(locations_config.values()))
+    locations_config = cast(
+        list[dict[str, Any]],
+        next(iter(raw_locations_config.values())),
+    )
 
     logger.info(
         "Locations configuration loaded from %s",
@@ -1051,7 +1054,7 @@ def load_stac_config() -> dict[str, Any]:
 
     :returns: The stac configuration
     """
-    return load_yml_config(RESOURCES_DIR / "stac.yml")
+    return load_yml_config(str(RESOURCES_DIR / "stac.yml"))
 
 
 def load_stac_api_config() -> dict[str, Any]:
@@ -1059,7 +1062,7 @@ def load_stac_api_config() -> dict[str, Any]:
 
     :returns: The stac API configuration
     """
-    return load_yml_config(RESOURCES_DIR / "stac_api.yml")
+    return load_yml_config(str(RESOURCES_DIR / "stac_api.yml"))
 
 
 def load_stac_provider_config() -> dict[str, Any]:

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018, CS GROUP - France, https://www.csgroup.eu/
 #
 # This file is part of EODAG project
@@ -19,9 +18,11 @@ from __future__ import annotations
 
 import logging
 import os
-import pathlib
+import shutil
+import tempfile
 import warnings
 from importlib.resources import files as res_files
+from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, Union
 
 import orjson
@@ -30,6 +31,8 @@ import yaml
 import yaml.parser
 from annotated_types import Gt
 from jsonpath_ng import JSONPath
+from pydantic import BeforeValidator, Field, computed_field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import TypedDict
 
 from eodag.utils import (
@@ -46,7 +49,7 @@ from eodag.utils.exceptions import ValidationError
 from eodag.utils.yaml import cached_yaml_load, cached_yaml_load_all
 
 if TYPE_CHECKING:
-    from typing import ItemsView, Iterator, ValuesView
+    from collections.abc import ItemsView, Iterator, ValuesView
 
     from typing_extensions import Self
 
@@ -57,6 +60,233 @@ logger = logging.getLogger("eodag.config")
 EXT_COLLECTIONS_CONF_URI = (
     "https://cs-si.github.io/eodag/eodag/resources/ext_collections.json"
 )
+
+# Bundled resources
+RESOURCES_DIR = Path(str(res_files("eodag") / "resources"))
+DEFAULT_COLLECTIONS_FILE = RESOURCES_DIR / "collections.yml"
+DEFAULT_PROVIDERS_DIR = RESOURCES_DIR / "providers"
+USER_CONFIG_TEMPLATE_FILE = RESOURCES_DIR / "user_conf_template.yml"
+LOCATIONS_CONFIG_TEMPLATE_FILE = RESOURCES_DIR / "locations_conf_template.yml"
+SHAPEFILES_TEMPLATE_DIR = RESOURCES_DIR / "shp"
+
+
+def default_config_dir() -> Path:
+    """Get the default EODAG configuration directory path."""
+    return Path(os.path.expanduser("~")) / ".config" / "eodag"
+
+
+def comma_separated_str_to_list(value: object) -> object:
+    """Convert a comma-separated string to a list."""
+
+    if not isinstance(value, str):
+        return value
+
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+class EODAGSettings(BaseSettings):
+    """Global EODAG configuration parameters."""
+
+    cfg_dir: Path = Field(
+        default_factory=default_config_dir,
+        description=(
+            "Base EODAG configuration directory. "
+            "Created automatically if it does not exist."
+        ),
+    )
+
+    cfg_file: Optional[Path] = Field(
+        default=None,
+        description="Path to the main EODAG user configuration file. If not set, defaults to '<cfg_dir>/eodag.yml'.",
+    )
+
+    locations_cfg_file: Optional[Path] = Field(
+        default=None,
+        validation_alias="EODAG_LOCS_CFG_FILE",
+        description="Path to the locations configuration file. If not set, defaults to '<cfg_dir>/locations.yml'.",
+    )
+
+    collections_cfg_file: Path = Field(
+        default=DEFAULT_COLLECTIONS_FILE,
+        description=(
+            "Path to the collections configuration file. "
+            "Defaults to the bundled EODAG collections definition."
+        ),
+    )
+
+    providers_cfg_file: Optional[Path] = Field(
+        default=None,
+        deprecated=("Deprecated since v4.5.0. Use EODAG_PROVIDERS_CFG_DIR instead."),
+        description=("Legacy single provider configuration file."),
+    )
+
+    providers_cfg_dir: Path = Field(
+        default=DEFAULT_PROVIDERS_DIR,
+        description=(
+            "Directory containing provider configuration files. "
+            "All '*.yml' files in this directory are loaded. "
+            "Ignored if providers_cfg_file is set."
+        ),
+    )
+
+    ext_collections_cfg_uri: str = Field(
+        default=EXT_COLLECTIONS_CONF_URI,
+        validation_alias="EODAG_EXT_COLLECTIONS_CFG_FILE",
+        description=(
+            "URI of the external collections configuration. "
+            "Supports HTTP(S), file:// URIs and local filesystem paths."
+        ),
+    )
+
+    strict_collections: bool = Field(
+        default=False,
+        description=("Enable strict collection synchronization."),
+    )
+
+    providers_whitelist: Annotated[
+        list[str], BeforeValidator(comma_separated_str_to_list)
+    ] = Field(
+        default_factory=list,
+        description=(
+            "List of provider names to whitelist. "
+            "Can be set as a comma-separated string."
+        ),
+    )
+
+    validate_collections: bool = Field(
+        default=False, description="Log collections validation errors as warning."
+    )
+
+    @computed_field
+    @property
+    def resolved_cfg_file(self) -> Path:
+        """Get the resolved path to the main EODAG user configuration file."""
+        return self.cfg_file or self.cfg_dir / "eodag.yml"
+
+    @computed_field
+    @property
+    def resolved_locations_cfg_file(self) -> Path:
+        """Get the resolved path to the locations configuration file."""
+        return self.locations_cfg_file or self.cfg_dir / "locations.yml"
+
+    model_config = SettingsConfigDict(
+        env_prefix="EODAG_",
+        validate_by_name=True,
+    )
+
+    @model_validator(mode="after")
+    def warn_deprecated_settings(self) -> Self:
+        """Warn about deprecated settings."""
+        if "providers_cfg_file" in self.model_fields_set:
+            warnings.warn(
+                "EODAG_PROVIDERS_CFG_FILE is deprecated since v4.5.0. "
+                "Use EODAG_PROVIDERS_CFG_DIR instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return self
+
+
+def ensure_user_config_exists(config_file: Path) -> None:
+    """Create a default user configuration file if it does not exist.
+
+    The file is initialized from the bundled EODAG template.
+
+    :param config_file: Path to the user configuration file to create.
+    """
+    if config_file.exists():
+        return
+
+    if not USER_CONFIG_TEMPLATE_FILE.is_file():
+        raise FileNotFoundError(
+            f"Missing bundled resource {USER_CONFIG_TEMPLATE_FILE} "
+            "to create user configuration file"
+        )
+
+    config_file.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    shutil.copy(
+        USER_CONFIG_TEMPLATE_FILE,
+        config_file,
+    )
+
+
+def ensure_cfg_dir_exists(config_dir: Path) -> Path:
+    """Ensure the EODAG configuration directory exists.
+
+    If the configured directory cannot be created, fall back to a
+    temporary directory.
+    """
+    try:
+        config_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.debug(exc)
+
+        requested_dir = config_dir
+        fallback_dir = Path(tempfile.gettempdir()) / ".config" / "eodag"
+
+        logger.warning(
+            "Cannot create configuration directory %s. "
+            "Falling back to temporary directory %s.",
+            requested_dir,
+            fallback_dir,
+        )
+
+        fallback_dir.mkdir(parents=True, exist_ok=True)
+
+        config_dir = fallback_dir
+
+    return config_dir
+
+
+def ensure_locations_config_exists(
+    locations_cfg_file: Path,
+    cfg_dir: Path,
+) -> None:
+    """Create the default locations configuration if it does not exist.
+
+    The generated configuration is initialized from the bundled EODAG
+    locations template. Sample shapefiles are copied to ``<cfg_dir>/shp``
+    and template paths are rewritten accordingly.
+
+    :param locations_cfg_file: Target locations configuration file.
+    :param cfg_dir: EODAG configuration directory.
+    """
+    if locations_cfg_file.exists():
+        return
+
+    if not LOCATIONS_CONFIG_TEMPLATE_FILE.is_file():
+        raise FileNotFoundError(
+            f"Missing bundled resource: {LOCATIONS_CONFIG_TEMPLATE_FILE}"
+        )
+
+    if not SHAPEFILES_TEMPLATE_DIR.is_dir():
+        raise FileNotFoundError(
+            f"Missing bundled resource directory: {SHAPEFILES_TEMPLATE_DIR}"
+        )
+
+    locations_cfg_file.parent.mkdir(parents=True, exist_ok=True)
+
+    shapefiles_dir = cfg_dir / "shp"
+
+    with (
+        LOCATIONS_CONFIG_TEMPLATE_FILE.open(encoding="utf-8") as infile,
+        locations_cfg_file.open("w", encoding="utf-8") as outfile,
+    ):
+        for line in infile:
+            outfile.write(
+                line.replace(
+                    "/path/to/locations/",
+                    f"{shapefiles_dir}{os.path.sep}",
+                )
+            )
+
+    shutil.copytree(SHAPEFILES_TEMPLATE_DIR, shapefiles_dir, dirs_exist_ok=True)
+
+
 AUTH_TOPIC_KEYS = ("auth", "search_auth", "download_auth")
 PLUGINS_TOPICS_KEYS = ("api", "search", "download") + AUTH_TOPIC_KEYS
 
@@ -68,9 +298,9 @@ class SimpleYamlProxyConfig:
     def __init__(self, conf_file_path: str) -> None:
         try:
             self.source: dict[str, Any] = cached_yaml_load(conf_file_path)
-        except yaml.parser.ParserError as e:
+        except yaml.parser.ParserError:
             print("Unable to load user configuration file")
-            raise e
+            raise
 
     def __getitem__(self, item: Any) -> Any:
         return self.source[item]
@@ -89,10 +319,10 @@ class SimpleYamlProxyConfig:
         """Iterate over values of source"""
         return self.source.values()
 
-    def update(self, other: "SimpleYamlProxyConfig") -> None:
+    def update(self, other: SimpleYamlProxyConfig) -> None:
         """Update a :class:`~eodag.config.SimpleYamlProxyConfig`"""
         if not isinstance(other, self.__class__):
-            raise ValueError("'{}' must be of type {}".format(other, self.__class__))
+            raise TypeError(f"'{other}' must be of type {self.__class__}")
         self.source.update(other.source)
 
 
@@ -697,37 +927,62 @@ def credentials_in_auth(auth_conf: PluginConfig) -> bool:
     )
 
 
-def load_default_config() -> dict[str, ProviderConfig]:
-    """Load the providers configuration into a dictionary.
+def load_locations_config(location_cfg_file: str) -> dict[str, Any]:
+    """Load locations configuration.
 
-    Load from eodag `resources/providers` files or `EODAG_PROVIDERS_CFG_DIR` environment
-    variable if exists.
+    This configuration (YML format) will contain a shapefile list associated
+    to a name and attribute parameters needed to identify the needed geometry.
+    You can also configure parent attributes, which can be used for creating
+    a catalogs path when using eodag as a REST server.
+    Example of locations configuration file content:
 
-    For backwards compatibility, if `EODAG_PROVIDERS_CFG_FILE` environment variable is set, load from it instead of
-    `EODAG_PROVIDERS_CFG_DIR`.
+    .. code-block:: yaml
 
-    :returns: The default provider's configuration
+        shapefiles:
+            - name: country
+                path: /path/to/countries_list.shp
+                attr: ISO3
+            - name: department
+                path: /path/to/FR_departments.shp
+                attr: code_insee
+                parent:
+                name: country
+                attr: FRA
     """
-    eodag_providers_cfg_file = os.getenv("EODAG_PROVIDERS_CFG_FILE")
-    eodag_providers_cfg_dir = os.getenv("EODAG_PROVIDERS_CFG_DIR")
+    locations_config = load_yml_config(location_cfg_file)
 
-    if eodag_providers_cfg_file:
-        warnings.warn(
-            "Usage of deprecated environment variable EODAG_PROVIDERS_CFG_FILE. "
-            "(Please use EODAG_PROVIDERS_CFG_DIR instead)"
-            " -- Deprecated since v4.5.0",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return load_config(eodag_providers_cfg_file)
+    locations_config = next(iter(locations_config.values()))
 
-    config_dir = eodag_providers_cfg_dir or str(
-        res_files("eodag") / "resources" / "providers"
+    logger.info(
+        "Locations configuration loaded from %s",
+        location_cfg_file,
     )
+
+    return locations_config
+
+
+def load_provider_configs(
+    providers_cfg_file: Optional[Path] = None,
+    providers_cfg_dir: Path = DEFAULT_PROVIDERS_DIR,
+) -> dict[str, ProviderConfig]:
+    """Load provider configurations.
+
+    Provider definitions are loaded from the source configured in
+    EODAG settings.
+
+    EODAG_PROVIDERS_CFG_FILE takes precedence over
+    EODAG_PROVIDERS_CFG_DIR for backward compatibility.
+    """
+
+    if providers_cfg_file is not None:
+        return load_config(str(providers_cfg_file))
+
     providers: dict[str, ProviderConfig] = {}
-    for f in pathlib.Path(config_dir).glob("*.yml"):
-        if f.is_file():
-            providers.update(load_config(str(f)))
+
+    for config_file in providers_cfg_dir.glob("*.yml"):
+        if config_file.is_file():
+            providers.update(load_config(str(config_file)))
+
     return dict(sorted(providers.items()))
 
 
@@ -755,7 +1010,7 @@ def load_config(config_path: str) -> dict[str, ProviderConfig]:
     from eodag.api.provider import ProviderConfig as ProviderConfigClass
 
     providers_configs: list[ProviderConfig] = []
-    default_provider_name = pathlib.Path(config_path).stem
+    default_provider_name = Path(config_path).stem
     for provider_dict in providers_configs_dicts:
         if provider_dict is not None:
             if isinstance(provider_dict, ProviderConfigClass):
@@ -796,7 +1051,7 @@ def load_stac_config() -> dict[str, Any]:
 
     :returns: The stac configuration
     """
-    return load_yml_config(str(res_files("eodag") / "resources" / "stac.yml"))
+    return load_yml_config(RESOURCES_DIR / "stac.yml")
 
 
 def load_stac_api_config() -> dict[str, Any]:
@@ -804,7 +1059,7 @@ def load_stac_api_config() -> dict[str, Any]:
 
     :returns: The stac API configuration
     """
-    return load_yml_config(str(res_files("eodag") / "resources" / "stac_api.yml"))
+    return load_yml_config(RESOURCES_DIR / "stac_api.yml")
 
 
 def load_stac_provider_config() -> dict[str, Any]:
@@ -812,9 +1067,7 @@ def load_stac_provider_config() -> dict[str, Any]:
 
     :returns: The stac provider configuration
     """
-    return SimpleYamlProxyConfig(
-        str(res_files("eodag") / "resources" / "stac_provider.yml")
-    ).source
+    return SimpleYamlProxyConfig(str(RESOURCES_DIR / "stac_provider.yml")).source
 
 
 def get_ext_collections_conf(

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -184,7 +184,7 @@ class EODAGSettings(BaseSettings):
                 "EODAG_PROVIDERS_CFG_FILE is deprecated since v4.5.0. "
                 "Use EODAG_PROVIDERS_CFG_DIR instead.",
                 DeprecationWarning,
-                stacklevel=2,
+                stacklevel=5,
             )
         return self
 

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -97,13 +97,13 @@ class EODAGSettings(BaseSettings):
 
     cfg_file: Optional[Path] = Field(
         default=None,
-        description="Path to the main EODAG user configuration file. If not set, defaults to '<cfg_dir>/eodag.yml'.",
+        description="Path to the main EODAG user configuration file. If not set, defaults to ``<cfg_dir>/eodag.yml``.",
     )
 
     locations_cfg_file: Optional[Path] = Field(
         default=None,
         validation_alias="EODAG_LOCS_CFG_FILE",
-        description="Path to the locations configuration file. If not set, defaults to '<cfg_dir>/locations.yml'.",
+        description="Path to the locations configuration file. If not set, defaults to ``<cfg_dir>/locations.yml``.",
     )
 
     collections_cfg_file: Path = Field(
@@ -116,18 +116,18 @@ class EODAGSettings(BaseSettings):
 
     providers_cfg_file: Optional[Path] = Field(
         default=None,
-        deprecated=(
-            "EODAG_PROVIDERS_CFG_FILE is deprecated since v4.5.0. Use EODAG_PROVIDERS_CFG_DIR instead."
+        description=(
+            "Legacy single provider configuration file. Deprecated since ``v4.5.0``; "
+            "use :attr:`providers_cfg_dir` instead."
         ),
-        description=("Legacy single provider configuration file."),
     )
 
     providers_cfg_dir: Path = Field(
         default=DEFAULT_PROVIDERS_DIR,
         description=(
             "Directory containing provider configuration files. "
-            "All '*.yml' files in this directory are loaded. "
-            "Ignored if providers_cfg_file is set."
+            "All ``*.yml`` files in this directory are loaded. "
+            "Ignored if :attr:`providers_cfg_file` is set."
         ),
     )
 
@@ -136,7 +136,7 @@ class EODAGSettings(BaseSettings):
         validation_alias="EODAG_EXT_COLLECTIONS_CFG_FILE",
         description=(
             "URI of the external collections configuration. "
-            "Supports HTTP(S), file:// URIs and local filesystem paths."
+            "Supports HTTP(S), ``file://`` URIs and local filesystem paths."
         ),
     )
 

--- a/eodag/config.py
+++ b/eodag/config.py
@@ -116,7 +116,9 @@ class EODAGSettings(BaseSettings):
 
     providers_cfg_file: Optional[Path] = Field(
         default=None,
-        deprecated=("Deprecated since v4.5.0. Use EODAG_PROVIDERS_CFG_DIR instead."),
+        deprecated=(
+            "EODAG_PROVIDERS_CFG_FILE is deprecated since v4.5.0. Use EODAG_PROVIDERS_CFG_DIR instead."
+        ),
         description=("Legacy single provider configuration file."),
     )
 

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -20,8 +20,9 @@ from __future__ import annotations
 import logging
 import pathlib
 import re
+from collections.abc import Iterator
 from operator import attrgetter
-from typing import TYPE_CHECKING, Any, Iterator, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import importlib_metadata
 
@@ -68,13 +69,14 @@ class PluginManager:
                       supported by ``eodag``
     """
 
-    supported_topics = set(PLUGINS_TOPICS_KEYS)
-
     collection_to_provider_config_map: dict[str, list[ProviderConfig]]
 
     skipped_plugins: dict[str, str]
 
+    supported_topics: set[str]
+
     def __init__(self, providers: ProvidersDict) -> None:
+        self.supported_topics = set(PLUGINS_TOPICS_KEYS)
         self.skipped_plugins = {}
         self.providers = providers
         # Load all the plugins. This will make all plugin classes of a particular
@@ -88,7 +90,7 @@ class PluginManager:
             # 'eodag.plugins.search' for example in its setup script. See the setup
             # script of eodag for an example of how to do this.
             for entry_point in importlib_metadata.entry_points(
-                group="eodag.plugins.{}".format(topic)
+                group=f"eodag.plugins.{topic}"
             ):
                 try:
                     entry_point.load()
@@ -249,7 +251,7 @@ class PluginManager:
                 )
                 configs = self.collection_to_provider_config_map[GENERIC_COLLECTION]
         else:
-            configs = list(p.config for p in self.providers.values())
+            configs = [p.config for p in self.providers.values()]
 
         if provider:
             self.check_provider_available(provider, include_groups=True)
@@ -357,22 +359,17 @@ class PluginManager:
             matching_conf: Optional[PluginConfig],
         ) -> bool:
             plugin_matching_conf = getattr(auth_conf, "matching_conf", {})
-            if matching_conf:
-                if (
-                    plugin_matching_conf
-                    and matching_conf.__dict__.items() >= plugin_matching_conf.items()
-                ):
-                    # conf matches
-                    return True
+            if matching_conf and (
+                plugin_matching_conf
+                and matching_conf.__dict__.items() >= plugin_matching_conf.items()
+            ):
+                # conf matches
+                return True
             plugin_matching_url = getattr(auth_conf, "matching_url", None)
-            if matching_url:
-                if plugin_matching_url and re.match(
-                    rf"{plugin_matching_url}", matching_url
-                ):
-                    # url matches
-                    return True
-            # no match
-            return False
+            if not matching_url or not plugin_matching_url:
+                return False
+
+            return bool(re.match(rf"{plugin_matching_url}", matching_url))
 
         # providers configs with given provider at first
         sorted_providers_config = deepcopy(self.providers.configs)
@@ -387,14 +384,10 @@ class PluginManager:
                 if auth_conf is None:
                     continue
                 # plugin without configured match criteria: only works for given provider
-                unconfigured_match = (
-                    True
-                    if (
-                        not getattr(auth_conf, "matching_conf", {})
-                        and not getattr(auth_conf, "matching_url", None)
-                        and provider == plugin_provider
-                    )
-                    else False
+                unconfigured_match = bool(
+                    not getattr(auth_conf, "matching_conf", {})
+                    and not getattr(auth_conf, "matching_url", None)
+                    and provider == plugin_provider
                 )
 
                 if unconfigured_match or _is_auth_plugin_matching(
@@ -429,7 +422,7 @@ class PluginManager:
                     auth = auth_plugin.authenticate()
                     return auth
                 except (AuthenticationError, MisconfiguredError) as e:
-                    logger.debug(f"Could not authenticate on {provider}: {str(e)}")
+                    logger.debug(f"Could not authenticate on {provider}: {e!s}")
                     continue
             else:
                 logger.debug(
@@ -463,10 +456,7 @@ class PluginManager:
         """
         # Update the priority in the configurations so that it is taken into account
         # when a plugin of this provider is latterly built
-        for (
-            _,
-            provider_configs,
-        ) in self.collection_to_provider_config_map.items():
+        for provider_configs in self.collection_to_provider_config_map.values():
             for config in provider_configs:
                 if config.name == provider:
                     config.priority = priority
@@ -510,7 +500,7 @@ class PluginManager:
         if cached_instance is not None:
             return cached_instance
         plugin_class = EODAGPluginMount.get_plugin_by_class_name(
-            topic_class, getattr(plugin_conf, "type")
+            topic_class, plugin_conf.type
         )
         plugin: Union[Api, Search, Download, Authentication, Crunch] = plugin_class(
             provider, plugin_conf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "lxml",
     "orjson",
     "pydantic >= 2.13.0",
+    "pydantic-settings>=2.11.0",
     "pydantic_core",
     "PyJWT[crypto] >= 2.5.0",
     "pyproj >= 2.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -289,4 +289,8 @@ testpaths = ["eodag/api", "eodag/types", "eodag/utils", "tests"]
 addopts = "--doctest-modules --disable-socket --allow-unix-socket"
 # logging disabled to prevent conflicts with click, see https://github.com/pallets/click/issues/824
 log_cli = false
-filterwarnings = ["ignore:Call to deprecated eodag:DeprecationWarning"]
+filterwarnings = [
+    """ignore:
+    .*(Call to deprecated eodag|locations_conf_path|user_conf_file_path|EODAG_PROVIDERS_CFG_FILE).*:
+    DeprecationWarning""",
+]

--- a/tests/context.py
+++ b/tests/context.py
@@ -51,7 +51,7 @@ from eodag.config import (
     EXT_COLLECTIONS_CONF_URI,
     PluginConfig,
     get_ext_collections_conf,
-    load_default_config,
+    load_provider_configs,
     load_stac_provider_config,
 )
 from eodag.plugins.apis.ecmwf import EcmwfApi

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -815,6 +815,7 @@ class TestEodagCli(unittest.TestCase):
         and with or without fetching provider according to the command.
         """
         provider = "cop_dataspace"
+        dag.settings = mock.Mock(validate_collections=False)
 
         dag.return_value.guess_collection.return_value = CollectionsList(
             [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,6 +20,7 @@ import os
 import tempfile
 import unittest
 from io import StringIO
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -259,20 +260,20 @@ class TestPluginConfig(unittest.TestCase):
 class TestConfigFunctions(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfigFunctions, cls).setUpClass()
+        super().setUpClass()
         # mock os.environ to empty env
         cls.mock_os_environ = mock.patch.dict(os.environ, {}, clear=True)
         cls.mock_os_environ.start()
 
     @classmethod
     def tearDownClass(cls):
-        super(TestConfigFunctions, cls).tearDownClass()
+        super().tearDownClass()
         # stop os.environ
         cls.mock_os_environ.stop()
 
     def test_load_default_config(self):
         """Default config must be successfully loaded"""
-        conf = config.load_default_config()
+        conf = config.load_provider_configs()
         self.assertIsInstance(conf, dict)
         for key, value in conf.items():
             # keys of the default conf dict are the names of the provider
@@ -285,11 +286,53 @@ class TestConfigFunctions(unittest.TestCase):
             # priority is set to 0 for all providers
             self.assertEqual(value.priority, 0)
 
+    def test_load_provider_configs_file_precedence(self):
+        """load_provider_configs must prioritize providers_cfg_file over providers_cfg_dir."""
+        providers_cfg_file_override = (
+            Path(TEST_RESOURCES_PATH) / "providers" / "file_providers_override.yml"
+        )
+        test_cases = [
+            {
+                "name": "file takes precedence",
+                "providers_cfg_file": providers_cfg_file_override,
+                "expected_provider": "foo_provider",
+            },
+            {
+                "name": "directory used without file",
+                "providers_cfg_file": None,
+                "expected_provider": "bar_provider",
+            },
+        ]
+
+        providers_cfg_dir_content = {
+            "bar_provider": {
+                "search": {
+                    "type": "StacSearch",
+                    "api_endpoint": "https://bar.example/search",
+                },
+                "products": {"GENERIC_COLLECTION": {"_collection": "{collection}"}},
+            }
+        }
+
+        for case in test_cases:
+            with self.subTest(case=case["name"]), TemporaryDirectory() as tmp_dir:
+                providers_cfg_dir = Path(tmp_dir)
+                (providers_cfg_dir / "bar_provider.yml").write_text(
+                    yaml.safe_dump(providers_cfg_dir_content),
+                    encoding="utf-8",
+                )
+                providers = config.load_provider_configs(
+                    providers_cfg_file=case["providers_cfg_file"],
+                    providers_cfg_dir=providers_cfg_dir,
+                )
+
+                self.assertEqual(set(providers.keys()), {case["expected_provider"]})
+
     def test_load_config_providers_whitelist(self):
         """Config must be loaded with only the selected whitelist of providers"""
         try:
             os.environ["EODAG_PROVIDERS_WHITELIST"] = "creodias"
-            providers = ProvidersDict.from_configs(config.load_default_config())
+            providers = ProvidersDict.from_configs(config.load_provider_configs())
 
             self.assertEqual({"creodias"}, set(providers.keys()))
         finally:
@@ -298,7 +341,7 @@ class TestConfigFunctions(unittest.TestCase):
     def test_override_config_from_str(self):
         """Default configuration must be overridden from a yaml conf str"""
 
-        providers = ProvidersDict.from_configs(config.load_default_config())
+        providers = ProvidersDict.from_configs(config.load_provider_configs())
         providers.update_from_configs(yaml.safe_load("""
                 my_new_provider:
                     priority: 4
@@ -379,7 +422,7 @@ class TestConfigFunctions(unittest.TestCase):
                   aws_access_key_id: access-key-id
                   aws_secret_access_key: secret-access-key
         """
-        providers = ProvidersDict.from_configs(config.load_default_config())
+        providers = ProvidersDict.from_configs(config.load_provider_configs())
         file_path_override = os.path.join(
             os.path.dirname(__file__), "resources", "file_config_override.yml"
         )
@@ -439,7 +482,7 @@ class TestConfigFunctions(unittest.TestCase):
 
     def test_override_config_from_env(self):
         """Default configuration must be overridden by environment variables"""
-        providers = ProvidersDict.from_configs(config.load_default_config())
+        providers = ProvidersDict.from_configs(config.load_provider_configs())
         os.environ["EODAG__USGS__PRIORITY"] = "5"
         os.environ["EODAG__USGS__API__EXTRACT"] = "false"
         os.environ["EODAG__USGS__API__CREDENTIALS__USERNAME"] = "usr"
@@ -527,7 +570,7 @@ class TestStacProviderConfig(unittest.TestCase):
             "eodag.api.provider.ProviderConfig._apply_defaults",
             lambda self: None,
         ):
-            providers_configs = config.load_default_config()
+            providers_configs = config.load_provider_configs()
 
         raw_provider_search_conf = providers_configs["usgs_satapi_aws"].search.__dict__
         common_stac_provider_search_conf = load_stac_provider_config()["search"]
@@ -557,10 +600,7 @@ class TestStacProviderConfig(unittest.TestCase):
         # check if raw_provider_search_conf is a subset of provider_search_conf
         for k, v in raw_provider_search_conf.items():
             if isinstance(v, dict):
-                assert (
-                    raw_provider_search_conf[k].items()
-                    <= provider_search_conf[k].items()
-                )
+                assert v.items() <= provider_search_conf[k].items()
             else:
                 self.assertEqual(v, provider_search_conf[k])
 
@@ -610,9 +650,6 @@ class TestStacProviderConfig(unittest.TestCase):
         # check if custom_stac_provider_conf is a subset of provider_search_conf
         for k, v in custom_stac_provider_conf.items():
             if isinstance(v, dict):
-                assert (
-                    custom_stac_provider_conf[k].items()
-                    <= provider_search_conf[k].items()
-                )
+                assert v.items() <= provider_search_conf[k].items()
             else:
                 self.assertEqual(v, provider_search_conf[k])

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -59,12 +59,39 @@ class TestEodagInit(unittest.TestCase):
 
         # Test all existing lazy imports
         self.assertTrue(hasattr(eodag, "EODataAccessGateway"))
+        self.assertTrue(hasattr(eodag, "EODAGSettings"))
         self.assertTrue(hasattr(eodag, "EOProduct"))
         self.assertTrue(hasattr(eodag, "SearchResult"))
         self.assertTrue(hasattr(eodag, "setup_logging"))
 
         # These should be callable/usable
         self.assertIsNotNone(eodag.EODataAccessGateway)
+        self.assertIsNotNone(eodag.EODAGSettings)
         self.assertIsNotNone(eodag.EOProduct)
         self.assertIsNotNone(eodag.SearchResult)
         self.assertIsNotNone(eodag.setup_logging)
+
+    def test_eodag_settings_importable_from_top_level(self):
+        """Test that EODAGSettings is importable from top-level eodag package."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "from eodag import EODataAccessGateway, EODAGSettings;"
+                    " print(EODataAccessGateway.__name__, EODAGSettings.__name__)"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"Command failed with stderr: {result.stderr}",
+        )
+        self.assertEqual(
+            result.stdout.strip(),
+            "EODataAccessGateway EODAGSettings",
+        )

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -33,7 +33,7 @@ try:
 except ModuleNotFoundError:
     import tomli as tomllib
 
-from eodag.config import PluginConfig, load_default_config
+from eodag.config import PluginConfig, load_provider_configs
 from tests.context import MisconfiguredError
 
 project_path = "./eodag"
@@ -174,7 +174,7 @@ class TestRequirements(unittest.TestCase):
         plugins_extras_dict = get_entrypoints_extras(pyproject_path)
         all_providers_extras = get_resulting_extras(pyproject_path, "all-providers")
 
-        providers_config = load_default_config()
+        providers_config = load_provider_configs()
         plugins = set()
         for provider_conf in providers_config.values():
             plugins.update(

--- a/tests/units/test_apis_plugins.py
+++ b/tests/units/test_apis_plugins.py
@@ -43,7 +43,7 @@ from tests.context import (
     USGSAuthExpiredError,
     USGSError,
     get_geometry_from_various,
-    load_default_config,
+    load_provider_configs,
     path_to_uri,
     urlsplit,
 )
@@ -53,7 +53,7 @@ class BaseApisPluginTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(BaseApisPluginTest, cls).setUpClass()
-        providers = ProvidersDict.from_configs(load_default_config())
+        providers = ProvidersDict.from_configs(load_provider_configs())
         cls.plugins_manager = PluginManager(providers)
         # Mock home and eodag conf directory to tmp dir
         cls.tmp_home_dir = TemporaryDirectory()

--- a/tests/units/test_collection.py
+++ b/tests/units/test_collection.py
@@ -35,7 +35,7 @@ from tests.context import (
 
 class TestCollection(unittest.TestCase):
     def setUp(self):
-        super(TestCollection, self).setUp()
+        super().setUp()
         # Mock home and eodag conf directory to tmp dir
         self.tmp_home_dir = TemporaryDirectory()
         self.expanduser_mock = mock.patch(
@@ -51,7 +51,7 @@ class TestCollection(unittest.TestCase):
         self.mock_os_environ.start()
 
     def tearDown(self):
-        super(TestCollection, self).tearDown()
+        super().tearDown()
         # stop os.environ
         self.mock_os_environ.stop()
 
@@ -72,153 +72,121 @@ class TestCollection(unittest.TestCase):
         self.assertEqual(collection._id, "foo")
 
     def test_collection_enable_validation(self):
-        """Collection validation is enabled by an environment variable.
-        It allows to log warnings on bad formatted attributes spotted during collection initialization
-        """
-        try:
-            # ensure validation is enabled for collections
-            os.environ["EODAG_VALIDATE_COLLECTIONS"] = "True"
+        """Collection validation logging defaults from EODataAccessGateway settings."""
+        self.dag.settings.validate_collections = True
 
-            # try to create a collection with bad formatted attributes
-            # and check that logs have been emitted
-            with self.assertLogs(level="DEBUG") as cm:
-                collection = Collection(id="foo", platform=0, bar="bat")
+        # try to create a collection with bad formatted attributes
+        # and check that logs have been emitted
+        with self.assertLogs(level="DEBUG") as cm:
+            collection = Collection.create_with_dag(
+                self.dag, id="foo", platform=0, bar="bat"
+            )
 
-            self.assertIn("2 validation errors for collection foo", str(cm.output))
-            self.assertIn("platform\\n  Input should be a valid string", str(cm.output))
-            self.assertIn("bar\\n  Extra inputs are not permitted", str(cm.output))
+        self.assertIn("2 validation errors for collection foo", str(cm.output))
+        self.assertIn("platform\\n  Input should be a valid string", str(cm.output))
+        self.assertIn("bar\\n  Extra inputs are not permitted", str(cm.output))
 
-            # check that the collection has been created
-            # and that its incorrectly formatted attribute is set to None
-            # and its extra attribute is removed
-            self.assertIsInstance(collection, Collection)
-            self.assertEqual(collection.id, "foo")
-            self.assertIsNone(collection.platform)
-            self.assertFalse(getattr(collection, "bar", False))
-        finally:
-            # remove the environment variable
-            os.environ.pop("EODAG_VALIDATE_COLLECTIONS", None)
+        # check that the collection has been created
+        # and that its incorrectly formatted attribute is set to None
+        # and its extra attribute is removed
+        self.assertIsInstance(collection, Collection)
+        self.assertEqual(collection.id, "foo")
+        self.assertIsNone(collection.platform)
+        self.assertFalse(getattr(collection, "bar", False))
 
     def test_collection_wrong_id(self):
         """Collection with a missing or wrong id must raise an error
         even if validation of collections is disabled"""
-        try:
-            # ensure validation is disabled for collections
-            os.environ["EODAG_VALIDATE_COLLECTIONS"] = "False"
+        # try to create a collection with a missing id
+        with self.assertRaises(ValidationError) as context:
+            Collection()
 
-            # try to create a collection with a missing id
-            with self.assertRaises(ValidationError) as context:
-                Collection()
+        self.assertIn("id\n  Field required", str(context.exception))
 
-            self.assertIn("id\n  Field required", str(context.exception))
+        # try to create a collection with a wrong id
+        with self.assertRaises(ValidationError) as context:
+            Collection(id=1)
 
-            # try to create a collection with a wrong id
-            with self.assertRaises(ValidationError) as context:
-                Collection(id=1)
-
-            self.assertIn(
-                "id\n  Input should be a valid string", str(context.exception)
-            )
-        finally:
-            # remove the environment variable
-            os.environ.pop("EODAG_VALIDATE_COLLECTIONS", None)
+        self.assertIn("id\n  Input should be a valid string", str(context.exception))
 
     def test_collection_wrong_spatial_extent(self):
         """Collection with a spatial extent bbox in a wrong format
         must raise the custom pydantic error from their field validator"""
-        try:
-            # ensure validation is activated for collections
-            os.environ["EODAG_VALIDATE_COLLECTIONS"] = "True"
-
-            # try to create a collection with wrong start and end temporal extent datetimes
-            # and check that logs have been emitted
-            with self.assertLogs(level="DEBUG") as cm:
-                Collection(
-                    id="foo",
-                    extent={
-                        "spatial": {
-                            "bbox": [
-                                [
-                                    "not-a-lonmin",
-                                    "not-a-latmin",
-                                    "not-a-lonmax",
-                                    "not-a-latmax",
-                                ]
+        # try to create a collection with wrong start and end temporal extent datetimes
+        # and check that logs have been emitted
+        with self.assertLogs(level="DEBUG") as cm:
+            Collection.create(
+                validate_collections=True,
+                id="foo",
+                extent={
+                    "spatial": {
+                        "bbox": [
+                            [
+                                "not-a-lonmin",
+                                "not-a-latmin",
+                                "not-a-lonmax",
+                                "not-a-latmax",
                             ]
-                        },
-                        "temporal": {
-                            "interval": [
-                                ["2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z"]
-                            ]
-                        },
+                        ]
                     },
-                )
-
-            self.assertIn(
-                (
-                    "extent.spatial.bbox.0.tuple[union[float,int], union[float,int], union[float,int], "
-                    "union[float,int]].0.float\\n  Input should be a valid number, unable to parse string as a number"
-                ),
-                str(cm.output),
-            )
-            self.assertIn(
-                (
-                    "extent.spatial.bbox.0.tuple[union[float,int], union[float,int], union[float,int], "
-                    "union[float,int]].1.float\\n  Input should be a valid number, unable to parse string as a number"
-                ),
-                str(cm.output),
-            )
-            self.assertIn(
-                (
-                    "extent.spatial.bbox.0.tuple[union[float,int], union[float,int], union[float,int], "
-                    "union[float,int]].2.float\\n  Input should be a valid number, unable to parse string as a number"
-                ),
-                str(cm.output),
-            )
-            self.assertIn(
-                (
-                    "extent.spatial.bbox.0.tuple[union[float,int], union[float,int], union[float,int], "
-                    "union[float,int]].3.float\\n  Input should be a valid number, unable to parse string as a number"
-                ),
-                str(cm.output),
+                    "temporal": {
+                        "interval": [["2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z"]]
+                    },
+                },
             )
 
-        finally:
-            # remove the environment variable
-            os.environ.pop("EODAG_VALIDATE_COLLECTIONS", None)
+        self.assertIn(
+            (
+                "extent.spatial.bbox.0.tuple[union[float,int], union[float,int], union[float,int], "
+                "union[float,int]].0.float\\n  Input should be a valid number, unable to parse string as a number"
+            ),
+            str(cm.output),
+        )
+        self.assertIn(
+            (
+                "extent.spatial.bbox.0.tuple[union[float,int], union[float,int], union[float,int], "
+                "union[float,int]].1.float\\n  Input should be a valid number, unable to parse string as a number"
+            ),
+            str(cm.output),
+        )
+        self.assertIn(
+            (
+                "extent.spatial.bbox.0.tuple[union[float,int], union[float,int], union[float,int], "
+                "union[float,int]].2.float\\n  Input should be a valid number, unable to parse string as a number"
+            ),
+            str(cm.output),
+        )
+        self.assertIn(
+            (
+                "extent.spatial.bbox.0.tuple[union[float,int], union[float,int], union[float,int], "
+                "union[float,int]].3.float\\n  Input should be a valid number, unable to parse string as a number"
+            ),
+            str(cm.output),
+        )
 
     def test_collection_wrong_temporal_extent(self):
         """Collection with a start or end temporal extent date in a wrong format
         must raise the custom pydantic error from their field validator"""
-        try:
-            # ensure validation is activated for collections
-            os.environ["EODAG_VALIDATE_COLLECTIONS"] = "True"
-
-            # try to create a collection with wrong start and end temporal extent datetimes
-            # and check that logs have been emitted
-            with self.assertLogs(level="DEBUG") as cm:
-                Collection(
-                    id="foo",
-                    extent={
-                        "spatial": {"bbox": [[-180.0, -90.0, 180.0, 90.0]]},
-                        "temporal": {
-                            "interval": [["not-a-datetime", "not-a-datetime"]]
-                        },
-                    },
-                )
-
-            self.assertIn(
-                "extent.temporal.interval.0.0\\n  Input should be a valid datetime or date, invalid character in year",
-                str(cm.output),
-            )
-            self.assertIn(
-                "extent.temporal.interval.0.1\\n  Input should be a valid datetime or date, invalid character in year",
-                str(cm.output),
+        # try to create a collection with wrong start and end temporal extent datetimes
+        # and check that logs have been emitted
+        with self.assertLogs(level="DEBUG") as cm:
+            Collection.create(
+                validate_collections=True,
+                id="foo",
+                extent={
+                    "spatial": {"bbox": [[-180.0, -90.0, 180.0, 90.0]]},
+                    "temporal": {"interval": [["not-a-datetime", "not-a-datetime"]]},
+                },
             )
 
-        finally:
-            # remove the environment variable
-            os.environ.pop("EODAG_VALIDATE_COLLECTIONS", None)
+        self.assertIn(
+            "extent.temporal.interval.0.0\\n  Input should be a valid datetime or date, invalid character in year",
+            str(cm.output),
+        )
+        self.assertIn(
+            "extent.temporal.interval.0.1\\n  Input should be a valid datetime or date, invalid character in year",
+            str(cm.output),
+        )
 
     def test_collection_missing_dag(self):
         """Collection.search must raise an error if no dag is set"""

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -26,6 +26,7 @@ import shutil
 import tempfile
 import unittest
 from importlib.resources import files as res_files
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -60,7 +61,7 @@ from tests.context import (
     SearchResult,
     UnsupportedProvider,
     get_geometry_from_various,
-    load_default_config,
+    load_provider_configs,
     makedirs,
     mock,
     model_fields_to_annotated,
@@ -90,7 +91,7 @@ class TestCoreBase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super(TestCoreBase, cls).tearDownClass()
+        super().tearDownClass()
         # stop Mock and remove tmp config dir
         cls.expanduser_mock.stop()
         cls.tmp_home_dir.cleanup()
@@ -1430,23 +1431,27 @@ class TestCore(TestCoreBase):
         self, mock_discover_collections, mock_get_ext_collections_conf
     ):
         """Core api must fetch collections list and update if needed"""
+        default_ext_collections_cfg_uri = self.dag.settings.ext_collections_cfg_uri
+
         # check that no provider has already been fetched
         for provider in self.dag._providers.values():
             self.assertFalse(provider.collections_fetched)
 
-        # check that by default get_ext_collections_conf() is called without args
+        # check that by default get_ext_collections_conf() is called with settings value
         self.dag.fetch_collections_list()
-        mock_get_ext_collections_conf.assert_called_with()
+        mock_get_ext_collections_conf.assert_called_with(
+            self.dag.settings.ext_collections_cfg_uri
+        )
 
         # check that with an empty/mocked ext-conf, no provider has been fetched
         for provider in self.dag._providers.values():
             self.assertFalse(provider.collections_fetched)
 
-        # check that EODAG_EXT_COLLECTIONS_CFG_FILE env var will be used as get_ext_collections_conf() arg
-        os.environ["EODAG_EXT_COLLECTIONS_CFG_FILE"] = "some/file"
+        # check that runtime settings override is used as get_ext_collections_conf() arg
+        self.dag.settings.ext_collections_cfg_uri = "some/file"
         self.dag.fetch_collections_list()
         mock_get_ext_collections_conf.assert_called_with("some/file")
-        os.environ.pop("EODAG_EXT_COLLECTIONS_CFG_FILE")
+        self.dag.settings.ext_collections_cfg_uri = default_ext_collections_cfg_uri
 
         # check that with a non-empty ext-conf, a provider will be marked as fetched, and eodag conf updated
         mock_get_ext_collections_conf.return_value = {
@@ -1538,25 +1543,30 @@ class TestCore(TestCoreBase):
     ):
         """fetch_collections_list must launch collections discovery for new system-wide providers"""
         # add a new system-wide provider not listed in ext-conf
-        new_default_conf = load_default_config()
+        new_default_conf = load_provider_configs()
         new_default_conf["new_provider"] = new_default_conf["earth_search"].with_name(
             "new_provider"
         )
 
         with mock.patch(
-            "eodag.api.core.load_default_config",
+            "eodag.api.core.load_provider_configs",
             return_value=new_default_conf,
             autospec=True,
         ):
             self.dag = EODataAccessGateway()
+            default_ext_collections_cfg_uri = self.dag.settings.ext_collections_cfg_uri
 
             mock_get_ext_collections_conf.return_value = {}
 
-            # disabled collections discovery
-            os.environ["EODAG_EXT_COLLECTIONS_CFG_FILE"] = ""
+            # an empty configured URI still falls back to discovery
+            self.dag.settings.ext_collections_cfg_uri = ""
             self.dag.fetch_collections_list()
-            mock_discover_collections.assert_not_called()
-            os.environ.pop("EODAG_EXT_COLLECTIONS_CFG_FILE")
+            mock_get_ext_collections_conf.assert_called_with("")
+            mock_discover_collections.assert_called_once_with(self.dag, provider=None)
+
+            mock_discover_collections.reset_mock()
+
+            self.dag.settings.ext_collections_cfg_uri = default_ext_collections_cfg_uri
 
             # add an empty ext-conf for other providers to prevent them to be fetched
             for provider in self.dag._providers.values():
@@ -1572,14 +1582,16 @@ class TestCore(TestCoreBase):
         "eodag.api.core.EODataAccessGateway.discover_collections", autospec=True
     )
     def test_fetch_collections_list_disabled(self, mock_discover_collections):
-        """fetch_collections_list must not launch collections discovery if disabled"""
+        """An empty ext collections URI still falls back to collections discovery."""
 
-        # disable collections discovery
-        os.environ["EODAG_EXT_COLLECTIONS_CFG_FILE"] = ""
+        # configure an empty external collections URI
+        self.dag.settings.ext_collections_cfg_uri = ""
 
-        # default settings
+        # default settings still fall back to discover_collections
         self.dag.fetch_collections_list()
-        mock_discover_collections.assert_not_called()
+        mock_discover_collections.assert_called_once_with(self.dag, provider=None)
+
+        mock_discover_collections.reset_mock()
 
         # only user-defined providers must be fetched
         self.dag.update_providers_config("""
@@ -1596,7 +1608,14 @@ class TestCore(TestCoreBase):
                         _collection: '{collection}'
             """)
         self.dag.fetch_collections_list()
-        self.assertEqual(mock_discover_collections.call_count, 2)
+        self.assertEqual(
+            mock_discover_collections.call_args_list,
+            [
+                mock.call(self.dag, provider=None),
+                mock.call(self.dag, provider="earth_search"),
+                mock.call(self.dag, provider="foo_provider"),
+            ],
+        )
 
     def test_core_object_set_default_locations_config(self):
         """The core object must set the default locations config on instantiation"""
@@ -1610,9 +1629,24 @@ class TestCore(TestCoreBase):
         )
 
     def test_core_object_locations_file_not_found(self):
-        """The core object must set the locations to an empty list when the file is not found"""
-        dag = EODataAccessGateway(locations_conf_path="no_locations.yml")
-        self.assertEqual(dag.locations_config, [])
+        """The core object must create a default locations file when the configured file is missing"""
+        missing_locations_path = os.path.join(
+            self.tmp_home_dir.name, "missing_locations.yml"
+        )
+        dag = EODataAccessGateway(locations_conf_path=missing_locations_path)
+        self.assertTrue(os.path.exists(missing_locations_path))
+        self.assertEqual(
+            dag.locations_config,
+            [
+                {
+                    "attr": "ADM0_A3_US",
+                    "name": "country",
+                    "path": os.path.join(
+                        self.conf_dir, "shp", "ne_110m_admin_0_map_units.shp"
+                    ),
+                }
+            ],
+        )
 
     def test_prune_providers_list(self):
         """Providers needing auth for search but without credentials must be pruned on init"""
@@ -2747,8 +2781,9 @@ class TestCoreInvolvingConfDir(unittest.TestCase):
 
     def tearDown(self):
         super().tearDown()
-        for old_path in glob.glob(os.path.join(self.dag.conf_dir, "*.old")) + glob.glob(
-            os.path.join(self.dag.conf_dir, ".*.old")
+        conf_dir = str(self.dag.settings.cfg_dir)
+        for old_path in glob.glob(os.path.join(conf_dir, "*.old")) + glob.glob(
+            os.path.join(conf_dir, ".*.old")
         ):
             if os.path.exists(old_path):
                 try:
@@ -2806,15 +2841,17 @@ class TestCoreInvolvingConfDir(unittest.TestCase):
         del os.environ["EODAG_CFG_DIR"]
 
         # fallback temporary folder
-        def makedirs_side_effect(dir):
-            if dir == os.path.join(os.path.expanduser("~"), ".config", "eodag"):
-                raise OSError("Mock makedirs error")
-            else:
-                return makedirs(dir)
+        def ensure_cfg_dir_exists_side_effect(config_dir):
+            if config_dir == Path(home_dir):
+                temp_dir = Path(tempfile.gettempdir()) / ".config" / "eodag"
+                makedirs(str(temp_dir))
+                return temp_dir
+            return config_dir
 
         with mock.patch(
-            "eodag.api.core.makedirs", side_effect=makedirs_side_effect
-        ) as mock_makedirs:
+            "eodag.api.core.ensure_cfg_dir_exists",
+            side_effect=ensure_cfg_dir_exists_side_effect,
+        ) as mock_ensure_cfg_dir_exists:
             # backup temp_dir if exists
             temp_dir = temp_dir_old = os.path.join(
                 tempfile.gettempdir(), ".config", "eodag"
@@ -2824,8 +2861,7 @@ class TestCoreInvolvingConfDir(unittest.TestCase):
                 shutil.move(temp_dir, temp_dir_old)
 
             EODataAccessGateway()
-            expected = [unittest.mock.call(home_dir), unittest.mock.call(temp_dir)]
-            mock_makedirs.assert_has_calls(expected)
+            mock_ensure_cfg_dir_exists.assert_called_once_with(Path(home_dir))
             self.assertTrue(os.path.exists(temp_dir))
 
             # restore temp_dir

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -2695,8 +2695,9 @@ class TestCoreConfWithEnvVar(TestCoreBase):
             )
             with pytest.warns(
                 DeprecationWarning, match=r".*EODAG_PROVIDERS_CFG_FILE.*"
-            ):
+            ) as warnings_record:
                 self.dag = EODataAccessGateway()
+            self.assertEqual(warnings_record[0].filename, __file__)
             # only foo_provider in conf
             self.assertEqual(self.dag.providers.names, ["foo_provider"])
             self.assertEqual(

--- a/tests/units/test_download_plugins.py
+++ b/tests/units/test_download_plugins.py
@@ -54,7 +54,7 @@ from tests.context import (
     ProvidersDict,
     S3FileInfo,
     StreamResponse,
-    load_default_config,
+    load_provider_configs,
     path_to_uri,
     uri_to_path,
 )
@@ -64,7 +64,7 @@ class BaseDownloadPluginTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(BaseDownloadPluginTest, cls).setUpClass()
-        providers = ProvidersDict.from_configs(load_default_config())
+        providers = ProvidersDict.from_configs(load_provider_configs())
         cls.plugins_manager = PluginManager(providers)
         # Mock home and eodag conf directory to tmp dir
         cls.tmp_home_dir = TemporaryDirectory()

--- a/tests/units/test_search_plugins.py
+++ b/tests/units/test_search_plugins.py
@@ -91,14 +91,14 @@ from tests.context import (
     cached_yaml_load_all,
     ecmwf_temporal_to_eodag,
     get_geometry_from_various,
-    load_default_config,
+    load_provider_configs,
 )
 
 
 class BaseSearchPluginTest(unittest.TestCase):
     def setUp(self):
         super(BaseSearchPluginTest, self).setUp()
-        providers = ProvidersDict.from_configs(load_default_config())
+        providers = ProvidersDict.from_configs(load_provider_configs())
         self.plugins_manager = PluginManager(providers)
         self.collection = "S2_MSI_L1C"
         geom = [137.772897, 13.134202, 153.749135, 23.885986]
@@ -3473,7 +3473,7 @@ class TestSearchPluginECMWFSearch(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestSearchPluginECMWFSearch, cls).setUpClass()
-        providers = ProvidersDict.from_configs(load_default_config())
+        providers = ProvidersDict.from_configs(load_provider_configs())
         cls.plugins_manager = PluginManager(providers)
 
     def setUp(self):
@@ -5854,7 +5854,7 @@ class TestSearchPluginWekeoSearch(BaseSearchPluginTest):
     def test_plugins_search_wekeosearch_init_wekeomain(self):
         """Check that the WekeoSearch plugin is initialized correctly for wekeo_main provider"""
 
-        default_config = load_default_config()["wekeo_main"]
+        default_config = load_provider_configs()["wekeo_main"]
         # "eodag:order_link" in S1_SAR_GRD but not in provider conf or S1_SAR_SLC conf
         self.assertNotIn("eodag:order_link", default_config.search.metadata_mapping)
         self.assertIn(

--- a/utils/collections_information_to_csv.py
+++ b/utils/collections_information_to_csv.py
@@ -24,7 +24,7 @@ from typing import Any
 
 from eodag.api.collection import Collection
 from eodag.api.core import EODataAccessGateway
-from eodag.config import load_default_config
+from eodag.config import load_provider_configs
 
 DEFAULT_COLLECTIONS_CSV_FILE_PATH = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
@@ -40,7 +40,7 @@ def collections_info_to_csv(
     :param collections_csv_file_path: (optional) Path to collections information csv output file
     """
     config = {}
-    for provider_config in load_default_config().values():
+    for provider_config in load_provider_configs().values():
         config[provider_config.name] = list(provider_config.products.keys())
 
     # backup os.environ as it will be modified by the script
@@ -49,7 +49,7 @@ def collections_info_to_csv(
         k: v for k, v in os.environ.items() if eodag_env_pattern.match(k)
     }
 
-    providers = sorted(load_default_config().keys())
+    providers = sorted(load_provider_configs().keys())
     for provider in providers:
         os.environ[f"EODAG__{provider}__AUTH__CREDENTIALS__FOO"] = "bar"
 


### PR DESCRIPTION
Introduce a [pydantic settings](https://pydantic-docs.helpmanual.io/usage/settings/) interface to manage EODAG settings.

All EODAG global settings are now described in a model. The parameters can be configured either in python or with the environment variables.

```python
from eodag import EODataAccessGateway, EODAGSettings

settings = EODAGSettings(
    cfg_dir="~/.config/eodag",
    locations_cfg_file="/tmp/locations.yml",
    validate_collections=False,
)

dag = EODataAccessGateway(settings=settings)
```

Previous [EODataAccessGateway](https://eodag.readthedocs.io/en/latest/api_reference/core.html#eodag.api.core.EODataAccessGateway) configuration parameters (`user_conf_file_path`, `locations_conf_path`) are now deprecated.
