### PR TITLE
fix(providers): complete removal of deprecated eocat configuration

### DIFF
--- a/eodag/resources/user_conf_template.yml
+++ b/eodag/resources/user_conf_template.yml
@@ -58,6 +58,10 @@ cop_ghsl:
     priority: # Lower value means lower priority (Default: 0)
 cop_marine:
     priority: # Lower value means lower priority (Default: 0)
+    auth:
+        credentials:
+            username:
+            password:
 creodias:
     priority: # Lower value means lower priority (Default: 0)
     auth:
@@ -117,12 +121,6 @@ earth_search_gcs:
 ecmwf:
     priority: # Lower value means lower priority (Default: 0)
     api:
-        credentials:
-            username:
-            password:
-eocat:
-    priority: # Lower value means lower priority (Default: 0)
-    auth:
         credentials:
             username:
             password:

--- a/eodag/resources/user_conf_template.yml
+++ b/eodag/resources/user_conf_template.yml
@@ -58,10 +58,6 @@ cop_ghsl:
     priority: # Lower value means lower priority (Default: 0)
 cop_marine:
     priority: # Lower value means lower priority (Default: 0)
-    auth:
-        credentials:
-            username:
-            password:
 creodias:
     priority: # Lower value means lower priority (Default: 0)
     auth:


### PR DESCRIPTION
Fixes #2338.

Removed the deprecated `eocat` provider configuration block from `user_conf_template.yml` as `eocat` has already been removed from core providers.