### PR TITLE
feat(core): explicit error messages and doc for not-available providers

### DIFF
--- a/docs/getting_started_guide/configure.rst
+++ b/docs/getting_started_guide/configure.rst
@@ -20,6 +20,18 @@ for products in a provider's catalog, how to download products, etc. However, us
 to complete this configuration with additional settings, such as provider credentials. Users can
 also override pre-configured settings (e.g. the download folder).
 
+During initialization, EODAG builds its active providers registry from the bundled configuration,
+user configuration, environment overrides, and available plugin classes. Some configured providers
+may be pruned from the active registry when they cannot be used in the current environment. This can
+happen when credentials required for search are missing, when an authentication plugin is not
+configured, when no search/API plugin is configured, or when a provider depends on an optional
+plugin whose dependencies are not installed.
+
+Pruned provider configurations are kept internally with an explicit prune reason. A provider pruned
+because of missing credentials can be restored by updating the configuration with the required
+credentials. A provider pruned because a plugin was skipped requires installing the corresponding
+optional dependencies, for example with ``eodag[usgs]`` or ``eodag[all-providers]``.
+
 YAML user configuration file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/getting_started_guide/install.rst
+++ b/docs/getting_started_guide/install.rst
@@ -43,6 +43,13 @@ Also available:
   and linting tools)
 * ``eodag[docs]``, includes dependencies required to build documentation
 
+.. note::
+
+    Providers implemented by optional plugins are available only when the corresponding extra dependencies are
+    installed. If an optional plugin cannot be loaded, providers using it are removed from the active providers list.
+    Direct use of such a provider raises an ``UnsupportedProvider`` error containing the missing extra, for example:
+    ``UsgsApi plugin skipped, eodag[usgs] or eodag[all] needed``.
+
 Conda
 """""
 

--- a/docs/notebooks/api_user_guide/1_providers_collections_available.ipynb
+++ b/docs/notebooks/api_user_guide/1_providers_collections_available.ipynb
@@ -13,7 +13,7 @@
     "- [Combine both methods](#Combine-these-two-methods)  \n",
     "- [Discover collections dynamically](#collections-discovery)\n",
     "\n",
-    "Only providers that do not need authentication for search will be listed here. This notebook is executed in CI/CD without providers credentials, and EODAG hides providers needing authentication for search that do not have credentials set."
+    "Only providers available in the current documentation build environment will be listed here. This notebook is executed in CI/CD without provider credentials, so EODAG hides providers that require authentication for search when their credentials are not configured."
    ]
   },
   {

--- a/docs/notebooks/api_user_guide/3_search.ipynb
+++ b/docs/notebooks/api_user_guide/3_search.ipynb
@@ -5696,7 +5696,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`eodag` has an internal collection catalog which stores a number of metadata for each collection (see [this page](../../getting_started_guide/collections.rst) for more information). It is actually possible to search for products by using some of these metadata. In that case, `eodag` will query its own catalog and use **the collection that best matches the query** among the available collections (i.e. all collections offered by providers where the necessary credentials are provided). The supported parameters are:\n",
+    "`eodag` has an internal collection catalog which stores a number of metadata for each collection (see [this page](../../getting_started_guide/collections.rst) for more information). It is actually possible to search for products by using some of these metadata. In that case, `eodag` will query its own catalog and use **the collection that best matches the query** among the available collections (i.e. collections offered by providers that are active in the current environment). The supported parameters are:\n",
     "\n",
     "* `free_text`: *search applied to all of the following fields*\n",
     "* `instruments` (e.g. *MSI*)\n",

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -9,9 +9,9 @@ Featured providers
 This section introduces the featured providers that are already integrated, so you can
 easily start searching, accessing, and downloading products.
 
-Some providers are completely open, while others require an account to access their data.
-Check provider ``Registration info`` in this page to see if credentials are expected and how to get
-them.
+Some providers are completely open, while others require an account to access their data or optional
+dependencies to load their plugin. Check provider ``Registration info`` in this page to see if
+credentials are expected and how to get them.
 
 .. admonition::  EODAG is not limited to the providers listed here
    :class: note
@@ -1029,6 +1029,11 @@ No credentials are needed
 
         :fas:`external-link-alt`
 
+.. note::
+
+    This provider requires the ``ecmwf`` optional dependencies. Install them with ``eodag[ecmwf]``
+    or ``eodag[all-providers]``.
+
 .. dropdown:: Registration info
   :color: muted
   :class-container: dropdown-fade-in slim-dropdown
@@ -1213,6 +1218,11 @@ No credentials are needed
         :tooltip: USGS website
 
         :fas:`external-link-alt`
+
+.. note::
+
+    This provider requires the ``usgs`` optional dependencies. Install them with ``eodag[usgs]``
+    or ``eodag[all-providers]``.
 
 .. dropdown:: Registration info
   :color: muted

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -221,7 +221,7 @@ class EODataAccessGateway:
         :param provider: The name of the provider that should be considered as the
                          preferred provider to be used for this instance
         """
-        self._providers.check_supported(provider)
+        self._plugins_manager.check_provider_available(provider)
 
         preferred_provider, max_priority = self.get_preferred_provider()
         if preferred_provider != provider:
@@ -259,11 +259,30 @@ class EODataAccessGateway:
         for name in list(self._providers.pruned_providers_config):
             config = self._providers.pruned_providers_config[name]
             if name in conf_update:
+                updated_provider = Provider(config)
+                updated_provider.update_from_config(conf_update[name])
+                if self._plugins_manager.get_skipped_plugin_messages(
+                    updated_provider.config
+                ):
+                    # provider pruned because of missing plugin (not restorable)
+                    self._providers.pruned_providers_config[name] = (
+                        updated_provider.config
+                    )
+                    self._providers.pruned_providers_reasons[name] = {
+                        "reason": "; ".join(
+                            self._plugins_manager.get_skipped_plugin_messages(
+                                updated_provider.config
+                            )
+                        ),
+                        "reason_type": "skipped_plugin",
+                    }
+                    continue
                 logger.info(
                     "%s: provider restored from the pruned configurations", name
                 )
-                self._providers[name] = Provider(config)
+                self._providers[name] = updated_provider
                 self._providers.pruned_providers_config.pop(name)
+                self._providers.pruned_providers_reasons.pop(name, None)
 
         self._providers.update_from_configs(conf_update)
 
@@ -346,13 +365,22 @@ class EODataAccessGateway:
             conf = provider.config
 
             # remove providers using skipped plugins
-            if [
+            skipped_plugin_configs = [
                 v
                 for v in conf.__dict__.values()
                 if isinstance(v, PluginConfig)
                 and getattr(v, "type", None) in self._plugins_manager.skipped_plugins
-            ]:
+            ]
+            if skipped_plugin_configs:
+                self._providers.pruned_providers_config[provider.name] = conf
+                self._providers.pruned_providers_reasons[provider.name] = {
+                    "reason": "; ".join(
+                        self._plugins_manager.get_skipped_plugin_messages(conf)
+                    ),
+                    "reason_type": "skipped_plugin",
+                }
                 del self._providers[provider.name]
+                update_needed = True
                 logger.debug(
                     f"{provider}: provider needing unavailable plugin has been removed"
                 )
@@ -364,6 +392,13 @@ class EODataAccessGateway:
                 if not credentials_exist:
                     # credentials needed but not found
                     self._providers.pruned_providers_config[provider.name] = conf
+                    self._providers.pruned_providers_reasons[provider.name] = {
+                        "reason": (
+                            "provider needing auth for search was pruned because "
+                            "no credentials could be found"
+                        ),
+                        "reason_type": "missing_credentials",
+                    }
                     del self._providers[provider.name]
 
                     update_needed = True
@@ -376,6 +411,10 @@ class EODataAccessGateway:
                 if not hasattr(conf, "auth") and not hasattr(conf, "search_auth"):
                     # credentials needed but no auth plugin was found
                     self._providers.pruned_providers_config[provider.name] = conf
+                    self._providers.pruned_providers_reasons[provider.name] = {
+                        "reason": "provider needing auth for search was pruned because no auth plugin could be found",
+                        "reason_type": "missing_auth_plugin",
+                    }
                     del self._providers[provider.name]
 
                     update_needed = True
@@ -396,6 +435,13 @@ class EODataAccessGateway:
                 if not credentials_exist:
                     # credentials needed but not found
                     self._providers.pruned_providers_config[provider.name] = conf
+                    self._providers.pruned_providers_reasons[provider.name] = {
+                        "reason": (
+                            "provider needing auth for search was pruned because "
+                            "no credentials could be found"
+                        ),
+                        "reason_type": "missing_credentials",
+                    }
                     del self._providers[provider.name]
 
                     update_needed = True
@@ -407,6 +453,13 @@ class EODataAccessGateway:
             elif not hasattr(conf, "api") and not hasattr(conf, "search"):
                 # provider should have at least an api or search plugin
                 self._providers.pruned_providers_config[provider.name] = conf
+                self._providers.pruned_providers_reasons[provider.name] = {
+                    "reason": (
+                        "provider has been pruned because no api or search plugin "
+                        "could be found"
+                    ),
+                    "reason_type": "missing_search_plugin",
+                }
                 del self._providers[provider.name]
 
                 update_needed = True
@@ -508,7 +561,7 @@ class EODataAccessGateway:
         )
 
         if provider and not any(providers_check):
-            self._providers.check_supported(provider)
+            self._plugins_manager.check_provider_available(provider)
 
         # unique collection ids from providers configs
         collection_ids = {
@@ -668,7 +721,7 @@ class EODataAccessGateway:
         )
 
         if provider and not any(providers_check):
-            self._providers.check_supported(provider)
+            self._plugins_manager.check_provider_available(provider)
 
         ext_collections_conf: dict[str, Any] = {}
 

--- a/eodag/api/core.py
+++ b/eodag/api/core.py
@@ -175,9 +175,6 @@ class EODataAccessGateway:
         # re-build _plugins_manager using up-to-date providers_config
         self._plugins_manager.rebuild(self._providers)
 
-        # store pruned providers configs
-        self._pruned_providers_config: dict[str, Any] = {}
-
         # filter out providers needing auth that have no credentials set
         self._prune_providers_list()
 
@@ -224,10 +221,7 @@ class EODataAccessGateway:
         :param provider: The name of the provider that should be considered as the
                          preferred provider to be used for this instance
         """
-        if provider not in self.providers.names:
-            raise UnsupportedProvider(
-                f"This provider is not recognised by eodag: {provider}"
-            )
+        self._providers.check_supported(provider)
 
         preferred_provider, max_priority = self.get_preferred_provider()
         if preferred_provider != provider:
@@ -262,14 +256,14 @@ class EODataAccessGateway:
             return None
 
         # restore the pruned configuration
-        for name in list(self._pruned_providers_config):
-            config = self._pruned_providers_config[name]
+        for name in list(self._providers.pruned_providers_config):
+            config = self._providers.pruned_providers_config[name]
             if name in conf_update:
                 logger.info(
                     "%s: provider restored from the pruned configurations", name
                 )
                 self._providers[name] = Provider(config)
-                self._pruned_providers_config.pop(name)
+                self._providers.pruned_providers_config.pop(name)
 
         self._providers.update_from_configs(conf_update)
 
@@ -369,7 +363,7 @@ class EODataAccessGateway:
                 credentials_exist = credentials_in_auth(conf.api)
                 if not credentials_exist:
                     # credentials needed but not found
-                    self._pruned_providers_config[provider.name] = conf
+                    self._providers.pruned_providers_config[provider.name] = conf
                     del self._providers[provider.name]
 
                     update_needed = True
@@ -381,7 +375,7 @@ class EODataAccessGateway:
             elif hasattr(conf, "search") and getattr(conf.search, "need_auth", False):
                 if not hasattr(conf, "auth") and not hasattr(conf, "search_auth"):
                     # credentials needed but no auth plugin was found
-                    self._pruned_providers_config[provider.name] = conf
+                    self._providers.pruned_providers_config[provider.name] = conf
                     del self._providers[provider.name]
 
                     update_needed = True
@@ -401,7 +395,7 @@ class EODataAccessGateway:
                 )
                 if not credentials_exist:
                     # credentials needed but not found
-                    self._pruned_providers_config[provider.name] = conf
+                    self._providers.pruned_providers_config[provider.name] = conf
                     del self._providers[provider.name]
 
                     update_needed = True
@@ -412,7 +406,7 @@ class EODataAccessGateway:
 
             elif not hasattr(conf, "api") and not hasattr(conf, "search"):
                 # provider should have at least an api or search plugin
-                self._pruned_providers_config[provider.name] = conf
+                self._providers.pruned_providers_config[provider.name] = conf
                 del self._providers[provider.name]
 
                 update_needed = True
@@ -514,9 +508,7 @@ class EODataAccessGateway:
         )
 
         if provider and not any(providers_check):
-            raise UnsupportedProvider(
-                f"The requested provider is not (yet) supported: {provider}"
-            )
+            self._providers.check_supported(provider)
 
         # unique collection ids from providers configs
         collection_ids = {
@@ -676,9 +668,7 @@ class EODataAccessGateway:
         )
 
         if provider and not any(providers_check):
-            raise UnsupportedProvider(
-                f"The requested provider is not (yet) supported: {provider}"
-            )
+            self._providers.check_supported(provider)
 
         ext_collections_conf: dict[str, Any] = {}
 

--- a/eodag/api/provider.py
+++ b/eodag/api/provider.py
@@ -593,6 +593,28 @@ class ProvidersDict(UserDict[str, Provider]):
     :param providers: Initial providers to populate the dictionary.
     """
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # configs of providers removed because they needed auth but had no credentials set
+        self.pruned_providers_config: dict[str, Any] = {}
+
+    def check_supported(self, provider: str, include_groups: bool = False) -> None:
+        """
+        Check that a provider is known and usable, raising the most relevant error.
+
+        :param provider: The name of the provider (or group, if ``include_groups``) to check.
+        :param include_groups: Whether a provider group name is also accepted as known.
+        :raises MisconfiguredError: If the provider was pruned because no credentials could be found.
+        :raises UnsupportedProvider: If the provider is not recognised by eodag.
+        """
+        if provider in self.pruned_providers_config:
+            msg = f"{provider}: provider needing auth for search was pruned because no credentials could be found"
+            raise MisconfiguredError(msg)
+        known = provider in self.names or (include_groups and provider in self.groups)
+        if not known:
+            msg = f"{provider}: provider is not recognised by eodag"
+            raise UnsupportedProvider(msg)
+
     def __contains__(self, item: object) -> bool:
         """
         Check if a provider is in the dictionary by name or :class:`~eodag.api.provider.Provider` instance.

--- a/eodag/api/provider.py
+++ b/eodag/api/provider.py
@@ -27,8 +27,10 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Iterator,
+    Literal,
     Mapping,
     Optional,
+    TypedDict,
     Union,
     get_type_hints,
 )
@@ -66,6 +68,18 @@ logger = logging.getLogger("eodag.provider")
 
 AUTH_TOPIC_KEYS = ("auth", "search_auth", "download_auth")
 PLUGINS_TOPICS_KEYS = ("api", "search", "download") + AUTH_TOPIC_KEYS
+
+
+class PrunedProviderReason(TypedDict):
+    """Reason why a provider was removed from the active providers registry."""
+
+    reason: str
+    reason_type: Literal[
+        "skipped_plugin",
+        "missing_credentials",
+        "missing_auth_plugin",
+        "missing_search_plugin",
+    ]
 
 
 class ProviderConfig(yaml.YAMLObject):
@@ -595,21 +609,39 @@ class ProvidersDict(UserDict[str, Provider]):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        # configs of providers removed because they needed auth but had no credentials set
-        self.pruned_providers_config: dict[str, Any] = {}
+        # configs of providers removed from active providers list
+        self.pruned_providers_config: dict[str, ProviderConfig] = {}
+        self.pruned_providers_reasons: dict[str, PrunedProviderReason] = {}
 
-    def check_supported(self, provider: str, include_groups: bool = False) -> None:
+    def check_supported(
+        self,
+        provider: str,
+        include_groups: bool = False,
+    ) -> None:
         """
-        Check that a provider is known and usable, raising the most relevant error.
+        Check that a provider or provider group is known in the provider registry.
+
+        Providers removed from the active registry are reported using their stored
+        prune reason. This method does not inspect plugin loading state directly;
+        plugin-related prune reasons must be recorded by the pruning code.
 
         :param provider: The name of the provider (or group, if ``include_groups``) to check.
         :param include_groups: Whether a provider group name is also accepted as known.
-        :raises MisconfiguredError: If the provider was pruned because no credentials could be found.
-        :raises UnsupportedProvider: If the provider is not recognised by eodag.
+        :raises MisconfiguredError: If the provider was pruned for a configuration reason.
+        :raises UnsupportedProvider: If the provider/group is unknown, or if the provider
+                                     was pruned because a required plugin was skipped.
         """
         if provider in self.pruned_providers_config:
-            msg = f"{provider}: provider needing auth for search was pruned because no credentials could be found"
-            raise MisconfiguredError(msg)
+            if reason_dict := self.pruned_providers_reasons.get(provider):
+                reason = reason_dict["reason"]
+                if reason_dict["reason_type"] == "skipped_plugin":
+                    msg = f"{provider}: provider is not available because {reason}"
+                    raise UnsupportedProvider(msg)
+                msg = f"{provider}: {reason}"
+                raise MisconfiguredError(msg)
+            # Fallback for legacy/manual pruned entries missing an explicit reason.
+            msg = f"{provider}: provider has been pruned and is not available"
+            raise UnsupportedProvider(msg)
         known = provider in self.names or (include_groups and provider in self.groups)
         if not known:
             msg = f"{provider}: provider is not recognised by eodag"

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any, Iterator, Optional, Union, cast
 import importlib_metadata
 
 from eodag.api.provider import ProvidersDict
-from eodag.config import AUTH_TOPIC_KEYS, PLUGINS_TOPICS_KEYS, load_config
+from eodag.config import AUTH_TOPIC_KEYS, PLUGINS_TOPICS_KEYS, PluginConfig, load_config
 from eodag.plugins.apis.base import Api
 from eodag.plugins.authentication.base import Authentication
 from eodag.plugins.base import EODAGPluginMount
@@ -46,7 +46,6 @@ if TYPE_CHECKING:
 
     from eodag.api.product._product import EOProduct
     from eodag.api.provider import ProviderConfig
-    from eodag.config import PluginConfig
     from eodag.plugins.base import PluginTopic
 
 
@@ -73,10 +72,10 @@ class PluginManager:
 
     collection_to_provider_config_map: dict[str, list[ProviderConfig]]
 
-    skipped_plugins: list[str]
+    skipped_plugins: dict[str, str]
 
     def __init__(self, providers: ProvidersDict) -> None:
-        self.skipped_plugins = []
+        self.skipped_plugins = {}
         self.providers = providers
         # Load all the plugins. This will make all plugin classes of a particular
         # type to be available in the base plugin class's 'plugins' attribute.
@@ -94,12 +93,12 @@ class PluginManager:
                 try:
                     entry_point.load()
                 except ModuleNotFoundError:
-                    logger.debug(
-                        "%s plugin skipped, eodag[%s] or eodag[all] needed",
-                        entry_point.name,
-                        ",".join(entry_point.extras),
+                    msg = (
+                        f"{entry_point.name} plugin skipped, "
+                        f"eodag[{','.join(entry_point.extras)}] or eodag[all] needed"
                     )
-                    self.skipped_plugins.append(entry_point.name)
+                    logger.debug(msg)
+                    self.skipped_plugins[entry_point.name] = msg
                 except ImportError:
                     import traceback as tb
 
@@ -190,6 +189,25 @@ class PluginManager:
                 collection_providers.append(provider.config)
                 collection_providers.sort(key=attrgetter("priority"), reverse=True)
 
+    def get_skipped_plugin_messages(self, provider_config: ProviderConfig) -> list[str]:
+        """Return skipped plugin messages for plugins used by a provider config."""
+        return [
+            self.skipped_plugins[plugin_conf.type]
+            for plugin_conf in provider_config.__dict__.values()
+            if isinstance(plugin_conf, PluginConfig)
+            and getattr(plugin_conf, "type", None) in self.skipped_plugins
+        ]
+
+    def check_provider_available(
+        self, provider: str, include_groups: bool = False
+    ) -> None:
+        """Check whether a provider or provider group can be used by plugins.
+
+        Plugin availability is reflected in the provider prune reasons recorded during
+        gateway initialization. The final exception is raised by ``ProvidersDict``.
+        """
+        self.providers.check_supported(provider, include_groups=include_groups)
+
     def get_search_plugins(
         self, collection: Optional[str] = None, provider: Optional[str] = None
     ) -> Iterator[Union[Search, Api]]:
@@ -234,7 +252,7 @@ class PluginManager:
             configs = list(p.config for p in self.providers.values())
 
         if provider:
-            self.providers.check_supported(provider, include_groups=True)
+            self.check_provider_available(provider, include_groups=True)
             configs = [
                 c for c in configs if provider in [getattr(c, "group", None), c.name]
             ]

--- a/eodag/plugins/manager.py
+++ b/eodag/plugins/manager.py
@@ -234,6 +234,7 @@ class PluginManager:
             configs = list(p.config for p in self.providers.values())
 
         if provider:
+            self.providers.check_supported(provider, include_groups=True)
             configs = [
                 c for c in configs if provider in [getattr(c, "group", None), c.name]
             ]

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -51,6 +51,7 @@ from tests.context import (
     CommonQueryables,
     EODataAccessGateway,
     EOProduct,
+    MisconfiguredError,
     NoMatchingCollection,
     PluginImplementationError,
     ProviderConfig,
@@ -1756,6 +1757,22 @@ class TestCore(TestCoreBase):
         self.assertListEqual(
             ["creodias", "cop_dataspace"], list(self.dag.providers.keys())[:2]
         )
+
+    def test_set_preferred_provider_pruned(self):
+        """set_preferred_provider must raise MisconfiguredError for a pruned provider"""
+        self.dag._providers.pruned_providers_config["creodias"] = self.dag._providers[
+            "creodias"
+        ].config
+        try:
+            self.assertRaisesRegex(
+                MisconfiguredError,
+                "creodias: provider needing auth for search was pruned "
+                "because no credentials could be found",
+                self.dag.set_preferred_provider,
+                "creodias",
+            )
+        finally:
+            self.dag._providers.pruned_providers_config.pop("creodias", None)
 
     def test_update_providers_config(self):
         """update_providers_config must update providers configuration"""
@@ -5121,6 +5138,31 @@ class TestCoreProviderGroup(TestCoreBase):
         )
 
         self.assertCountEqual(group_plugins, [*plugin1, *plugin2])
+
+    def test_get_search_plugins_unknown_provider(self) -> None:
+        """get_search_plugins must raise UnsupportedProvider for an unknown provider/group"""
+        with self.assertRaisesRegex(
+            UnsupportedProvider, "unknown: provider is not recognised by eodag"
+        ):
+            list(self.dag._plugins_manager.get_search_plugins(provider="unknown"))
+
+    def test_get_search_plugins_pruned_provider(self) -> None:
+        """get_search_plugins must raise MisconfiguredError for a pruned provider"""
+        manager_providers = self.dag._plugins_manager.providers
+        manager_providers.pruned_providers_config[self.group[0]] = manager_providers[
+            self.group[0]
+        ].config
+        try:
+            with self.assertRaisesRegex(
+                MisconfiguredError,
+                f"{self.group[0]}: provider needing auth for search was pruned "
+                "because no credentials could be found",
+            ):
+                list(
+                    self.dag._plugins_manager.get_search_plugins(provider=self.group[0])
+                )
+        finally:
+            manager_providers.pruned_providers_config.pop(self.group[0], None)
 
 
 class TestCoreStrictMode(TestCoreBase):

--- a/tests/units/test_core.py
+++ b/tests/units/test_core.py
@@ -1664,19 +1664,28 @@ class TestCore(TestCoreBase):
             res_files("eodag") / "resources" / "user_conf_template.yml"
         )
 
-        def skip_qssearch(group):
+        def skip_usgs_api(group):
             ep = mock.MagicMock()
-            if group == "eodag.plugins.search":
-                ep.name = "QueryStringSearch"
+            if group == "eodag.plugins.api":
+                ep.name = "UsgsApi"
+                ep.extras = ["usgs"]
                 ep.load = mock.MagicMock(side_effect=ModuleNotFoundError())
             return [ep]
 
-        mock_iter_ep.side_effect = skip_qssearch
+        mock_iter_ep.side_effect = skip_usgs_api
 
         dag = EODataAccessGateway(user_conf_file_path=empty_conf_file)
-        self.assertNotIn("sara", dag.providers.names)
-        self.assertEqual(dag._plugins_manager.skipped_plugins, ["QueryStringSearch"])
-        dag._plugins_manager.skipped_plugins = []
+        self.assertNotIn("usgs", dag.providers.names)
+        self.assertEqual(
+            dag._plugins_manager.skipped_plugins,
+            {"UsgsApi": "UsgsApi plugin skipped, eodag[usgs] or eodag[all] needed"},
+        )
+        with self.assertRaisesRegex(
+            UnsupportedProvider,
+            r"usgs: provider is not available because UsgsApi plugin skipped, eodag\[usgs\] or eodag\[all\] needed",
+        ):
+            list(dag._plugins_manager.get_search_plugins(provider="usgs"))
+        dag._plugins_manager.skipped_plugins = {}
 
     def test_prune_providers_list_for_search_without_auth(self):
         """Providers needing auth for search but without auth plugin must be pruned on init"""
@@ -1763,6 +1772,10 @@ class TestCore(TestCoreBase):
         self.dag._providers.pruned_providers_config["creodias"] = self.dag._providers[
             "creodias"
         ].config
+        self.dag._providers.pruned_providers_reasons["creodias"] = {
+            "reason": "provider needing auth for search was pruned because no credentials could be found",
+            "reason_type": "missing_credentials",
+        }
         try:
             self.assertRaisesRegex(
                 MisconfiguredError,
@@ -1773,6 +1786,7 @@ class TestCore(TestCoreBase):
             )
         finally:
             self.dag._providers.pruned_providers_config.pop("creodias", None)
+            self.dag._providers.pruned_providers_reasons.pop("creodias", None)
 
     def test_update_providers_config(self):
         """update_providers_config must update providers configuration"""
@@ -5152,6 +5166,10 @@ class TestCoreProviderGroup(TestCoreBase):
         manager_providers.pruned_providers_config[self.group[0]] = manager_providers[
             self.group[0]
         ].config
+        manager_providers.pruned_providers_reasons[self.group[0]] = {
+            "reason": "provider needing auth for search was pruned because no credentials could be found",
+            "reason_type": "missing_credentials",
+        }
         try:
             with self.assertRaisesRegex(
                 MisconfiguredError,
@@ -5163,6 +5181,7 @@ class TestCoreProviderGroup(TestCoreBase):
                 )
         finally:
             manager_providers.pruned_providers_config.pop(self.group[0], None)
+            manager_providers.pruned_providers_reasons.pop(self.group[0], None)
 
 
 class TestCoreStrictMode(TestCoreBase):

--- a/tests/units/test_provider.py
+++ b/tests/units/test_provider.py
@@ -418,10 +418,24 @@ class TestProvidersDict(unittest.TestCase):
 
         # pruned provider: MisconfiguredError takes precedence over UnsupportedProvider
         providers.pruned_providers_config["provider1"] = providers["provider1"].config
+        providers.pruned_providers_reasons["provider1"] = {
+            "reason": "provider needing auth for search was pruned because no credentials could be found",
+            "reason_type": "missing_credentials",
+        }
         with self.assertRaisesRegex(
             MisconfiguredError,
             "provider1: provider needing auth for search was pruned "
             "because no credentials could be found",
+        ):
+            providers.check_supported("provider1")
+
+        providers.pruned_providers_reasons["provider1"] = {
+            "reason": "SkippedSearch plugin skipped",
+            "reason_type": "skipped_plugin",
+        }
+        with self.assertRaisesRegex(
+            UnsupportedProvider,
+            "provider1: provider is not available because SkippedSearch plugin skipped",
         ):
             providers.check_supported("provider1")
 

--- a/tests/units/test_provider.py
+++ b/tests/units/test_provider.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 
 from tests.context import (
     EODataAccessGateway,
+    MisconfiguredError,
     PluginConfig,
     Provider,
     ProviderConfig,
@@ -396,6 +397,33 @@ class TestProvidersDict(unittest.TestCase):
 
         config = self.sample_providers.get_config("nonexistent")
         self.assertIsNone(config)
+
+    def test_providers_dict_check_supported(self):
+        """Test ProvidersDict check_supported method."""
+        providers = ProvidersDict.from_configs(self.sample_configs)
+
+        # known provider name: no error
+        providers.check_supported("provider1")
+
+        # unknown provider: UnsupportedProvider
+        with self.assertRaisesRegex(
+            UnsupportedProvider, "unknown: provider is not recognised by eodag"
+        ):
+            providers.check_supported("unknown")
+
+        # group name is rejected unless include_groups is set
+        with self.assertRaises(UnsupportedProvider):
+            providers.check_supported("group_a")
+        providers.check_supported("group_a", include_groups=True)
+
+        # pruned provider: MisconfiguredError takes precedence over UnsupportedProvider
+        providers.pruned_providers_config["provider1"] = providers["provider1"].config
+        with self.assertRaisesRegex(
+            MisconfiguredError,
+            "provider1: provider needing auth for search was pruned "
+            "because no credentials could be found",
+        ):
+            providers.check_supported("provider1")
 
     @patch.dict("os.environ", {"EODAG_PROVIDERS_WHITELIST": "provider1"})
     def test_providers_dict_whitelist(self):


### PR DESCRIPTION
Use more explicit error messages and documentation for not-available providers. All are now handled in *pruned* providers, together with the reason that caused the provider removal:
- skipped plugin because of missing dependencies
- missing credentials when auth is required for search
- missing search plugin
- missing auth plugin when auth is required for search


Raise `MisconfiguredError` when provider is missing because of lacking credentials instead of `UnsupportedProvider('provider is not (yet) supported')`:

> eodag.utils.exceptions.MisconfiguredError: provider needing auth for search was pruned because no credentials could be found

Related to https://github.com/CS-SI/eodag/issues/1497
Updates https://github.com/CS-SI/eodag/issues/1772
